### PR TITLE
feat(epic-36): Story 36-4 — Cost & Spend Analytics API (BYOK vs Platform)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/TenantAnalyticsEndpoints.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Services.Analytics;
+using Tamma.Api.Services.PromptStore;
 
 namespace Tamma.Api.Endpoints;
 
@@ -128,6 +129,76 @@ public static class TenantAnalyticsEndpoints
         LogWindowDebug(log, tenantId, from, to, window);
 
         var result = await analytics.GetBreakdownAsync(tenantId, window, dim, met, clampedLimit, ct);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Story 36-4 — <c>GET /api/v1/orgs/{tenantId}/analytics/cost</c>. A daily
+    /// BYOK/platform cost split over <c>[from, to)</c> (optionally grouped by
+    /// <c>provider</c>|<c>agent</c>), plus month-to-date + linear-run-rate
+    /// projected platform-billed spend, a <c>BudgetConfig</c> join, and a trend
+    /// vs the prior equivalent window.
+    ///
+    /// <para>Reuses the Story 36-3 <see cref="AnalyticsWindow"/> for forced-UTC
+    /// binding + range clamp; the only difference from <see cref="GetUsage"/> is
+    /// (a) the window <b>defaults to the current calendar month</b> (UTC) when
+    /// omitted — the natural budget/MTD frame — and (b) <c>groupBy</c> accepts
+    /// only <c>provider</c>|<c>agent</c> (cost has no workflow/repo split).</para>
+    /// </summary>
+    public static async Task<IResult> GetCost(
+        Guid tenantId,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? groupBy,
+        ICostAnalyticsService cost,
+        ITammaModeProvider modeProvider,
+        TimeProvider timeProvider,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var log = loggerFactory.CreateLogger("Tamma.Api.Endpoints.TenantAnalyticsEndpoints");
+
+        // groupBy is optional; cost only splits by provider|agent (not workflow/repo).
+        AnalyticsDimension? groupByDim = null;
+        if (!string.IsNullOrWhiteSpace(groupBy))
+        {
+            switch (groupBy.Trim().ToLowerInvariant())
+            {
+                case "provider":
+                    groupByDim = AnalyticsDimension.Provider;
+                    break;
+                case "agent":
+                    groupByDim = AnalyticsDimension.Agent;
+                    break;
+                default:
+                    return Results.BadRequest(new { error = "groupBy must be one of: provider, agent" });
+            }
+        }
+
+        // Default the window to the current calendar month (UTC) when omitted —
+        // the frame budget-vs-actual + MTD projection are reasoned about. Then
+        // hand off to AnalyticsWindow.Resolve for the shared forced-UTC binding,
+        // from<to validation, and 365-day clamp (reused verbatim from 36-3).
+        var nowUtc = timeProvider.GetUtcNow().UtcDateTime;
+        var monthStart = new DateTime(nowUtc.Year, nowUtc.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var nextMonthStart = monthStart.AddMonths(1);
+        var effectiveFrom = from ?? monthStart;
+        var effectiveTo = to ?? nextMonthStart;
+
+        var window = AnalyticsWindow.Resolve(effectiveFrom, effectiveTo, "day");
+        if (!window.IsValid)
+        {
+            log.LogWarning(
+                "Tenant cost query rejected: tenantId={TenantId} requestedFrom={From} "
+                    + "requestedTo={To} error={Error}",
+                tenantId, from, to, window.Error);
+            return Results.BadRequest(new { error = window.Error });
+        }
+
+        LogWindowDebug(log, tenantId, from, to, window);
+
+        var mode = modeProvider.Mode == TammaMode.SaaS ? "saas" : "single-user";
+        var result = await cost.GetCostAsync(tenantId, window, groupByDim, mode, ct);
         return Results.Ok(result);
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1048,6 +1048,16 @@ builder.Services.AddScoped<
     Tamma.Api.Services.Analytics.ITenantAnalyticsService,
     Tamma.Api.Services.Analytics.TenantAnalyticsService>();
 
+// Story 36-4 — tenant-facing cost & spend analytics read seam. Reads the same
+// per-tenant Story 36-1 analytics_usage_daily fact table (populated by 36-2)
+// through ITenantDbContextFactory, splitting BYOK CostUsd (informational) from
+// the materialised PlatformBilledUsd (billable). Reads PlatformBilledUsd as the
+// single source of truth — NO markup/pricing dependency (AC4/AC10). Joins
+// BudgetConfig read-only and emits the deduped budget-exceeded DCB event.
+builder.Services.AddScoped<
+    Tamma.Api.Services.Analytics.ICostAnalyticsService,
+    Tamma.Api.Services.Analytics.CostAnalyticsService>();
+
 // Story 34-11 — swap the frozen ProviderPricingService for the DB-backed
 // DbProviderPricingService behind the unchanged IProviderPricingService seam
 // (a one-line DI change; zero downstream consumer edits). Must run AFTER
@@ -1958,6 +1968,14 @@ orgs.MapGet("/{tenantId:guid}/dashboard/stats", UserDashboardEndpoints.GetStats)
 orgs.MapGet("/{tenantId:guid}/analytics/usage", TenantAnalyticsEndpoints.GetUsage)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapGet("/{tenantId:guid}/analytics/usage/breakdown", TenantAnalyticsEndpoints.GetBreakdown)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+
+// Story 36-4 — tenant cost & spend analytics API (BYOK vs platform split +
+// budget projection). Same MemberAccess + membership-filter gate as the usage
+// routes above; reads the per-tenant analytics_usage_daily fact table only and
+// exposes the tenant's own BYOK cost + billed amount (never a platform-internal
+// margin). Read-only aggregation + one deduped budget-exceeded DCB event.
+orgs.MapGet("/{tenantId:guid}/analytics/cost", TenantAnalyticsEndpoints.GetCost)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 
 // Story 5.6 / 1.5-37 (Wave C.3) — tenant-scope alert surface.

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsDtos.cs
@@ -1,0 +1,75 @@
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-4 — request/response contract for the tenant-facing cost &amp; spend
+/// analytics API (<c>GET /api/v1/orgs/{tenantId}/analytics/cost</c>).
+///
+/// <para>The <b>read</b> side over the Story 36-1 <c>analytics_usage_daily</c>
+/// fact table (populated by Story 36-2). It separates the raw provider cost the
+/// tenant paid on their own BYOK keys (<see cref="CostSeriesBucket.ByokCostUsd"/>
+/// — informational, never marked up) from the platform-fronted <b>billable</b>
+/// amount (<see cref="CostSeriesBucket.PlatformBilledUsd"/> — already
+/// materialized upstream; this endpoint sums it, never recomputes it).</para>
+///
+/// <para><b>No margin leak:</b> a platform row's raw <c>CostUsd</c> (Tamma's
+/// underlying provider cost — from which the margin <c>= billed − cost</c> could
+/// be derived) is <b>never</b> summed into any response field. Only the tenant's
+/// own BYOK cost and the tenant's own billed amount are exposed.</para>
+///
+/// <para>These types ride the app-wide camelCase JSON policy (Program.cs
+/// <c>ConfigureHttpJsonOptions</c>); <see cref="DateOnly"/> serialises as
+/// <c>yyyy-MM-dd</c> (System.Text.Json default), matching the daily grain.</para>
+/// </summary>
+
+/// <summary>The effective (clamped, UTC) window echoed back on the response.</summary>
+public sealed record CostWindow(DateOnly From, DateOnly To);
+
+/// <summary>
+/// One daily bucket of the cost time-series. When ungrouped, <see cref="Group"/>
+/// is <c>null</c> and there is one row per day. When grouped by provider/agent,
+/// there is one row per <c>(day, group)</c> and the <c>NULL</c> dimension value
+/// is surfaced as <c>"unattributed"</c> — never dropped, so per-group sums
+/// reconcile to the ungrouped total.
+/// </summary>
+public sealed record CostSeriesBucket(
+    DateOnly Day,
+    string? Group,
+    decimal ByokCostUsd,
+    decimal PlatformBilledUsd);
+
+/// <summary>
+/// Cost/spend summary: the window's informational BYOK total, month-to-date +
+/// linear-run-rate projected platform-billed spend, and the budget-vs-actual
+/// context (all budget/utilisation fields are <c>null</c> when no
+/// <c>BudgetConfig</c> row exists for the tenant).
+/// </summary>
+public sealed record CostSummary(
+    decimal ByokCostUsd,
+    decimal MtdPlatformBilledUsd,
+    decimal ProjectedPlatformBilledUsd,
+    decimal? BudgetUsd,
+    double? AlertThreshold,
+    double? BudgetUtilizationPct,
+    double? ProjectedUtilizationPct,
+    bool ProjectedToExceedBudget);
+
+/// <summary>
+/// Trend vs the immediately-preceding window of the same length. Carries the
+/// prior window's totals and the percentage delta of the requested window vs the
+/// prior window (delta is <c>null</c> when the prior window is empty — no
+/// divide-by-zero).
+/// </summary>
+public sealed record CostTrend(
+    decimal PlatformBilledUsd,
+    double? PlatformBilledDeltaPct,
+    decimal ByokCostUsd,
+    double? ByokCostDeltaPct);
+
+/// <summary>Response envelope for <c>GET …/analytics/cost</c>.</summary>
+public sealed record CostAnalyticsResponse(
+    Guid TenantId,
+    CostWindow Window,
+    string? GroupBy,
+    IReadOnlyList<CostSeriesBucket> Series,
+    CostSummary Summary,
+    CostTrend Trend);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsEvents.cs
@@ -1,0 +1,17 @@
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-4 — DCB event constant(s) emitted by <see cref="CostAnalyticsService"/>.
+/// Follows the <c>AGGREGATE.ACTION.STATUS</c> convention (CLAUDE.md "Event Types").
+/// </summary>
+public static class CostAnalyticsEvents
+{
+    /// <summary>
+    /// Emitted (best-effort, per-<c>(tenantId, period)</c> deduped) when a
+    /// tenant's linear run-rate projection for the current calendar period
+    /// crosses its configured <c>BudgetConfig.LimitUsd</c>. Consumed by the
+    /// alerting / scheduled-report pipeline (a downstream Epic 36 / Story 5.6
+    /// consumer). Tenant-scoped (<c>DomainEvent.TenantId</c> set).
+    /// </summary>
+    public const string BudgetProjectedExceeded = "ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs
@@ -1,0 +1,308 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-4 — cost/spend read side over the per-tenant Story 36-1
+/// <c>analytics_usage_daily</c> fact table. Mirrors
+/// <see cref="TenantAnalyticsService"/>'s materialise-then-group shape (open the
+/// tenant schema via <c>ITenantDbContextFactory</c>, project only the columns
+/// the roll-up needs, aggregate in memory) so grouping — including the
+/// <c>NULL</c> dimension key — is byte-identical on EF-InMemory and Npgsql.
+///
+/// <para><b>Read-only + no re-markup (AC4/AC10):</b> the ctor takes NO markup
+/// engine (Story 34-5) or pricing-config dependency. <c>byokCostUsd</c> sums
+/// <c>CostUsd</c> of <see cref="CostBasis.Byok"/> rows (informational);
+/// <c>platformBilledUsd</c> sums the materialised <c>PlatformBilledUsd</c>
+/// column (byok rows are structurally 0 — Story 36-2). The only write is the
+/// deduped budget-exceeded DCB event.</para>
+/// </summary>
+public sealed class CostAnalyticsService(
+    ITenantDbContextFactory tenantDbFactory,
+    IBudgetConfigRepository budgets,
+    IEventRepository events,
+    TimeProvider timeProvider,
+    ILogger<CostAnalyticsService> logger)
+    : ICostAnalyticsService
+{
+    private const string Unattributed = "unattributed";
+
+    public async Task<CostAnalyticsResponse> GetCostAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension? groupBy,
+        string mode,
+        CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var monthStart = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var mtdEndExclusive = now.Date.AddDays(1);   // include today's UTC-midnight bucket
+        var daysInMonth = DateTime.DaysInMonth(now.Year, now.Month);
+        var daysElapsed = now.Day;                   // 1..daysInMonth
+
+        // Prior equivalent window — the immediately-preceding window of the same
+        // length (for the trend delta).
+        var windowLength = window.To - window.From;
+        var priorTo = window.From;
+        var priorFrom = window.From - windowLength;
+
+        // One tenant context, three bounded half-open [from, to) reads. The
+        // per-tenant factory binds a schema-scoped connection, so every read is
+        // physically confined to this tenant's schema (no TenantId predicate).
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var windowRows = await LoadDailyAsync(db, window.From, window.To, ct);
+        var priorRows = await LoadDailyAsync(db, priorFrom, priorTo, ct);
+        var mtdRows = await LoadDailyAsync(db, monthStart, mtdEndExclusive, ct);
+
+        // ── Series (BYOK/platform split, optionally grouped) ──
+        var series = BuildSeries(windowRows, groupBy);
+
+        // ── Window totals ──
+        var windowByok = SumByokCost(windowRows);        // informational
+        var windowPlatform = SumPlatformBilled(windowRows); // billable
+
+        // ── Month-to-date + linear run-rate projection (platform-billed only) ──
+        var mtdPlatform = SumPlatformBilled(mtdRows);
+        var projected = daysElapsed <= 0 ? 0m : mtdPlatform / daysElapsed * daysInMonth;
+
+        // ── Budget join (read-only; tenant GUID string is the account scope key) ──
+        var budget = await budgets.GetAsync(tenantId, tenantId.ToString(), ct);
+        var hasBudget = budget is not null && budget.LimitUsd > 0m;
+        decimal? budgetUsd = budget?.LimitUsd;
+        double? alertThreshold = budget?.AlertThreshold;
+        double? budgetUtil = hasBudget ? (double)(mtdPlatform / budget!.LimitUsd) : null;
+        double? projectedUtil = hasBudget ? (double)(projected / budget!.LimitUsd) : null;
+        var projectedToExceed = budget is not null && projected > budget.LimitUsd;
+
+        var summary = new CostSummary(
+            windowByok, mtdPlatform, projected,
+            budgetUsd, alertThreshold, budgetUtil, projectedUtil, projectedToExceed);
+
+        // ── Trend vs prior equivalent window ──
+        var priorByok = SumByokCost(priorRows);
+        var priorPlatform = SumPlatformBilled(priorRows);
+        var trend = new CostTrend(
+            priorPlatform, DeltaPct(windowPlatform, priorPlatform),
+            priorByok, DeltaPct(windowByok, priorByok));
+
+        logger.LogInformation(
+            "Tenant cost analytics served: tenantId={TenantId} from={From:o} to={To:o} "
+                + "groupBy={GroupBy} rows={Rows} mtdPlatformBilledUsd={Mtd} "
+                + "projectedPlatformBilledUsd={Projected} durationMs={DurationMs}",
+            tenantId, window.From, window.To, groupBy?.ToWire() ?? "(none)",
+            series.Count, mtdPlatform, projected, sw.ElapsedMilliseconds);
+
+        // ── Best-effort, per-period deduped budget-exceeded DCB event ──
+        if (projectedToExceed)
+        {
+            await TryEmitBudgetExceededAsync(
+                tenantId, mode, budget!, mtdPlatform, projected, window, monthStart, ct);
+        }
+
+        return new CostAnalyticsResponse(
+            tenantId,
+            new CostWindow(DateOnly.FromDateTime(window.From), DateOnly.FromDateTime(window.To)),
+            groupBy?.ToWire(),
+            series,
+            summary,
+            trend);
+    }
+
+    /// <summary>
+    /// Half-open <c>[from, to)</c> read against <c>analytics_usage_daily</c>,
+    /// projecting only the cost columns this endpoint needs.
+    /// </summary>
+    private static async Task<List<CostRow>> LoadDailyAsync(
+        TenantDbContext db, DateTime from, DateTime to, CancellationToken ct)
+    {
+        if (to <= from)
+        {
+            return [];
+        }
+
+        return await db.AnalyticsUsageDaily
+            .Where(r => r.Day >= from && r.Day < to)
+            .Select(r => new CostRow(
+                r.Day, r.Provider, r.AgentId, r.CostBasis, r.CostUsd, r.PlatformBilledUsd))
+            .ToListAsync(ct);
+    }
+
+    private List<CostSeriesBucket> BuildSeries(List<CostRow> rows, AnalyticsDimension? groupBy)
+    {
+        if (groupBy is null)
+        {
+            return rows
+                .GroupBy(r => r.Day)
+                .OrderBy(g => g.Key)
+                .Select(g => new CostSeriesBucket(
+                    DateOnly.FromDateTime(g.Key), null,
+                    SumByokCost(g), SumPlatformBilled(g)))
+                .ToList();
+        }
+
+        var keyOf = DimensionKeySelector(groupBy.Value);
+        return rows
+            .GroupBy(r => new SeriesKey(r.Day, keyOf(r) ?? Unattributed))
+            .OrderBy(g => g.Key.Day)
+            .ThenBy(g => g.Key.Group, StringComparer.Ordinal)
+            .Select(g => new CostSeriesBucket(
+                DateOnly.FromDateTime(g.Key.Day), g.Key.Group,
+                SumByokCost(g), SumPlatformBilled(g)))
+            .ToList();
+    }
+
+    private static Func<CostRow, string?> DimensionKeySelector(AnalyticsDimension dim) => dim switch
+    {
+        AnalyticsDimension.Provider => r => r.Provider,
+        AnalyticsDimension.Agent => r => r.AgentId,
+        // Only Provider/Agent are wired for cost (the endpoint rejects the rest);
+        // fall back to a single unattributed bucket rather than throw.
+        _ => _ => null,
+    };
+
+    /// <summary>Σ <c>CostUsd</c> of BYOK rows — the raw provider cost, informational only.</summary>
+    private static decimal SumByokCost(IEnumerable<CostRow> rows)
+    {
+        decimal sum = 0m;
+        foreach (var r in rows)
+        {
+            if (r.CostBasis == CostBasis.Byok)
+            {
+                sum += r.CostUsd;
+            }
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Σ <c>PlatformBilledUsd</c> — the materialised billable amount (single
+    /// source of truth). BYOK rows carry 0 (Story 36-2), so summing every row
+    /// yields the platform-billed total with no cost-basis branch, and a
+    /// fully-BYOK tenant is structurally 0.
+    /// </summary>
+    private static decimal SumPlatformBilled(IEnumerable<CostRow> rows)
+    {
+        decimal sum = 0m;
+        foreach (var r in rows)
+        {
+            sum += r.PlatformBilledUsd;
+        }
+
+        return sum;
+    }
+
+    /// <summary>
+    /// Percentage delta of <paramref name="current"/> vs <paramref name="prior"/>;
+    /// <c>null</c> when the prior window is empty (no divide-by-zero).
+    /// </summary>
+    private static double? DeltaPct(decimal current, decimal prior) =>
+        prior == 0m ? null : (double)((current - prior) / prior);
+
+    private async Task TryEmitBudgetExceededAsync(
+        Guid tenantId, string mode, BudgetConfig budget,
+        decimal mtdPlatform, decimal projected, AnalyticsWindow window,
+        DateTime monthStart, CancellationToken ct)
+    {
+        var period = $"{monthStart:yyyy-MM}";
+        try
+        {
+            // Dedup keyed (tenantId, period): a hot dashboard polling this
+            // endpoint emits at most one event per tenant per calendar period.
+            var last = await events.GetLastByTypeAsync(
+                tenantId, CostAnalyticsEvents.BudgetProjectedExceeded);
+            if (last is not null && TryReadPeriodTag(last.Tags) == period)
+            {
+                logger.LogDebug(
+                    "Budget-exceeded event already present this period {Period} for "
+                        + "tenant {TenantId}; skipping (dedup).",
+                    period, tenantId);
+                return;
+            }
+
+            var windowTag =
+                $"{DateOnly.FromDateTime(window.From):yyyy-MM-dd}..{DateOnly.FromDateTime(window.To):yyyy-MM-dd}";
+
+            await events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = CostAnalyticsEvents.BudgetProjectedExceeded,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(new Dictionary<string, string?>
+                {
+                    ["tenantId"] = tenantId.ToString(),
+                    ["mode"] = mode,
+                    ["period"] = period,
+                }),
+                Data = JsonSerializer.Serialize(new
+                {
+                    budgetUsd = budget.LimitUsd,
+                    projectedPlatformBilledUsd = projected,
+                    mtdPlatformBilledUsd = mtdPlatform,
+                    window = windowTag,
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+            });
+
+            logger.LogInformation(
+                "Budget-projected-exceeded event emitted: tenantId={TenantId} budgetUsd={Budget} "
+                    + "projectedPlatformBilledUsd={Projected} period={Period}",
+                tenantId, budget.LimitUsd, projected, period);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a failed append is logged WARN and never propagates
+            // into the read path — the response still returns.
+            logger.LogWarning(
+                ex,
+                "Budget-projected-exceeded event append failed for tenant {TenantId} "
+                    + "(best-effort; the cost response is still returned).",
+                tenantId);
+        }
+    }
+
+    private static string? TryReadPeriodTag(string? tagsJson)
+    {
+        if (string.IsNullOrWhiteSpace(tagsJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(tagsJson);
+            return doc.RootElement.TryGetProperty("period", out var p)
+                ? p.GetString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Lightweight projection of a fact row (only the cost columns).</summary>
+    private readonly record struct CostRow(
+        DateTime Day,
+        string? Provider,
+        string? AgentId,
+        CostBasis CostBasis,
+        decimal CostUsd,
+        decimal PlatformBilledUsd);
+
+    /// <summary>Grouping key for a grouped series — a <c>(day, dimension-value)</c> tuple.</summary>
+    private readonly record struct SeriesKey(DateTime Day, string Group);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/CostAnalyticsService.cs
@@ -81,7 +81,11 @@ public sealed class CostAnalyticsService(
         double? alertThreshold = budget?.AlertThreshold;
         double? budgetUtil = hasBudget ? (double)(mtdPlatform / budget!.LimitUsd) : null;
         double? projectedUtil = hasBudget ? (double)(projected / budget!.LimitUsd) : null;
-        var projectedToExceed = budget is not null && projected > budget.LimitUsd;
+        // Gate on the SAME hasBudget predicate as the utilisation pcts: a stored
+        // BudgetConfig with LimitUsd <= 0 (e.g. BudgetConfigDefaults.DefaultLimitUsd = 0)
+        // is "no meaningful budget" — projectedToExceed must be false (and no
+        // BUDGET_PROJECTED_EXCEEDED event is emitted), not true-with-budgetUsd:0.
+        var projectedToExceed = hasBudget && projected > budget!.LimitUsd;
 
         var summary = new CostSummary(
             windowByok, mtdPlatform, projected,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ICostAnalyticsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Analytics/ICostAnalyticsService.cs
@@ -1,0 +1,46 @@
+namespace Tamma.Api.Services.Analytics;
+
+/// <summary>
+/// Story 36-4 — the tenant-scoped <b>cost &amp; spend</b> read seam over the
+/// Story 36-1 <c>analytics_usage_daily</c> fact table (populated by Story 36-2).
+/// The cost/spend sibling of <see cref="ITenantAnalyticsService"/> (usage): it
+/// reuses the same per-tenant data plane (<c>ITenantDbContextFactory</c>) and
+/// the same <see cref="AnalyticsWindow"/> (forced-UTC, clamp), and adds the
+/// BYOK-vs-platform split (<c>CostUsd</c> for BYOK, <c>PlatformBilledUsd</c> for
+/// billable), month-to-date + linear-run-rate projection, a read-only
+/// <c>BudgetConfig</c> join, and a trend vs the prior equivalent window.
+///
+/// <para><b>Reads pre-aggregated facts ONLY, through the tenant's own schema.</b>
+/// It never reads the control-plane <c>platform_analytics_hourly</c> or another
+/// tenant's schema, and <b>never recomputes a margin</b> — <c>PlatformBilledUsd</c>
+/// is the single source of truth (Story 36-2 materialised it via Story 34-5's
+/// markup engine). Its only persisted side effect is the deduped
+/// <see cref="CostAnalyticsEvents.BudgetProjectedExceeded"/> DCB event.</para>
+/// </summary>
+public interface ICostAnalyticsService
+{
+    /// <summary>
+    /// Tenant-scoped cost/spend analytics over the (already-clamped, UTC)
+    /// <paramref name="window"/>: a daily BYOK/platform split series (optionally
+    /// grouped by <c>provider</c>|<c>agent</c>), month-to-date + linear-run-rate
+    /// projected platform-billed spend, a <c>BudgetConfig</c> join for
+    /// budget-vs-actual, and a trend vs the prior equivalent window. Emits
+    /// <see cref="CostAnalyticsEvents.BudgetProjectedExceeded"/> (best-effort,
+    /// per-period deduped) when the projection crosses the budget.
+    /// </summary>
+    /// <param name="tenantId">The route tenant (already membership-gated).</param>
+    /// <param name="window">Effective UTC window for the series + trend.</param>
+    /// <param name="groupBy">
+    /// <c>null</c> = one row per day; <see cref="AnalyticsDimension.Provider"/> /
+    /// <see cref="AnalyticsDimension.Agent"/> = one row per <c>(day, group)</c>,
+    /// the <c>NULL</c> dimension surfaced as <c>"unattributed"</c>. Only Provider
+    /// and Agent are valid here (the endpoint rejects other dimensions with 400).
+    /// </param>
+    /// <param name="mode">Process <c>ITammaModeProvider</c> value, carried only as an event tag.</param>
+    Task<CostAnalyticsResponse> GetCostAsync(
+        Guid tenantId,
+        AnalyticsWindow window,
+        AnalyticsDimension? groupBy,
+        string mode,
+        CancellationToken ct);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsEndpointTests.cs
@@ -1,0 +1,215 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Authorization;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Analytics;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-4 — endpoint-level tests for the tenant cost analytics API:
+/// validation (400s), member-read (no owner/admin gate — AC8), current-month
+/// window defaulting + UTC (AC12), mode threading (AC9), the read-only /
+/// no-control-plane invariant (AC10), and the cross-tenant 403 that stops the
+/// handler before it can read another tenant's schema (AC8). No Postgres —
+/// validation short-circuits before the service, the service is mocked for happy
+/// paths, and the membership filter is driven directly.
+/// </summary>
+[TestFixture]
+public class CostAnalyticsEndpointTests
+{
+    private static readonly DateTime From = new(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime To = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTimeOffset July15 = new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static ServiceProvider MinimalServices() =>
+        new ServiceCollection().AddLogging().BuildServiceProvider();
+
+    private static async Task<int> Status(IResult result)
+    {
+        var ctx = new DefaultHttpContext { RequestServices = MinimalServices() };
+        ctx.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(ctx);
+        return ctx.Response.StatusCode;
+    }
+
+    private static Mock<ITammaModeProvider> Mode(TammaMode mode)
+    {
+        var m = new Mock<ITammaModeProvider>();
+        m.SetupGet(x => x.Mode).Returns(mode);
+        return m;
+    }
+
+    private static CostAnalyticsResponse EmptyResponse(Guid tenantId) => new(
+        tenantId,
+        new CostWindow(new DateOnly(2026, 7, 1), new DateOnly(2026, 8, 1)),
+        null,
+        Array.Empty<CostSeriesBucket>(),
+        new CostSummary(0m, 0m, 0m, null, null, null, null, false),
+        new CostTrend(0m, null, 0m, null));
+
+    // ─────────────────────────────── Validation ───────────────────────────────
+
+    [Test]
+    public async Task GetCost_UnknownGroupBy_Returns400()
+    {
+        var svc = new Mock<ICostAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetCost(
+            Guid.NewGuid(), From, To, "team", svc.Object, Mode(TammaMode.SaaS).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+        svc.Verify(s => s.GetCostAsync(It.IsAny<Guid>(), It.IsAny<AnalyticsWindow>(),
+            It.IsAny<AnalyticsDimension?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetCost_WorkflowGroupBy_IsRejected_CostOnlySplitsByProviderOrAgent()
+    {
+        var svc = new Mock<ICostAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetCost(
+            Guid.NewGuid(), From, To, "workflow", svc.Object, Mode(TammaMode.SaaS).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task GetCost_FromAfterTo_Returns400()
+    {
+        var svc = new Mock<ICostAnalyticsService>(MockBehavior.Strict);
+        var result = await TenantAnalyticsEndpoints.GetCost(
+            Guid.NewGuid(), To, From, null, svc.Object, Mode(TammaMode.SaaS).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ─────────────────────── Defaulting / mode / happy path ───────────────────────
+
+    [Test]
+    public async Task GetCost_OmittedWindow_DefaultsToCurrentCalendarMonth_Utc()
+    {
+        var tenantId = Guid.NewGuid();
+        AnalyticsWindow captured = default;
+        var svc = new Mock<ICostAnalyticsService>();
+        svc.Setup(s => s.GetCostAsync(tenantId, It.IsAny<AnalyticsWindow>(),
+                It.IsAny<AnalyticsDimension?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, AnalyticsWindow, AnalyticsDimension?, string, CancellationToken>(
+                (_, w, _, _, _) => captured = w)
+            .ReturnsAsync(EmptyResponse(tenantId));
+
+        var result = await TenantAnalyticsEndpoints.GetCost(
+            tenantId, null, null, null, svc.Object, Mode(TammaMode.SaaS).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status200OK);
+        captured.From.Should().Be(new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc));
+        captured.To.Should().Be(new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc));
+        captured.From.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public async Task GetCost_ThreadsTheProcessModeIntoTheServiceCall()
+    {
+        var tenantId = Guid.NewGuid();
+        string? capturedMode = null;
+        var svc = new Mock<ICostAnalyticsService>();
+        svc.Setup(s => s.GetCostAsync(tenantId, It.IsAny<AnalyticsWindow>(),
+                It.IsAny<AnalyticsDimension?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, AnalyticsWindow, AnalyticsDimension?, string, CancellationToken>(
+                (_, _, _, m, _) => capturedMode = m)
+            .ReturnsAsync(EmptyResponse(tenantId));
+
+        await TenantAnalyticsEndpoints.GetCost(
+            tenantId, From, To, "agent", svc.Object, Mode(TammaMode.SingleUser).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        capturedMode.Should().Be("single-user");
+    }
+
+    [Test]
+    public async Task GetCost_HappyPath_MemberReadable_Returns200()
+    {
+        var tenantId = Guid.NewGuid();
+        var svc = new Mock<ICostAnalyticsService>();
+        svc.Setup(s => s.GetCostAsync(tenantId, It.IsAny<AnalyticsWindow>(),
+                It.IsAny<AnalyticsDimension?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmptyResponse(tenantId));
+
+        // No role argument on the handler — a plain authenticated member read
+        // reaches the service (RBAC is MemberAccess + the membership filter at the
+        // wiring site; NO owner/admin gate — AC8).
+        var result = await TenantAnalyticsEndpoints.GetCost(
+            tenantId, From, To, "provider", svc.Object, Mode(TammaMode.SaaS).Object,
+            new FixedClock(July15), NullLoggerFactory.Instance, default);
+
+        (await Status(result)).Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ─────────────────── AC10 — read-only, no control-plane / markup dep ───────────────────
+
+    [Test]
+    public void CostAnalyticsService_DependsOnlyOnTheTenantReadPlane_NoControlPlaneNoMarkup()
+    {
+        var ctorParams = typeof(CostAnalyticsService)
+            .GetConstructors().Single()
+            .GetParameters().Select(p => p.ParameterType).ToList();
+
+        ctorParams.Should().Contain(typeof(ITenantDbContextFactory),
+            "the read seam is the per-tenant factory (physical isolation)");
+        ctorParams.Should().Contain(typeof(IBudgetConfigRepository), "budget context is read-only");
+        ctorParams.Should().Contain(typeof(IEventRepository), "the only write is the budget-exceeded DCB event");
+        ctorParams.Should().NotContain(typeof(IPlatformAnalyticsService),
+            "AC1/AC10 — the tenant cost surface must never read the control-plane analytics service");
+    }
+
+    // ─────────────────────── AC8 — cross-tenant 403, no leakage ───────────────────────
+
+    [Test]
+    public async Task CrossTenantRoute_NonMember_Returns403_AndTheCostHandlerNeverRuns()
+    {
+        var memberOfA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+
+        var membership = new Mock<ITenantMembershipRepository>();
+        membership.Setup(r => r.GetRoleAsync(tenantB, memberOfA)).ReturnsAsync((string?)null);
+        var filter = new RequireTenantMembershipFilter(membership.Object);
+
+        var ctx = new DefaultHttpContext { RequestServices = MinimalServices() };
+        ctx.Response.Body = new MemoryStream();
+        ctx.User = new ClaimsPrincipal(new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, memberOfA.ToString()) }, "Test"));
+        ctx.Request.RouteValues["tenantId"] = tenantB.ToString();
+
+        var handlerRan = false;
+        EndpointFilterDelegate next = _ =>
+        {
+            handlerRan = true; // would be the cost handler reading tenant B's schema
+            return ValueTask.FromResult<object?>(Results.Ok());
+        };
+
+        var result = await filter.InvokeAsync(new DefaultEndpointFilterInvocationContext(ctx), next);
+        if (result is IResult r)
+        {
+            await r.ExecuteAsync(ctx);
+        }
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        handlerRan.Should().BeFalse(
+            "the membership filter 403s before the handler → no tenant-B cost row is ever returned (AC8)");
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsIsolationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsIsolationTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-4 (AC5/AC11) — Postgres 17 Testcontainer proof for the cost/spend
+/// read seam. EF-InMemory models neither schema isolation nor real
+/// <c>timestamptz</c> selection, so a real Postgres is the only proof of:
+///
+/// <list type="number">
+///   <item><description><b>Fully-BYOK ⇒ platform-billed = 0 (AC5).</b> A tenant
+///     whose <c>analytics_usage_daily</c> rows are all <c>byok</c>
+///     (<c>PlatformBilledUsd = 0</c>) reports <c>summary.platformBilledUsd == 0</c>
+///     and <c>projectedPlatformBilledUsd == 0</c> while <c>byokCostUsd &gt; 0</c> —
+///     markup on a BYOK call is structurally impossible here.</description></item>
+///   <item><description><b>Physical isolation (AC11).</b> A request for tenant A
+///     returns only A's spend; B's rows are unreachable through A's context (no
+///     <c>TenantId</c> column, no query filter — the schema is the isolation
+///     plane). The <c>BudgetConfig</c> join reads only A's row.</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class CostAnalyticsIsolationTests
+{
+    private static readonly DateTimeOffset May15 = new(2026, 5, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("cost_analytics_api_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    private static AnalyticsWindow MayWindow() => AnalyticsWindow.Resolve(
+        new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+        new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc), "day");
+
+    // ───────────────────── AC5 — fully-BYOK ⇒ platformBilled = 0 ─────────────────────
+
+    [Test]
+    public async Task GetCost_FullyByokTenant_HasZeroPlatformBilled_ButNonZeroByokCost()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        await SeedDailyAsync(schema, tenant, new DateTime(2026, 5, 3, 0, 0, 0, DateTimeKind.Utc),
+            CostBasis.Byok, cost: 5m, billed: 0m, provider: "anthropic");
+        await SeedDailyAsync(schema, tenant, new DateTime(2026, 5, 4, 0, 0, 0, DateTimeKind.Utc),
+            CostBasis.Byok, cost: 7m, billed: 0m, provider: "openai");
+
+        var service = BuildService(tenant, schema, budgets: NoBudget());
+        var res = await service.GetCostAsync(tenant, MayWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.MtdPlatformBilledUsd.Should().Be(0m, "byok rows carry PlatformBilledUsd = 0");
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(0m);
+        res.Summary.ByokCostUsd.Should().Be(12m, "the informational raw provider cost is still reported");
+        res.Series.Should().OnlyContain(s => s.PlatformBilledUsd == 0m);
+    }
+
+    // ───────────────────── AC11 — physical isolation + budget-join scope ─────────────────────
+
+    [Test]
+    public async Task GetCost_IsHardScopedToTheCallersSchema_IncludingTheBudgetJoin()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var schemaA = TenantNaming.SchemaName(tenantA);
+        var schemaB = TenantNaming.SchemaName(tenantB);
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(schemaB));
+
+        var day = new DateTime(2026, 5, 3, 0, 0, 0, DateTimeKind.Utc);
+        await SeedDailyAsync(schemaA, tenantA, day, CostBasis.Platform, cost: 10m, billed: 12m, provider: "anthropic");
+        await SeedDailyAsync(schemaB, tenantB, day, CostBasis.Platform, cost: 100m, billed: 200m, provider: "openai");
+
+        // Budget only in tenant A's schema — proves the join is tenant-scoped.
+        await SeedBudgetAsync(schemaA, tenantA, limitUsd: 1000m);
+
+        var factory = new SchemaRoutingFactory(_baseConnectionString)
+            .Map(tenantA, schemaA)
+            .Map(tenantB, schemaB);
+        // Real BudgetConfigRepository over the same routing factory → the join
+        // physically reads each tenant's own schema.
+        var budgets = new BudgetConfigRepository(factory, NullLogger<BudgetConfigRepository>.Instance);
+        var service = new CostAnalyticsService(
+            factory, budgets, NoOpEvents(), new FixedClock(May15), NullLogger<CostAnalyticsService>.Instance);
+
+        var a = await service.GetCostAsync(tenantA, MayWindow(), null, "saas", CancellationToken.None);
+        a.Summary.MtdPlatformBilledUsd.Should().Be(12m, "tenant A sees only its own spend");
+        a.Series.Should().OnlyContain(s => s.PlatformBilledUsd != 200m, "tenant B's spend must never leak into A");
+        a.Summary.BudgetUsd.Should().Be(1000m, "the budget join reads tenant A's BudgetConfig");
+
+        var b = await service.GetCostAsync(tenantB, MayWindow(), null, "saas", CancellationToken.None);
+        b.Summary.MtdPlatformBilledUsd.Should().Be(200m, "tenant B sees only its own spend");
+        b.Summary.BudgetUsd.Should().BeNull("tenant B has no BudgetConfig row — the join is scoped to B");
+    }
+
+    // ──────────────────────────────── Helpers ────────────────────────────────
+
+    private CostAnalyticsService BuildService(Guid tenant, string schema, IBudgetConfigRepository budgets)
+    {
+        var factory = new SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        return new CostAnalyticsService(
+            factory, budgets, NoOpEvents(), new FixedClock(May15), NullLogger<CostAnalyticsService>.Instance);
+    }
+
+    private static IBudgetConfigRepository NoBudget()
+    {
+        var m = new Mock<IBudgetConfigRepository>();
+        m.Setup(b => b.GetAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((BudgetConfig?)null);
+        return m.Object;
+    }
+
+    private static IEventRepository NoOpEvents()
+    {
+        var m = new Mock<IEventRepository>();
+        m.Setup(e => e.GetLastByTypeAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync((DomainEvent?)null);
+        m.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>())).ReturnsAsync((DomainEvent e) => e);
+        return m.Object;
+    }
+
+    private async Task SeedDailyAsync(
+        string schema, Guid tenantId, DateTime day, CostBasis basis,
+        decimal cost, decimal billed, string? provider)
+    {
+        var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options;
+        await using var ctx = new TenantDbContext(opts, tenantId);
+        ctx.AnalyticsUsageDaily.Add(new AnalyticsUsageDaily
+        {
+            Id = Guid.NewGuid(),
+            Day = day,
+            Provider = provider,
+            CostBasis = basis,
+            TokensIn = 0,
+            TokensOut = 0,
+            CostUsd = cost,
+            PlatformBilledUsd = billed,
+            WorkflowsStarted = 0,
+            WorkflowsCompleted = 0,
+            WorkflowsFailed = 0,
+            AgentDispatches = 0,
+            ComputedAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    private async Task SeedBudgetAsync(string schema, Guid tenantId, decimal limitUsd)
+    {
+        var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options;
+        await using var ctx = new TenantDbContext(opts, tenantId);
+        ctx.BudgetConfigs.Add(new BudgetConfig
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            AccountId = tenantId.ToString(),
+            LimitUsd = limitUsd,
+            AlertThreshold = 0.8,
+            PeriodDays = 30,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await ctx.SaveChangesAsync();
+    }
+
+    /// <summary>Routes each tenant id to its own search-path schema connection.</summary>
+    private sealed class SchemaRoutingFactory(string baseCs) : ITenantDbContextFactory
+    {
+        private readonly Dictionary<Guid, string> _schemas = new();
+
+        public SchemaRoutingFactory Map(Guid tenantId, string schema)
+        {
+            _schemas[tenantId] = schema;
+            return this;
+        }
+
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            if (!_schemas.TryGetValue(tenantId, out var schema))
+            {
+                throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+            }
+
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options;
+            return new ValueTask<TenantDbContext>(new TenantDbContext(opts, tenantId));
+        }
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsServiceTests.cs
@@ -1,0 +1,419 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Analytics;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Analytics;
+
+/// <summary>
+/// Story 36-4 — unit tests for the cost/spend read seam (EF-InMemory; no
+/// Postgres). Covers the BYOK/platform split (AC2/AC5), month-to-date + linear
+/// run-rate projection against a fixed clock (AC3), the <c>BudgetConfig</c> join
+/// + budget-vs-actual (AC3/AC7), grouping with <c>NULL→"unattributed"</c>
+/// reconciliation (AC2), the read-only / no-re-markup contract (AC4/AC10), trend
+/// (AC6), the budget-exceeded DCB event + per-period dedup + swallowed failure
+/// (AC9), and empty-state (AC12). Physical isolation + the fully-BYOK end-to-end
+/// split are proven on real Postgres in <see cref="CostAnalyticsIsolationTests"/>.
+/// </summary>
+[TestFixture]
+public class CostAnalyticsServiceTests
+{
+    private static readonly DateTimeOffset July15 =
+        new(2026, 7, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private static DateTime Utc(int y, int m, int d) => new(y, m, d, 0, 0, 0, DateTimeKind.Utc);
+
+    private static AnalyticsWindow JulyWindow() =>
+        AnalyticsWindow.Resolve(Utc(2026, 7, 1), Utc(2026, 8, 1), "day");
+
+    // ─────────────────────────── BYOK / platform split ───────────────────────────
+
+    [Test]
+    public async Task GetCost_SplitsByokCostFromPlatformBilled_ByokRowsNeverContributeToPlatform()
+    {
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 3), CostBasis.Byok, cost: 5m, billed: 0m),
+            Daily(Utc(2026, 7, 4), CostBasis.Platform, cost: 10m, billed: 12m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Series.Should().HaveCount(2);
+        var byokDay = res.Series.Single(s => s.Day == new DateOnly(2026, 7, 3));
+        byokDay.ByokCostUsd.Should().Be(5m);
+        byokDay.PlatformBilledUsd.Should().Be(0m, "a BYOK row carries PlatformBilledUsd=0");
+
+        var platDay = res.Series.Single(s => s.Day == new DateOnly(2026, 7, 4));
+        platDay.ByokCostUsd.Should().Be(0m, "a platform row never adds to byokCostUsd");
+        platDay.PlatformBilledUsd.Should().Be(12m);
+
+        res.Summary.ByokCostUsd.Should().Be(5m, "window BYOK total is informational");
+    }
+
+    [Test]
+    public async Task GetCost_PlatformBilled_IsTheMaterialisedColumn_NotRawCost_NoReMarkup()
+    {
+        // billed (12) != cost (10) and != cost×anyMargin — proving the endpoint
+        // reads the materialised PlatformBilledUsd column, never recomputes it.
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 10m, billed: 12m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Series.Single().PlatformBilledUsd.Should().Be(12m);
+        res.Summary.MtdPlatformBilledUsd.Should().Be(12m);
+    }
+
+    [Test]
+    public void CostAnalyticsService_HasNoMarkupOrPricingDependency_AC4_AC10()
+    {
+        var ctorParamNames = typeof(CostAnalyticsService)
+            .GetConstructors().Single()
+            .GetParameters().Select(p => p.ParameterType.Name).ToList();
+
+        ctorParamNames.Should().NotContain(
+            n => n.Contains("Pricing") || n.Contains("Markup") || n.Contains("Margin"),
+            "the cost endpoint reads PlatformBilledUsd as the single source of truth — "
+                + "it must not depend on the Story 34-5 markup engine or any pricing config");
+    }
+
+    // ──────────────────────── Projection (fixed clock) ────────────────────────
+
+    [Test]
+    public async Task GetCost_Projection_IsLinearRunRate_MtdOverDaysElapsedTimesDaysInMonth()
+    {
+        // day 15 of 31; mtd platform-billed = 150 → projected = 150/15*31 = 310.
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 2), CostBasis.Platform, cost: 50m, billed: 50m),
+            Daily(Utc(2026, 7, 8), CostBasis.Platform, cost: 100m, billed: 100m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.MtdPlatformBilledUsd.Should().Be(150m);
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(310m);
+    }
+
+    [Test]
+    public async Task GetCost_MtdExcludesRowsDatedAfterToday_ProjectionIsToDate()
+    {
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 10), CostBasis.Platform, cost: 100m, billed: 100m),
+            Daily(Utc(2026, 7, 20), CostBasis.Platform, cost: 999m, billed: 999m)); // future — excluded from MTD
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.MtdPlatformBilledUsd.Should().Be(100m, "MTD is to-date; the July-20 row is in the future");
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(100m / 15 * 31);
+    }
+
+    [Test]
+    public async Task GetCost_ZeroMtd_ProjectsZero_NoDivideByZero()
+    {
+        var ctx = await SeedAsync(July15, budget: null); // no rows at all
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.MtdPlatformBilledUsd.Should().Be(0m);
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(0m);
+    }
+
+    // ──────────────────────── Budget join / budget-vs-actual ────────────────────────
+
+    [Test]
+    public async Task GetCost_WithBudget_ReportsUtilizationAndProjectedToExceed()
+    {
+        // day 15; mtd = 300 → projected = 620. budget = 400 → projected exceeds.
+        var budget = new BudgetConfig { LimitUsd = 400m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.BudgetUsd.Should().Be(400m);
+        res.Summary.AlertThreshold.Should().Be(0.8);
+        res.Summary.BudgetUtilizationPct.Should().BeApproximately(0.75, 1e-9);     // 300/400
+        res.Summary.ProjectedUtilizationPct.Should().BeApproximately(1.55, 1e-9);  // 620/400
+        res.Summary.ProjectedToExceedBudget.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task GetCost_NoBudget_UtilizationFieldsAreNull_SeriesStillReturned()
+    {
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 100m, billed: 100m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.BudgetUsd.Should().BeNull();
+        res.Summary.AlertThreshold.Should().BeNull();
+        res.Summary.BudgetUtilizationPct.Should().BeNull();
+        res.Summary.ProjectedUtilizationPct.Should().BeNull();
+        res.Summary.ProjectedToExceedBudget.Should().BeFalse();
+        res.Series.Should().ContainSingle();
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(100m / 15 * 31);
+    }
+
+    // ───────────────────────── Grouping + reconciliation ─────────────────────────
+
+    [Test]
+    public async Task GetCost_GroupByProvider_NullSurfacedAsUnattributed_ReconcilesToTotal()
+    {
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 6), CostBasis.Byok, cost: 4m, billed: 0m, provider: "anthropic"),
+            Daily(Utc(2026, 7, 6), CostBasis.Platform, cost: 6m, billed: 6m, provider: "openai"),
+            Daily(Utc(2026, 7, 6), CostBasis.Platform, cost: 2m, billed: 3m, provider: null));
+
+        var grouped = await ctx.Svc.GetCostAsync(
+            ctx.TenantId, JulyWindow(), AnalyticsDimension.Provider, "saas", CancellationToken.None);
+        var ungrouped = await ctx.Svc.GetCostAsync(
+            ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        grouped.GroupBy.Should().Be("provider");
+        grouped.Series.Should().HaveCount(3);
+        grouped.Series.Should().ContainSingle(s => s.Group == "unattributed")
+            .Which.PlatformBilledUsd.Should().Be(3m, "the NULL-provider bucket is surfaced, never dropped");
+
+        var day = new DateOnly(2026, 7, 6);
+        grouped.Series.Where(s => s.Day == day).Sum(s => s.ByokCostUsd)
+            .Should().Be(ungrouped.Series.Single(s => s.Day == day).ByokCostUsd);
+        grouped.Series.Where(s => s.Day == day).Sum(s => s.PlatformBilledUsd)
+            .Should().Be(ungrouped.Series.Single(s => s.Day == day).PlatformBilledUsd);
+    }
+
+    [Test]
+    public async Task GetCost_GroupByAgent_NullSurfacedAsUnattributed()
+    {
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 6), CostBasis.Platform, cost: 6m, billed: 6m, agent: "reviewer"),
+            Daily(Utc(2026, 7, 6), CostBasis.Platform, cost: 2m, billed: 3m, agent: null));
+
+        var grouped = await ctx.Svc.GetCostAsync(
+            ctx.TenantId, JulyWindow(), AnalyticsDimension.Agent, "saas", CancellationToken.None);
+
+        grouped.GroupBy.Should().Be("agent");
+        grouped.Series.Should().Contain(s => s.Group == "reviewer");
+        grouped.Series.Should().Contain(s => s.Group == "unattributed");
+    }
+
+    // ──────────────────────────────── Trend ────────────────────────────────
+
+    [Test]
+    public async Task GetCost_Trend_ComparesToPriorEquivalentWindow()
+    {
+        // window [Jul8, Jul15) len 7 → prior [Jul1, Jul8).
+        var window = AnalyticsWindow.Resolve(Utc(2026, 7, 8), Utc(2026, 7, 15), "day");
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 10), CostBasis.Platform, cost: 120m, billed: 120m), // in-window
+            Daily(Utc(2026, 7, 10), CostBasis.Byok, cost: 30m, billed: 0m),
+            Daily(Utc(2026, 7, 3), CostBasis.Platform, cost: 100m, billed: 100m),  // prior
+            Daily(Utc(2026, 7, 3), CostBasis.Byok, cost: 20m, billed: 0m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, window, null, "saas", CancellationToken.None);
+
+        res.Trend.PlatformBilledUsd.Should().Be(100m, "prior-window platform-billed total");
+        res.Trend.PlatformBilledDeltaPct.Should().BeApproximately(0.20, 1e-9); // (120-100)/100
+        res.Trend.ByokCostUsd.Should().Be(20m);
+        res.Trend.ByokCostDeltaPct.Should().BeApproximately(0.50, 1e-9);       // (30-20)/20
+    }
+
+    [Test]
+    public async Task GetCost_Trend_EmptyPriorWindow_YieldsNullDelta()
+    {
+        var window = AnalyticsWindow.Resolve(Utc(2026, 7, 8), Utc(2026, 7, 15), "day");
+        var ctx = await SeedAsync(July15, budget: null,
+            Daily(Utc(2026, 7, 10), CostBasis.Platform, cost: 120m, billed: 120m)); // in-window only
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, window, null, "saas", CancellationToken.None);
+
+        res.Trend.PlatformBilledUsd.Should().Be(0m);
+        res.Trend.PlatformBilledDeltaPct.Should().BeNull();
+        res.Trend.ByokCostDeltaPct.Should().BeNull();
+    }
+
+    // ──────────────────────── Budget-exceeded DCB event ────────────────────────
+
+    [Test]
+    public async Task GetCost_ProjectionOverBudget_EmitsOneBudgetExceededEvent()
+    {
+        var budget = new BudgetConfig { LimitUsd = 400m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m)); // proj 620 > 400
+
+        await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        ctx.Events.Verify(e => e.AppendAsync(It.Is<DomainEvent>(ev =>
+            ev.Type == CostAnalyticsEvents.BudgetProjectedExceeded
+            && ev.TenantId == ctx.TenantId
+            && ev.Tags.Contains("\"period\":\"2026-07\"")
+            && ev.Tags.Contains("\"mode\":\"saas\"")
+            && ev.Data.Contains("projectedPlatformBilledUsd"))), Times.Once);
+    }
+
+    [Test]
+    public async Task GetCost_ProjectionOverBudget_DedupsWithinTheSamePeriod()
+    {
+        var budget = new BudgetConfig { LimitUsd = 400m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m));
+
+        // An event for this same period (2026-07) already exists → skip.
+        ctx.Events.Setup(e => e.GetLastByTypeAsync(ctx.TenantId, CostAnalyticsEvents.BudgetProjectedExceeded))
+            .ReturnsAsync(new DomainEvent
+            {
+                Type = CostAnalyticsEvents.BudgetProjectedExceeded,
+                TenantId = ctx.TenantId,
+                Tags = "{\"tenantId\":\"x\",\"mode\":\"saas\",\"period\":\"2026-07\"}",
+            });
+
+        await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        ctx.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetCost_ProjectionOverBudget_EmitsAgainWhenLastEventIsAPriorPeriod()
+    {
+        var budget = new BudgetConfig { LimitUsd = 400m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m));
+
+        ctx.Events.Setup(e => e.GetLastByTypeAsync(ctx.TenantId, CostAnalyticsEvents.BudgetProjectedExceeded))
+            .ReturnsAsync(new DomainEvent
+            {
+                Type = CostAnalyticsEvents.BudgetProjectedExceeded,
+                TenantId = ctx.TenantId,
+                Tags = "{\"period\":\"2026-06\"}", // a different (prior) period
+            });
+
+        await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        ctx.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Once);
+    }
+
+    [Test]
+    public async Task GetCost_ProjectionUnderBudget_EmitsNoEvent()
+    {
+        var budget = new BudgetConfig { LimitUsd = 100_000m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 10m, billed: 10m));
+
+        await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        ctx.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    [Test]
+    public async Task GetCost_EventAppendFailure_IsSwallowed_ResponseStillReturns()
+    {
+        var budget = new BudgetConfig { LimitUsd = 400m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m));
+
+        ctx.Events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ThrowsAsync(new InvalidOperationException("event store down"));
+
+        var act = async () => await ctx.Svc.GetCostAsync(
+            ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        var res = await act.Should().NotThrowAsync();
+        res.Which.Summary.ProjectedToExceedBudget.Should().BeTrue();
+    }
+
+    // ──────────────────────────────── Empty state ────────────────────────────────
+
+    [Test]
+    public async Task GetCost_NoFactRows_ReturnsWellFormedEmptyResponse()
+    {
+        var ctx = await SeedAsync(July15, budget: null);
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Series.Should().BeEmpty();
+        res.Summary.ByokCostUsd.Should().Be(0m);
+        res.Summary.MtdPlatformBilledUsd.Should().Be(0m);
+        res.Summary.ProjectedPlatformBilledUsd.Should().Be(0m);
+        res.Trend.PlatformBilledUsd.Should().Be(0m);
+        res.Trend.PlatformBilledDeltaPct.Should().BeNull();
+        res.Window.From.Should().Be(new DateOnly(2026, 7, 1));
+        res.Window.To.Should().Be(new DateOnly(2026, 8, 1));
+    }
+
+    // ──────────────────────────────── Helpers ────────────────────────────────
+
+    private sealed record Ctx(
+        CostAnalyticsService Svc,
+        Guid TenantId,
+        Mock<IEventRepository> Events,
+        Mock<IBudgetConfigRepository> Budgets);
+
+    private static async Task<Ctx> SeedAsync(
+        DateTimeOffset now, BudgetConfig? budget, params AnalyticsUsageDaily[] rows)
+    {
+        var tenantId = Guid.NewGuid();
+        var dbName = $"cost_{Guid.NewGuid():N}";
+        await using (var seed = NewContext(dbName, tenantId))
+        {
+            seed.AnalyticsUsageDaily.AddRange(rows);
+            await seed.SaveChangesAsync();
+        }
+
+        var budgets = new Mock<IBudgetConfigRepository>();
+        budgets.Setup(b => b.GetAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(budget);
+
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.GetLastByTypeAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .ReturnsAsync((DomainEvent?)null);
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent e) => e);
+
+        var svc = new CostAnalyticsService(
+            new InMemoryFactory(dbName), budgets.Object, events.Object,
+            new FixedClock(now), NullLogger<CostAnalyticsService>.Instance);
+        return new Ctx(svc, tenantId, events, budgets);
+    }
+
+    private static TenantDbContext NewContext(string dbName, Guid tenantId) =>
+        new(new DbContextOptionsBuilder<TenantDbContext>().UseInMemoryDatabase(dbName).Options, tenantId);
+
+    private static AnalyticsUsageDaily Daily(
+        DateTime day, CostBasis basis, decimal cost, decimal billed,
+        string? provider = null, string? agent = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Day = day,
+        Provider = provider,
+        AgentId = agent,
+        WorkflowDefinitionId = null,
+        RepoId = null,
+        CostBasis = basis,
+        TokensIn = 0,
+        TokensOut = 0,
+        CostUsd = cost,
+        PlatformBilledUsd = billed,
+        WorkflowsStarted = 0,
+        WorkflowsCompleted = 0,
+        WorkflowsFailed = 0,
+        AgentDispatches = 0,
+        ComputedAt = DateTime.UtcNow,
+    };
+
+    private sealed class InMemoryFactory(string dbName) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken cancellationToken = default) =>
+            new(new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseInMemoryDatabase(dbName).Options, tenantId));
+    }
+
+    private sealed class FixedClock(DateTimeOffset now) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => now;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Analytics/CostAnalyticsServiceTests.cs
@@ -160,6 +160,26 @@ public class CostAnalyticsServiceTests
         res.Summary.ProjectedPlatformBilledUsd.Should().Be(100m / 15 * 31);
     }
 
+    [Test]
+    public async Task GetCost_StoredZeroLimitBudget_TreatedAsNoMeaningfulBudget_NoExceedNoEvent()
+    {
+        // A persisted BudgetConfig with LimitUsd = 0 (e.g. BudgetConfigDefaults.DefaultLimitUsd)
+        // plus real platform spend must be consistent: projectedToExceedBudget=false and null
+        // utilisation pcts (the "no meaningful budget" story), NOT the asymmetric
+        // projectedToExceed:true / budgetUsd:0 mix — and NO spurious budget-exceeded event.
+        var budget = new BudgetConfig { LimitUsd = 0m, AlertThreshold = 0.8, PeriodDays = 30 };
+        var ctx = await SeedAsync(July15, budget,
+            Daily(Utc(2026, 7, 5), CostBasis.Platform, cost: 300m, billed: 300m));
+
+        var res = await ctx.Svc.GetCostAsync(ctx.TenantId, JulyWindow(), null, "saas", CancellationToken.None);
+
+        res.Summary.ProjectedToExceedBudget.Should().BeFalse(
+            "a LimitUsd <= 0 budget is not a meaningful budget to exceed");
+        res.Summary.BudgetUtilizationPct.Should().BeNull();
+        res.Summary.ProjectedUtilizationPct.Should().BeNull();
+        ctx.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
     // ───────────────────────── Grouping + reconciliation ─────────────────────────
 
     [Test]


### PR DESCRIPTION
## What

Story 36-4 (P0). Tenant-facing cost/spend breakdown over the 36-1/36-2 dimensional facts: `GET /api/v1/orgs/{tenantId}/analytics/cost` — daily `byokCostUsd` (Σ CostUsd of byok rows) + `platformBilledUsd` (tenant's own billed), optional `groupBy=provider|agent` (NULL → "unattributed", reconciles to total), MTD summary + linear run-rate projection + budget utilization, and a best-effort per-(tenant, period)-deduped `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` DCB event.

Reuses 36-3's `AnalyticsWindow` (UTC + caps), `RequireTenantMembershipFilter`, and `ITenantDbContextFactory` verbatim — no reinvention. Membership-gated, physically tenant-scoped. **No migration** (reads existing columns).

## Review outcome

Focused adversarial review (leak + projection math were the skepticism targets): **no revenue/margin leak** (a platform row's raw `CostUsd` is never summed into any field), projection math clean (no div-by-zero, `TimeProvider`, decimal), BYOK/platform reconciliation correct, budget-join tenant-isolated. One finding fixed:
- **Asymmetric budget gate:** `projectedToExceedBudget` + the alert event fired on a stored `LimitUsd <= 0` budget while utilization pcts went null → now gated on the same `hasBudget` predicate, so a non-positive budget yields `false` + null pcts + no event.

(Accepted as-is per review: dedup is best-effort read-then-write; `summary` is always current-month by design.)

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes." Cost tests: 48 passed (incl. two-schema Postgres isolation + reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)