### PR TITLE
feat(epic-36): Story 36-3 — Tenant Usage Analytics API

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs
@@ -1,0 +1,148 @@
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Api.Services.Analytics;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 36-3 — tenant-facing usage analytics endpoints mounted under
+/// <c>/api/v1/orgs/{tenantId}/analytics/*</c>. The tenant-facing mirror of the
+/// platform-owner <see cref="AdminAnalyticsEndpoints"/>: it reads the
+/// <b>per-tenant</b> Story 36-1 fact tables (<c>analytics_usage_hourly</c> /
+/// <c>analytics_usage_daily</c>) through <c>ITenantAnalyticsService</c>, never
+/// the control-plane <c>platform_analytics_hourly</c> / <c>IPlatformAnalyticsService</c>.
+///
+/// <para><b>Auth (AC4/AC5/AC6):</b> both routes carry the group's
+/// <c>MemberAccess</c> policy + the
+/// <see cref="Tamma.Api.Authorization.RequireTenantMembershipFilter"/> (403 for
+/// a non-member of the route <c>{tenantId}</c>). <b>No</b> owner/admin gate —
+/// usage analytics is member-readable. The endpoint shape is identical across
+/// single-user / SaaS; the membership filter + the per-tenant
+/// <c>TenantDbContext</c> do all the mode + isolation work, so the handlers
+/// have no per-mode branch.</para>
+///
+/// <para><b>Thin by design (AC1/AC3/AC10):</b> the handlers parse + clamp the
+/// window (forced-UTC, 365-day max, hour cap), 400 on bad input, and delegate
+/// the grouped/aggregated read to the service.</para>
+/// </summary>
+public static class TenantAnalyticsEndpoints
+{
+    private const int DefaultBreakdownLimit = 10;
+    private const int MaxBreakdownLimit = 100;
+
+    /// <summary>
+    /// <c>GET /api/v1/orgs/{tenantId}/analytics/usage</c> — time-bucketed usage
+    /// over <c>[from, to)</c> at <c>hour</c>|<c>day</c> grain, optionally grouped
+    /// by <c>provider</c>|<c>agent</c>|<c>workflow</c>|<c>repo</c>.
+    /// </summary>
+    public static async Task<IResult> GetUsage(
+        Guid tenantId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? granularity,
+        [FromQuery] string? groupBy,
+        ITenantAnalyticsService analytics,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var log = loggerFactory.CreateLogger("Tamma.Api.Endpoints.TenantAnalyticsEndpoints");
+
+        var window = AnalyticsWindow.Resolve(from, to, granularity);
+        if (!window.IsValid)
+        {
+            log.LogWarning(
+                "Tenant usage query rejected: tenantId={TenantId} requestedFrom={From} "
+                    + "requestedTo={To} granularity={Granularity} error={Error}",
+                tenantId, from, to, granularity, window.Error);
+            return Results.BadRequest(new { error = window.Error });
+        }
+
+        AnalyticsDimension? groupByDim = null;
+        if (!string.IsNullOrWhiteSpace(groupBy))
+        {
+            if (!AnalyticsEnums.TryParseDimension(groupBy, out var dim))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "groupBy must be one of: provider, agent, workflow, repo",
+                });
+            }
+
+            groupByDim = dim;
+        }
+
+        LogWindowDebug(log, tenantId, from, to, window);
+
+        var result = await analytics.GetUsageAsync(tenantId, window, groupByDim, ct);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// <c>GET /api/v1/orgs/{tenantId}/analytics/usage/breakdown</c> — top-N rows
+    /// for a single <c>dimension</c> over the window, ranked by <c>metric</c>
+    /// (<c>tokens</c>|<c>runs</c>|<c>dispatches</c>|<c>cost</c>) descending.
+    /// Always daily grain (the natural breakdown source).
+    /// </summary>
+    public static async Task<IResult> GetBreakdown(
+        Guid tenantId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? dimension,
+        [FromQuery] string? metric,
+        [FromQuery] int? limit,
+        ITenantAnalyticsService analytics,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var log = loggerFactory.CreateLogger("Tamma.Api.Endpoints.TenantAnalyticsEndpoints");
+
+        // Breakdown ranks over the whole window at daily grain — resolve with the
+        // default (day) granularity so the 365-day max range still applies.
+        var window = AnalyticsWindow.Resolve(from, to, null);
+        if (!window.IsValid)
+        {
+            log.LogWarning(
+                "Tenant breakdown query rejected: tenantId={TenantId} requestedFrom={From} "
+                    + "requestedTo={To} error={Error}",
+                tenantId, from, to, window.Error);
+            return Results.BadRequest(new { error = window.Error });
+        }
+
+        if (!AnalyticsEnums.TryParseDimension(dimension, out var dim))
+        {
+            return Results.BadRequest(new
+            {
+                error = "dimension is required and must be one of: provider, agent, workflow, repo",
+            });
+        }
+
+        if (!AnalyticsEnums.TryParseMetric(metric, out var met))
+        {
+            return Results.BadRequest(new
+            {
+                error = "metric must be one of: tokens, runs, dispatches, cost",
+            });
+        }
+
+        var clampedLimit = Math.Clamp(limit ?? DefaultBreakdownLimit, 1, MaxBreakdownLimit);
+
+        LogWindowDebug(log, tenantId, from, to, window);
+
+        var result = await analytics.GetBreakdownAsync(tenantId, window, dim, met, clampedLimit, ct);
+        return Results.Ok(result);
+    }
+
+    private static void LogWindowDebug(
+        ILogger log, Guid tenantId, DateTime? requestedFrom, DateTime? requestedTo, AnalyticsWindow window)
+    {
+        if (!log.IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
+        log.LogDebug(
+            "Tenant analytics window resolved: tenantId={TenantId} requestedFrom={RequestedFrom} "
+                + "requestedTo={RequestedTo} effectiveFrom={EffectiveFrom:o} effectiveTo={EffectiveTo:o} "
+                + "granularity={Granularity}",
+            tenantId, requestedFrom, requestedTo, window.From, window.To, window.Granularity.ToWire());
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1031,6 +1031,14 @@ builder.Services.AddScoped<
     Tamma.Api.Services.Analytics.IPlatformAnalyticsService,
     Tamma.Api.Services.Analytics.PlatformAnalyticsService>();
 
+// Story 36-3 — tenant-facing usage analytics read seam. Reads the per-tenant
+// Story 36-1 fact tables (analytics_usage_hourly / analytics_usage_daily,
+// populated by Story 36-2) through ITenantDbContextFactory — NOT the
+// control-plane platform_analytics_hourly surface above.
+builder.Services.AddScoped<
+    Tamma.Api.Services.Analytics.ITenantAnalyticsService,
+    Tamma.Api.Services.Analytics.TenantAnalyticsService>();
+
 // Story 34-11 — swap the frozen ProviderPricingService for the DB-backed
 // DbProviderPricingService behind the unchanged IProviderPricingService seam
 // (a one-line DI change; zero downstream consumer edits). Must run AFTER
@@ -1930,6 +1938,17 @@ orgs.MapGet("/{tenantId:guid}/dashboard/summary", UserDashboardEndpoints.GetOrgS
 orgs.MapGet("/{tenantId:guid}/dashboard/runs", UserDashboardEndpoints.GetRecentRuns)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapGet("/{tenantId:guid}/dashboard/stats", UserDashboardEndpoints.GetStats)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+
+// Story 36-3 — tenant usage analytics API. Reads Story 36-1's per-tenant
+// analytics_usage_hourly / analytics_usage_daily fact tables (populated by
+// Story 36-2) through ITenantDbContextFactory. Member-read (the group's
+// MemberAccess policy + the path-tenant membership filter); NO owner/admin
+// gate — usage analytics is read-only and tenant-wide. A member of org A can
+// never reach org B's route (403) nor its schema (physical isolation).
+orgs.MapGet("/{tenantId:guid}/analytics/usage", TenantAnalyticsEndpoints.GetUsage)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+orgs.MapGet("/{tenantId:guid}/analytics/usage/breakdown", TenantAnalyticsEndpoints.GetBreakdown)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 
 // Story 5.6 / 1.5-37 (Wave C.3) — tenant-scope alert surface.

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ITenantAnalyticsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ITenantAnalyticsService.cs
@@ -1,0 +1,40 @@
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-3 — the single read seam over the per-tenant Story 36-1 fact
+/// tables (<c>analytics_usage_hourly</c> / <c>analytics_usage_daily</c>). Reads
+/// pre-aggregated facts ONLY through <c>ITenantDbContextFactory.CreateAsync</c>
+/// (per-tenant schema isolation) — it never re-scans <c>domain_events</c> and
+/// never touches the control-plane <c>IPlatformAnalyticsService</c>.
+///
+/// <para>Isolation is physical: the factory binds a schema-scoped connection,
+/// so a call for tenant A can only ever see tenant A's schema. There is no
+/// <c>TenantId</c> column on the fact tables and no tenant predicate in the
+/// query (Story 36-1 §1.4).</para>
+/// </summary>
+public interface ITenantAnalyticsService
+{
+    /// <summary>
+    /// Time-bucketed usage over the (already-clamped, UTC) <paramref name="window"/>.
+    /// With <paramref name="groupBy"/> <c>null</c>, one summed row per bucket;
+    /// with it set, one row per <c>(bucket, dimension-value)</c> — the <c>NULL</c>
+    /// dimension bucket surfaced with a <c>null</c> key.
+    /// </summary>
+    Task<UsageResponse> GetUsageAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension? groupBy,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Top-<paramref name="limit"/> rows for a single <paramref name="dimension"/>
+    /// over the window, ranked by <paramref name="metric"/> descending.
+    /// </summary>
+    Task<BreakdownResponse> GetBreakdownAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension dimension,
+        AnalyticsMetric metric,
+        int limit,
+        CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsDtos.cs
@@ -1,0 +1,308 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-3 — request/response contract + validation for the tenant usage
+/// analytics API (<c>GET /api/v1/orgs/{tenantId}/analytics/usage[/breakdown]</c>).
+///
+/// <para>These types are the stable, additive-only contract the tenant
+/// dashboard (Story 36-6) and the CSV/JSON exporter (Story 36-8) consume. The
+/// wire names are pinned: <c>period_start</c>/<c>period_end</c> are snake_case
+/// (the effective, clamped UTC window echoes); every other field rides the
+/// app-wide camelCase JSON policy (Program.cs
+/// <c>ConfigureHttpJsonOptions</c>).</para>
+/// </summary>
+
+/// <summary>Roll-up grain for a usage query.</summary>
+public enum AnalyticsGranularity
+{
+    /// <summary>Top-of-hour buckets — reads <c>analytics_usage_hourly</c>.</summary>
+    Hour,
+
+    /// <summary>UTC-midnight buckets — reads <c>analytics_usage_daily</c> (default).</summary>
+    Day,
+}
+
+/// <summary>Dimension a usage query groups by / a breakdown ranks over.</summary>
+public enum AnalyticsDimension
+{
+    Provider,
+    Agent,
+    Workflow,
+    Repo,
+}
+
+/// <summary>The measure a breakdown ranks its top-N rows by.</summary>
+public enum AnalyticsMetric
+{
+    /// <summary><c>TokensIn + TokensOut</c>.</summary>
+    Tokens,
+
+    /// <summary><c>WorkflowsStarted</c>.</summary>
+    Runs,
+
+    /// <summary><c>AgentDispatches</c>.</summary>
+    Dispatches,
+
+    /// <summary><c>CostUsd</c>.</summary>
+    Cost,
+}
+
+/// <summary>
+/// Parse helpers for the string query params. Absent (null/empty) is treated
+/// as "use the default" for granularity/metric; an unknown non-empty value is
+/// a hard parse failure (the endpoint maps it to 400).
+/// </summary>
+public static class AnalyticsEnums
+{
+    /// <summary>
+    /// Parse <c>granularity</c>. Absent → <see cref="AnalyticsGranularity.Day"/>
+    /// (the default grain). Returns <c>false</c> for an unknown non-empty value.
+    /// </summary>
+    public static bool TryParseGranularity(string? raw, out AnalyticsGranularity value)
+    {
+        value = AnalyticsGranularity.Day;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case "hour":
+                value = AnalyticsGranularity.Hour;
+                return true;
+            case "day":
+                value = AnalyticsGranularity.Day;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Parse a dimension (<c>groupBy</c> / breakdown <c>dimension</c>). There is
+    /// no default — an absent or unknown value returns <c>false</c>; the caller
+    /// decides whether "absent" means "no grouping" (usage) or 400 (breakdown).
+    /// </summary>
+    public static bool TryParseDimension(string? raw, out AnalyticsDimension value)
+    {
+        value = default;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return false;
+        }
+
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case "provider":
+                value = AnalyticsDimension.Provider;
+                return true;
+            case "agent":
+                value = AnalyticsDimension.Agent;
+                return true;
+            case "workflow":
+                value = AnalyticsDimension.Workflow;
+                return true;
+            case "repo":
+                value = AnalyticsDimension.Repo;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Parse the breakdown <c>metric</c>. Absent → <see cref="AnalyticsMetric.Tokens"/>
+    /// (the default). Returns <c>false</c> for an unknown non-empty value.
+    /// </summary>
+    public static bool TryParseMetric(string? raw, out AnalyticsMetric value)
+    {
+        value = AnalyticsMetric.Tokens;
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return true;
+        }
+
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case "tokens":
+                value = AnalyticsMetric.Tokens;
+                return true;
+            case "runs":
+                value = AnalyticsMetric.Runs;
+                return true;
+            case "dispatches":
+                value = AnalyticsMetric.Dispatches;
+                return true;
+            case "cost":
+                value = AnalyticsMetric.Cost;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>Lowercase wire token for a granularity (echoed in the response).</summary>
+    public static string ToWire(this AnalyticsGranularity g) =>
+        g == AnalyticsGranularity.Hour ? "hour" : "day";
+
+    /// <summary>Lowercase wire token for a dimension (echoed in the response).</summary>
+    public static string ToWire(this AnalyticsDimension d) => d switch
+    {
+        AnalyticsDimension.Provider => "provider",
+        AnalyticsDimension.Agent => "agent",
+        AnalyticsDimension.Workflow => "workflow",
+        AnalyticsDimension.Repo => "repo",
+        _ => d.ToString().ToLowerInvariant(),
+    };
+
+    /// <summary>Lowercase wire token for a metric (echoed in the response).</summary>
+    public static string ToWire(this AnalyticsMetric m) => m switch
+    {
+        AnalyticsMetric.Tokens => "tokens",
+        AnalyticsMetric.Runs => "runs",
+        AnalyticsMetric.Dispatches => "dispatches",
+        AnalyticsMetric.Cost => "cost",
+        _ => m.ToString().ToLowerInvariant(),
+    };
+}
+
+/// <summary>
+/// The <b>effective, clamped, UTC</b> query window (Story 36-3 AC7/AC9). Built
+/// by <see cref="Resolve"/> from the raw <c>from</c>/<c>to</c>/<c>granularity</c>
+/// query params:
+///
+/// <list type="bullet">
+///   <item><description><b>Forced-UTC</b> — <c>from</c>/<c>to</c> are normalized
+///     via <c>DateTime.SpecifyKind(v.ToUniversalTime(), DateTimeKind.Utc)</c>
+///     (the exact <c>AdminAnalyticsEndpoints.GetEventHistogram</c> fix) so the
+///     window lands on the stored top-of-hour / midnight-UTC buckets, not a
+///     Local shift (AC9).</description></item>
+///   <item><description><b>Defaults</b> — <c>to</c>→now, <c>from</c>→30 days
+///     before <c>to</c> when omitted.</description></item>
+///   <item><description><b>365-day max range</b> — a wider window is truncated to
+///     the most-recent 365 days (clamped, not rejected — the dashboard stays
+///     forgiving); the effective window is echoed.</description></item>
+///   <item><description><b>Hour-granularity cap</b> — an <c>hour</c> query over a
+///     window wider than 31 days is <b>rejected</b> (400); an unbounded hourly
+///     scan is the anti-pattern.</description></item>
+/// </list>
+/// </summary>
+public readonly record struct AnalyticsWindow(
+    DateTime From,
+    DateTime To,
+    AnalyticsGranularity Granularity,
+    bool IsValid,
+    string? Error)
+{
+    /// <summary>Hard ceiling on the <c>from..to</c> span (clamped, not rejected).</summary>
+    public const int MaxRangeDays = 365;
+
+    /// <summary>Widest window an <c>hour</c>-granularity query may scan (rejected past this).</summary>
+    public const int HourGranularityMaxDays = 31;
+
+    /// <summary>Window applied when <c>from</c> is omitted.</summary>
+    public const int DefaultWindowDays = 30;
+
+    private static AnalyticsWindow Invalid(string error) =>
+        new(default, default, default, false, error);
+
+    /// <summary>
+    /// Resolve the raw query params into a validated, clamped, UTC window.
+    /// Never throws — an invalid request yields <c>IsValid == false</c> and an
+    /// <see cref="Error"/> the endpoint returns as 400.
+    /// </summary>
+    public static AnalyticsWindow Resolve(DateTime? from, DateTime? to, string? granularity)
+    {
+        if (!AnalyticsEnums.TryParseGranularity(granularity, out var gran))
+        {
+            return Invalid("granularity must be one of: hour, day");
+        }
+
+        var toUtc = ToUtc(to) ?? DateTime.UtcNow;
+        var fromUtc = ToUtc(from) ?? toUtc.AddDays(-DefaultWindowDays);
+
+        if (fromUtc >= toUtc)
+        {
+            return Invalid("from must precede to");
+        }
+
+        // 365-day max range — truncate to the most-recent 365 days, echo the
+        // effective window (clamp, don't reject).
+        if ((toUtc - fromUtc).TotalDays > MaxRangeDays)
+        {
+            fromUtc = toUtc.AddDays(-MaxRangeDays);
+        }
+
+        // Hourly scans are capped — an hour query over a window wider than the
+        // cap is rejected (an unbounded hourly scan is the anti-pattern).
+        if (gran == AnalyticsGranularity.Hour
+            && (toUtc - fromUtc).TotalDays > HourGranularityMaxDays)
+        {
+            return Invalid($"granularity=hour requires a window <= {HourGranularityMaxDays} days");
+        }
+
+        return new AnalyticsWindow(fromUtc, toUtc, gran, true, null);
+    }
+
+    // Forced-UTC binding — mirror AdminAnalyticsEndpoints.GetEventHistogram.
+    private static DateTime? ToUtc(DateTime? v) =>
+        v is null ? null : DateTime.SpecifyKind(v.Value.ToUniversalTime(), DateTimeKind.Utc);
+}
+
+/// <summary>
+/// One time-bucket row of a usage response. When the query is ungrouped there
+/// is one row per bucket (<see cref="Key"/> <c>null</c>); when grouped there is
+/// one row per <c>(bucket, dimension-value)</c> — and the <c>NULL</c>
+/// "unattributed" dimension bucket is surfaced with a <c>null</c> key, never
+/// dropped or coerced to a sentinel (preserving 36-2's reconciliation).
+/// </summary>
+public sealed record UsageBucketRow(
+    DateTime Period,
+    string? Key,
+    long WorkflowsStarted,
+    long WorkflowsCompleted,
+    long WorkflowsFailed,
+    long AgentDispatches,
+    long TokensIn,
+    long TokensOut,
+    decimal CostUsd,
+    decimal PlatformBilledUsd);
+
+/// <summary>Response envelope for <c>GET …/analytics/usage</c>.</summary>
+public sealed record UsageResponse(
+    Guid TenantId,
+    [property: JsonPropertyName("period_start")] DateTime PeriodStart,
+    [property: JsonPropertyName("period_end")] DateTime PeriodEnd,
+    string Granularity,
+    string? GroupBy,
+    IReadOnlyList<UsageBucketRow> Rows);
+
+/// <summary>
+/// One top-N row of a breakdown response: the dimension <see cref="Key"/>
+/// (<c>null</c> = unattributed), the ranked <see cref="Value"/> (the selected
+/// metric's aggregate), and the full measure set for context.
+/// </summary>
+public sealed record BreakdownRow(
+    string? Key,
+    decimal Value,
+    long TokensIn,
+    long TokensOut,
+    decimal CostUsd,
+    decimal PlatformBilledUsd,
+    long WorkflowsStarted,
+    long WorkflowsCompleted,
+    long WorkflowsFailed,
+    long AgentDispatches);
+
+/// <summary>Response envelope for <c>GET …/analytics/usage/breakdown</c>.</summary>
+public sealed record BreakdownResponse(
+    Guid TenantId,
+    [property: JsonPropertyName("period_start")] DateTime PeriodStart,
+    [property: JsonPropertyName("period_end")] DateTime PeriodEnd,
+    string Dimension,
+    string Metric,
+    int Limit,
+    IReadOnlyList<BreakdownRow> Rows);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/TenantAnalyticsService.cs
@@ -1,0 +1,236 @@
+using System.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Data.Abstractions;
+
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-3 — per-tenant aggregation over the Story 36-1 dimensional fact
+/// tables. Mirrors the <c>UserDashboardEndpoints.GetStats</c> read shape:
+/// <c>await using var db = await tenantDbFactory.CreateAsync(tenantId)</c>, then
+/// a LINQ read against the tenant schema. Reads the pre-aggregated facts ONLY.
+///
+/// <para><b>Why materialize-then-group:</b> the two grains live on separate
+/// DbSets with different bucket columns (<c>Hour</c>/<c>Day</c>). The query
+/// pushes the indexed half-open <c>[from, to)</c> bucket-range filter to
+/// Postgres (using <c>IX_analytics_usage_*_breakdown</c>), projects only the
+/// needed columns, and rolls the (bounded — 365 daily buckets, or ≤31 days
+/// hourly per the AC7 caps) result up in memory. In-memory rollup gives
+/// byte-identical grouping on InMemory and Npgsql — including the <c>NULL</c>
+/// dimension key, which EF providers translate inconsistently — so the 36-2
+/// reconciliation contract (Σ grouped == ungrouped) holds under both.</para>
+/// </summary>
+public sealed class TenantAnalyticsService(
+    ITenantDbContextFactory tenantDbFactory,
+    ILogger<TenantAnalyticsService> logger)
+    : ITenantAnalyticsService
+{
+    public async Task<UsageResponse> GetUsageAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension? groupBy,
+        CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var facts = await LoadFactsAsync(tenantId, window, ct);
+
+        List<UsageBucketRow> rows;
+        if (groupBy is null)
+        {
+            rows = facts
+                .GroupBy(f => f.Bucket)
+                .OrderBy(g => g.Key)
+                .Select(g => AggregateBucket(g.Key, null, g))
+                .ToList();
+        }
+        else
+        {
+            var keyOf = DimensionKeySelector(groupBy.Value);
+            rows = facts
+                .GroupBy(f => new BucketKey(f.Bucket, keyOf(f)))
+                .OrderBy(g => g.Key.Bucket)
+                .ThenBy(g => g.Key.Key, StringComparer.Ordinal)
+                .Select(g => AggregateBucket(g.Key.Bucket, g.Key.Key, g))
+                .ToList();
+        }
+
+        logger.LogInformation(
+            "Tenant usage analytics served: tenantId={TenantId} granularity={Granularity} "
+                + "groupBy={GroupBy} periodStart={PeriodStart:o} periodEnd={PeriodEnd:o} "
+                + "rowCount={RowCount} durationMs={DurationMs}",
+            tenantId, window.Granularity.ToWire(), groupBy?.ToWire() ?? "(none)",
+            window.From, window.To, rows.Count, sw.ElapsedMilliseconds);
+
+        if (rows.Count == 0)
+        {
+            logger.LogWarning(
+                "Tenant usage analytics returned no rows for a non-trivial window "
+                    + "(tenantId={TenantId}, periodStart={PeriodStart:o}, periodEnd={PeriodEnd:o}) "
+                    + "— tenant may be un-projected; check the 36-2 rollup lag SLO.",
+                tenantId, window.From, window.To);
+        }
+
+        return new UsageResponse(
+            tenantId,
+            window.From,
+            window.To,
+            window.Granularity.ToWire(),
+            groupBy?.ToWire(),
+            rows);
+    }
+
+    public async Task<BreakdownResponse> GetBreakdownAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension dimension,
+        AnalyticsMetric metric,
+        int limit,
+        CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var facts = await LoadFactsAsync(tenantId, window, ct);
+        var keyOf = DimensionKeySelector(dimension);
+
+        var rows = facts
+            .GroupBy(keyOf)
+            .Select(g => AggregateBreakdown(g.Key, g, metric))
+            .OrderByDescending(r => r.Value)
+            .ThenBy(r => r.Key, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList();
+
+        logger.LogInformation(
+            "Tenant breakdown analytics served: tenantId={TenantId} dimension={Dimension} "
+                + "metric={Metric} limit={Limit} periodStart={PeriodStart:o} periodEnd={PeriodEnd:o} "
+                + "rowCount={RowCount} durationMs={DurationMs}",
+            tenantId, dimension.ToWire(), metric.ToWire(), limit,
+            window.From, window.To, rows.Count, sw.ElapsedMilliseconds);
+
+        return new BreakdownResponse(
+            tenantId,
+            window.From,
+            window.To,
+            dimension.ToWire(),
+            metric.ToWire(),
+            limit,
+            rows);
+    }
+
+    /// <summary>
+    /// Pushes the granularity switch + half-open <c>[from, to)</c> bucket filter
+    /// to the tenant schema, projecting only the dimensions + measures needed
+    /// for the rollup.
+    /// </summary>
+    private async Task<List<FactRow>> LoadFactsAsync(
+        Guid tenantId, AnalyticsWindow window, CancellationToken ct)
+    {
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+
+        if (window.Granularity == AnalyticsGranularity.Day)
+        {
+            return await db.AnalyticsUsageDaily
+                .Where(r => r.Day >= window.From && r.Day < window.To)
+                .Select(r => new FactRow(
+                    r.Day, r.Provider, r.AgentId, r.WorkflowDefinitionId, r.RepoId,
+                    r.TokensIn, r.TokensOut, r.CostUsd, r.PlatformBilledUsd,
+                    r.WorkflowsStarted, r.WorkflowsCompleted, r.WorkflowsFailed, r.AgentDispatches))
+                .ToListAsync(ct);
+        }
+
+        return await db.AnalyticsUsageHourly
+            .Where(r => r.Hour >= window.From && r.Hour < window.To)
+            .Select(r => new FactRow(
+                r.Hour, r.Provider, r.AgentId, r.WorkflowDefinitionId, r.RepoId,
+                r.TokensIn, r.TokensOut, r.CostUsd, r.PlatformBilledUsd,
+                r.WorkflowsStarted, r.WorkflowsCompleted, r.WorkflowsFailed, r.AgentDispatches))
+            .ToListAsync(ct);
+    }
+
+    private static Func<FactRow, string?> DimensionKeySelector(AnalyticsDimension dim) => dim switch
+    {
+        AnalyticsDimension.Provider => f => f.Provider,
+        AnalyticsDimension.Agent => f => f.AgentId,
+        AnalyticsDimension.Workflow => f => f.WorkflowDefinitionId?.ToString(),
+        AnalyticsDimension.Repo => f => f.RepoId,
+        _ => f => null,
+    };
+
+    private static UsageBucketRow AggregateBucket(
+        DateTime bucket, string? key, IEnumerable<FactRow> group)
+    {
+        var m = Measures.Sum(group);
+        return new UsageBucketRow(
+            bucket, key,
+            m.WorkflowsStarted, m.WorkflowsCompleted, m.WorkflowsFailed, m.AgentDispatches,
+            m.TokensIn, m.TokensOut, m.CostUsd, m.PlatformBilledUsd);
+    }
+
+    private static BreakdownRow AggregateBreakdown(
+        string? key, IEnumerable<FactRow> group, AnalyticsMetric metric)
+    {
+        var m = Measures.Sum(group);
+        var value = metric switch
+        {
+            AnalyticsMetric.Tokens => m.TokensIn + m.TokensOut,
+            AnalyticsMetric.Runs => m.WorkflowsStarted,
+            AnalyticsMetric.Dispatches => m.AgentDispatches,
+            AnalyticsMetric.Cost => m.CostUsd,
+            _ => 0m,
+        };
+        return new BreakdownRow(
+            key, value,
+            m.TokensIn, m.TokensOut, m.CostUsd, m.PlatformBilledUsd,
+            m.WorkflowsStarted, m.WorkflowsCompleted, m.WorkflowsFailed, m.AgentDispatches);
+    }
+
+    /// <summary>Lightweight projection of a fact row (only the columns the rollup needs).</summary>
+    private readonly record struct FactRow(
+        DateTime Bucket,
+        string? Provider,
+        string? AgentId,
+        Guid? WorkflowDefinitionId,
+        string? RepoId,
+        long TokensIn,
+        long TokensOut,
+        decimal CostUsd,
+        decimal PlatformBilledUsd,
+        long WorkflowsStarted,
+        long WorkflowsCompleted,
+        long WorkflowsFailed,
+        long AgentDispatches);
+
+    /// <summary>Grouping key for a grouped usage query — a <c>(bucket, dimension-value)</c> tuple.</summary>
+    private readonly record struct BucketKey(DateTime Bucket, string? Key);
+
+    /// <summary>Accumulated measure totals for a group.</summary>
+    private readonly record struct Measures(
+        long TokensIn,
+        long TokensOut,
+        decimal CostUsd,
+        decimal PlatformBilledUsd,
+        long WorkflowsStarted,
+        long WorkflowsCompleted,
+        long WorkflowsFailed,
+        long AgentDispatches)
+    {
+        public static Measures Sum(IEnumerable<FactRow> group)
+        {
+            long tin = 0, tout = 0, ws = 0, wc = 0, wf = 0, ad = 0;
+            decimal cu = 0m, pb = 0m;
+            foreach (var f in group)
+            {
+                tin += f.TokensIn;
+                tout += f.TokensOut;
+                cu += f.CostUsd;
+                pb += f.PlatformBilledUsd;
+                ws += f.WorkflowsStarted;
+                wc += f.WorkflowsCompleted;
+                wf += f.WorkflowsFailed;
+                ad += f.AgentDispatches;
+            }
+
+            return new Measures(tin, tout, cu, pb, ws, wc, wf, ad);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsEndpointsTests.cs
@@ -1,0 +1,192 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Authorization;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Analytics;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-3 — endpoint-level tests for the tenant usage analytics API:
+/// request validation (400s), member-read (no owner/admin gate), the
+/// CP-untouched invariant (AC11), and the cross-tenant 403 + no-leakage guard
+/// (AC4/AC12). No Postgres — validation short-circuits before the service, the
+/// service is mocked for happy paths, and the cross-tenant guard is proven by
+/// driving <see cref="RequireTenantMembershipFilter"/> directly (its 403 stops
+/// the handler from ever reading the other tenant's schema).
+/// </summary>
+[TestFixture]
+public class TenantAnalyticsEndpointsTests
+{
+    private static readonly DateTime From = new(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime To = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static ServiceProvider MinimalServices() =>
+        new ServiceCollection().AddLogging().BuildServiceProvider();
+
+    private static async Task<int> Status(IResult result)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = MinimalServices() };
+        ctx.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(ctx);
+        return ctx.Response.StatusCode;
+    }
+
+    // ─────────────────────────── GetUsage validation ───────────────────────────
+
+    [Test]
+    public async Task GetUsage_UnknownGroupBy_Returns400()
+    {
+        var svc = new Mock<ITenantAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetUsage(
+            Guid.NewGuid(), From, To, "day", "team", svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+        svc.Verify(s => s.GetUsageAsync(It.IsAny<Guid>(), It.IsAny<AnalyticsWindow>(),
+            It.IsAny<AnalyticsDimension?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetUsage_UnknownGranularity_Returns400()
+    {
+        var svc = new Mock<ITenantAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetUsage(
+            Guid.NewGuid(), From, To, "weekly", null, svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetUsage_HourGranularityOverCap_Returns400()
+    {
+        var svc = new Mock<ITenantAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetUsage(
+            Guid.NewGuid(), To.AddDays(-90), To, "hour", null, svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetUsage_HappyPath_MemberReadable_Returns200()
+    {
+        var tenantId = Guid.NewGuid();
+        var svc = new Mock<ITenantAnalyticsService>();
+        svc.Setup(s => s.GetUsageAsync(tenantId, It.IsAny<AnalyticsWindow>(),
+                It.IsAny<AnalyticsDimension?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UsageResponse(tenantId, From, To, "day", "provider", Array.Empty<UsageBucketRow>()));
+
+        // No role argument exists on the handler — a plain authenticated member
+        // read reaches the service (the only RBAC is MemberAccess + the
+        // membership filter at the wiring site; NO owner/admin gate — AC5).
+        var result = await TenantAnalyticsEndpoints.GetUsage(
+            tenantId, From, To, "day", "provider", svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ───────────────────────── GetBreakdown validation ─────────────────────────
+
+    [Test]
+    public async Task GetBreakdown_MissingDimension_Returns400()
+    {
+        var svc = new Mock<ITenantAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetBreakdown(
+            Guid.NewGuid(), From, To, dimension: null, metric: "tokens", limit: 10,
+            svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetBreakdown_UnknownMetric_Returns400()
+    {
+        var svc = new Mock<ITenantAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetBreakdown(
+            Guid.NewGuid(), From, To, dimension: "agent", metric: "latency", limit: 10,
+            svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetBreakdown_ClampsLimitTo100_AndDelegates()
+    {
+        var tenantId = Guid.NewGuid();
+        int? capturedLimit = null;
+        var svc = new Mock<ITenantAnalyticsService>();
+        svc.Setup(s => s.GetBreakdownAsync(tenantId, It.IsAny<AnalyticsWindow>(),
+                It.IsAny<AnalyticsDimension>(), It.IsAny<AnalyticsMetric>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, AnalyticsWindow, AnalyticsDimension, AnalyticsMetric, int, CancellationToken>(
+                (_, _, _, _, lim, _) => capturedLimit = lim)
+            .ReturnsAsync(new BreakdownResponse(tenantId, From, To, "agent", "tokens", 100, Array.Empty<BreakdownRow>()));
+
+        var result = await TenantAnalyticsEndpoints.GetBreakdown(
+            tenantId, From, To, dimension: "agent", metric: "tokens", limit: 9999,
+            svc.Object, NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status200OK);
+        capturedLimit.Should().Be(100, "limit is clamped to 1..100");
+    }
+
+    // ─────────────────────── AC11 — control-plane untouched ───────────────────────
+
+    [Test]
+    public void TenantAnalyticsService_DependsOnlyOnTenantFactory_NeverTheControlPlaneAnalyticsSurface()
+    {
+        var ctorParamTypes = typeof(TenantAnalyticsService)
+            .GetConstructors().Single()
+            .GetParameters().Select(p => p.ParameterType).ToList();
+
+        ctorParamTypes.Should().Contain(typeof(ITenantDbContextFactory),
+            "the read seam is the per-tenant factory (the physical isolation plane)");
+        ctorParamTypes.Should().NotContain(typeof(IPlatformAnalyticsService),
+            "AC11 — this tenant surface must never read the control-plane analytics service");
+        ctorParamTypes.Should().NotContain(typeof(ControlPlaneDbContext),
+            "AC11 — this tenant surface must never read the control-plane DbContext");
+    }
+
+    // ──────────────────── AC4/AC12 — cross-tenant 403, no leakage ────────────────────
+
+    [Test]
+    public async Task CrossTenantRoute_NonMember_Returns403_AndTheAnalyticsHandlerNeverRuns()
+    {
+        var memberOfA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        // The caller is NOT a member of tenant B (the route tenant).
+        var membership = new Mock<ITenantMembershipRepository>();
+        membership.Setup(r => r.GetRoleAsync(tenantB, memberOfA)).ReturnsAsync((string?)null);
+        var filter = new RequireTenantMembershipFilter(membership.Object);
+
+        var ctx = new DefaultHttpContext { RequestServices = MinimalServices() };
+        ctx.Response.Body = new MemoryStream();
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, memberOfA.ToString()) }, "Test"));
+        ctx.Request.RouteValues["tenantId"] = tenantB.ToString();
+
+        var handlerRan = false;
+        EndpointFilterDelegate next = _ =>
+        {
+            handlerRan = true; // would be the analytics handler reading tenant B's schema
+            return ValueTask.FromResult<object?>(Results.Ok());
+        };
+
+        var result = await filter.InvokeAsync(new DefaultEndpointFilterInvocationContext(ctx), next);
+        if (result is IResult r)
+        {
+            await r.ExecuteAsync(ctx);
+        }
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        handlerRan.Should().BeFalse(
+            "the membership filter 403s before the handler → no tenant-B fact row is ever returned (AC4/AC12)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsIntegrationTests.cs
@@ -1,0 +1,217 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-3 (AC4/AC12) — Postgres 17 Testcontainer proof for the tenant
+/// usage analytics read seam. Two tenant schemas in one DB (search-path
+/// isolation, per <c>AnalyticsUsageMigrationTests</c> /
+/// <c>DimensionalRollupIsolationTests</c>). EF InMemory models neither schema
+/// isolation nor real <c>timestamp with time zone</c> window selection, so a
+/// real Postgres is the only proof of:
+///
+/// <list type="number">
+///   <item><description><b>Isolation</b> — a tenant-A call returns only A's fact
+///     rows; a tenant-B call returns only B's. A row in schema A is physically
+///     unreachable through schema B's context (no <c>TenantId</c> column, no
+///     query filter — the schema is the isolation plane).</description></item>
+///   <item><description><b>Grouping + reconciliation</b> against real rows —
+///     Σ(grouped per bucket) == the ungrouped bucket total, NULL dimension
+///     surfaced.</description></item>
+///   <item><description><b>Range clamp + UTC window</b> on real
+///     <c>timestamptz</c> columns — a &gt;365-day window truncates to the
+///     most-recent 365 days (the older row is excluded); a Local-kind
+///     <c>from</c> selects the same buckets as its UTC equivalent.</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class TenantAnalyticsIntegrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tenant_analytics_api_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    // ─────────────────────────────── Isolation ───────────────────────────────
+
+    [Test]
+    public async Task GetUsage_IsHardScopedToTheCallersSchema_NoCrossTenantLeak()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var schemaA = TenantNaming.SchemaName(tenantA);
+        var schemaB = TenantNaming.SchemaName(tenantB);
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(schemaB));
+
+        var day = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        await SeedDailyAsync(schemaA, tenantA, day, "anthropic", tokensIn: 100, cost: 1.0m);
+        await SeedDailyAsync(schemaB, tenantB, day, "openai", tokensIn: 999, cost: 9.0m);
+
+        var factory = new SchemaRoutingFactory(_baseConnectionString)
+            .Map(tenantA, schemaA)
+            .Map(tenantB, schemaB);
+        var service = new TenantAnalyticsService(factory, NullLogger<TenantAnalyticsService>.Instance);
+        var window = AnalyticsWindow.Resolve(
+            new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc), "day");
+
+        var aResult = await service.GetUsageAsync(tenantA, window, null, CancellationToken.None);
+        aResult.Rows.Should().ContainSingle();
+        aResult.Rows[0].TokensIn.Should().Be(100, "tenant A sees only its own row");
+        aResult.Rows.Should().NotContain(r => r.TokensIn == 999, "tenant B's row must never leak into A");
+
+        var bResult = await service.GetUsageAsync(tenantB, window, null, CancellationToken.None);
+        bResult.Rows.Should().ContainSingle();
+        bResult.Rows[0].TokensIn.Should().Be(999, "tenant B sees only its own row");
+    }
+
+    // ──────────────────── Grouping + reconciliation (real GROUP BY) ────────────────────
+
+    [Test]
+    public async Task GetUsage_GroupBy_ReconcilesToUngrouped_OnRealPostgres_NullKeyPreserved()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        var day = new DateTime(2026, 5, 3, 0, 0, 0, DateTimeKind.Utc);
+        await SeedDailyAsync(schema, tenant, day, "anthropic", tokensIn: 100, cost: 1.0m, ws: 2, ad: 3);
+        await SeedDailyAsync(schema, tenant, day, "openai", tokensIn: 200, cost: 2.0m, ws: 1, ad: 1);
+        await SeedDailyAsync(schema, tenant, day, provider: null, tokensIn: 0, cost: 0m, ws: 5, ad: 0);
+
+        var factory = new SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var service = new TenantAnalyticsService(factory, NullLogger<TenantAnalyticsService>.Instance);
+        var window = AnalyticsWindow.Resolve(
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc), "day");
+
+        var ungrouped = await service.GetUsageAsync(tenant, window, null, CancellationToken.None);
+        var grouped = await service.GetUsageAsync(tenant, window, AnalyticsDimension.Provider, CancellationToken.None);
+
+        grouped.Rows.Should().HaveCount(3);
+        grouped.Rows.Should().Contain(r => r.Key == null, "the NULL-provider bucket is surfaced, never dropped");
+        grouped.Rows.Sum(r => r.TokensIn).Should().Be(ungrouped.Rows.Single().TokensIn);
+        grouped.Rows.Sum(r => r.WorkflowsStarted).Should().Be(ungrouped.Rows.Single().WorkflowsStarted);
+        grouped.Rows.Sum(r => r.CostUsd).Should().Be(ungrouped.Rows.Single().CostUsd);
+
+        var breakdown = await service.GetBreakdownAsync(
+            tenant, window, AnalyticsDimension.Provider, AnalyticsMetric.Tokens, 10, CancellationToken.None);
+        breakdown.Rows[0].Key.Should().Be("openai", "openai has the most tokens (200 > 100 > 0)");
+    }
+
+    // ─────────────────── Range clamp + UTC window (real timestamptz) ───────────────────
+
+    [Test]
+    public async Task GetUsage_ClampsWindowTo365Days_AndSelectsUtcBuckets_OnRealTimestamptz()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        var to = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var recent = to.AddDays(-10);              // inside the clamped 365-day window
+        var ancient = to.AddDays(-400);            // outside — must be truncated away
+        await SeedDailyAsync(schema, tenant, recent, "anthropic", tokensIn: 50, cost: 0.5m);
+        await SeedDailyAsync(schema, tenant, ancient, "anthropic", tokensIn: 77, cost: 0.7m);
+
+        var factory = new SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var service = new TenantAnalyticsService(factory, NullLogger<TenantAnalyticsService>.Instance);
+
+        // Request a 400-day window → clamps to the most-recent 365 days.
+        var window = AnalyticsWindow.Resolve(ancient, to, "day");
+        window.From.Should().Be(to.AddDays(-365));
+        var res = await service.GetUsageAsync(tenant, window, null, CancellationToken.None);
+
+        res.Rows.Should().ContainSingle("the 400-day-old row is truncated out of the effective window");
+        res.Rows[0].TokensIn.Should().Be(50);
+
+        // UTC binding: a Local-kind `from` at the same instant selects identically.
+        var localWindow = AnalyticsWindow.Resolve(
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc).ToLocalTime(), to, "day");
+        var localRes = await service.GetUsageAsync(tenant, localWindow, null, CancellationToken.None);
+        localRes.Rows.Should().ContainSingle();
+        localRes.Rows[0].TokensIn.Should().Be(50, "a non-UTC-offset `from` selects the same bucket as its UTC equivalent");
+    }
+
+    // ──────────────────────────────── Helpers ────────────────────────────────
+
+    private async Task SeedDailyAsync(
+        string schema, Guid tenantId, DateTime day, string? provider,
+        long tokensIn = 0, decimal cost = 0m, long ws = 0, long ad = 0)
+    {
+        var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options;
+        await using var ctx = new TenantDbContext(opts, tenantId);
+        ctx.AnalyticsUsageDaily.Add(new AnalyticsUsageDaily
+        {
+            Id = Guid.NewGuid(),
+            Day = day,
+            Provider = provider,
+            CostBasis = CostBasis.Platform,
+            TokensIn = tokensIn,
+            TokensOut = 0,
+            CostUsd = cost,
+            PlatformBilledUsd = cost,
+            WorkflowsStarted = ws,
+            WorkflowsCompleted = 0,
+            WorkflowsFailed = 0,
+            AgentDispatches = ad,
+            ComputedAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    /// <summary>Routes each tenant id to its own search-path schema connection.</summary>
+    private sealed class SchemaRoutingFactory(string baseCs) : ITenantDbContextFactory
+    {
+        private readonly Dictionary<Guid, string> _schemas = new();
+
+        public SchemaRoutingFactory Map(Guid tenantId, string schema)
+        {
+            _schemas[tenantId] = schema;
+            return this;
+        }
+
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            if (!_schemas.TryGetValue(tenantId, out var schema))
+            {
+                throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+            }
+
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options;
+            return new ValueTask<TenantDbContext>(new TenantDbContext(opts, tenantId));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/TenantAnalyticsServiceTests.cs
@@ -1,0 +1,328 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-3 — unit tests for the tenant usage analytics read seam.
+///
+/// <para>Two layers, no Postgres:</para>
+/// <list type="number">
+///   <item><description><b>Window clamp / UTC</b> — pure
+///     <see cref="AnalyticsWindow.Resolve"/> matrix (defaults, 365-day max,
+///     hour cap, from&gt;=to, bad enum, forced-UTC equivalence).</description></item>
+///   <item><description><b>Grouping shape / reconciliation</b> — the service
+///     against a seeded EF-InMemory <see cref="TenantDbContext"/>: ungrouped =
+///     one summed row per bucket; grouped = one row per (bucket, dimension) with
+///     the NULL key surfaced; Σ(grouped per bucket) == ungrouped bucket; breakdown
+///     top-N by each metric.</description></item>
+/// </list>
+///
+/// <para>Physical schema isolation + real Npgsql GROUP BY / timestamptz window
+/// selection are proven in <see cref="TenantAnalyticsIntegrationTests"/> (a real
+/// Postgres 17 container) — InMemory models neither.</para>
+/// </summary>
+[TestFixture]
+public class TenantAnalyticsServiceTests
+{
+    private static readonly DateTime D1 = new(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime D2 = new(2026, 5, 2, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime WindowFrom = new(2026, 4, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime WindowTo = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    // ─────────────────────────── Window clamp / UTC ───────────────────────────
+
+    [Test]
+    public void Resolve_Defaults_To30DayDailyWindow_WhenBothOmitted()
+    {
+        var w = AnalyticsWindow.Resolve(null, null, null);
+
+        w.IsValid.Should().BeTrue();
+        w.Granularity.Should().Be(AnalyticsGranularity.Day);
+        (w.To - w.From).TotalDays.Should().BeApproximately(30, 0.01);
+        w.From.Kind.Should().Be(DateTimeKind.Utc);
+        w.To.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public void Resolve_Truncates_WindowWiderThan365Days_ToMostRecent365()
+    {
+        var to = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = to.AddDays(-400);
+
+        var w = AnalyticsWindow.Resolve(from, to, "day");
+
+        w.IsValid.Should().BeTrue();
+        w.To.Should().Be(to);
+        w.From.Should().Be(to.AddDays(-AnalyticsWindow.MaxRangeDays),
+            "a >365-day window truncates to the most-recent 365 days (clamp, not reject)");
+    }
+
+    [Test]
+    public void Resolve_Rejects_HourGranularity_OverTheHourCap()
+    {
+        var to = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = to.AddDays(-40); // > 31-day hour cap
+
+        var w = AnalyticsWindow.Resolve(from, to, "hour");
+
+        w.IsValid.Should().BeFalse();
+        w.Error.Should().Contain("hour");
+    }
+
+    [Test]
+    public void Resolve_Allows_HourGranularity_WithinTheHourCap()
+    {
+        var to = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var from = to.AddDays(-10);
+
+        var w = AnalyticsWindow.Resolve(from, to, "hour");
+
+        w.IsValid.Should().BeTrue();
+        w.Granularity.Should().Be(AnalyticsGranularity.Hour);
+    }
+
+    [Test]
+    public void Resolve_Rejects_FromNotBeforeTo()
+    {
+        var t = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        AnalyticsWindow.Resolve(t, t, "day").IsValid.Should().BeFalse();
+        AnalyticsWindow.Resolve(t.AddDays(1), t, "day").IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public void Resolve_Rejects_UnknownGranularity()
+    {
+        var w = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "weekly");
+        w.IsValid.Should().BeFalse();
+        w.Error.Should().Contain("granularity");
+    }
+
+    [Test]
+    public void Resolve_ForcesUtc_SoAnOffsetFromSelectsTheSameWindowAsItsUtcEquivalent()
+    {
+        var utcFrom = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2026, 5, 20, 0, 0, 0, DateTimeKind.Utc);
+
+        // Same instant as utcFrom, but Kind=Local (what a non-UTC-offset bind
+        // yields). ToLocalTime()/ToUniversalTime() round-trip is deterministic
+        // on any machine TZ.
+        var localFrom = utcFrom.ToLocalTime();
+
+        var wUtc = AnalyticsWindow.Resolve(utcFrom, to, "day");
+        var wLocal = AnalyticsWindow.Resolve(localFrom, to, "day");
+
+        wLocal.From.Should().Be(wUtc.From, "forced-UTC normalization collapses both to the same instant");
+        wUtc.From.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    // ─────────────────────── Grouping shape / reconciliation ───────────────────────
+
+    [Test]
+    public async Task GetUsage_Ungrouped_SumsAllDimensionsPerBucket_OneRowPerBucket()
+    {
+        var (service, tenantId) = await SeededServiceAsync();
+        var window = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "day");
+
+        var res = await service.GetUsageAsync(tenantId, window, groupBy: null, CancellationToken.None);
+
+        res.GroupBy.Should().BeNull();
+        res.Granularity.Should().Be("day");
+        res.PeriodStart.Should().Be(window.From);
+        res.PeriodEnd.Should().Be(window.To);
+        res.Rows.Should().HaveCount(2, "two seeded buckets → one summed row each");
+
+        var d1 = res.Rows.Single(r => r.Period == D1);
+        d1.Key.Should().BeNull();
+        d1.WorkflowsStarted.Should().Be(8);
+        d1.WorkflowsCompleted.Should().Be(6);
+        d1.WorkflowsFailed.Should().Be(2);
+        d1.AgentDispatches.Should().Be(4);
+        d1.TokensIn.Should().Be(300);
+        d1.TokensOut.Should().Be(130);
+        d1.CostUsd.Should().Be(3.0m);
+
+        var d2 = res.Rows.Single(r => r.Period == D2);
+        d2.TokensIn.Should().Be(300);
+        d2.CostUsd.Should().Be(3.0m);
+    }
+
+    [Test]
+    public async Task GetUsage_GroupByProvider_OneRowPerBucketDimension_NullKeyPreserved()
+    {
+        var (service, tenantId) = await SeededServiceAsync();
+        var window = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "day");
+
+        var res = await service.GetUsageAsync(
+            tenantId, window, AnalyticsDimension.Provider, CancellationToken.None);
+
+        res.GroupBy.Should().Be("provider");
+        // D1: anthropic, openai, NULL ; D2: anthropic
+        res.Rows.Should().HaveCount(4);
+        res.Rows.Should().ContainSingle(r => r.Period == D1 && r.Key == "anthropic");
+        res.Rows.Should().ContainSingle(r => r.Period == D1 && r.Key == "openai");
+        res.Rows.Should().ContainSingle(r => r.Period == D1 && r.Key == null)
+            .Which.WorkflowsStarted.Should().Be(5, "the unattributed NULL-provider bucket is surfaced, never dropped");
+    }
+
+    [Test]
+    public async Task GetUsage_GroupedRows_ReconcileToTheUngroupedBucketTotal()
+    {
+        var (service, tenantId) = await SeededServiceAsync();
+        var window = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "day");
+
+        var ungrouped = await service.GetUsageAsync(tenantId, window, null, CancellationToken.None);
+
+        foreach (var dim in new[]
+        {
+            AnalyticsDimension.Provider, AnalyticsDimension.Agent,
+            AnalyticsDimension.Workflow, AnalyticsDimension.Repo,
+        })
+        {
+            var grouped = await service.GetUsageAsync(tenantId, window, dim, CancellationToken.None);
+
+            foreach (var bucket in ungrouped.Rows)
+            {
+                var partsForBucket = grouped.Rows.Where(r => r.Period == bucket.Period).ToList();
+                partsForBucket.Sum(r => r.TokensIn).Should().Be(bucket.TokensIn,
+                    $"Σ(grouped by {dim}) must equal the ungrouped bucket total (36-2 reconciliation)");
+                partsForBucket.Sum(r => r.WorkflowsStarted).Should().Be(bucket.WorkflowsStarted);
+                partsForBucket.Sum(r => r.AgentDispatches).Should().Be(bucket.AgentDispatches);
+                partsForBucket.Sum(r => r.CostUsd).Should().Be(bucket.CostUsd);
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetUsage_HourGranularity_ReadsTheHourlyTable()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = $"tenant_analytics_hourly_{Guid.NewGuid():N}";
+        await using (var seed = NewContext(db, tenantId))
+        {
+            seed.AnalyticsUsageHourly.Add(NewHourly(new DateTime(2026, 5, 1, 12, 0, 0, DateTimeKind.Utc), "anthropic", tokensIn: 10, tokensOut: 5));
+            seed.AnalyticsUsageHourly.Add(NewHourly(new DateTime(2026, 5, 1, 13, 0, 0, DateTimeKind.Utc), "anthropic", tokensIn: 20, tokensOut: 7));
+            await seed.SaveChangesAsync();
+        }
+
+        var service = new TenantAnalyticsService(new InMemoryFactory(db), NullLogger<TenantAnalyticsService>.Instance);
+        var window = AnalyticsWindow.Resolve(
+            new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            new DateTime(2026, 5, 2, 0, 0, 0, DateTimeKind.Utc),
+            "hour");
+
+        var res = await service.GetUsageAsync(tenantId, window, null, CancellationToken.None);
+
+        res.Granularity.Should().Be("hour");
+        res.Rows.Should().HaveCount(2, "two distinct hour buckets");
+        res.Rows.Sum(r => r.TokensIn).Should().Be(30);
+    }
+
+    // ──────────────────────────────── Breakdown ────────────────────────────────
+
+    [Test]
+    public async Task GetBreakdown_ByProvider_TokensMetric_OrdersDescending_AndClampsLimit()
+    {
+        var (service, tenantId) = await SeededServiceAsync();
+        var window = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "day");
+
+        var res = await service.GetBreakdownAsync(
+            tenantId, window, AnalyticsDimension.Provider, AnalyticsMetric.Tokens, limit: 2, CancellationToken.None);
+
+        res.Dimension.Should().Be("provider");
+        res.Metric.Should().Be("tokens");
+        res.Rows.Should().HaveCount(2, "limit=2 keeps only the top two dimension values");
+        res.Rows[0].Key.Should().Be("anthropic");
+        res.Rows[0].Value.Should().Be(550, "anthropic tokens = (100+50)+(300+100)");
+        res.Rows[1].Key.Should().Be("openai");
+        res.Rows[1].Value.Should().Be(280);
+    }
+
+    [Test]
+    public async Task GetBreakdown_CostMetric_RanksByCost_AndIncludesNullKey()
+    {
+        var (service, tenantId) = await SeededServiceAsync();
+        var window = AnalyticsWindow.Resolve(WindowFrom, WindowTo, "day");
+
+        var res = await service.GetBreakdownAsync(
+            tenantId, window, AnalyticsDimension.Provider, AnalyticsMetric.Cost, limit: 100, CancellationToken.None);
+
+        res.Rows.Should().HaveCount(3, "anthropic, openai, and the NULL-provider bucket");
+        res.Rows[0].Key.Should().Be("anthropic");
+        res.Rows[0].Value.Should().Be(4.0m);
+        res.Rows.Should().Contain(r => r.Key == null, "the unattributed bucket is ranked, never dropped");
+    }
+
+    // ──────────────────────────────── Helpers ────────────────────────────────
+
+    private static async Task<(TenantAnalyticsService Service, Guid TenantId)> SeededServiceAsync()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = $"tenant_analytics_{Guid.NewGuid():N}";
+        await using (var seed = NewContext(db, tenantId))
+        {
+            seed.AnalyticsUsageDaily.AddRange(
+                NewDaily(D1, "anthropic", "a1", tokensIn: 100, tokensOut: 50, cost: 1.0m, ws: 2, wc: 2, wf: 0, ad: 3),
+                NewDaily(D1, "openai", "a2", tokensIn: 200, tokensOut: 80, cost: 2.0m, ws: 1, wc: 0, wf: 1, ad: 1),
+                NewDaily(D1, provider: null, agentId: null, tokensIn: 0, tokensOut: 0, cost: 0m, ws: 5, wc: 4, wf: 1, ad: 0),
+                NewDaily(D2, "anthropic", "a1", tokensIn: 300, tokensOut: 100, cost: 3.0m, ws: 1, wc: 1, wf: 0, ad: 2));
+            await seed.SaveChangesAsync();
+        }
+
+        var service = new TenantAnalyticsService(new InMemoryFactory(db), NullLogger<TenantAnalyticsService>.Instance);
+        return (service, tenantId);
+    }
+
+    private static TenantDbContext NewContext(string dbName, Guid tenantId) =>
+        new(new DbContextOptionsBuilder<TenantDbContext>().UseInMemoryDatabase(dbName).Options, tenantId);
+
+    private static AnalyticsUsageDaily NewDaily(
+        DateTime day, string? provider, string? agentId,
+        long tokensIn, long tokensOut, decimal cost, long ws, long wc, long wf, long ad) => new()
+    {
+        Id = Guid.NewGuid(),
+        Day = day,
+        Provider = provider,
+        AgentId = agentId,
+        WorkflowDefinitionId = null,
+        RepoId = null,
+        CostBasis = CostBasis.Platform,
+        TokensIn = tokensIn,
+        TokensOut = tokensOut,
+        CostUsd = cost,
+        PlatformBilledUsd = cost,
+        WorkflowsStarted = ws,
+        WorkflowsCompleted = wc,
+        WorkflowsFailed = wf,
+        AgentDispatches = ad,
+        ComputedAt = DateTime.UtcNow,
+    };
+
+    private static AnalyticsUsageHourly NewHourly(
+        DateTime hour, string provider, long tokensIn, long tokensOut) => new()
+    {
+        Id = Guid.NewGuid(),
+        Hour = hour,
+        Provider = provider,
+        CostBasis = CostBasis.Byok,
+        TokensIn = tokensIn,
+        TokensOut = tokensOut,
+        ComputedAt = DateTime.UtcNow,
+    };
+
+    /// <summary>Fake factory that hands out contexts over one shared InMemory database.</summary>
+    private sealed class InMemoryFactory(string dbName) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken cancellationToken = default) =>
+            new(new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseInMemoryDatabase(dbName).Options, tenantId));
+    }
+}


### PR DESCRIPTION
## What

Story 36-3 (P0). A per-tenant, membership-gated, **read-only** query API over the 36-1/36-2 dimensional fact tables (`AnalyticsUsageHourly`/`Daily`) — the first tenant-facing read surface over the usage facts (unblocks the analytics dashboard 36-6 + exports 36-8).

- `GET /api/v1/orgs/{tenantId}/analytics/usage` — time-bucketed measures (workflows/dispatches/tokens/cost); `from`/`to`/`granularity`(hour|day)/`groupBy`(provider|agent|workflow|repo|costBasis); ungrouped = one summed row/bucket, grouped = one row per (bucket, dimension) with the NULL key surfaced.
- `GET .../analytics/usage/breakdown` — top-N single-dimension by metric (tokens/runs/dispatches/cost), limit clamped 1..100.
- Isolation is **physical** (per-tenant `Search Path`-scoped schema); `RequireTenantMembershipFilter` 403s a non-member of the path tenant before the handler runs. Window caps (30d default, 365d max, 31d hourly) enforced pre-query. Forced-UTC binding (reuses the `AdminAnalyticsEndpoints` fix). Control-plane `PlatformAnalyticsService` untouched (AC11 reflection guard).

## Review outcome

Adversarial review: **no findings at confidence ≥80** — isolation (no IDOR), auth/RBAC, window bounds, UTC handling, aggregation reconciliation (Σgrouped == ungrouped), and DTO leakage all verified SOLID.

## No migration

Reads existing 36-1/36-2 tables. `has-pending-model-changes -c TenantDbContext` → "No changes."

## Verification

- Build: 0 errors, no TAMMA001. Tests: 25 passed (incl. two-schema Postgres isolation + reconciliation) + 13 host-boot regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)