### PR TITLE
feat(epic-34): Story 34-5 — Cost→Price Markup Engine (IUsagePricingEngine)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs
@@ -86,6 +86,16 @@ public static class AdminPricingEndpoints
         {
             return Results.BadRequest(new { error = "negative_markup_multiplier" });
         }
+        // A markup is by definition >= 1: sell = cost * multiplier, so a supplied
+        // multiplier in [0,1) would price AT/BELOW the platform's own wholesale
+        // cost (a fat-fingered 0.13 = ~87% revenue loss) while still passing
+        // ck_margin_policies_has_knob. Only guard when the multiplier is actually
+        // supplied — a null multiplier with a FixedUsdPer1M knob is a legitimate
+        // "cost + fixed per-token fee" policy and must stay allowed.
+        if (body.MarkupMultiplier is not null && body.MarkupMultiplier < 1m)
+        {
+            return Results.BadRequest(new { error = "markup_multiplier_below_one" });
+        }
         if (body.FixedUsdPer1M is < 0m)
         {
             return Results.BadRequest(new { error = "negative_fixed_usd_per_1m" });
@@ -133,6 +143,22 @@ public static class AdminPricingEndpoints
 
             if (tx is not null) await tx.CommitAsync(ct);
         }
+        catch (DbUpdateException dbEx) when (IsUniqueViolation(dbEx))
+        {
+            // A concurrent PUT for the same (scope, refKey) won the race and
+            // inserted its active row first; our insert then hit the partial
+            // unique index (Postgres 23505). This is a benign lost-write, not a
+            // server fault — surface 409 so the caller retries (pre-fix it leaked
+            // as a 500). The one-active-per-scope invariant is preserved.
+            if (tx is not null) await tx.RollbackAsync(ct);
+            return Results.Conflict(new
+            {
+                error = "margin_policy_conflict",
+                scope = body.Scope,
+                refKey,
+                message = "A concurrent update superseded this margin policy; retry the request.",
+            });
+        }
         catch
         {
             if (tx is not null) await tx.RollbackAsync(ct);
@@ -161,6 +187,17 @@ public static class AdminPricingEndpoints
             supersededPolicyId = prior?.Id,
         });
     }
+
+    /// <summary>
+    /// Detects the Postgres 23505 unique-violation raised by the partial unique
+    /// index (one active row per <c>(scope, refKey)</c>) when two concurrent PUTs
+    /// race the supersede-then-insert. EF wraps the Npgsql exception in a
+    /// <see cref="DbUpdateException"/>. Same shape as
+    /// <c>PromptEndpoints.IsUniqueViolation</c>.
+    /// </summary>
+    private static bool IsUniqueViolation(DbUpdateException dbEx)
+        => dbEx.InnerException is Npgsql.PostgresException pgEx
+           && string.Equals(pgEx.SqlState, "23505", StringComparison.Ordinal);
 
     /// <summary>Canonicalize a provider-scope refKey; trim others; global -> null.</summary>
     private static string? NormalizeRefKey(string scope, string? refKey)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingEndpoints.cs
@@ -1,0 +1,225 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 34-5 — admin view/version of platform MARGIN policies under
+/// <c>/api/admin/pricing/margins</c>. Every route MUST be gated behind the
+/// <c>PlatformOwnerAccess</c> policy at the wiring site (NOT <c>OwnerAccess</c>,
+/// which admits every personal-tenant owner): margin policies are platform-GLOBAL
+/// in both single-user and SaaS modes (no per-tenant margin rows), so this is
+/// platform-scoped admin work.
+///
+/// <para>Write is immutable-versioned (mirrors <c>AdminProviderPricingEndpoints</c>):
+/// a <c>PUT</c> supersedes the prior <c>active</c> row for the same
+/// <c>(scope, refKey)</c> and inserts a new one — so a historical usage event
+/// stays priced under the policy that was active at its timestamp. Mutations emit
+/// <c>PRICING.MARGIN.UPDATED</c> to the control-plane <c>platform_events</c> store
+/// via <see cref="IPlatformEventPublisher"/>.</para>
+/// </summary>
+public static class AdminPricingEndpoints
+{
+    private const string WorkflowVersion = "1.0.0";
+
+    // ── GET /api/admin/pricing/margins ──
+    public static async Task<IResult> ListMargins(
+        ControlPlaneDbContext db,
+        CancellationToken ct)
+    {
+        var policies = await db.MarginPolicies
+            .AsNoTracking()
+            .OrderBy(p => p.Scope)
+            .ThenBy(p => p.RefKey)
+            .ThenByDescending(p => p.EffectiveFrom)
+            .Select(p => new MarginPolicyDto(
+                p.Id, p.Scope, p.RefKey, p.MarkupMultiplier, p.FixedUsdPer1M,
+                p.EffectiveFrom, p.Status, p.CreatedAt, p.UpdatedAt))
+            .ToListAsync(ct);
+
+        return Results.Ok(new { policies });
+    }
+
+    // ── PUT /api/admin/pricing/margins ──
+    public static async Task<IResult> VersionMargin(
+        VersionMarginRequest body,
+        ControlPlaneDbContext db,
+        IPlatformEventPublisher publisher,
+        ClaimsPrincipal principal,
+        TimeProvider time,
+        CancellationToken ct)
+    {
+        if (body is null || string.IsNullOrWhiteSpace(body.Scope))
+        {
+            return Results.BadRequest(new { error = "scope_required" });
+        }
+        if (body.Scope is not ("global" or "plan" or "provider"))
+        {
+            return Results.BadRequest(new { error = "invalid_scope", scope = body.Scope });
+        }
+
+        // RefKey discipline: NULL only for global; required for plan/provider.
+        var refKey = NormalizeRefKey(body.Scope, body.RefKey);
+        if (body.Scope == "global" && !string.IsNullOrWhiteSpace(body.RefKey))
+        {
+            return Results.BadRequest(new { error = "global_refkey_must_be_null" });
+        }
+        if (body.Scope != "global" && string.IsNullOrWhiteSpace(refKey))
+        {
+            return Results.BadRequest(new { error = "refkey_required", scope = body.Scope });
+        }
+
+        // At least one knob non-null (mirrors ck_margin_policies_has_knob).
+        if (body.MarkupMultiplier is null && body.FixedUsdPer1M is null)
+        {
+            return Results.BadRequest(new { error = "at_least_one_knob_required" });
+        }
+        // A malformed/typo'd negative markup must not poison the sell price.
+        if (body.MarkupMultiplier is < 0m)
+        {
+            return Results.BadRequest(new { error = "negative_markup_multiplier" });
+        }
+        if (body.FixedUsdPer1M is < 0m)
+        {
+            return Results.BadRequest(new { error = "negative_fixed_usd_per_1m" });
+        }
+
+        var now = time.GetUtcNow().UtcDateTime;
+        var effectiveFrom = (body.EffectiveFrom ?? now).ToUniversalTime();
+        var newId = Guid.NewGuid();
+
+        // The prior active row for (scope, refKey) — flipped to superseded.
+        MarginPolicy? prior = await db.MarginPolicies
+            .FirstOrDefaultAsync(p =>
+                p.Scope == body.Scope
+                && p.RefKey == refKey
+                && p.Status == "active", ct);
+
+        var ownsTx = db.Database.CurrentTransaction is null && db.Database.IsRelational();
+        var tx = ownsTx ? await db.Database.BeginTransactionAsync(ct) : null;
+        try
+        {
+            if (prior is not null)
+            {
+                // Flip-then-insert in two saves inside one tx (deterministic
+                // ordering, same rationale as PlanVersionEditor): the partial
+                // unique index rejects a second active row, so the insert must
+                // follow the supersede.
+                prior.Status = "superseded";
+                prior.UpdatedAt = now;
+                await db.SaveChangesAsync(ct);
+            }
+
+            db.MarginPolicies.Add(new MarginPolicy
+            {
+                Id = newId,
+                Scope = body.Scope,
+                RefKey = refKey,
+                MarkupMultiplier = body.MarkupMultiplier,
+                FixedUsdPer1M = body.FixedUsdPer1M,
+                EffectiveFrom = effectiveFrom,
+                Status = "active",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            await db.SaveChangesAsync(ct);
+
+            if (tx is not null) await tx.CommitAsync(ct);
+        }
+        catch
+        {
+            if (tx is not null) await tx.RollbackAsync(ct);
+            throw;
+        }
+        finally
+        {
+            if (tx is not null) await tx.DisposeAsync();
+        }
+
+        await publisher.AppendAndPublishAsync(
+            BuildEvent(PricingEventTypes.MarginUpdated, principal, new Dictionary<string, string?>
+            {
+                ["scope"] = body.Scope,
+                ["refKey"] = refKey,
+                ["effectiveFrom"] = effectiveFrom.ToString("O"),
+                ["supersededPolicyId"] = prior?.Id.ToString("D"),
+            }),
+            ct);
+
+        return Results.Ok(new
+        {
+            policy = new MarginPolicyDto(
+                newId, body.Scope, refKey, body.MarkupMultiplier, body.FixedUsdPer1M,
+                effectiveFrom, "active", now, now),
+            supersededPolicyId = prior?.Id,
+        });
+    }
+
+    /// <summary>Canonicalize a provider-scope refKey; trim others; global -> null.</summary>
+    private static string? NormalizeRefKey(string scope, string? refKey)
+    {
+        if (scope == "global") return null;
+        if (string.IsNullOrWhiteSpace(refKey)) return null;
+        return scope == "provider"
+            ? ProviderRateLookup.Canonicalize(refKey)
+            : refKey.Trim();
+    }
+
+    private static PlatformEvent BuildEvent(
+        string type,
+        ClaimsPrincipal? principal,
+        IReadOnlyDictionary<string, string?> extraTags)
+    {
+        var tags = new Dictionary<string, string?> { ["source"] = "admin" };
+        foreach (var (k, v) in extraTags)
+        {
+            if (v is not null) tags[k] = v;
+        }
+
+        var userId = principal?.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var email = principal?.FindFirst(JwtRegisteredClaimNames.Email)?.Value
+            ?? principal?.FindFirst(ClaimTypes.Email)?.Value
+            ?? principal?.FindFirst("email")?.Value;
+        if (!string.IsNullOrEmpty(userId)) tags["actorUserId"] = userId;
+        if (!string.IsNullOrEmpty(email)) tags["actorEmail"] = email;
+
+        var data = new Dictionary<string, object?>(
+            tags.ToDictionary(kv => kv.Key, kv => (object?)kv.Value));
+
+        return new PlatformEvent
+        {
+            Type = type,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = $"{{\"workflowVersion\":\"{WorkflowVersion}\",\"eventSource\":\"system\"}}",
+            Data = JsonSerializer.Serialize(data),
+        };
+    }
+}
+
+/// <summary>Wire projection of a <see cref="MarginPolicy"/> row.</summary>
+public sealed record MarginPolicyDto(
+    Guid Id,
+    string Scope,
+    string? RefKey,
+    decimal? MarkupMultiplier,
+    decimal? FixedUsdPer1M,
+    DateTime EffectiveFrom,
+    string Status,
+    DateTime CreatedAt,
+    DateTime UpdatedAt);
+
+/// <summary>Body for <c>PUT /api/admin/pricing/margins</c>.</summary>
+public sealed record VersionMarginRequest(
+    string Scope,
+    string? RefKey = null,
+    decimal? MarkupMultiplier = null,
+    decimal? FixedUsdPer1M = null,
+    DateTime? EffectiveFrom = null);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -75,6 +75,11 @@ public static class PricingEndpoints
                 "Pricing estimate served: tenantId={TenantId} provider={Provider} model={Model} mode={Mode}",
                 tenantId, provider, model ?? "", pricingMode);
 
+            // AC10 — the tenant-facing estimate exposes ONLY the SELL price the
+            // caller would be charged. The platform cost basis and margin are
+            // business-confidential (a customer could otherwise compute the exact
+            // platform markup) and are surfaced solely on the platform-owner admin
+            // surface, never here.
             return Results.Ok(new
             {
                 provider,
@@ -82,13 +87,9 @@ public static class PricingEndpoints
                 inputTokens,
                 outputTokens,
                 pricingMode = priced.PricingMode.ToString(),
-                costBasisUsd = priced.CostBasisUsd,
-                marginUsd = priced.MarginUsd,
                 sellPriceUsd = priced.SellPriceUsd,
                 invoice = new
                 {
-                    costBasisUsd = PricedUsage.InvoiceUsd(priced.CostBasisUsd),
-                    marginUsd = PricedUsage.InvoiceUsd(priced.MarginUsd),
                     sellPriceUsd = PricedUsage.InvoiceUsd(priced.SellPriceUsd),
                 },
             });

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -1,0 +1,112 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 34-5 — tenant-facing pricing endpoints under <c>/api/pricing</c>
+/// (<c>MemberAccess</c>). Powers the upgrade / cost UI in
+/// <c>packages/dashboard-user</c> by pricing a hypothetical usage line under the
+/// caller's OWN plan + the caller's <c>(tenant, provider)</c> pricing mode.
+///
+/// <para><b>Tenant isolation (AC14):</b> the plan and pricing mode are resolved
+/// strictly from <see cref="ITenantContext.TenantId"/> (SaaS) / the sole user's
+/// instance (single-user). There is no cross-tenant read path here, and the
+/// margin-policy rows themselves are only mutable via the platform-owner admin
+/// routes — a tenant role gets 403 on <c>/api/admin/pricing/*</c>.</para>
+/// </summary>
+public static class PricingEndpoints
+{
+    // ── GET /api/pricing/estimate?provider=&model=&inputTokens=&outputTokens= ──
+    public static async Task<IResult> GetEstimate(
+        string? provider,
+        string? model,
+        int inputTokens,
+        int outputTokens,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider,
+        IPlanCatalogService planCatalog,
+        ITenantProviderPricingModeResolver modeResolver,
+        IMarginPolicyResolver policyResolver,
+        IUsagePricingEngine engine,
+        TimeProvider time,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.PricingEndpoints");
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return Results.BadRequest(new { error = "provider_required" });
+        }
+        if (inputTokens < 0 || outputTokens < 0)
+        {
+            return Results.BadRequest(new { error = "negative_tokens" });
+        }
+
+        // Resolve the caller's tenant strictly — SaaS uses the ambient tenant;
+        // single-user has no tenant (the sole user's instance uses the global
+        // policy, no per-tenant plan tier).
+        var tenantId = modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid tid
+            ? tid
+            : (Guid?)null;
+
+        string? planSlug = null;
+        if (tenantId is Guid resolvedTenant)
+        {
+            var snapshot = await planCatalog.GetForTenantAsync(resolvedTenant, ct);
+            planSlug = snapshot?.Slug;
+        }
+
+        var pricingMode = await modeResolver.ResolveModeAsync(tenantId, provider, ct);
+        var occurredAt = time.GetUtcNow().UtcDateTime;
+        var line = new UsageLine(provider, model, inputTokens, outputTokens, pricingMode, occurredAt);
+
+        try
+        {
+            var policy = await policyResolver.ResolveAsync(provider, planSlug, occurredAt, ct);
+            var priced = engine.PriceUsage(line, policy);
+
+            logger.LogInformation(
+                "Pricing estimate served: tenantId={TenantId} provider={Provider} model={Model} mode={Mode}",
+                tenantId, provider, model ?? "", pricingMode);
+
+            return Results.Ok(new
+            {
+                provider,
+                model,
+                inputTokens,
+                outputTokens,
+                pricingMode = priced.PricingMode.ToString(),
+                costBasisUsd = priced.CostBasisUsd,
+                marginUsd = priced.MarginUsd,
+                sellPriceUsd = priced.SellPriceUsd,
+                invoice = new
+                {
+                    costBasisUsd = PricedUsage.InvoiceUsd(priced.CostBasisUsd),
+                    marginUsd = PricedUsage.InvoiceUsd(priced.MarginUsd),
+                    sellPriceUsd = PricedUsage.InvoiceUsd(priced.SellPriceUsd),
+                },
+            });
+        }
+        catch (TammaError ex) when (ex.Code == "PRICING.UNKNOWN_MODEL")
+        {
+            // Client asked for an unpriced (provider, model) — a 4xx, not a 500.
+            return Results.BadRequest(new { error = ex.Code, message = ex.Message });
+        }
+        catch (TammaError ex) when (ex.Code == "PRICING.MARGIN.NO_POLICY")
+        {
+            // No margin policy resolves — a server-side misconfiguration
+            // (global policy not seeded). Fail loud, never price at zero margin.
+            logger.LogError(
+                "Pricing estimate failed — no margin policy: provider={Provider} planSlug={PlanSlug}",
+                provider, planSlug ?? "");
+            return Results.Problem(
+                title: ex.Code, detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -27,4 +27,26 @@ public static class PricingServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Story 34-5 — the cost->price markup engine + its policy/mode resolvers.
+    /// The engine is a pure singleton (depends only on the singleton
+    /// <c>IProviderPricingService</c>); the resolvers are scoped (they read the
+    /// scoped <c>ControlPlaneDbContext</c>). The
+    /// <see cref="ITenantProviderPricingModeResolver"/> default reads the
+    /// per-tenant <c>BillingCustomer.BillingMode</c> until Story 34-3 swaps a
+    /// per-<c>(tenant, provider)</c> implementation behind the same seam.
+    /// </summary>
+    public static IServiceCollection AddUsagePricingEngine(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        services.TryAddSingleton<IUsagePricingEngine, UsagePricingEngine>();
+        services.TryAddScoped<IMarginPolicyResolver, MarginPolicyResolver>();
+        services.TryAddScoped<ITenantProviderPricingModeResolver, BillingCustomerPricingModeResolver>();
+
+        return services;
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1020,6 +1020,11 @@ builder.Services.AddTammaAuditProjection();
 // platform-owned in both modes.
 builder.Services.AddPlanCatalog();
 
+// Story 34-5 — the canonical cost->price markup engine (pure IUsagePricingEngine)
+// + the DB-backed IMarginPolicyResolver + the (interim) per-tenant pricing-mode
+// resolver. CP-resident; platform-owned margin policies in both modes.
+builder.Services.AddUsagePricingEngine();
+
 // Wave C.4 §4 — per-process health monitor for TammaApiClient.
 // Singleton so the rolling 5-min failure window is shared across every
 // call site. Fires PLATFORM.API.UNHEALTHY via IAlertEventEmitter when
@@ -1676,6 +1681,17 @@ admin.MapPut("/providers/{key}/prices",
         Tamma.Api.Endpoints.Admin.AdminProviderPricingEndpoints.VersionPrice)
     .RequireAuthorization("PlatformOwnerAccess");
 
+// Story 34-5 — platform MARGIN policy admin (view + version). PlatformOwnerAccess:
+// margin policies are platform-GLOBAL in both modes (no per-tenant margin rows),
+// so it is platform-scoped admin work — NOT OwnerAccess. The PUT supersedes the
+// prior active row + inserts a new one and emits PRICING.MARGIN.UPDATED.
+admin.MapGet("/pricing/margins",
+        Tamma.Api.Endpoints.Admin.AdminPricingEndpoints.ListMargins)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPut("/pricing/margins",
+        Tamma.Api.Endpoints.Admin.AdminPricingEndpoints.VersionMargin)
+    .RequireAuthorization("PlatformOwnerAccess");
+
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
 // Epic-28 shadow columns on tenants (Status, PlanId, KekVersion,
 // FailureReason, DeleteRequestedAt); action endpoints re-drive the Story
@@ -1840,6 +1856,13 @@ admin.MapPost("/secrets/{id:guid}/retire-version/{versionNumber:int}",
 // previous `AdminAccess` / `OwnerAccess` policies checked JWT *platform*
 // permissions, not the caller's role within the path tenant, and were the
 // root cause of audit findings 001, 012, 013, 020, 021.
+// Story 34-5 — tenant-facing pricing estimate (MemberAccess). Prices a
+// hypothetical usage line under the caller's OWN plan + (tenant, provider)
+// pricing mode; the margin-policy rows themselves stay platform-owner-only
+// (/api/admin/pricing/*). Powers the upgrade/cost UI in packages/dashboard-user.
+var pricing = app.MapGroup("/api/pricing").RequireAuthorization("MemberAccess");
+pricing.MapGet("/estimate", Tamma.Api.Endpoints.PricingEndpoints.GetEstimate);
+
 var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");
 orgs.MapPost("/", OrgEndpoints.CreateOrg);
 orgs.MapPost("/invites/accept", OrgEndpoints.AcceptInvite);
@@ -2579,6 +2602,7 @@ using (var scope = app.Services.CreateScope())
                     mentorship_events, mentorship_sessions,
                     password_reset_tokens,
                     plan_features, plan_entitlements, plan_prices, plans,
+                    margin_policies,
                     provider_model_prices, providers,
                     platform_analytics_hourly,
                     platform_api_key_index,
@@ -2619,6 +2643,11 @@ using (var scope = app.Services.CreateScope())
         // seeder validates each persona's (provider, model) against the active
         // price rows this seeder writes (the in-data IsKnown guard).
         await Tamma.Data.Seeders.ProviderPricingSeeder.SeedAsync(dbContext);
+
+        // Story 34-5 — the default GLOBAL margin policy (1.3x = +30%). Gives the
+        // cost->price engine a global safety-net policy to resolve to.
+        // Insert-missing-only; no-op on re-run and never reverts an admin edit.
+        await Tamma.Data.Seeders.MarginPolicySeeder.SeedAsync(dbContext);
 
         // Story 32-15 — public/system PERSONAS (named cross-role agents:
         // claude/gemini/codegpt, Role=NULL, explicit provider+model, no prompts).

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/BillingCustomerPricingModeResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/BillingCustomerPricingModeResolver.cs
@@ -1,0 +1,49 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Enums;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 (interim) — resolves the pricing mode from the per-tenant
+/// <c>BillingCustomer.BillingMode</c> column (Story 35-1). This is a real,
+/// persisted mode (never invented), but it is per-TENANT rather than
+/// per-<c>(tenant, provider)</c>; Story 34-3 replaces it with a per-provider
+/// <c>TenantProviderBilling</c> read behind the same
+/// <see cref="ITenantProviderPricingModeResolver"/> seam.
+///
+/// <para>A null tenant (single-user mode) or a tenant with no billing-customer
+/// row resolves to <see cref="PricingMode.PlatformProvided"/> — BYOK is opt-in
+/// and only ever the result of an explicit <c>BillingMode = "Byok"</c> row.</para>
+/// </summary>
+public sealed class BillingCustomerPricingModeResolver : ITenantProviderPricingModeResolver
+{
+    private readonly ControlPlaneDbContext _db;
+
+    public BillingCustomerPricingModeResolver(ControlPlaneDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    /// <inheritdoc />
+    public async Task<PricingMode> ResolveModeAsync(
+        Guid? tenantId, string provider, CancellationToken ct = default)
+    {
+        if (tenantId is not Guid tid)
+        {
+            return PricingMode.PlatformProvided;
+        }
+
+        var billingMode = await _db.BillingCustomers
+            .AsNoTracking()
+            .Where(c => c.TenantId == tid)
+            .Select(c => c.BillingMode)
+            .FirstOrDefaultAsync(ct);
+
+        // BillingMode persists the Core.Billing.BillingMode member name
+        // ("PlatformProvided" | "Byok"). Only an explicit Byok row flips to BYOK.
+        return string.Equals(billingMode, "Byok", StringComparison.OrdinalIgnoreCase)
+            ? PricingMode.Byok
+            : PricingMode.PlatformProvided;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IMarginPolicyResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IMarginPolicyResolver.cs
@@ -1,0 +1,31 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — resolves the applicable <see cref="MarginPolicy"/> for a usage
+/// line. This is the IMPURE half of the engine (the ONLY DB read); the pure
+/// <see cref="IUsagePricingEngine"/> takes the resolved policy as an input.
+///
+/// <para>Resolution order is strictly <b>provider-override -> plan -> global</b>:
+/// the most-specific scope with a policy whose <c>EffectiveFrom &lt;=
+/// atTimestamp</c> wins. Selection within a scope is timestamp-effective — the
+/// row with the greatest <c>EffectiveFrom &lt;= atTimestamp</c> (which may now be
+/// <c>superseded</c> but was active during that window), so a historical event
+/// prices under the policy that was active at its <c>OccurredAt</c>, not the
+/// latest. If NO scope has a matching policy, it throws
+/// <c>PRICING.MARGIN.NO_POLICY</c> — it never silently prices at a zero margin
+/// (the no-empty-fallback rule applied to pricing).</para>
+/// </summary>
+public interface IMarginPolicyResolver
+{
+    /// <summary>
+    /// Resolve the margin policy for <paramref name="provider"/> under
+    /// <paramref name="planSlug"/> (nullable — single-user / unassigned tenants
+    /// skip the plan scope) effective at <paramref name="atTimestamp"/>. Throws
+    /// <c>PRICING.MARGIN.NO_POLICY</c> (severity High) when no policy matches at
+    /// any scope.
+    /// </summary>
+    Task<MarginPolicy> ResolveAsync(
+        string provider, string? planSlug, DateTime atTimestamp, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderPricingModeResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderPricingModeResolver.cs
@@ -1,0 +1,28 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — the consumption seam for the per-<c>(tenant, provider)</c>
+/// pricing mode (BYOK vs platform-provided). The engine and the estimate
+/// endpoint READ the mode through this seam; they never invent it (AC12).
+///
+/// <para><b>Ownership / interim note:</b> the authoritative source is Story
+/// 34-3's <c>TenantProviderBilling</c> / <c>ProviderDiagnostic.BillingMode</c>,
+/// which is per-<c>(tenant, provider)</c>. Until 34-3 lands, the default
+/// implementation (<see cref="BillingCustomerPricingModeResolver"/>) reads the
+/// per-tenant <c>BillingCustomer.BillingMode</c> (Story 35-1) — the best signal
+/// available today — and 34-3 swaps a per-provider implementation behind this
+/// same interface with no engine change.</para>
+/// </summary>
+public interface ITenantProviderPricingModeResolver
+{
+    /// <summary>
+    /// The pricing mode for <paramref name="tenantId"/> on
+    /// <paramref name="provider"/>. A null tenant (single-user mode) or an
+    /// unknown tenant resolves to <see cref="PricingMode.PlatformProvided"/> —
+    /// the safe default (a BYOK tenant is opt-in and explicitly recorded).
+    /// </summary>
+    Task<PricingMode> ResolveModeAsync(
+        Guid? tenantId, string provider, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IUsagePricingEngine.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IUsagePricingEngine.cs
@@ -1,0 +1,28 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — the CANONICAL cost->price markup engine. Given a measured
+/// <see cref="UsageLine"/> and the resolved <see cref="MarginPolicy"/>, computes
+/// the billable sell price by applying the margin on top of the
+/// <c>IProviderPricingService</c> cost basis (34-11). Consumers — Billing (Epic
+/// 35), cost analytics (Epic 36-7), and the usage-event producer (Epic 32-9) —
+/// MUST call this engine rather than re-deriving markup.
+///
+/// <para><b>Pure / side-effect-free:</b> <see cref="PriceUsage"/> does no I/O and
+/// is deterministic given the same inputs and the same cost table, which is what
+/// makes the golden-file reproducibility test possible. The DB read for the
+/// applicable policy lives in <see cref="IMarginPolicyResolver"/>, kept
+/// separate.</para>
+/// </summary>
+public interface IUsagePricingEngine
+{
+    /// <summary>
+    /// Price one usage line under the given margin policy. Throws
+    /// <c>PRICING.UNKNOWN_MODEL</c> (a typed <see cref="Tamma.Core.TammaError"/>,
+    /// severity Medium) if the <c>(provider, model)</c> pair is unpriced — the
+    /// engine never silently prices an unknown model at <c>0</c>.
+    /// </summary>
+    PricedUsage PriceUsage(UsageLine line, MarginPolicy policy);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/MarginPolicyResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/MarginPolicyResolver.cs
@@ -1,0 +1,120 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Providers;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — DB-backed <see cref="IMarginPolicyResolver"/> over the
+/// control-plane <c>margin_policies</c> table. Scoped (depends on the scoped
+/// <see cref="ControlPlaneDbContext"/>). Resolves provider-override -> plan ->
+/// global with timestamp-effective selection, mirroring the 34-11
+/// <c>ProviderCostResolver.ResolveAtAsync</c> window logic on the sell side.
+/// </summary>
+public sealed class MarginPolicyResolver : IMarginPolicyResolver
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly ILogger<MarginPolicyResolver> _logger;
+
+    public MarginPolicyResolver(
+        ControlPlaneDbContext db,
+        ILogger<MarginPolicyResolver> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<MarginPolicy> ResolveAsync(
+        string provider, string? planSlug, DateTime atTimestamp, CancellationToken ct = default)
+    {
+        var at = NormalizeUtc(atTimestamp);
+
+        // Provider scope uses the canonical provider key (alias-normalized) so a
+        // provider-scoped override keys off the same handle 34-11 stores.
+        var providerKey = string.IsNullOrWhiteSpace(provider)
+            ? provider
+            : ProviderRateLookup.Canonicalize(provider);
+
+        // Most-specific first: provider override -> plan -> global.
+        var providerHit = await ResolveAtScopeAsync("provider", providerKey, at, ct);
+        if (providerHit is not null)
+        {
+            return Resolved(providerHit, at);
+        }
+
+        if (!string.IsNullOrWhiteSpace(planSlug))
+        {
+            var planHit = await ResolveAtScopeAsync("plan", planSlug, at, ct);
+            if (planHit is not null)
+            {
+                return Resolved(planHit, at);
+            }
+        }
+
+        var globalHit = await ResolveAtScopeAsync("global", null, at, ct);
+        if (globalHit is not null)
+        {
+            return Resolved(globalHit, at);
+        }
+
+        _logger.LogWarning(
+            "No margin policy resolves for provider={Provider}, planSlug={PlanSlug} at {AtTimestamp}",
+            providerKey, planSlug ?? "", at);
+
+        throw new TammaError(
+            "PRICING.MARGIN.NO_POLICY",
+            $"No margin policy resolves for provider '{providerKey}'"
+            + (planSlug is null ? "" : $" / plan '{planSlug}'")
+            + $" at {at:O}. Seed a global policy or configure a plan/provider override.",
+            new Dictionary<string, object?>
+            {
+                ["provider"] = providerKey,
+                ["planSlug"] = planSlug,
+                ["atTimestamp"] = at.ToString("O"),
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// The row for <paramref name="scope"/>/<paramref name="refKey"/> with the
+    /// greatest <c>EffectiveFrom &lt;= atTimestamp</c> (active OR superseded —
+    /// the time-travel selection). Null when the scope has no matching row.
+    /// </summary>
+    private async Task<MarginPolicy?> ResolveAtScopeAsync(
+        string scope, string? refKey, DateTime at, CancellationToken ct)
+    {
+        var query = _db.MarginPolicies
+            .AsNoTracking()
+            .Where(p => p.Scope == scope && p.EffectiveFrom <= at);
+
+        // RefKey NULL (global) needs an IS NULL comparison, not = NULL.
+        query = refKey is null
+            ? query.Where(p => p.RefKey == null)
+            : query.Where(p => p.RefKey == refKey);
+
+        return await query
+            .OrderByDescending(p => p.EffectiveFrom)
+            .ThenByDescending(p => p.CreatedAt)
+            .FirstOrDefaultAsync(ct);
+    }
+
+    private MarginPolicy Resolved(MarginPolicy policy, DateTime at)
+    {
+        _logger.LogDebug(
+            "Margin policy resolved: scope={Scope} refKey={RefKey} effectiveFrom={EffectiveFrom} at {AtTimestamp}",
+            policy.Scope, policy.RefKey ?? "", policy.EffectiveFrom, at);
+        return policy;
+    }
+
+    private static DateTime NormalizeUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Unspecified => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        _ => value.ToUniversalTime(),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricedUsage.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricedUsage.cs
@@ -1,0 +1,23 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — the result of pricing a single <see cref="UsageLine"/>. All USD
+/// amounts carry 6-decimal internal precision (banker's rounding at each
+/// accumulation boundary); invoice-facing projections round to 2dp via
+/// <see cref="InvoiceUsd"/>.
+/// </summary>
+/// <param name="CostBasisUsd">The provider cost (always computed, even for BYOK — for reporting/analytics).</param>
+/// <param name="MarginUsd"><c>SellPriceUsd - CostBasisUsd</c> (0 for the BYOK token component).</param>
+/// <param name="SellPriceUsd">What the tenant is charged for tokens (0 for BYOK).</param>
+/// <param name="PricingMode">The mode this line was priced under.</param>
+public sealed record PricedUsage(
+    decimal CostBasisUsd,
+    decimal MarginUsd,
+    decimal SellPriceUsd,
+    PricingMode PricingMode)
+{
+    /// <summary>Round a 6dp internal amount to the 2dp invoice-facing value (banker's rounding).</summary>
+    public static decimal InvoiceUsd(decimal amount) => Math.Round(amount, 2, MidpointRounding.ToEven);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
@@ -1,0 +1,14 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — DCB event type names emitted by the admin margin-policy write
+/// path to the control-plane <c>platform_events</c> store (mirrors
+/// <c>PlanCatalogEventTypes</c> / <c>ProviderPricingEventTypes</c>). Pattern:
+/// <c>AGGREGATE.ACTION.STATUS</c>. The pure engine emits NO events (it does no
+/// I/O); only the versioning admin endpoint does.
+/// </summary>
+public static class PricingEventTypes
+{
+    /// <summary>A margin policy was versioned (supersede prior active + insert new active).</summary>
+    public const string MarginUpdated = "PRICING.MARGIN.UPDATED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsageLine.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsageLine.cs
@@ -1,0 +1,25 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — one measured usage event to be priced. Built from a
+/// <c>ProviderDiagnostic</c> row (its <c>InputTokens</c> / <c>OutputTokens</c> /
+/// <c>ProviderKey</c> / <c>Model</c> / billing-mode columns) or the equivalent
+/// DCB usage event emitted in Epic 32-9. Input and output tokens are carried
+/// separately because <c>IProviderPricingService</c> bills them at different
+/// rates.
+/// </summary>
+/// <param name="Provider">Canonical provider key (e.g. <c>anthropic</c>).</param>
+/// <param name="Model">Model id (e.g. <c>claude-sonnet-4-20250514</c>); null/"default" resolves to the provider's first model.</param>
+/// <param name="InputTokens">Prompt tokens billed at the input rate (clamped to &gt;= 0).</param>
+/// <param name="OutputTokens">Completion tokens billed at the output rate (clamped to &gt;= 0).</param>
+/// <param name="PricingMode">Platform-provided (markup applied) vs BYOK (token sell price 0).</param>
+/// <param name="OccurredAt">UTC instant the call happened — drives timestamp-effective margin-policy selection.</param>
+public sealed record UsageLine(
+    string Provider,
+    string? Model,
+    int InputTokens,
+    int OutputTokens,
+    PricingMode PricingMode,
+    DateTime OccurredAt);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsagePricingEngine.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/UsagePricingEngine.cs
@@ -1,0 +1,91 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Providers;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-5 — the pure, deterministic implementation of
+/// <see cref="IUsagePricingEngine"/>. Applies the margin policy on top of the
+/// <see cref="IProviderPricingService"/> cost basis (34-11).
+///
+/// <para><b>Arithmetic (AC5 / AC7):</b> <c>decimal</c> throughout with banker's
+/// rounding (<see cref="MidpointRounding.ToEven"/>) to 6 decimal places at every
+/// accumulation boundary, so the output is byte-stable across runs. Platform:
+/// <c>sell = round6(costBasis * (multiplier ?? 1) + (fixedUsdPer1M ?? 0) *
+/// totalTokens/1e6)</c>, <c>margin = round6(sell - costBasis)</c>. BYOK: the
+/// token component of the sell price and the margin are exactly <c>0</c>, but the
+/// cost basis is STILL computed (for reporting/analytics).</para>
+///
+/// <para><b>Fail-loud (AC8):</b> <see cref="IProviderPricingService.Compute"/>
+/// returns <c>0m</c> for an unknown <c>(provider, model)</c>, so the engine gates
+/// on <see cref="IProviderPricingService.IsKnown"/> FIRST and throws
+/// <c>PRICING.UNKNOWN_MODEL</c> — a misconfigured model is loud, never free.</para>
+/// </summary>
+public sealed class UsagePricingEngine : IUsagePricingEngine
+{
+    private readonly IProviderPricingService _pricing;
+    private readonly ILogger<UsagePricingEngine> _logger;
+
+    public UsagePricingEngine(
+        IProviderPricingService pricing,
+        ILogger<UsagePricingEngine> logger)
+    {
+        _pricing = pricing ?? throw new ArgumentNullException(nameof(pricing));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public PricedUsage PriceUsage(UsageLine line, MarginPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        // AC8 — gate on IsKnown so an unpriced model is loud, not silently $0.
+        if (!_pricing.IsKnown(line.Provider, line.Model))
+        {
+            _logger.LogWarning(
+                "Unknown (provider, model) for pricing: {Provider}/{Model} — refusing to price at 0",
+                line.Provider, line.Model ?? "");
+
+            throw new TammaError(
+                "PRICING.UNKNOWN_MODEL",
+                $"No cost pricing exists for {line.Provider}/{line.Model ?? "(default)"}.",
+                new Dictionary<string, object?>
+                {
+                    ["provider"] = line.Provider,
+                    ["model"] = line.Model ?? "",
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var costBasis = Round6(_pricing.Compute(
+            line.Provider, line.Model, line.InputTokens, line.OutputTokens));
+
+        // BYOK — the tenant pays their provider directly; Tamma bills no token
+        // price. Cost basis is still reported (analytics), margin is 0.
+        if (line.PricingMode == PricingMode.Byok)
+        {
+            return new PricedUsage(costBasis, 0m, 0m, PricingMode.Byok);
+        }
+
+        // Platform-provided — apply the margin policy.
+        var totalTokens = (long)Math.Max(0, line.InputTokens) + Math.Max(0, line.OutputTokens);
+        var multiplied = Round6(costBasis * (policy.MarkupMultiplier ?? 1m));
+        var fixedAdd = Round6((policy.FixedUsdPer1M ?? 0m) * (totalTokens / 1_000_000m));
+        var sell = Round6(multiplied + fixedAdd);
+        var margin = Round6(sell - costBasis);
+
+        _logger.LogDebug(
+            "Priced {Provider}/{Model}: costBasisUsd={CostBasis} sellPriceUsd={Sell} (scope={Scope}, refKey={RefKey})",
+            line.Provider, line.Model ?? "", costBasis, sell, policy.Scope, policy.RefKey ?? "");
+
+        return new PricedUsage(costBasis, margin, sell, PricingMode.PlatformProvided);
+    }
+
+    /// <summary>Banker's rounding to 6dp — the internal precision boundary (AC7).</summary>
+    private static decimal Round6(decimal v) => Math.Round(v, 6, MidpointRounding.ToEven);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/PricingMode.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/PricingMode.cs
@@ -1,0 +1,33 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-5 — the pricing-side vocabulary for how a measured usage line is
+/// priced by <c>IUsagePricingEngine</c>. Distinct enum from
+/// <see cref="Tamma.Core.Billing.BillingMode"/> (which is the billing-customer
+/// column vocabulary, Story 35-1) but carries the SAME two members so the two
+/// layers agree on the BYOK-vs-platform split. The engine's public records
+/// (<c>UsageLine</c> / <c>PricedUsage</c>) speak "pricing mode"; a caller that
+/// only has a <see cref="Tamma.Core.Billing.BillingMode"/> maps member-for-member.
+///
+/// <para><b>Load-bearing rule (Story 34-5 AC5):</b> on the
+/// <see cref="PlatformProvided"/> leg the token sell price is the cost basis
+/// times the margin policy; on the <see cref="Byok"/> leg the token sell price
+/// (and margin) is exactly <c>0</c> — the tenant pays their own provider
+/// directly, Tamma bills no token price. The cost basis is computed on BOTH legs
+/// for reporting/analytics.</para>
+/// </summary>
+public enum PricingMode
+{
+    /// <summary>
+    /// Tamma supplies the provider credential and bills the tenant for metered
+    /// token usage with the platform markup applied.
+    /// </summary>
+    PlatformProvided,
+
+    /// <summary>
+    /// Bring-your-own-key — the tenant supplies their own provider credential.
+    /// The token component of the sell price is <c>0</c> (no platform markup);
+    /// the cost basis is still computed for reporting only.
+    /// </summary>
+    Byok,
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -686,6 +686,13 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<ProviderModelPrice> ProviderModelPrices => Set<ProviderModelPrice>();
 
+    /// <summary>
+    /// Story 34-5 — versioned platform margin policies (global/plan/provider
+    /// scope) applied by the cost->price engine. Platform-global (no TenantId);
+    /// immutable + EffectiveFrom-windowed like <see cref="ProviderModelPrices"/>.
+    /// </summary>
+    public DbSet<MarginPolicy> MarginPolicies => Set<MarginPolicy>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -793,6 +800,11 @@ public class ControlPlaneDbContext : DbContext
         // every tenant. Mirrors the ConfigurePlans versioning pattern.
         ConfigureProviders(modelBuilder);
         ConfigureProviderModelPrices(modelBuilder);
+
+        // Story 34-5 — versioned platform margin policies (sell-side). Same
+        // CP-resident, platform-global, immutable-versioned shape as the 34-11
+        // cost rows above.
+        ConfigureMarginPolicies(modelBuilder);
     }
 
     /// <summary>
@@ -885,6 +897,59 @@ public class ControlPlaneDbContext : DbContext
                 .HasForeignKey(e => e.ProviderKey)
                 .HasPrincipalKey(p => p.Key)
                 .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+
+    /// <summary>
+    /// Story 34-5 — <c>margin_policies</c> table. Three CHECKs pin the closed
+    /// enums (<c>Scope</c>, <c>Status</c>) and the "at least one knob" invariant
+    /// (<c>ck_margin_policies_has_knob</c> — never an all-null policy row). The
+    /// partial unique index <c>UX_margin_policies_OneActivePerScopeRef</c> on
+    /// <c>(Scope, RefKey) WHERE "Status" = 'active'</c> with
+    /// <c>NULLS NOT DISTINCT</c> guarantees exactly one active policy per
+    /// <c>(Scope, RefKey)</c> — including the single global row whose
+    /// <c>RefKey</c> is NULL (mirrors <c>UX_provider_model_prices_OneActivePerModel</c>).
+    /// The window index supports the EffectiveFrom-windowed resolution.
+    /// </summary>
+    private static void ConfigureMarginPolicies(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<MarginPolicy>(entity =>
+        {
+            entity.ToTable("margin_policies", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_margin_policies_scope",
+                    "\"Scope\" IN ('global','plan','provider')");
+                t.HasCheckConstraint(
+                    "ck_margin_policies_status",
+                    "\"Status\" IN ('active','superseded')");
+                // At least one knob must be set — never an all-null policy row.
+                t.HasCheckConstraint(
+                    "ck_margin_policies_has_knob",
+                    "\"MarkupMultiplier\" IS NOT NULL OR \"FixedUsdPer1M\" IS NOT NULL");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Scope).IsRequired().HasMaxLength(20);
+            entity.Property(e => e.RefKey).HasMaxLength(200);
+            entity.Property(e => e.MarkupMultiplier).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.FixedUsdPer1M).HasColumnType("decimal(20,8)");
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("active");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // Exactly one active policy per (Scope, RefKey); NULLS NOT DISTINCT so
+            // the single global row (RefKey NULL) is unique too.
+            entity.HasIndex(e => new { e.Scope, e.RefKey })
+                .HasDatabaseName("UX_margin_policies_OneActivePerScopeRef")
+                .HasFilter("\"Status\" = 'active'")
+                .IsUnique()
+                .AreNullsDistinct(false);
+
+            // Resolution-window lookup (scope+refKey, ordered by EffectiveFrom).
+            entity.HasIndex(e => new { e.Scope, e.RefKey, e.EffectiveFrom })
+                .HasDatabaseName("IX_margin_policies_Window");
         });
     }
 

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/MarginPolicy.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/MarginPolicy.cs
@@ -1,0 +1,59 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Control-plane margin policy applied by the cost->price engine (Story 34-5).
+/// Versioned: an edit SUPERSEDES the prior active row rather than mutating it,
+/// so a usage event is always priced under the policy that was active at its
+/// timestamp (reproducible historical invoices — the sell-side companion of the
+/// 34-11 <see cref="ProviderModelPrice"/> cost-side versioning). Platform-owned
+/// global config — there are NO per-tenant margin rows; only
+/// <c>PlatformOwnerAccess</c> may mutate these in SaaS, and the sole user owns
+/// them in single-user mode.
+///
+/// <para>Resolution is provider-override -> plan -> global (most specific wins).
+/// The cost basis itself is NOT here — it comes from
+/// <c>IProviderPricingService</c> (34-11); this row only supplies the margin
+/// applied on top.</para>
+/// </summary>
+public class MarginPolicy
+{
+    /// <summary>
+    /// Primary key. New admin rows get a v4 GUID (DB default
+    /// <c>gen_random_uuid()</c> / <c>Guid.NewGuid()</c>); ONLY the seeder bakes a
+    /// deterministic, UUIDv7-shaped id (for insert-missing-only idempotency).
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Scope discriminator: <c>global</c> | <c>plan</c> | <c>provider</c>. A CHECK pins the enum.</summary>
+    public string Scope { get; set; } = null!;
+
+    /// <summary>
+    /// NULL for <c>global</c>; the plan slug for <c>plan</c> scope; the canonical
+    /// provider key for <c>provider</c> scope.
+    /// </summary>
+    public string? RefKey { get; set; }
+
+    /// <summary>
+    /// Multiplicative markup on the provider cost basis (e.g. <c>1.3</c> = +30%).
+    /// Nullable — at least one of this / <see cref="FixedUsdPer1M"/> is set
+    /// (CHECK <c>ck_margin_policies_has_knob</c>). Null is treated as
+    /// <c>1.0</c> (no multiplier) by the engine.
+    /// </summary>
+    public decimal? MarkupMultiplier { get; set; }
+
+    /// <summary>
+    /// Additive USD per 1,000,000 total (input+output) tokens. Nullable — at
+    /// least one of this / <see cref="MarkupMultiplier"/> is set. Null is treated
+    /// as <c>0</c> by the engine.
+    /// </summary>
+    public decimal? FixedUsdPer1M { get; set; }
+
+    /// <summary>UTC instant this policy became effective (the resolution-window key).</summary>
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>Lifecycle: <c>active</c> | <c>superseded</c>. A CHECK pins the enum.</summary>
+    public string Status { get; set; } = "active";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702160326_AddMarginPolicy.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702160326_AddMarginPolicy.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702160326_AddMarginPolicy")]
+    partial class AddMarginPolicy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702160326_AddMarginPolicy.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702160326_AddMarginPolicy.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddMarginPolicy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "margin_policies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Scope = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    RefKey = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    MarkupMultiplier = table.Column<decimal>(type: "numeric(20,8)", nullable: true),
+                    FixedUsdPer1M = table.Column<decimal>(type: "numeric(20,8)", nullable: true),
+                    EffectiveFrom = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "active"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_margin_policies", x => x.Id);
+                    table.CheckConstraint("ck_margin_policies_has_knob", "\"MarkupMultiplier\" IS NOT NULL OR \"FixedUsdPer1M\" IS NOT NULL");
+                    table.CheckConstraint("ck_margin_policies_scope", "\"Scope\" IN ('global','plan','provider')");
+                    table.CheckConstraint("ck_margin_policies_status", "\"Status\" IN ('active','superseded')");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_margin_policies_Window",
+                table: "margin_policies",
+                columns: new[] { "Scope", "RefKey", "EffectiveFrom" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_margin_policies_OneActivePerScopeRef",
+                table: "margin_policies",
+                columns: new[] { "Scope", "RefKey" },
+                unique: true,
+                filter: "\"Status\" = 'active'")
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "margin_policies");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Seeders/MarginPolicySeeder.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Seeders/MarginPolicySeeder.cs
@@ -1,0 +1,100 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Seeders;
+
+/// <summary>
+/// Story 34-5 — seeds the default <b>global</b> margin policy
+/// (<c>MarkupMultiplier = 1.3</c>, i.e. +30%) into the control-plane
+/// <c>margin_policies</c> table so the cost->price engine always has a global
+/// safety-net policy to resolve to.
+///
+/// <para><b>Insert-missing-only</b> (mirrors <see cref="ProviderPricingSeeder"/>
+/// / <see cref="PlansSeeder"/> and the convention system-defaults ownership
+/// rule): the row is inserted only when absent. A re-run is a no-op and NEVER
+/// reverts an admin-edited multiplier — re-pricing happens through the admin
+/// write path (supersede + insert), not the seeder. The idempotency check keys
+/// off the deterministic seed id, so even after an admin supersedes the seeded
+/// global row (leaving it <c>superseded</c> plus a fresh <c>active</c> row) the
+/// re-run still short-circuits.</para>
+///
+/// <para><b>Deterministic UUIDv7-shaped id.</b> .NET 8 lacks
+/// <c>Guid.CreateVersion7</c>, so the seed id is derived deterministically from a
+/// stable namespace + name (SHA-256), with the RFC-4122 version nibble forced to
+/// 7 and the variant bits set — a stable id across environments.</para>
+/// </summary>
+public static class MarginPolicySeeder
+{
+    /// <summary>
+    /// The fixed seed epoch the v1 global policy carries as
+    /// <c>EffectiveFrom</c> — a stable past instant so the EffectiveFrom window
+    /// always selects it for any realistic <c>OccurredAt</c>. NEVER change.
+    /// </summary>
+    public static readonly DateTime SeedEpoch =
+        new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>DNS-style namespace for the deterministic seed id. NEVER change.</summary>
+    private const string IdNamespace = "tamma.margin-policy.v1";
+
+    /// <summary>The default platform markup: +30% on the provider cost basis.</summary>
+    public const decimal DefaultGlobalMarkupMultiplier = 1.3m;
+
+    /// <summary>
+    /// Inserts the missing global margin policy. Safe to call on every startup —
+    /// the per-id existence check makes re-runs a no-op and never reverts an
+    /// admin edit. Returns the number of policy rows inserted (0 or 1).
+    /// </summary>
+    public static async Task<int> SeedAsync(
+        ControlPlaneDbContext context,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var globalId = DeterministicId("global");
+
+        var exists = await context.MarginPolicies
+            .AsNoTracking()
+            .AnyAsync(p => p.Id == globalId, cancellationToken);
+        if (exists)
+        {
+            return 0;
+        }
+
+        var now = DateTime.UtcNow;
+        context.MarginPolicies.Add(new MarginPolicy
+        {
+            Id = globalId,
+            Scope = "global",
+            RefKey = null,
+            MarkupMultiplier = DefaultGlobalMarkupMultiplier,
+            FixedUsdPer1M = null,
+            EffectiveFrom = SeedEpoch,
+            Status = "active",
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+
+        await context.SaveChangesAsync(cancellationToken);
+        return 1;
+    }
+
+    /// <summary>
+    /// Derive a stable, deterministic UUIDv7-shaped GUID from a name. SHA-256 of
+    /// <c>"{namespace}:{name}"</c>, version nibble forced to 7, RFC-4122 variant.
+    /// </summary>
+    public static Guid DeterministicId(string name)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes($"{IdNamespace}:{name}"));
+        Span<byte> guid = stackalloc byte[16];
+        bytes.AsSpan(0, 16).CopyTo(guid);
+
+        // RFC-4122: version 7 in the high nibble of byte 6.
+        guid[6] = (byte)((guid[6] & 0x0F) | 0x70);
+        // RFC-4122 variant (10xx) in the high bits of byte 8.
+        guid[8] = (byte)((guid[8] & 0x3F) | 0x80);
+
+        return new Guid(guid, bigEndian: true);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -169,6 +169,10 @@ public class PlatformOwnerAccessPolicyTests
         // modes (no per-tenant override layer). Same Finding-C1 gate: a
         // tenant-owner who is not a platform admin must NOT read or edit it.
         "/api/admin/providers",
+        // Story 34-5 — MARGIN policies are platform-global (no per-tenant margin
+        // rows). Same Finding-C1 gate: a tenant-owner who is not a platform admin
+        // must NOT view or version them (AC14).
+        "/api/admin/pricing/margins",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -134,6 +134,10 @@ public class ControlPlaneDbContextModelTests
             // sheet behind the unchanged IProviderPricingService seam.
             "providers",
             "provider_model_prices",
+            // Story 34-5 — cost→price markup policy (global/plan/provider
+            // scope, versioned). Platform-owned (PlatformOwnerAccess); CP-resident
+            // because margin is a platform-global pricing concern, not per-tenant.
+            "margin_policies",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
@@ -146,6 +150,7 @@ public class ControlPlaneDbContextModelTests
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
             + "Story 37-1 adds audit_records + audit_projector_cursor. "
             + "Story 34-11 adds providers + provider_model_prices. "
+            + "Story 34-5 adds margin_policies. "
             + "Story 38-3 adds slack_outbox.");
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs
@@ -188,4 +188,78 @@ public class AdminPricingEndpointsTests
             db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
         AssertStatus(result, StatusCodes.Status400BadRequest);
     }
+
+    // ── Fix B: a supplied markup multiplier < 1 prices at/below platform cost ──
+    [Test]
+    public async Task VersionMargin_FatFingeredMultiplier_Returns400()
+    {
+        await using var db = NewContext();
+        // 0.13 = ~87% revenue loss (sell = cost * 0.13) — must be rejected.
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, 0.13m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task VersionMargin_ZeroMultiplier_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, 0m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task VersionMargin_ValidMultiplier_Returns200()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, 1.3m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status200OK);
+    }
+
+    // A null multiplier with only a fixed per-token fee is a legitimate policy —
+    // the < 1 guard must NOT reject it.
+    [Test]
+    public async Task VersionMargin_NullMultiplierWithFixedFee_Returns200()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, null, 5m),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status200OK);
+    }
+
+    // ── Fix C: concurrent PUTs on the same (scope, refKey) must not 500 ──
+    [Test]
+    public async Task VersionMargin_ConcurrentPuts_NeverReturn500_AndKeepOneActive()
+    {
+        // Fire several PUTs for the SAME (scope, refKey) in parallel. The partial
+        // unique index (one active row per scope) forces a loser's insert to hit
+        // Postgres 23505; the endpoint must translate that to 409 (retryable),
+        // never a bare 500. Regardless of interleaving the one-active-per-scope
+        // invariant must still hold afterwards.
+        var tasks = Enumerable.Range(0, 8).Select(async i =>
+        {
+            await using var db = NewContext();
+            return await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("global", null, 1.0m + (i * 0.1m), null),
+                db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        }).ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        var codes = results.Select(r => ((IStatusCodeHttpResult)r).StatusCode).ToArray();
+        codes.Should().OnlyContain(c =>
+            c == StatusCodes.Status200OK || c == StatusCodes.Status409Conflict);
+        codes.Should().Contain(StatusCodes.Status200OK);
+
+        await using var verify = NewContext();
+        var active = await verify.MarginPolicies.AsNoTracking()
+            .CountAsync(p => p.Scope == "global" && p.Status == "active");
+        active.Should().Be(1);
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingEndpointsTests.cs
@@ -1,0 +1,191 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-5 (AC9) — <see cref="AdminPricingEndpoints"/> against a real Postgres
+/// testcontainer. Covers the supersede/version chain + the one-active partial-
+/// unique-index invariant, the GET active+history read, the PRICING.MARGIN.UPDATED
+/// DCB emit, and request validation. (The PlatformOwnerAccess 403 gate is pinned
+/// by <c>PlatformOwnerAccessPolicyTests</c>, which lists /api/admin/pricing/margins.)
+/// </summary>
+[TestFixture]
+public class AdminPricingEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("admin_pricing_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE margin_policies CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static ClaimsPrincipal Actor(string userId = "user-34-5", string email = "owner@tamma.dev") =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId),
+            new Claim(JwtRegisteredClaimNames.Email, email),
+            new Claim("platformRole", "platform_admin"),
+        }, "test"));
+
+    private static void AssertStatus(IResult result, int expected)
+    {
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(expected);
+    }
+
+    [Test]
+    public async Task VersionMargin_Supersedes_Prior_And_Inserts_New_Active()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+
+        await using (var db = NewContext())
+        {
+            await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("global", null, 1.3m, null),
+                db, publisher, Actor(), TimeProvider.System, default);
+        }
+
+        await using (var db = NewContext())
+        {
+            var result = await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("global", null, 1.5m, null),
+                db, publisher, Actor(), TimeProvider.System, default);
+            AssertStatus(result, StatusCodes.Status200OK);
+        }
+
+        await using var verify = NewContext();
+        var rows = await verify.MarginPolicies.AsNoTracking()
+            .Where(p => p.Scope == "global")
+            .OrderBy(p => p.EffectiveFrom)
+            .ToListAsync();
+
+        rows.Should().HaveCount(2);
+        rows.Count(r => r.Status == "active").Should().Be(1);
+        rows.Single(r => r.Status == "active").MarkupMultiplier.Should().Be(1.5m);
+        rows.Single(r => r.Status == "superseded").MarkupMultiplier.Should().Be(1.3m);
+
+        publisher.Events.Should().Contain(e => e.Type == PricingEventTypes.MarginUpdated);
+    }
+
+    [Test]
+    public async Task ListMargins_Returns_Active_And_History()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using (var db = NewContext())
+        {
+            await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("global", null, 1.3m, null),
+                db, publisher, Actor(), TimeProvider.System, default);
+        }
+        await using (var db = NewContext())
+        {
+            await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("global", null, 1.5m, null),
+                db, publisher, Actor(), TimeProvider.System, default);
+        }
+
+        await using var db2 = NewContext();
+        var result = await AdminPricingEndpoints.ListMargins(db2, default);
+
+        AssertStatus(result, StatusCodes.Status200OK);
+        var value = ((IValueHttpResult)result).Value!;
+        var policies = (System.Collections.IEnumerable)value.GetType()
+            .GetProperty("policies")!.GetValue(value)!;
+        policies.Cast<MarginPolicyDto>().Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task VersionMargin_ProviderScope_CanonicalizesRefKey()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using (var db = NewContext())
+        {
+            var result = await AdminPricingEndpoints.VersionMargin(
+                new VersionMarginRequest("provider", "Anthropic", 2.0m, null),
+                db, publisher, Actor(), TimeProvider.System, default);
+            AssertStatus(result, StatusCodes.Status200OK);
+        }
+
+        var row = await NewContext().MarginPolicies.AsNoTracking()
+            .SingleAsync(p => p.Scope == "provider");
+        row.RefKey.Should().Be("anthropic");
+    }
+
+    [Test]
+    public async Task VersionMargin_AllNullKnobs_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, null, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task VersionMargin_GlobalWithRefKey_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", "pro", 1.3m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task VersionMargin_PlanWithoutRefKey_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("plan", null, 1.3m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task VersionMargin_NegativeMultiplier_Returns400()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, -1.0m, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicyResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicyResolverTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-5 (AC4, AC7-time-travel, AC13) — <see cref="MarginPolicyResolver"/>
+/// resolution order (provider &gt; plan &gt; global), timestamp-effective
+/// selection (an event resolves the policy active at its OccurredAt, not the
+/// latest), and the fail-loud no-policy error. Uses the InMemory provider — the
+/// resolution logic is provider-agnostic; the SQL CHECK/unique-index invariants
+/// are pinned by the Postgres-backed schema tests.
+/// </summary>
+[TestFixture]
+public class MarginPolicyResolverTests
+{
+    private static readonly DateTime Epoch = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static MarginPolicyResolver NewResolver(ControlPlaneDbContext db) =>
+        new(db, NullLogger<MarginPolicyResolver>.Instance);
+
+    private static MarginPolicy P(
+        string scope, string? refKey, decimal mult, DateTime effectiveFrom, string status = "active") => new()
+    {
+        Id = Guid.NewGuid(),
+        Scope = scope,
+        RefKey = refKey,
+        MarkupMultiplier = mult,
+        EffectiveFrom = effectiveFrom,
+        Status = status,
+        CreatedAt = effectiveFrom,
+        UpdatedAt = effectiveFrom,
+    };
+
+    [Test]
+    public async Task ResolveAsync_PrefersProviderOverride_ThenPlan_ThenGlobal()
+    {
+        await using var db = NewContext();
+        db.MarginPolicies.AddRange(
+            P("global", null, 1.3m, Epoch),
+            P("plan", "pro", 1.5m, Epoch),
+            P("provider", "anthropic", 2.0m, Epoch));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+
+        var providerHit = await resolver.ResolveAsync("anthropic", "pro", Epoch.AddYears(1), default);
+        providerHit.Scope.Should().Be("provider");
+        providerHit.MarkupMultiplier.Should().Be(2.0m);
+
+        // No provider override for openai ⇒ falls to the plan policy.
+        var planHit = await resolver.ResolveAsync("openai", "pro", Epoch.AddYears(1), default);
+        planHit.Scope.Should().Be("plan");
+        planHit.MarkupMultiplier.Should().Be(1.5m);
+
+        // No plan slug ⇒ falls straight to global.
+        var globalHit = await resolver.ResolveAsync("openai", null, Epoch.AddYears(1), default);
+        globalHit.Scope.Should().Be("global");
+        globalHit.MarkupMultiplier.Should().Be(1.3m);
+    }
+
+    [Test]
+    public async Task ResolveAsync_SelectsPolicyActiveAtTimestamp_NotLatest()
+    {
+        await using var db = NewContext();
+        var v1From = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var v2From = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        db.MarginPolicies.AddRange(
+            P("global", null, 1.3m, v1From, status: "superseded"),
+            P("global", null, 1.5m, v2From, status: "active"));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+
+        // An event in March 2026 prices under v1 (1.3x) — the policy active then,
+        // even though v1 is now superseded.
+        var march = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+        (await resolver.ResolveAsync("anthropic", null, march, default))
+            .MarkupMultiplier.Should().Be(1.3m);
+
+        // An event in July 2026 prices under v2 (1.5x).
+        var july = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+        (await resolver.ResolveAsync("anthropic", null, july, default))
+            .MarkupMultiplier.Should().Be(1.5m);
+    }
+
+    [Test]
+    public async Task ResolveAsync_BeforeAnyEffectiveFrom_FallsThroughToError()
+    {
+        await using var db = NewContext();
+        db.MarginPolicies.Add(P("global", null, 1.3m, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+
+        // A timestamp before the only policy's EffectiveFrom ⇒ no policy applies.
+        var before = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var act = async () => await resolver.ResolveAsync("anthropic", null, before, default);
+
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PRICING.MARGIN.NO_POLICY");
+    }
+
+    [Test]
+    public async Task ResolveAsync_NoPolicyAtAnyScope_ThrowsNoPolicy()
+    {
+        await using var db = NewContext();
+        var resolver = NewResolver(db);
+
+        var act = async () => await resolver.ResolveAsync("anthropic", "pro", Epoch.AddYears(1), default);
+
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Severity.Should().Be(TammaErrorSeverity.High);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicySeederTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/MarginPolicySeederTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-5 (AC1-AC3) — <see cref="MarginPolicySeeder"/> + the SQL invariants
+/// on <c>margin_policies</c>, against a real Postgres testcontainer so the CHECK
+/// constraints and the partial <c>NULLS NOT DISTINCT</c> unique index behave like
+/// production.
+/// </summary>
+[TestFixture]
+public class MarginPolicySeederTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("margin_policy_seeder_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE margin_policies CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    [Test]
+    public async Task SeedAsync_FreshDb_InsertsGlobal1Point3xPolicy()
+    {
+        await using var ctx = NewContext();
+
+        var inserted = await MarginPolicySeeder.SeedAsync(ctx);
+
+        inserted.Should().Be(1);
+        var row = await NewContext().MarginPolicies.AsNoTracking().SingleAsync();
+        row.Scope.Should().Be("global");
+        row.RefKey.Should().BeNull();
+        row.MarkupMultiplier.Should().Be(1.3m);
+        row.Status.Should().Be("active");
+        row.Id.Should().Be(MarginPolicySeeder.DeterministicId("global"));
+    }
+
+    [Test]
+    public async Task SeedAsync_SecondRun_IsNoOp()
+    {
+        await using (var ctx = NewContext()) { await MarginPolicySeeder.SeedAsync(ctx); }
+        await using var ctx2 = NewContext();
+
+        var inserted = await MarginPolicySeeder.SeedAsync(ctx2);
+
+        inserted.Should().Be(0);
+        (await NewContext().MarginPolicies.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task SeedAsync_NeverRevertsAdminEditedMultiplier()
+    {
+        await using (var ctx = NewContext()) { await MarginPolicySeeder.SeedAsync(ctx); }
+
+        // Admin re-prices the seeded global row in place (simulating an edit).
+        await using (var edit = NewContext())
+        {
+            var row = await edit.MarginPolicies.SingleAsync();
+            row.MarkupMultiplier = 1.9m;
+            await edit.SaveChangesAsync();
+        }
+
+        // Re-run must NOT revert the edit (insert-missing-only, keyed by id).
+        await using (var reseed = NewContext()) { await MarginPolicySeeder.SeedAsync(reseed); }
+
+        (await NewContext().MarginPolicies.SingleAsync()).MarkupMultiplier.Should().Be(1.9m);
+    }
+
+    [Test]
+    public async Task Schema_RejectsAllNullKnobPolicy()
+    {
+        await using var ctx = NewContext();
+        ctx.MarginPolicies.Add(new MarginPolicy
+        {
+            Id = Guid.NewGuid(),
+            Scope = "global",
+            RefKey = null,
+            MarkupMultiplier = null,
+            FixedUsdPer1M = null,
+            EffectiveFrom = DateTime.UtcNow,
+            Status = "active",
+        });
+
+        var act = async () => await ctx.SaveChangesAsync();
+
+        var ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        ex.InnerException.Should().BeOfType<PostgresException>()
+            .Which.ConstraintName.Should().Be("ck_margin_policies_has_knob");
+    }
+
+    [Test]
+    public async Task Schema_RejectsTwoActivePoliciesPerScopeRef()
+    {
+        await using (var ctx = NewContext())
+        {
+            await MarginPolicySeeder.SeedAsync(ctx); // one active global row
+        }
+
+        await using var ctx2 = NewContext();
+        ctx2.MarginPolicies.Add(new MarginPolicy
+        {
+            Id = Guid.NewGuid(),
+            Scope = "global",
+            RefKey = null, // NULLS NOT DISTINCT ⇒ collides with the existing global
+            MarkupMultiplier = 1.4m,
+            EffectiveFrom = DateTime.UtcNow,
+            Status = "active",
+        });
+
+        var act = async () => await ctx2.SaveChangesAsync();
+
+        var ex = (await act.Should().ThrowAsync<DbUpdateException>()).Which;
+        ex.InnerException.Should().BeOfType<PostgresException>()
+            .Which.SqlState.Should().Be(PostgresErrorCodes.UniqueViolation);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
@@ -1,0 +1,219 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-5 (AC10, AC14) — <see cref="PricingEndpoints.GetEstimate"/> priced
+/// under the caller's plan + <c>(tenant, provider)</c> mode. Direct handler calls
+/// with a real engine (frozen <see cref="ProviderPricingService"/> cost basis) +
+/// a real <see cref="MarginPolicyResolver"/> over an InMemory context seeded with
+/// the global 1.3x policy; the tenant/plan/mode seams are fakes so the isolation
+/// contract (each tenant's own mode) is exercised deterministically.
+/// </summary>
+[TestFixture]
+public class PricingEstimateEndpointTests
+{
+    private static readonly DateTime Epoch = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static ControlPlaneDbContext SeededContext()
+    {
+        var db = new ControlPlaneDbContext(
+            new DbContextOptionsBuilder<ControlPlaneDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
+        db.MarginPolicies.Add(new MarginPolicy
+        {
+            Id = Guid.NewGuid(),
+            Scope = "global",
+            RefKey = null,
+            MarkupMultiplier = 1.3m,
+            EffectiveFrom = Epoch,
+            Status = "active",
+        });
+        db.SaveChanges();
+        return db;
+    }
+
+    private static Task<IResult> Invoke(
+        ControlPlaneDbContext db,
+        string? provider,
+        string? model,
+        int inputTokens,
+        int outputTokens,
+        Guid? tenantId,
+        TammaMode mode,
+        PricingMode pricingMode)
+    {
+        var engine = new UsagePricingEngine(new ProviderPricingService(), NullLogger<UsagePricingEngine>.Instance);
+        var resolver = new MarginPolicyResolver(db, NullLogger<MarginPolicyResolver>.Instance);
+
+        return PricingEndpoints.GetEstimate(
+            provider, model, inputTokens, outputTokens,
+            new FakeTenantContext { TenantId = tenantId },
+            new FakeModeProvider(mode),
+            new FakePlanCatalog(),
+            new FakeModeResolver((_, _) => pricingMode),
+            resolver,
+            engine,
+            TimeProvider.System,
+            NullLoggerFactory.Instance,
+            default);
+    }
+
+    private static object Value(IResult result)
+    {
+        result.Should().BeAssignableTo<IValueHttpResult>();
+        return ((IValueHttpResult)result).Value!;
+    }
+
+    private static decimal Dec(object value, string prop) =>
+        (decimal)value.GetType().GetProperty(prop)!.GetValue(value)!;
+
+    private static string Str(object value, string prop) =>
+        (string)value.GetType().GetProperty(prop)!.GetValue(value)!;
+
+    [Test]
+    public async Task GetEstimate_PlatformProvidedTenant_ReturnsMarkedUpPrice()
+    {
+        await using var db = SeededContext();
+
+        var result = await Invoke(
+            db, "anthropic", "claude-sonnet-4-20250514", 1000, 500,
+            Guid.NewGuid(), TammaMode.SaaS, PricingMode.PlatformProvided);
+
+        var value = Value(result);
+        var cost = Dec(value, "costBasisUsd");
+        var sell = Dec(value, "sellPriceUsd");
+        var margin = Dec(value, "marginUsd");
+
+        // 1000*3/1e6 + 500*15/1e6 = 0.0105 cost basis; *1.3 = 0.01365 sell.
+        cost.Should().Be(0.010500m);
+        sell.Should().Be(0.013650m);
+        margin.Should().Be(0.003150m);
+        Str(value, "pricingMode").Should().Be("PlatformProvided");
+    }
+
+    [Test]
+    public async Task GetEstimate_ByokTenant_ReturnsZeroTokenSellPrice()
+    {
+        await using var db = SeededContext();
+
+        var result = await Invoke(
+            db, "anthropic", "claude-sonnet-4-20250514", 1000, 500,
+            Guid.NewGuid(), TammaMode.SaaS, PricingMode.Byok);
+
+        var value = Value(result);
+        Dec(value, "costBasisUsd").Should().Be(0.010500m); // still computed
+        Dec(value, "sellPriceUsd").Should().Be(0m);
+        Dec(value, "marginUsd").Should().Be(0m);
+        Str(value, "pricingMode").Should().Be("Byok");
+    }
+
+    [Test]
+    public async Task GetEstimate_UnknownModel_Returns400()
+    {
+        await using var db = SeededContext();
+
+        var result = await Invoke(
+            db, "anthropic", "totally-made-up-model", 1000, 500,
+            Guid.NewGuid(), TammaMode.SaaS, PricingMode.PlatformProvided);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetEstimate_TenantIsolation_EachTenantUsesItsOwnMode()
+    {
+        await using var db = SeededContext();
+        var tenantPlatform = Guid.NewGuid();
+        var tenantByok = Guid.NewGuid();
+
+        var engine = new UsagePricingEngine(new ProviderPricingService(), NullLogger<UsagePricingEngine>.Instance);
+        var resolver = new MarginPolicyResolver(db, NullLogger<MarginPolicyResolver>.Instance);
+
+        // A mode resolver that keys strictly off the tenant id — the only way the
+        // handler can pick the right mode is by passing the caller's own tenant.
+        var modeResolver = new FakeModeResolver((tid, _) =>
+            tid == tenantByok ? PricingMode.Byok : PricingMode.PlatformProvided);
+
+        async Task<object> EstimateFor(Guid tenant)
+        {
+            var res = await PricingEndpoints.GetEstimate(
+                "anthropic", "claude-sonnet-4-20250514", 1000, 500,
+                new FakeTenantContext { TenantId = tenant },
+                new FakeModeProvider(TammaMode.SaaS),
+                new FakePlanCatalog(), modeResolver, resolver, engine,
+                TimeProvider.System, NullLoggerFactory.Instance, default);
+            return Value(res);
+        }
+
+        var platformValue = await EstimateFor(tenantPlatform);
+        var byokValue = await EstimateFor(tenantByok);
+
+        Str(platformValue, "pricingMode").Should().Be("PlatformProvided");
+        Dec(platformValue, "sellPriceUsd").Should().Be(0.013650m);
+
+        Str(byokValue, "pricingMode").Should().Be("Byok");
+        Dec(byokValue, "sellPriceUsd").Should().Be(0m);
+    }
+
+    [Test]
+    public async Task GetEstimate_MissingProvider_Returns400()
+    {
+        await using var db = SeededContext();
+
+        var result = await Invoke(
+            db, null, "claude-sonnet-4-20250514", 1000, 500,
+            Guid.NewGuid(), TammaMode.SaaS, PricingMode.PlatformProvided);
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ── Fakes ──────────────────────────────────────────────────────────────
+
+    private sealed class FakeTenantContext : ITenantContext
+    {
+        public Guid? TenantId { get; set; }
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class FakeModeProvider : ITammaModeProvider
+    {
+        public FakeModeProvider(TammaMode mode) => Mode = mode;
+        public TammaMode Mode { get; }
+    }
+
+    private sealed class FakeModeResolver : ITenantProviderPricingModeResolver
+    {
+        private readonly Func<Guid?, string, PricingMode> _resolve;
+        public FakeModeResolver(Func<Guid?, string, PricingMode> resolve) => _resolve = resolve;
+        public Task<PricingMode> ResolveModeAsync(Guid? tenantId, string provider, CancellationToken ct = default) =>
+            Task.FromResult(_resolve(tenantId, provider));
+    }
+
+    private sealed class FakePlanCatalog : IPlanCatalogService
+    {
+        public Task<PlanSnapshot?> GetActiveBySlugAsync(string slug, CancellationToken ct = default) =>
+            Task.FromResult<PlanSnapshot?>(null);
+        public Task<PlanSnapshot?> GetByIdAsync(Guid planId, CancellationToken ct = default) =>
+            Task.FromResult<PlanSnapshot?>(null);
+        public Task<PlanSnapshot?> GetForTenantAsync(Guid tenantId, CancellationToken ct = default) =>
+            Task.FromResult<PlanSnapshot?>(null);
+        public Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
+        public Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
@@ -82,6 +82,9 @@ public class PricingEstimateEndpointTests
     private static string Str(object value, string prop) =>
         (string)value.GetType().GetProperty(prop)!.GetValue(value)!;
 
+    private static bool HasProp(object value, string prop) =>
+        value.GetType().GetProperty(prop) is not null;
+
     [Test]
     public async Task GetEstimate_PlatformProvidedTenant_ReturnsMarkedUpPrice()
     {
@@ -92,15 +95,21 @@ public class PricingEstimateEndpointTests
             Guid.NewGuid(), TammaMode.SaaS, PricingMode.PlatformProvided);
 
         var value = Value(result);
-        var cost = Dec(value, "costBasisUsd");
         var sell = Dec(value, "sellPriceUsd");
-        var margin = Dec(value, "marginUsd");
 
         // 1000*3/1e6 + 500*15/1e6 = 0.0105 cost basis; *1.3 = 0.01365 sell.
-        cost.Should().Be(0.010500m);
         sell.Should().Be(0.013650m);
-        margin.Should().Be(0.003150m);
         Str(value, "pricingMode").Should().Be("PlatformProvided");
+
+        // AC10 — the tenant estimate must NOT leak the platform cost basis or
+        // margin (a customer could otherwise compute the exact platform markup).
+        HasProp(value, "costBasisUsd").Should().BeFalse();
+        HasProp(value, "marginUsd").Should().BeFalse();
+
+        var invoice = value.GetType().GetProperty("invoice")!.GetValue(value)!;
+        Dec(invoice, "sellPriceUsd").Should().Be(0.01m);
+        HasProp(invoice, "costBasisUsd").Should().BeFalse();
+        HasProp(invoice, "marginUsd").Should().BeFalse();
     }
 
     [Test]
@@ -113,10 +122,12 @@ public class PricingEstimateEndpointTests
             Guid.NewGuid(), TammaMode.SaaS, PricingMode.Byok);
 
         var value = Value(result);
-        Dec(value, "costBasisUsd").Should().Be(0.010500m); // still computed
         Dec(value, "sellPriceUsd").Should().Be(0m);
-        Dec(value, "marginUsd").Should().Be(0m);
         Str(value, "pricingMode").Should().Be("Byok");
+
+        // AC10 — no cost/margin leak on the BYOK estimate either.
+        HasProp(value, "costBasisUsd").Should().BeFalse();
+        HasProp(value, "marginUsd").Should().BeFalse();
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/UsagePricingEngineTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/UsagePricingEngineTests.cs
@@ -1,0 +1,213 @@
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-5 (AC5, AC7, AC8) — the PURE cost->price engine. Cost basis is a
+/// controlled input (mocked <see cref="IProviderPricingService"/>); no DB. Covers
+/// the platform markup math (multiplier-only / fixed-only / combined), the BYOK
+/// zero-token-markup rule, the unknown-model fail-loud, rounding determinism, and
+/// a committed golden-file byte-stability regression.
+/// </summary>
+[TestFixture]
+public class UsagePricingEngineTests
+{
+    private static UsagePricingEngine NewEngine(IProviderPricingService pricing) =>
+        new(pricing, NullLogger<UsagePricingEngine>.Instance);
+
+    private static Mock<IProviderPricingService> KnownPricing(decimal costBasis)
+    {
+        var mock = new Mock<IProviderPricingService>();
+        mock.Setup(m => m.IsKnown(It.IsAny<string>(), It.IsAny<string?>())).Returns(true);
+        mock.Setup(m => m.Compute(
+                It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(costBasis);
+        return mock;
+    }
+
+    private static MarginPolicy Policy(decimal? multiplier, decimal? fixedPer1M) => new()
+    {
+        Id = Guid.NewGuid(),
+        Scope = "global",
+        RefKey = null,
+        MarkupMultiplier = multiplier,
+        FixedUsdPer1M = fixedPer1M,
+        EffectiveFrom = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        Status = "active",
+    };
+
+    private static UsageLine Line(PricingMode mode, int inTok = 1000, int outTok = 500) =>
+        new("anthropic", "claude-sonnet-4-20250514", inTok, outTok, mode,
+            new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+    [Test]
+    public void PriceUsage_PlatformMultiplierOnly_AppliesMarkup()
+    {
+        var engine = NewEngine(KnownPricing(1.0m).Object);
+
+        var result = engine.PriceUsage(Line(PricingMode.PlatformProvided), Policy(1.3m, null));
+
+        result.CostBasisUsd.Should().Be(1.000000m);
+        result.SellPriceUsd.Should().Be(1.300000m);
+        result.MarginUsd.Should().Be(0.300000m);
+        result.PricingMode.Should().Be(PricingMode.PlatformProvided);
+    }
+
+    [Test]
+    public void PriceUsage_PlatformFixedPer1MOnly_AddsFixedComponent()
+    {
+        var engine = NewEngine(KnownPricing(1.0m).Object);
+
+        // 600k + 400k = 1,000,000 total tokens ⇒ fixed adds exactly $0.50.
+        var result = engine.PriceUsage(
+            Line(PricingMode.PlatformProvided, 600_000, 400_000), Policy(null, 0.50m));
+
+        result.CostBasisUsd.Should().Be(1.000000m);
+        result.SellPriceUsd.Should().Be(1.500000m);
+        result.MarginUsd.Should().Be(0.500000m);
+    }
+
+    [Test]
+    public void PriceUsage_PlatformMultiplierPlusFixed_CombinesBoth()
+    {
+        var engine = NewEngine(KnownPricing(1.0m).Object);
+
+        var result = engine.PriceUsage(
+            Line(PricingMode.PlatformProvided, 600_000, 400_000), Policy(1.3m, 0.50m));
+
+        // 1.0 * 1.3 = 1.30 (+ 0.50 fixed) = 1.80.
+        result.SellPriceUsd.Should().Be(1.800000m);
+        result.MarginUsd.Should().Be(0.800000m);
+    }
+
+    [Test]
+    public void PriceUsage_Byok_ZeroTokenSellPrice_ButCostBasisComputed()
+    {
+        var engine = NewEngine(KnownPricing(1.0m).Object);
+
+        var result = engine.PriceUsage(Line(PricingMode.Byok), Policy(1.3m, 0.50m));
+
+        result.CostBasisUsd.Should().Be(1.000000m); // still computed for reporting
+        result.SellPriceUsd.Should().Be(0m);        // no token markup for BYOK
+        result.MarginUsd.Should().Be(0m);
+        result.PricingMode.Should().Be(PricingMode.Byok);
+    }
+
+    [Test]
+    public void PriceUsage_UnknownModel_ThrowsPricingUnknownModel_NotSilentZero()
+    {
+        var mock = new Mock<IProviderPricingService>();
+        mock.Setup(m => m.IsKnown(It.IsAny<string>(), It.IsAny<string?>())).Returns(false);
+        var engine = NewEngine(mock.Object);
+
+        var act = () => engine.PriceUsage(Line(PricingMode.PlatformProvided), Policy(1.3m, null));
+
+        act.Should().Throw<TammaError>()
+            .Which.Code.Should().Be("PRICING.UNKNOWN_MODEL");
+        // Compute is never even consulted once IsKnown is false.
+        mock.Verify(m => m.Compute(
+            It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<int>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Test]
+    public void PriceUsage_NullMultiplier_TreatedAsIdentity()
+    {
+        var engine = NewEngine(KnownPricing(2.0m).Object);
+
+        // fixed-only policy ⇒ multiplier defaults to 1.0 (no markup on the basis).
+        var result = engine.PriceUsage(
+            Line(PricingMode.PlatformProvided, 0, 0), Policy(null, 0.50m));
+
+        result.SellPriceUsd.Should().Be(2.000000m);
+        result.MarginUsd.Should().Be(0m);
+    }
+
+    [Test]
+    public void PriceUsage_RoundsCostBasisToSixDecimalsEven()
+    {
+        // 1.2345675 rounds to 1.234568 (6th digit 7 is odd ⇒ round half to even).
+        var engine = NewEngine(KnownPricing(1.2345675m).Object);
+
+        var result = engine.PriceUsage(
+            Line(PricingMode.PlatformProvided, 0, 0), Policy(1.0m, null));
+
+        result.CostBasisUsd.Should().Be(1.234568m);
+        result.SellPriceUsd.Should().Be(1.234568m);
+    }
+
+    [Test]
+    public void InvoiceUsd_ProjectsToTwoDecimalsEven()
+    {
+        PricedUsage.InvoiceUsd(1.234568m).Should().Be(1.23m);
+        PricedUsage.InvoiceUsd(1.800000m).Should().Be(1.80m);
+    }
+
+    // ── Golden-file byte-stability (AC7) ───────────────────────────────────
+
+    private sealed record GoldenScenario(
+        string Name,
+        string PricingMode,
+        string CostBasisUsd,
+        string MarginUsd,
+        string SellPriceUsd,
+        string InvoiceCostBasisUsd,
+        string InvoiceMarginUsd,
+        string InvoiceSellPriceUsd);
+
+    [Test]
+    public void PriceUsage_GoldenScenarios_AreByteStable()
+    {
+        var occurredAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        (string Name, decimal RawCost, PricingMode Mode, decimal? Mult, decimal? Fixed, int In, int Out)[] scenarios =
+        {
+            ("platform-multiplier-only", 1.0m, PricingMode.PlatformProvided, 1.3m, null, 1000, 500),
+            ("platform-fixed-only", 1.0m, PricingMode.PlatformProvided, null, 0.50m, 600_000, 400_000),
+            ("platform-both", 1.0m, PricingMode.PlatformProvided, 1.3m, 0.50m, 600_000, 400_000),
+            ("byok-zero-token-markup", 1.0m, PricingMode.Byok, 1.3m, null, 1000, 500),
+            ("platform-zero-tokens", 0.0m, PricingMode.PlatformProvided, 1.3m, null, 0, 0),
+            ("rounding-6dp-even", 1.2345675m, PricingMode.PlatformProvided, 1.0m, null, 0, 0),
+        };
+
+        var results = new List<GoldenScenario>();
+        foreach (var s in scenarios)
+        {
+            var engine = NewEngine(KnownPricing(s.RawCost).Object);
+            var line = new UsageLine("anthropic", "claude-sonnet-4-20250514", s.In, s.Out, s.Mode, occurredAt);
+            var priced = engine.PriceUsage(line, Policy(s.Mult, s.Fixed));
+
+            results.Add(new GoldenScenario(
+                s.Name,
+                priced.PricingMode.ToString(),
+                F6(priced.CostBasisUsd), F6(priced.MarginUsd), F6(priced.SellPriceUsd),
+                F2(PricedUsage.InvoiceUsd(priced.CostBasisUsd)),
+                F2(PricedUsage.InvoiceUsd(priced.MarginUsd)),
+                F2(PricedUsage.InvoiceUsd(priced.SellPriceUsd))));
+        }
+
+        var actual = JsonSerializer.Serialize(
+            results, new JsonSerializerOptions { WriteIndented = true });
+
+        var expected = File.ReadAllText(GoldenPath());
+        Normalize(actual).Should().Be(Normalize(expected));
+    }
+
+    private static string F6(decimal v) => v.ToString("F6", CultureInfo.InvariantCulture);
+    private static string F2(decimal v) => v.ToString("F2", CultureInfo.InvariantCulture);
+
+    private static string Normalize(string s) => s.Replace("\r\n", "\n").Trim();
+
+    private static string GoldenPath([CallerFilePath] string thisFile = "") =>
+        Path.Combine(Path.GetDirectoryName(thisFile)!, "golden", "pricing-scenarios.json");
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/golden/pricing-scenarios.json
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/golden/pricing-scenarios.json
@@ -1,0 +1,62 @@
+[
+  {
+    "Name": "platform-multiplier-only",
+    "PricingMode": "PlatformProvided",
+    "CostBasisUsd": "1.000000",
+    "MarginUsd": "0.300000",
+    "SellPriceUsd": "1.300000",
+    "InvoiceCostBasisUsd": "1.00",
+    "InvoiceMarginUsd": "0.30",
+    "InvoiceSellPriceUsd": "1.30"
+  },
+  {
+    "Name": "platform-fixed-only",
+    "PricingMode": "PlatformProvided",
+    "CostBasisUsd": "1.000000",
+    "MarginUsd": "0.500000",
+    "SellPriceUsd": "1.500000",
+    "InvoiceCostBasisUsd": "1.00",
+    "InvoiceMarginUsd": "0.50",
+    "InvoiceSellPriceUsd": "1.50"
+  },
+  {
+    "Name": "platform-both",
+    "PricingMode": "PlatformProvided",
+    "CostBasisUsd": "1.000000",
+    "MarginUsd": "0.800000",
+    "SellPriceUsd": "1.800000",
+    "InvoiceCostBasisUsd": "1.00",
+    "InvoiceMarginUsd": "0.80",
+    "InvoiceSellPriceUsd": "1.80"
+  },
+  {
+    "Name": "byok-zero-token-markup",
+    "PricingMode": "Byok",
+    "CostBasisUsd": "1.000000",
+    "MarginUsd": "0.000000",
+    "SellPriceUsd": "0.000000",
+    "InvoiceCostBasisUsd": "1.00",
+    "InvoiceMarginUsd": "0.00",
+    "InvoiceSellPriceUsd": "0.00"
+  },
+  {
+    "Name": "platform-zero-tokens",
+    "PricingMode": "PlatformProvided",
+    "CostBasisUsd": "0.000000",
+    "MarginUsd": "0.000000",
+    "SellPriceUsd": "0.000000",
+    "InvoiceCostBasisUsd": "0.00",
+    "InvoiceMarginUsd": "0.00",
+    "InvoiceSellPriceUsd": "0.00"
+  },
+  {
+    "Name": "rounding-6dp-even",
+    "PricingMode": "PlatformProvided",
+    "CostBasisUsd": "1.234568",
+    "MarginUsd": "0.000000",
+    "SellPriceUsd": "1.234568",
+    "InvoiceCostBasisUsd": "1.23",
+    "InvoiceMarginUsd": "0.00",
+    "InvoiceSellPriceUsd": "1.23"
+  }
+]


### PR DESCRIPTION
## What

Story 34-5 (P0). The canonical pricing math: `IUsagePricingEngine` computes billable price from provider cost (34-11 price book) + margin. `sell = round6(cost*mult + fixedUsdPer1M*totalTokens/1e6)`; BYOK ⇒ margin 0 (cost basis still computed); unknown model ⇒ `PRICING.UNKNOWN_MODEL` (fail-closed, never silent-$0).

- New `MarginPolicy` entity + `margin_policies` table (global/plan/provider scope, versioned) on ControlPlaneDbContext + one migration + insert-missing-only seeder (global 1.3x). Partial unique index (one active per scope+ref, NULLS NOT DISTINCT) + 3 CHECKs.
- `IMarginPolicyResolver` (provider→plan→global, timestamp-effective, `PRICING.MARGIN.NO_POLICY` fail-closed on miss).
- Admin `GET/PUT /api/admin/pricing/margins` (**PlatformOwnerAccess**, added to the policy regression test); tenant `GET /api/pricing/estimate` (MemberAccess).
- Consumes 34-11's `IProviderPricingService` (`IsKnown` gate avoids the frozen-table silent-zero). Interim `ITenantProviderPricingModeResolver` reads the real `BillingCustomer.BillingMode` (swappable to 34-3's per-provider impl).

## Review outcome

Adversarial review: **no Critical** — money math (decimal end-to-end, banker's 6dp/2dp, no overflow), BYOK/platform revenue integrity, resolution fail-closed, unknown-model gate, DB constraints, RBAC, isolation, DROP-list/seeder all verified SOLID. Three findings fixed:
- **A (confidentiality):** the tenant `/estimate` leaked `costBasisUsd` + `marginUsd` (platform economics) to members → now returns `sellPriceUsd` only.
- **B (revenue integrity):** the admin PUT allowed a markup multiplier `<1` (fat-fingered `0.13` → ~87% revenue loss) → now rejected (a markup is ≥1; null-multiplier fixed-fee policies still allowed).
- **C:** concurrent PUT on the same scope now returns 409, not 500.

## Flagged follow-on (out of scope)

Rewiring `ManagedAgent`'s interim `IProviderMarkupEngine`/`PassthroughProviderMarkupEngine` (and 36-2's `IAnalyticsPricingConfig`) onto this engine is deliberately NOT done here — needs its own story.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both contexts). Pricing tests: 267 passed.
- Startup-reset DROP-list updated with `margin_policies` (the new-table gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)