### PR TITLE
feat(epic-37): Story 37-3 — Audit Query, Search & Filter API

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditQueryResponse.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditQueryResponse.cs
@@ -1,0 +1,23 @@
+namespace Tamma.Api.Dtos.Audit;
+
+/// <summary>
+/// Story 37-3 — the audit query envelope. <see cref="NextCursor"/> is the
+/// opaque keyset cursor for the following page (<c>null</c> on the last page,
+/// AC5). <see cref="Total"/> is an ESTIMATE — a capped exact count (exact up to
+/// <see cref="CountCap"/>, then reported as the cap) so paging is never gated on
+/// a full <c>COUNT(*)</c> over millions of rows (AC9). When
+/// <see cref="TotalIsCapped"/> is true, the true total is "<see cref="Total"/>+".
+/// </summary>
+/// <param name="Records">The page of curated audit rows, most-recent first.</param>
+/// <param name="NextCursor">Opaque cursor for the next page, or null on the last page.</param>
+/// <param name="Total">Estimated count of rows matching the filters (capped).</param>
+/// <param name="TotalIsCapped">True when <see cref="Total"/> hit the count cap (true total is higher).</param>
+public sealed record AuditQueryResponse(
+    IReadOnlyList<AuditRecordResponse> Records,
+    string? NextCursor,
+    int Total,
+    bool TotalIsCapped)
+{
+    /// <summary>Exact-count cap — beyond this the total is reported as "<c>N+</c>".</summary>
+    public const int CountCap = 10_000;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditRecordResponse.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditRecordResponse.cs
@@ -1,0 +1,36 @@
+namespace Tamma.Api.Dtos.Audit;
+
+/// <summary>
+/// Story 37-3 (AC11) — the wire projection of one curated
+/// <c>audit_records</c> row. Mirrors the existing <c>AuditEventResponse</c>
+/// precedent by exposing the JSON payload as a raw string. Story-37-2 chain
+/// columns (<c>RecordHash</c>/<c>PrevRecordHash</c>) and raw DCB back-reference
+/// metadata are deliberately NOT exposed.
+/// </summary>
+/// <param name="Id">Surrogate row id.</param>
+/// <param name="ActionCategory">Compliance category (e.g. <c>secret</c>).</param>
+/// <param name="ActionCode">Canonical action / event-type code (e.g. <c>SECRET.REVEAL</c>).</param>
+/// <param name="ActorUserId">Acting user id, or null for system actions.</param>
+/// <param name="ActorLabel">Point-in-time actor email snapshot, or null.</param>
+/// <param name="TargetType">Target object type, or null.</param>
+/// <param name="TargetId">Target object id, or null.</param>
+/// <param name="Severity"><c>info</c> | <c>notice</c> | <c>warning</c> | <c>critical</c>.</param>
+/// <param name="Outcome"><c>success</c> | <c>failure</c> | <c>denied</c>.</param>
+/// <param name="IpAddress">Source IP, or null.</param>
+/// <param name="OccurredAt">When the audited action occurred (UTC).</param>
+/// <param name="Payload">Redacted JSON payload as a raw string.</param>
+/// <param name="SourceSequenceNumber">Monotonic DCB sequence — also the keyset cursor source.</param>
+public sealed record AuditRecordResponse(
+    Guid Id,
+    string ActionCategory,
+    string ActionCode,
+    Guid? ActorUserId,
+    string? ActorLabel,
+    string? TargetType,
+    string? TargetId,
+    string Severity,
+    string Outcome,
+    string? IpAddress,
+    DateTime OccurredAt,
+    string Payload,
+    long SourceSequenceNumber);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Auth;
 using Tamma.Api.Dtos.Admin;
 using Tamma.Api.Services;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.PromptStore;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Services.Provisioning;
 using Tamma.Api.Services.Provisioning.Cranl;
@@ -504,5 +506,56 @@ public static class AdminEndpoints
         if (registry.RegisteredKeys.Contains(CranlCapabilities.ProviderKey))
             return (CranlCapabilities.ProviderKey, ProvisioningTopology.DedicatedCompute);
         return (NullTenantProvider.Key, ProvisioningTopology.DatabaseOnly);
+    }
+
+    /// <summary>
+    /// Story 37-3 (AC2) — platform-scope audit query over the control-plane
+    /// <c>audit_records</c> rows (impersonation, tenant lifecycle, platform RBAC,
+    /// platform-level BYOK). Same filter + keyset surface as the tenant endpoint;
+    /// physically a DIFFERENT set of rows — this NEVER reads a tenant's audit and
+    /// vice-versa. Gated <c>PlatformOwnerAccess</c> at the wiring site (AC7).
+    /// </summary>
+    public static async Task<IResult> ListPlatformAudit(
+        IAuditQueryService auditQuery,
+        ITammaModeProvider modeProvider,
+        ClaimsPrincipal principal,
+        ILoggerFactory loggerFactory,
+        [FromQuery] string? category,
+        [FromQuery] string? action,
+        [FromQuery] string? actorUserId,
+        [FromQuery] string? targetType,
+        [FromQuery] string? targetId,
+        [FromQuery] string? severity,
+        [FromQuery] string? outcome,
+        [FromQuery] string? ipAddress,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? q,
+        [FromQuery] int? limit,
+        [FromQuery] string? cursor,
+        [FromQuery] string? type,
+        [FromQuery] int? offset,
+        CancellationToken ct)
+    {
+        var log = loggerFactory.CreateLogger("Tamma.Api.Endpoints.AdminEndpoints.ListPlatformAudit");
+
+        var effectiveAction = string.IsNullOrWhiteSpace(action) ? type : action;
+        if (offset is not null && offset != 0)
+        {
+            log.LogWarning(
+                "Deprecated 'offset' param supplied to platform audit query (ignored — "
+                    + "use keyset 'cursor').");
+        }
+
+        var (filter, error) = AuditQueryFilter.TryParse(
+            category, effectiveAction, actorUserId, targetType, targetId, severity,
+            outcome, ipAddress, from, to, q, limit, cursor);
+        if (filter is null)
+            return Results.BadRequest(new { error });
+
+        var callerUserId = principal.GetUserId();
+        var result = await auditQuery.QueryPlatformAsync(
+            callerUserId, filter, modeProvider.Mode, ct);
+        return Results.Ok(result);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -1,11 +1,14 @@
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Auth;
 using Tamma.Api.Authorization;
 using Tamma.Api.Dtos.Orgs;
+using Tamma.Api.Services.Audit;
 using Tamma.Api.Services.Email;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Api.Services.RateLimit;
 using Tamma.Api.Services.TenantStatus;
 using Tamma.Api.Validation;
@@ -532,54 +535,74 @@ public static class OrgEndpoints
     }
 
     /// <summary>
-    /// Story 18-7 task 2 — tenant-scoped audit-log read. Returns events
-    /// whose <c>TenantId</c> matches the path tenant, most-recent first,
-    /// paginated. <see cref="RequireTenantMembershipFilter"/> already
-    /// enforces caller membership; this handler additionally requires
-    /// admin+. The event store's global query filter provides defence
-    /// in depth (cross-tenant rows are rejected even if the explicit
-    /// filter regresses).
+    /// Story 37-3 (was 18-7 task 2) — tenant-scoped audit query over the curated
+    /// <c>audit_records</c> read-model (Story 37-1), replacing the thin type-prefix
+    /// read over raw <c>domain_events</c>. Rich filtering (<c>category</c> /
+    /// <c>action</c> / <c>actorUserId</c> / <c>targetType</c> / <c>targetId</c> /
+    /// <c>severity</c> / <c>outcome</c> / <c>ipAddress</c> / <c>from</c> / <c>to</c>
+    /// / <c>q</c>) with keyset (<c>cursor</c>) pagination.
+    ///
+    /// <para><b>RBAC (AC7):</b> <see cref="RequireTenantMembershipFilter"/> (wired
+    /// on the route) rejects non-members (403) and stashes the caller's role;
+    /// this handler additionally requires admin+ (a SaaS <c>member</c> gets 403).
+    /// A cross-tenant caller never reaches the handler (membership 403).</para>
+    ///
+    /// <para><b>Backward compat (AC12):</b> the legacy <c>?type=</c> maps onto the
+    /// new exact <c>action</c> filter; the legacy <c>?offset=</c> is
+    /// accepted-but-ignored-with-WARN (keyset replaces it) for one release so the
+    /// existing dashboard does not break.</para>
     /// </summary>
     public static async Task<IResult> ListTenantAudit(
         Guid tenantId,
-        IEventRepository events,
-        ITenantContext tenantContext,
+        IAuditQueryService auditQuery,
+        ITammaModeProvider modeProvider,
+        ClaimsPrincipal principal,
         HttpContext httpContext,
-        int? limit,
-        int? offset,
-        string? type)
+        ILoggerFactory loggerFactory,
+        [FromQuery] string? category,
+        [FromQuery] string? action,
+        [FromQuery] string? actorUserId,
+        [FromQuery] string? targetType,
+        [FromQuery] string? targetId,
+        [FromQuery] string? severity,
+        [FromQuery] string? outcome,
+        [FromQuery] string? ipAddress,
+        [FromQuery] DateTime? from,
+        [FromQuery] DateTime? to,
+        [FromQuery] string? q,
+        [FromQuery] int? limit,
+        [FromQuery] string? cursor,
+        [FromQuery] string? type,
+        [FromQuery] int? offset,
+        CancellationToken ct)
     {
+        var log = loggerFactory.CreateLogger("Tamma.Api.Endpoints.OrgEndpoints.ListTenantAudit");
+
         var requesterRole = httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey] as string;
         if (requesterRole is null)
             return Results.Json(new { error = "Not a member of this organization" }, statusCode: 403);
         if (!TenantRoleHierarchy.IsAtLeast(requesterRole, TenantRoleHierarchy.Admin))
             return Results.Json(new { error = "Requires admin role or higher" }, statusCode: 403);
 
-        var clampedLimit = Math.Clamp(limit ?? 50, 1, 200);
-        var clampedOffset = Math.Max(offset ?? 0, 0);
-
-        // Set ambient tenant context so the global query filter on
-        // domain_events triggers the defence-in-depth path. Idempotent —
-        // RequireTenantMembershipFilter usually sets this too, but be
-        // explicit so this handler is safe when called in isolation.
-        tenantContext.SetTenantId(tenantId);
-
-        var (rows, total) = await events.ListByTenantAsync(tenantId, type, clampedLimit, clampedOffset);
-
-        var projected = rows.Select(e => new AuditEventResponse(
-            e.Id,
-            e.Type,
-            e.CreatedAt,
-            e.Tags,
-            e.Data)).ToList();
-
-        return Results.Ok(new
+        // Backward-compat: legacy ?type= → exact `action`; legacy ?offset= ignored.
+        var effectiveAction = string.IsNullOrWhiteSpace(action) ? type : action;
+        if (offset is not null && offset != 0)
         {
-            events = projected,
-            total,
-            limit = clampedLimit,
-            offset = clampedOffset,
-        });
+            log.LogWarning(
+                "Deprecated 'offset' param supplied to tenant audit query (ignored — "
+                    + "use keyset 'cursor'). tenantId={TenantId}", tenantId);
+        }
+
+        var (filter, error) = AuditQueryFilter.TryParse(
+            category, effectiveAction, actorUserId, targetType, targetId, severity,
+            outcome, ipAddress, from, to, q, limit, cursor);
+        if (filter is null)
+            return Results.BadRequest(new { error });
+
+        var callerUserId = principal.GetUserId();
+        var result = await auditQuery.QueryTenantAsync(
+            tenantId, callerUserId, filter, modeProvider.Mode, ct);
+        return Results.Ok(result);
     }
 
     public static async Task<IResult> AcceptInvite(

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1015,6 +1015,16 @@ builder.Services.AddTammaAlertRuleEngine();
 // background loop is opt-in (AuditProjectorOptions.RunOnStartup defaults false).
 builder.Services.AddTammaAuditProjection();
 
+// Story 37-3 — audit query/search/filter read seam over the curated
+// audit_records read-model (Story 37-1). Scoped (depends on the scoped
+// ControlPlaneDbContext); reads the tenant schema via ITenantDbContextFactory
+// (SaaS) or the CP by user/tenant-null (single-user / platform). Read-only —
+// it never re-projects raw events; the only write is the best-effort
+// AUDIT.QUERIED meta-audit event.
+builder.Services.AddScoped<
+    Tamma.Api.Services.Audit.IAuditQueryService,
+    Tamma.Api.Services.Audit.AuditQueryService>();
+
 // Story 34-1 — plan price-book catalog: read-only IPlanCatalogService +
 // the PlanVersionEditor (immutable, versioned plan management). CP-resident;
 // platform-owned in both modes.
@@ -1838,6 +1848,13 @@ v1Admin.MapPatch("/alert-rules/{id:guid}", AlertRuleEndpoints.UpdateRule)
 v1Admin.MapDelete("/alert-rules/{id:guid}", AlertRuleEndpoints.DeleteRule)
     .RequireAuthorization("PlatformOwnerAccess");
 v1Admin.MapPost("/alert-rules/{id:guid}/_test", AlertRuleEndpoints.TestFireRule)
+    .RequireAuthorization("PlatformOwnerAccess");
+
+// Story 37-3 — platform-scope audit query. Same PlatformOwnerAccess gate as
+// the alerts/alert-rules platform-admin surface (cross-tenant + platform-
+// internal blast radius). Reads ONLY the control-plane audit_records rows;
+// a tenant's audit lives in a different schema and is never returned here.
+v1Admin.MapGet("/audit", AdminEndpoints.ListPlatformAudit)
     .RequireAuthorization("PlatformOwnerAccess");
 
 // Story 29-3 — platform-scope secret-cabinet create + rotate. Both

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryEventTypes.cs
@@ -1,0 +1,18 @@
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-3 — DCB event types emitted by the audit query surface itself.
+/// The meta-audit event (<see cref="Queried"/>) makes "who read the audit log,
+/// with what filters, and how many rows came back" itself auditable (AC10).
+///
+/// <para><b>Not an <c>audit_records</c> row.</b> <see cref="Queried"/> is a raw
+/// DCB event (<c>domain_events</c> / <c>platform_events</c>), NOT a curated
+/// audit row, so it does not feed back into this query surface (no recursion).
+/// Whether it is later PROJECTED into the curated trail is a Story 37-1 catalog
+/// decision, independent of this story.</para>
+/// </summary>
+public static class AuditQueryEventTypes
+{
+    /// <summary>Emitted best-effort after every successful audit read.</summary>
+    public const string Queried = "AUDIT.QUERIED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryFilter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryFilter.cs
@@ -4,6 +4,22 @@ using Tamma.Core.Audit;
 namespace Tamma.Api.Services.Audit;
 
 /// <summary>
+/// Story 37-3 — the keyset position: the last-seen row's TOTAL-order key. The
+/// audit read orders by <c>(source_sequence_number DESC, id DESC)</c>.
+///
+/// <para><b>Why the compound key:</b> in the control-plane <c>audit_records</c>
+/// table <c>source_sequence_number</c> is NOT unique — the table is fed by two
+/// independent identity sequences (<c>domain_events.SequenceNumber</c> AND
+/// <c>platform_events.SequenceNumber</c>, both starting at 1) whose values
+/// collide; the table is unique only on <c>source_event_id</c>. Seeking on the
+/// sequence alone would silently drop the OTHER row that shares the boundary
+/// sequence — a compliance completeness failure. The globally-unique surrogate
+/// <see cref="Id"/> (the PK Guid) is the deterministic tiebreak that makes the
+/// seek TOTAL: no row skipped or repeated at a page boundary.</para>
+/// </summary>
+public readonly record struct AuditCursor(long Seq, Guid Id);
+
+/// <summary>
 /// Story 37-3 — the parsed, validated, immutable filter for an audit query over
 /// the curated <c>audit_records</c> read-model (Story 37-1). Parsing is total:
 /// <see cref="TryParse"/> returns a descriptive error string for any bad input
@@ -18,10 +34,13 @@ namespace Tamma.Api.Services.Audit;
 /// matches nothing, which is the correct exact-match semantics.</para>
 ///
 /// <para><b>Keyset, not offset (AC5):</b> <see cref="Cursor"/> is the last-seen
-/// <c>source_sequence_number</c>, decoded from the opaque base64url
-/// <c>cursor</c> query value. The next page is
-/// <c>WHERE source_sequence_number &lt; cursor ORDER BY … DESC</c> — stable
-/// under concurrent inserts.</para>
+/// row's <see cref="AuditCursor"/> (<c>source_sequence_number</c> + row
+/// <c>id</c>), decoded from the opaque base64url <c>cursor</c> query value. The
+/// next page is
+/// <c>WHERE (source_sequence_number, id) &lt; (cursor.seq, cursor.id)
+/// ORDER BY source_sequence_number DESC, id DESC</c> — a TOTAL order (the
+/// unique <c>id</c> tiebreak) that stays stable under concurrent inserts AND
+/// never drops rows that share a non-unique <c>source_sequence_number</c>.</para>
 /// </summary>
 public sealed record AuditQueryFilter(
     string? Category,
@@ -36,7 +55,7 @@ public sealed record AuditQueryFilter(
     DateTime? To,
     string? Search,
     int Limit,
-    long? Cursor)
+    AuditCursor? Cursor)
 {
     public const int DefaultLimit = 50;
     public const int MinLimit = 1;
@@ -112,13 +131,13 @@ public sealed record AuditQueryFilter(
         if (fromUtc is not null && toUtc is not null && fromUtc > toUtc)
             return (null, "from must not be after to");
 
-        long? cursorSeq = null;
+        AuditCursor? cursorKey = null;
         var rawCursor = Trimmed(cursor);
         if (rawCursor is not null)
         {
-            if (!TryDecodeCursor(rawCursor, out var seq))
+            if (!TryDecodeCursor(rawCursor, out var key))
                 return (null, "cursor is malformed");
-            cursorSeq = seq;
+            cursorKey = key;
         }
 
         // limit is clamped, never rejected (AC6).
@@ -137,7 +156,7 @@ public sealed record AuditQueryFilter(
             To: toUtc,
             Search: Trimmed(q),
             Limit: clampedLimit,
-            Cursor: cursorSeq);
+            Cursor: cursorKey);
 
         return (filter, null);
     }
@@ -160,7 +179,12 @@ public sealed record AuditQueryFilter(
         if (To is not null) shape["to"] = To.Value.ToString("o");
         if (Search is not null) shape["hasSearch"] = true;
         shape["limit"] = Limit;
-        if (Cursor is not null) shape["cursor"] = Cursor;
+        if (Cursor is { } cur)
+            shape["cursor"] = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["seq"] = cur.Seq,
+                ["id"] = cur.Id.ToString(),
+            };
         return shape;
     }
 
@@ -184,26 +208,34 @@ public sealed record AuditQueryFilter(
         return keys.Count == 0 ? "(none)" : string.Join(",", keys);
     }
 
-    // ── Opaque cursor codec — base64url of a single big-endian long ──
+    // ── Opaque cursor codec — base64url of (big-endian seq | 16-byte id) ──
 
-    /// <summary>Encode a <c>source_sequence_number</c> as an opaque base64url
-    /// cursor. Opaque so clients don't hand-roll their own; trivially decodable
-    /// server-side.</summary>
-    public static string EncodeCursor(long sequenceNumber)
+    /// <summary>Encode a compound keyset position (<c>source_sequence_number</c>
+    /// + row <c>id</c>) as an opaque base64url cursor: 8 big-endian bytes of
+    /// sequence followed by the 16-byte row id. Opaque so clients don't hand-roll
+    /// their own; trivially decodable server-side. The row id makes the position
+    /// TOTAL — the sequence alone is not unique in the CP <c>audit_records</c>
+    /// table (two identity sequences feed it).</summary>
+    public static string EncodeCursor(long sequenceNumber, Guid id)
     {
-        Span<byte> buf = stackalloc byte[8];
+        Span<byte> buf = stackalloc byte[24];
         BinaryPrimitives.WriteInt64BigEndian(buf, sequenceNumber);
+        var wrote = id.TryWriteBytes(buf[8..]);
+        System.Diagnostics.Debug.Assert(wrote, "Guid is exactly 16 bytes");
         return Base64UrlEncode(buf);
     }
 
-    /// <summary>Decode an opaque cursor back to its <c>source_sequence_number</c>.
-    /// Returns <c>false</c> for any malformed input (→ 400).</summary>
-    public static bool TryDecodeCursor(string cursor, out long sequenceNumber)
+    /// <summary>Decode an opaque cursor back to its compound
+    /// <see cref="AuditCursor"/> (sequence + row id). Returns <c>false</c> for any
+    /// malformed input — wrong length included (→ 400).</summary>
+    public static bool TryDecodeCursor(string cursor, out AuditCursor value)
     {
-        sequenceNumber = 0;
+        value = default;
         if (string.IsNullOrWhiteSpace(cursor)) return false;
-        if (!TryBase64UrlDecode(cursor.Trim(), out var bytes) || bytes.Length != 8) return false;
-        sequenceNumber = BinaryPrimitives.ReadInt64BigEndian(bytes);
+        if (!TryBase64UrlDecode(cursor.Trim(), out var bytes) || bytes.Length != 24) return false;
+        var seq = BinaryPrimitives.ReadInt64BigEndian(bytes);
+        var id = new Guid(bytes.AsSpan(8, 16));
+        value = new AuditCursor(seq, id);
         return true;
     }
 
@@ -235,6 +267,28 @@ public sealed record AuditQueryFilter(
     private static string? Trimmed(string? v) =>
         string.IsNullOrWhiteSpace(v) ? null : v.Trim();
 
-    private static DateTime? ToUtc(DateTime? v) =>
-        v is null ? null : DateTime.SpecifyKind(v.Value.ToUniversalTime(), DateTimeKind.Utc);
+    /// <summary>
+    /// Normalize a from/to boundary to UTC WITHOUT shifting the intended instant:
+    /// <list type="bullet">
+    ///   <item><description><see cref="DateTimeKind.Utc"/> — kept as-is.</description></item>
+    ///   <item><description><see cref="DateTimeKind.Local"/> — converted, so a
+    ///     <c>+02:00</c>-offset input and its UTC equivalent select the SAME
+    ///     boundary.</description></item>
+    ///   <item><description><see cref="DateTimeKind.Unspecified"/> — treated as
+    ///     already-UTC. It is NOT passed through <c>ToUniversalTime()</c>, which
+    ///     would silently subtract the HOST's local offset and shift the window —
+    ///     the class of TZ drift that UTC-only CI hides.</description></item>
+    /// </list>
+    /// </summary>
+    private static DateTime? ToUtc(DateTime? v)
+    {
+        if (v is null) return null;
+        var d = v.Value;
+        return d.Kind switch
+        {
+            DateTimeKind.Utc => d,
+            DateTimeKind.Local => d.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(d, DateTimeKind.Utc),
+        };
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryFilter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryFilter.cs
@@ -1,0 +1,240 @@
+using System.Buffers.Binary;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-3 — the parsed, validated, immutable filter for an audit query over
+/// the curated <c>audit_records</c> read-model (Story 37-1). Parsing is total:
+/// <see cref="TryParse"/> returns a descriptive error string for any bad input
+/// (→ 400 in the handler) and NEVER throws or silently matches nothing (AC3).
+///
+/// <para>Closed enums (<c>category</c> / <c>severity</c> / <c>outcome</c>) are
+/// validated against the Story 37-1 projector's own vocabulary
+/// (<see cref="AuditCategory"/> / <see cref="AuditSeverity"/> + the
+/// <c>ck_audit_records_outcome</c> CHECK) so an unknown value 400s rather than
+/// returning an empty page. <c>action</c> (<c>action_code</c>) is a free-form
+/// exact match — the catalog carries dozens of codes and an unknown one simply
+/// matches nothing, which is the correct exact-match semantics.</para>
+///
+/// <para><b>Keyset, not offset (AC5):</b> <see cref="Cursor"/> is the last-seen
+/// <c>source_sequence_number</c>, decoded from the opaque base64url
+/// <c>cursor</c> query value. The next page is
+/// <c>WHERE source_sequence_number &lt; cursor ORDER BY … DESC</c> — stable
+/// under concurrent inserts.</para>
+/// </summary>
+public sealed record AuditQueryFilter(
+    string? Category,
+    string? Action,
+    Guid? ActorUserId,
+    string? TargetType,
+    string? TargetId,
+    string? Severity,
+    string? Outcome,
+    string? IpAddress,
+    DateTime? From,
+    DateTime? To,
+    string? Search,
+    int Limit,
+    long? Cursor)
+{
+    public const int DefaultLimit = 50;
+    public const int MinLimit = 1;
+    public const int MaxLimit = 200;
+
+    /// <summary>Closed vocab derived from the Story 37-1 enums (lowercased member
+    /// names, exactly as the projector writes them).</summary>
+    private static readonly HashSet<string> ValidCategories =
+        new(Enum.GetNames<AuditCategory>().Select(n => n.ToLowerInvariant()), StringComparer.Ordinal);
+
+    private static readonly HashSet<string> ValidSeverities =
+        new(Enum.GetNames<AuditSeverity>().Select(n => n.ToLowerInvariant()), StringComparer.Ordinal);
+
+    /// <summary>Matches the <c>ck_audit_records_outcome</c> CHECK constraint.</summary>
+    private static readonly HashSet<string> ValidOutcomes =
+        new(new[] { "success", "failure", "denied" }, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Parse + validate the raw query values. Returns <c>(filter, null)</c> on
+    /// success or <c>(null, error)</c> on the first validation failure. Never
+    /// throws.
+    /// </summary>
+    public static (AuditQueryFilter? Filter, string? Error) TryParse(
+        string? category,
+        string? action,
+        string? actorUserId,
+        string? targetType,
+        string? targetId,
+        string? severity,
+        string? outcome,
+        string? ipAddress,
+        DateTime? from,
+        DateTime? to,
+        string? q,
+        int? limit,
+        string? cursor)
+    {
+        var normCategory = Trimmed(category);
+        if (normCategory is not null)
+        {
+            normCategory = normCategory.ToLowerInvariant();
+            if (!ValidCategories.Contains(normCategory))
+                return (null, $"category must be one of: {string.Join(", ", ValidCategories.Order())}");
+        }
+
+        var normSeverity = Trimmed(severity);
+        if (normSeverity is not null)
+        {
+            normSeverity = normSeverity.ToLowerInvariant();
+            if (!ValidSeverities.Contains(normSeverity))
+                return (null, $"severity must be one of: {string.Join(", ", ValidSeverities.Order())}");
+        }
+
+        var normOutcome = Trimmed(outcome);
+        if (normOutcome is not null)
+        {
+            normOutcome = normOutcome.ToLowerInvariant();
+            if (!ValidOutcomes.Contains(normOutcome))
+                return (null, $"outcome must be one of: {string.Join(", ", ValidOutcomes.Order())}");
+        }
+
+        Guid? actorGuid = null;
+        var rawActor = Trimmed(actorUserId);
+        if (rawActor is not null)
+        {
+            if (!Guid.TryParse(rawActor, out var g))
+                return (null, "actorUserId must be a valid GUID");
+            actorGuid = g;
+        }
+
+        var fromUtc = ToUtc(from);
+        var toUtc = ToUtc(to);
+        if (fromUtc is not null && toUtc is not null && fromUtc > toUtc)
+            return (null, "from must not be after to");
+
+        long? cursorSeq = null;
+        var rawCursor = Trimmed(cursor);
+        if (rawCursor is not null)
+        {
+            if (!TryDecodeCursor(rawCursor, out var seq))
+                return (null, "cursor is malformed");
+            cursorSeq = seq;
+        }
+
+        // limit is clamped, never rejected (AC6).
+        var clampedLimit = Math.Clamp(limit ?? DefaultLimit, MinLimit, MaxLimit);
+
+        var filter = new AuditQueryFilter(
+            Category: normCategory,
+            Action: Trimmed(action),
+            ActorUserId: actorGuid,
+            TargetType: Trimmed(targetType),
+            TargetId: Trimmed(targetId),
+            Severity: normSeverity,
+            Outcome: normOutcome,
+            IpAddress: Trimmed(ipAddress),
+            From: fromUtc,
+            To: toUtc,
+            Search: Trimmed(q),
+            Limit: clampedLimit,
+            Cursor: cursorSeq);
+
+        return (filter, null);
+    }
+
+    /// <summary>The applied-filter shape recorded in the <c>AUDIT.QUERIED</c>
+    /// meta-audit event's <c>Data</c> (AC10) — the filter set, NEVER the result
+    /// rows. Only keys that were actually applied are present.</summary>
+    public IReadOnlyDictionary<string, object?> ToAuditableShape()
+    {
+        var shape = new Dictionary<string, object?>(StringComparer.Ordinal);
+        if (Category is not null) shape["category"] = Category;
+        if (Action is not null) shape["action"] = Action;
+        if (ActorUserId is not null) shape["actorUserId"] = ActorUserId.ToString();
+        if (TargetType is not null) shape["targetType"] = TargetType;
+        if (TargetId is not null) shape["targetId"] = TargetId;
+        if (Severity is not null) shape["severity"] = Severity;
+        if (Outcome is not null) shape["outcome"] = Outcome;
+        if (IpAddress is not null) shape["ipAddress"] = IpAddress;
+        if (From is not null) shape["from"] = From.Value.ToString("o");
+        if (To is not null) shape["to"] = To.Value.ToString("o");
+        if (Search is not null) shape["hasSearch"] = true;
+        shape["limit"] = Limit;
+        if (Cursor is not null) shape["cursor"] = Cursor;
+        return shape;
+    }
+
+    /// <summary>The set of applied filter KEYS (no values) — safe for INFO logs
+    /// (never leaks a search term, IP, or actor id).</summary>
+    public string AppliedFilterKeys()
+    {
+        var keys = new List<string>();
+        if (Category is not null) keys.Add("category");
+        if (Action is not null) keys.Add("action");
+        if (ActorUserId is not null) keys.Add("actorUserId");
+        if (TargetType is not null) keys.Add("targetType");
+        if (TargetId is not null) keys.Add("targetId");
+        if (Severity is not null) keys.Add("severity");
+        if (Outcome is not null) keys.Add("outcome");
+        if (IpAddress is not null) keys.Add("ipAddress");
+        if (From is not null) keys.Add("from");
+        if (To is not null) keys.Add("to");
+        if (Search is not null) keys.Add("q");
+        if (Cursor is not null) keys.Add("cursor");
+        return keys.Count == 0 ? "(none)" : string.Join(",", keys);
+    }
+
+    // ── Opaque cursor codec — base64url of a single big-endian long ──
+
+    /// <summary>Encode a <c>source_sequence_number</c> as an opaque base64url
+    /// cursor. Opaque so clients don't hand-roll their own; trivially decodable
+    /// server-side.</summary>
+    public static string EncodeCursor(long sequenceNumber)
+    {
+        Span<byte> buf = stackalloc byte[8];
+        BinaryPrimitives.WriteInt64BigEndian(buf, sequenceNumber);
+        return Base64UrlEncode(buf);
+    }
+
+    /// <summary>Decode an opaque cursor back to its <c>source_sequence_number</c>.
+    /// Returns <c>false</c> for any malformed input (→ 400).</summary>
+    public static bool TryDecodeCursor(string cursor, out long sequenceNumber)
+    {
+        sequenceNumber = 0;
+        if (string.IsNullOrWhiteSpace(cursor)) return false;
+        if (!TryBase64UrlDecode(cursor.Trim(), out var bytes) || bytes.Length != 8) return false;
+        sequenceNumber = BinaryPrimitives.ReadInt64BigEndian(bytes);
+        return true;
+    }
+
+    private static string Base64UrlEncode(ReadOnlySpan<byte> bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static bool TryBase64UrlDecode(string value, out byte[] bytes)
+    {
+        bytes = Array.Empty<byte>();
+        var s = value.Replace('-', '+').Replace('_', '/');
+        switch (s.Length % 4)
+        {
+            case 2: s += "=="; break;
+            case 3: s += "="; break;
+            case 1: return false; // never a valid base64 length
+        }
+
+        try
+        {
+            bytes = Convert.FromBase64String(s);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static string? Trimmed(string? v) =>
+        string.IsNullOrWhiteSpace(v) ? null : v.Trim();
+
+    private static DateTime? ToUtc(DateTime? v) =>
+        v is null ? null : DateTime.SpecifyKind(v.Value.ToUniversalTime(), DateTimeKind.Utc);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryService.cs
@@ -14,8 +14,9 @@ namespace Tamma.Api.Services.Audit;
 /// <summary>
 /// Story 37-3 — the audit query orchestrator. Parses are already done by
 /// <see cref="AuditQueryFilter"/>; this service builds the EF query (structured
-/// filters AND-combined, parameterized <c>ILIKE</c> search, keyset seek on
-/// <c>source_sequence_number</c>), projects <see cref="AuditRecordResponse"/>,
+/// filters AND-combined, parameterized <c>ILIKE</c> search, keyset seek on the
+/// TOTAL order <c>(source_sequence_number, id)</c>), projects
+/// <see cref="AuditRecordResponse"/>,
 /// computes a capped-estimate <c>total</c>, and appends the best-effort
 /// <c>AUDIT.QUERIED</c> meta-audit event (AC10).
 ///
@@ -121,17 +122,32 @@ public sealed class AuditQueryService(
         var total = await filtered.Take(AuditQueryResponse.CountCap).CountAsync(ct).ConfigureAwait(false);
         var totalIsCapped = total >= AuditQueryResponse.CountCap;
 
-        // Keyset seek (AC5): cursor < last-seen sequence, most-recent first. The
-        // sequence is unique + monotonic so it is its own deterministic tiebreak.
+        // Keyset seek (AC5), most-recent first, over a TOTAL order. The order key
+        // is COMPOUND — (source_sequence_number, id) — because
+        // source_sequence_number is NOT unique in the CP audit_records table (it
+        // is fed by two independent identity sequences — domain_events AND
+        // platform_events — whose values collide; the table is unique only on
+        // source_event_id). Seeking on the sequence alone would silently drop the
+        // OTHER row sharing a boundary sequence — a compliance completeness bug.
+        // The row id (globally-unique PK Guid) is the deterministic tiebreak.
+        //
+        // The seek uses a Postgres ROW-VALUE comparison
+        // `(source_sequence_number, id) < (cursor.seq, cursor.id)`
+        // (EF.Functions.LessThan over ValueTuples — Npgsql translates this to a
+        // native `(a, b) < (c, d)`), which is exactly "strictly before the cursor
+        // in (seq DESC, id DESC) order" and uses the uuid column's native ordering
+        // for the id leg — consistent with the ORDER BY below.
         var pageQuery = filtered;
-        if (f.Cursor is not null)
+        if (f.Cursor is { } cursor)
         {
-            var cursor = f.Cursor.Value;
-            pageQuery = pageQuery.Where(r => r.SourceSequenceNumber < cursor);
+            pageQuery = pageQuery.Where(r => EF.Functions.LessThan(
+                ValueTuple.Create(r.SourceSequenceNumber, r.Id),
+                ValueTuple.Create(cursor.Seq, cursor.Id)));
         }
 
         var page = await pageQuery
             .OrderByDescending(r => r.SourceSequenceNumber)
+            .ThenByDescending(r => r.Id)
             .Take(f.Limit + 1) // +1 sentinel to compute nextCursor without a second query
             .Select(r => new AuditRecordResponse(
                 r.Id,
@@ -153,7 +169,7 @@ public sealed class AuditQueryService(
         var hasMore = page.Count > f.Limit;
         var rows = hasMore ? page.Take(f.Limit).ToList() : page;
         var nextCursor = hasMore
-            ? AuditQueryFilter.EncodeCursor(rows[^1].SourceSequenceNumber)
+            ? AuditQueryFilter.EncodeCursor(rows[^1].SourceSequenceNumber, rows[^1].Id)
             : null;
 
         return new AuditQueryResponse(rows, nextCursor, total, totalIsCapped);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditQueryService.cs
@@ -1,0 +1,279 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Dtos.Audit;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-3 — the audit query orchestrator. Parses are already done by
+/// <see cref="AuditQueryFilter"/>; this service builds the EF query (structured
+/// filters AND-combined, parameterized <c>ILIKE</c> search, keyset seek on
+/// <c>source_sequence_number</c>), projects <see cref="AuditRecordResponse"/>,
+/// computes a capped-estimate <c>total</c>, and appends the best-effort
+/// <c>AUDIT.QUERIED</c> meta-audit event (AC10).
+///
+/// <para><b>Scope routing mirrors the Story 37-1 projector:</b> SaaS
+/// tenant-scoped rows live in the tenant's own schema (reached via
+/// <see cref="ITenantDbContextFactory"/>, filtered by <c>tenant_id</c>);
+/// single-user rows + platform rows live in the control plane (single-user keyed
+/// by <c>user_id</c>, platform keyed by both-null). Physical placement is the
+/// first isolation wall; the explicit predicate is the second.</para>
+/// </summary>
+public sealed class AuditQueryService(
+    ITenantDbContextFactory tenantDbFactory,
+    ControlPlaneDbContext controlPlane,
+    IEventRepository events,
+    IPlatformEventRepository platformEvents,
+    ITenantContext tenantContext,
+    TimeProvider timeProvider,
+    ILogger<AuditQueryService> logger)
+    : IAuditQueryService
+{
+    private const string TenantScope = "tenant";
+    private const string PlatformScope = "platform";
+
+    public async Task<AuditQueryResponse> QueryTenantAsync(
+        Guid tenantId, Guid? callerUserId, AuditQueryFilter filter, TammaMode mode, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+
+        AuditQueryResponse response;
+        if (mode == TammaMode.SaaS)
+        {
+            // Pin the ambient tenant context so any tenant-context-aware seam
+            // engages, then read the tenant's OWN schema. The explicit
+            // WHERE tenant_id == tid is the second wall behind the per-tenant
+            // physical connection.
+            tenantContext.SetTenantId(tenantId);
+            await using var db = await tenantDbFactory.CreateAsync(tenantId, ct).ConfigureAwait(false);
+            response = await RunAsync(db, filter, r => r.TenantId == tenantId, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            // single-user — the sole user owns every row; their rows live in the
+            // control plane keyed by user_id.
+            response = await RunAsync(
+                controlPlane, filter, r => r.UserId == callerUserId, ct).ConfigureAwait(false);
+        }
+
+        logger.LogInformation(
+            "Audit query served: scope={Scope} tenantId={TenantId} actorUserId={ActorUserId} "
+                + "filterKeys={FilterKeys} resultCount={ResultCount} total={Total} "
+                + "mode={Mode} durationMs={DurationMs}",
+            TenantScope, tenantId, callerUserId, filter.AppliedFilterKeys(),
+            response.Records.Count, response.Total, mode, sw.ElapsedMilliseconds);
+
+        await EmitMetaAuditAsync(TenantScope, tenantId, callerUserId, filter, response.Records.Count, mode, ct)
+            .ConfigureAwait(false);
+        return response;
+    }
+
+    public async Task<AuditQueryResponse> QueryPlatformAsync(
+        Guid? callerUserId, AuditQueryFilter filter, TammaMode mode, CancellationToken ct)
+    {
+        var sw = Stopwatch.StartNew();
+
+        // Platform-scope rows have no tenant owner. In single-user mode the sole
+        // user is the operator and their rows are also tenant_id-null, so the
+        // predicate is identical: read the CP rows with no tenant.
+        var response = await RunAsync(
+            controlPlane, filter, r => r.TenantId == null, ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Audit query served: scope={Scope} tenantId={TenantId} actorUserId={ActorUserId} "
+                + "filterKeys={FilterKeys} resultCount={ResultCount} total={Total} "
+                + "mode={Mode} durationMs={DurationMs}",
+            PlatformScope, (Guid?)null, callerUserId, filter.AppliedFilterKeys(),
+            response.Records.Count, response.Total, mode, sw.ElapsedMilliseconds);
+
+        await EmitMetaAuditAsync(PlatformScope, null, callerUserId, filter, response.Records.Count, mode, ct)
+            .ConfigureAwait(false);
+        return response;
+    }
+
+    /// <summary>
+    /// The load-bearing query: scope predicate + structured filters + search +
+    /// keyset seek, projected + paged, with a capped-estimate total.
+    /// </summary>
+    private static async Task<AuditQueryResponse> RunAsync(
+        DbContext db,
+        AuditQueryFilter f,
+        System.Linq.Expressions.Expression<Func<AuditRecord, bool>> scope,
+        CancellationToken ct)
+    {
+        // Search roots the query in a parameterized ILIKE over the text columns
+        // AND the payload (jsonb cast to text). Parameterization makes an
+        // injection-shaped q a literal (inert). No search ⇒ the plain DbSet.
+        var filtered = SearchRoot(db, f)
+            .Where(scope);
+        filtered = ApplyStructuredFilters(filtered, f);
+
+        // Capped exact count — bounds the cost so paging is never gated on a full
+        // COUNT(*) over millions of rows (AC9). Take(cap) then Count → the planner
+        // stops at the cap.
+        var total = await filtered.Take(AuditQueryResponse.CountCap).CountAsync(ct).ConfigureAwait(false);
+        var totalIsCapped = total >= AuditQueryResponse.CountCap;
+
+        // Keyset seek (AC5): cursor < last-seen sequence, most-recent first. The
+        // sequence is unique + monotonic so it is its own deterministic tiebreak.
+        var pageQuery = filtered;
+        if (f.Cursor is not null)
+        {
+            var cursor = f.Cursor.Value;
+            pageQuery = pageQuery.Where(r => r.SourceSequenceNumber < cursor);
+        }
+
+        var page = await pageQuery
+            .OrderByDescending(r => r.SourceSequenceNumber)
+            .Take(f.Limit + 1) // +1 sentinel to compute nextCursor without a second query
+            .Select(r => new AuditRecordResponse(
+                r.Id,
+                r.Category,
+                r.ActionCode,
+                r.ActorUserId,
+                r.ActorEmailSnapshot,
+                r.TargetType,
+                r.TargetId,
+                r.Severity,
+                r.Outcome,
+                r.IpAddress,
+                r.OccurredAt,
+                r.PayloadJson,
+                r.SourceSequenceNumber))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var hasMore = page.Count > f.Limit;
+        var rows = hasMore ? page.Take(f.Limit).ToList() : page;
+        var nextCursor = hasMore
+            ? AuditQueryFilter.EncodeCursor(rows[^1].SourceSequenceNumber)
+            : null;
+
+        return new AuditQueryResponse(rows, nextCursor, total, totalIsCapped);
+    }
+
+    /// <summary>
+    /// When <c>q</c> is present, root the query in a parameterized <c>ILIKE</c>
+    /// over the searchable text columns + the payload (jsonb <c>::text</c> cast).
+    /// Mirrors <c>EventRepository</c>'s raw-SQL jsonb search pattern. The
+    /// interpolated <c>{term}</c> is a parameter — an injection-shaped term is a
+    /// literal (inert). Unqualified <c>audit_records</c> resolves to the tenant
+    /// schema via the per-tenant connection's search_path (or public on the CP).
+    /// </summary>
+    private static IQueryable<AuditRecord> SearchRoot(DbContext db, AuditQueryFilter f)
+    {
+        var set = db.Set<AuditRecord>();
+        if (string.IsNullOrWhiteSpace(f.Search))
+        {
+            return set.AsNoTracking();
+        }
+
+        var term = "%" + EscapeLike(f.Search) + "%";
+        return set.FromSqlInterpolated($@"
+                SELECT * FROM audit_records
+                WHERE ""ActorEmailSnapshot"" ILIKE {term}
+                   OR ""TargetId"" ILIKE {term}
+                   OR ""ActionCode"" ILIKE {term}
+                   OR ""TargetType"" ILIKE {term}
+                   OR ""PayloadJson""::text ILIKE {term}")
+            .AsNoTracking();
+    }
+
+    private static IQueryable<AuditRecord> ApplyStructuredFilters(
+        IQueryable<AuditRecord> q, AuditQueryFilter f)
+    {
+        if (f.Category is not null) q = q.Where(r => r.Category == f.Category);
+        if (f.Action is not null) q = q.Where(r => r.ActionCode == f.Action);
+        if (f.ActorUserId is not null) q = q.Where(r => r.ActorUserId == f.ActorUserId);
+        if (f.TargetType is not null) q = q.Where(r => r.TargetType == f.TargetType);
+        if (f.TargetId is not null) q = q.Where(r => r.TargetId == f.TargetId);
+        if (f.Severity is not null) q = q.Where(r => r.Severity == f.Severity);
+        if (f.Outcome is not null) q = q.Where(r => r.Outcome == f.Outcome);
+        if (f.IpAddress is not null) q = q.Where(r => r.IpAddress == f.IpAddress);
+        if (f.From is not null) q = q.Where(r => r.OccurredAt >= f.From);
+        if (f.To is not null) q = q.Where(r => r.OccurredAt < f.To);
+        return q;
+    }
+
+    /// <summary>Escape LIKE/ILIKE wildcards so a wildcard-shaped term can't widen
+    /// the match. Postgres' default escape char is backslash.</summary>
+    private static string EscapeLike(string s) =>
+        s.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
+
+    /// <summary>
+    /// AC10 — append the <c>AUDIT.QUERIED</c> meta-audit event best-effort. A
+    /// tenant read (SaaS) routes to the tenant store; a single-user or platform
+    /// read routes to the control plane. A failure here is logged WARN and NEVER
+    /// fails the user's read (the data is already materialized).
+    /// </summary>
+    private async Task EmitMetaAuditAsync(
+        string scope, Guid? tenantId, Guid? actorUserId,
+        AuditQueryFilter filter, int resultCount, TammaMode mode, CancellationToken ct)
+    {
+        try
+        {
+            var tags = JsonSerializer.Serialize(new Dictionary<string, string?>
+            {
+                ["tenantId"] = tenantId?.ToString(),
+                ["actorUserId"] = actorUserId?.ToString(),
+                ["scope"] = scope,
+                ["mode"] = mode == TammaMode.SaaS ? "saas" : "single-user",
+            });
+            var data = JsonSerializer.Serialize(new
+            {
+                filters = filter.ToAuditableShape(),
+                resultCount,
+            });
+            var metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            });
+            var now = timeProvider.GetUtcNow().UtcDateTime;
+
+            if (scope == TenantScope && mode == TammaMode.SaaS && tenantId is Guid tid)
+            {
+                await events.AppendAsync(new DomainEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = AuditQueryEventTypes.Queried,
+                    TenantId = tid,
+                    Tags = tags,
+                    Data = data,
+                    Metadata = metadata,
+                    CreatedAt = now,
+                }).ConfigureAwait(false);
+            }
+            else
+            {
+                // single-user tenant reads + all platform reads live in the CP
+                // platform stream (tenant_id null).
+                await platformEvents.AppendAsync(new PlatformEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = AuditQueryEventTypes.Queried,
+                    TenantId = null,
+                    Tags = tags,
+                    Data = data,
+                    Metadata = metadata,
+                    CreatedAt = now,
+                }, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(
+                ex,
+                "AUDIT.QUERIED meta-audit append failed (best-effort; the audit read "
+                    + "was still served): scope={Scope} tenantId={TenantId}",
+                scope, tenantId);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditQueryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditQueryService.cs
@@ -1,0 +1,43 @@
+using Tamma.Api.Dtos.Audit;
+using Tamma.Api.Services.PromptStore;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-3 — read-only, keyset-paginated query surface over the curated
+/// <c>audit_records</c> read-model (Story 37-1). Two physically-separate scopes:
+/// per-tenant audit (a tenant's own schema, or the sole user's rows in
+/// single-user mode) and platform audit (the control-plane rows). A tenant
+/// query NEVER reads platform / another tenant's rows and vice-versa.
+///
+/// <para>This service reads the MATERIALIZED table only — it never re-projects
+/// from the raw DCB event streams.</para>
+/// </summary>
+public interface IAuditQueryService
+{
+    /// <summary>
+    /// Query one tenant's curated audit trail. In SaaS mode this reads the
+    /// tenant's own schema filtered by <paramref name="tenantId"/> (physical
+    /// isolation + explicit predicate = defence-in-depth). In single-user mode
+    /// the sole user's rows live in the control plane keyed by their user id, so
+    /// the read is scoped by <paramref name="callerUserId"/>.
+    /// </summary>
+    Task<AuditQueryResponse> QueryTenantAsync(
+        Guid tenantId,
+        Guid? callerUserId,
+        AuditQueryFilter filter,
+        TammaMode mode,
+        CancellationToken ct);
+
+    /// <summary>
+    /// Query the platform-scope curated audit trail (control-plane rows:
+    /// impersonation, tenant lifecycle, platform RBAC, platform-level BYOK).
+    /// Physically the control-plane <c>audit_records</c> rows with no tenant
+    /// owner — a tenant's rows are in a different schema and are never returned.
+    /// </summary>
+    Task<AuditQueryResponse> QueryPlatformAsync(
+        Guid? callerUserId,
+        AuditQueryFilter filter,
+        TammaMode mode,
+        CancellationToken ct);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryFilterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryFilterTests.cs
@@ -131,18 +131,30 @@ public class AuditQueryFilterTests
     [Test]
     public void Cursor_RoundTrips_Exactly()
     {
-        foreach (var seq in new[] { 0L, 1L, 42L, long.MaxValue, 9_876_543_210L })
+        // The cursor is COMPOUND — (source_sequence_number, row id) — because
+        // source_sequence_number is not unique in the CP audit_records table.
+        var samples = new (long Seq, Guid Id)[]
         {
-            var encoded = AuditQueryFilter.EncodeCursor(seq);
+            (0L, Guid.Empty),
+            (1L, Guid.NewGuid()),
+            (42L, Guid.NewGuid()),
+            (long.MaxValue, Guid.NewGuid()),
+            (9_876_543_210L, Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff")),
+        };
+
+        foreach (var (seq, id) in samples)
+        {
+            var encoded = AuditQueryFilter.EncodeCursor(seq, id);
             encoded.Should().NotContain("+").And.NotContain("/").And.NotContain("=",
                 "cursor is base64URL (opaque, URL-safe)");
             AuditQueryFilter.TryDecodeCursor(encoded, out var decoded).Should().BeTrue();
-            decoded.Should().Be(seq);
+            decoded.Seq.Should().Be(seq);
+            decoded.Id.Should().Be(id);
 
             // And through the full parse path.
             var (f, err) = Parse(cursor: encoded);
             err.Should().BeNull();
-            f!.Cursor.Should().Be(seq);
+            f!.Cursor.Should().Be(new AuditCursor(seq, id));
         }
     }
 
@@ -152,6 +164,55 @@ public class AuditQueryFilterTests
         var (f, err) = Parse(cursor: "!!!not-base64!!!");
         f.Should().BeNull();
         err.Should().Contain("cursor");
+    }
+
+    [Test]
+    public void WrongLength_Cursor_Yields_Error()
+    {
+        // A well-formed base64url payload of the WRONG length (e.g. the old
+        // 8-byte sequence-only cursor) is rejected — the decode is strict.
+        var eightBytes = Convert.ToBase64String(new byte[8]).TrimEnd('=')
+            .Replace('+', '-').Replace('/', '_');
+        AuditQueryFilter.TryDecodeCursor(eightBytes, out _).Should().BeFalse();
+
+        var (f, err) = Parse(cursor: eightBytes);
+        f.Should().BeNull();
+        err.Should().Contain("cursor");
+    }
+
+    [Test]
+    public void Unspecified_Kind_From_Is_Treated_As_Utc_Not_Shifted()
+    {
+        // A from/to boundary that arrives WITHOUT a zone (Kind=Unspecified) must
+        // be read as UTC — never passed through ToUniversalTime(), which would
+        // subtract the HOST's local offset and shift the window (a TZ drift that
+        // UTC-only CI hides).
+        var unspecified = new DateTime(2026, 1, 15, 8, 30, 0, DateTimeKind.Unspecified);
+        var utcEquivalent = new DateTime(2026, 1, 15, 8, 30, 0, DateTimeKind.Utc);
+
+        var fromUnspecified = Parse(from: unspecified).Filter!.From!.Value;
+        var fromUtc = Parse(from: utcEquivalent).Filter!.From!.Value;
+
+        fromUnspecified.Kind.Should().Be(DateTimeKind.Utc);
+        fromUnspecified.Should().Be(utcEquivalent, "the clock reading is preserved, not offset-shifted");
+        fromUnspecified.Should().Be(fromUtc,
+            "an unspecified-kind boundary selects the same instant as its UTC equivalent");
+    }
+
+    [Test]
+    public void Local_Kind_From_Converts_To_The_Same_Instant_As_Its_Utc_Equivalent()
+    {
+        // A boundary that arrives as Local (e.g. an offset-carrying input the
+        // model binder resolved to local) converts to the same UTC instant its
+        // UTC form would — the two select the same boundary.
+        var local = new DateTime(2026, 1, 15, 8, 30, 0, DateTimeKind.Local);
+        var utcEquivalent = local.ToUniversalTime();
+
+        var fromLocal = Parse(from: local).Filter!.From!.Value;
+
+        fromLocal.Kind.Should().Be(DateTimeKind.Utc);
+        fromLocal.Should().Be(utcEquivalent,
+            "a local-kind boundary and its UTC equivalent select the same instant");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryFilterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryFilterTests.cs
@@ -1,0 +1,178 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-3 (T1) — pure parse/validate/cursor tests for
+/// <see cref="AuditQueryFilter"/>. No DB. Parsing must be total: every bad input
+/// yields a descriptive error string, never an exception (AC3).
+/// </summary>
+[TestFixture]
+public class AuditQueryFilterTests
+{
+    private static (AuditQueryFilter? Filter, string? Error) Parse(
+        string? category = null, string? action = null, string? actorUserId = null,
+        string? targetType = null, string? targetId = null, string? severity = null,
+        string? outcome = null, string? ipAddress = null, DateTime? from = null,
+        DateTime? to = null, string? q = null, int? limit = null, string? cursor = null)
+        => AuditQueryFilter.TryParse(
+            category, action, actorUserId, targetType, targetId, severity,
+            outcome, ipAddress, from, to, q, limit, cursor);
+
+    [Test]
+    public void Empty_Query_Parses_With_Defaults()
+    {
+        var (f, err) = Parse();
+        err.Should().BeNull();
+        f.Should().NotBeNull();
+        f!.Limit.Should().Be(AuditQueryFilter.DefaultLimit);
+        f.Category.Should().BeNull();
+        f.Cursor.Should().BeNull();
+    }
+
+    [Test]
+    public void Valid_Combination_Parses()
+    {
+        var actor = Guid.NewGuid();
+        var (f, err) = Parse(
+            category: "Secret", action: "SECRET.REVEAL", actorUserId: actor.ToString(),
+            targetType: "secret", targetId: "abc", severity: "Critical", outcome: "Success",
+            ipAddress: "10.0.0.1", from: new DateTime(2026, 1, 1), to: new DateTime(2026, 2, 1),
+            q: "  hello  ", limit: 25);
+
+        err.Should().BeNull();
+        f.Should().NotBeNull();
+        f!.Category.Should().Be("secret", "enum values normalise to lowercase");
+        f.Severity.Should().Be("critical");
+        f.Outcome.Should().Be("success");
+        f.Action.Should().Be("SECRET.REVEAL", "action_code is a free-form exact match, not lowercased");
+        f.ActorUserId.Should().Be(actor);
+        f.Search.Should().Be("hello", "q is trimmed");
+        f.From!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Test]
+    public void Invalid_Category_Yields_Error()
+    {
+        var (f, err) = Parse(category: "not-a-category");
+        f.Should().BeNull();
+        err.Should().Contain("category");
+    }
+
+    [Test]
+    public void Invalid_Severity_Yields_Error()
+    {
+        var (f, err) = Parse(severity: "extreme");
+        f.Should().BeNull();
+        err.Should().Contain("severity");
+    }
+
+    [Test]
+    public void Invalid_Outcome_Yields_Error()
+    {
+        var (f, err) = Parse(outcome: "maybe");
+        f.Should().BeNull();
+        err.Should().Contain("outcome");
+    }
+
+    [Test]
+    public void Notice_Severity_Is_Valid()
+    {
+        // The real AuditSeverity enum includes Notice (the spec omitted it).
+        var (f, err) = Parse(severity: "notice");
+        err.Should().BeNull();
+        f!.Severity.Should().Be("notice");
+    }
+
+    [Test]
+    public void Invalid_ActorUserId_Yields_Error()
+    {
+        var (f, err) = Parse(actorUserId: "not-a-guid");
+        f.Should().BeNull();
+        err.Should().Contain("actorUserId");
+    }
+
+    [Test]
+    public void From_After_To_Yields_Error()
+    {
+        var (f, err) = Parse(from: new DateTime(2026, 3, 1), to: new DateTime(2026, 1, 1));
+        f.Should().BeNull();
+        err.Should().Contain("from");
+    }
+
+    [Test]
+    public void From_Equal_To_Is_Allowed()
+    {
+        var t = new DateTime(2026, 1, 1);
+        var (f, err) = Parse(from: t, to: t);
+        err.Should().BeNull();
+        f.Should().NotBeNull();
+    }
+
+    [Test]
+    public void Limit_Is_Clamped_Not_Rejected()
+    {
+        Parse(limit: 0).Filter!.Limit.Should().Be(AuditQueryFilter.MinLimit);
+        Parse(limit: 999).Filter!.Limit.Should().Be(AuditQueryFilter.MaxLimit);
+        Parse(limit: -5).Filter!.Limit.Should().Be(AuditQueryFilter.MinLimit);
+        Parse(limit: null).Filter!.Limit.Should().Be(AuditQueryFilter.DefaultLimit);
+        Parse(limit: 50).Filter!.Limit.Should().Be(50);
+    }
+
+    [Test]
+    public void Whitespace_Search_Normalises_To_Null()
+    {
+        Parse(q: "   ").Filter!.Search.Should().BeNull();
+        Parse(q: "").Filter!.Search.Should().BeNull();
+    }
+
+    [Test]
+    public void Cursor_RoundTrips_Exactly()
+    {
+        foreach (var seq in new[] { 0L, 1L, 42L, long.MaxValue, 9_876_543_210L })
+        {
+            var encoded = AuditQueryFilter.EncodeCursor(seq);
+            encoded.Should().NotContain("+").And.NotContain("/").And.NotContain("=",
+                "cursor is base64URL (opaque, URL-safe)");
+            AuditQueryFilter.TryDecodeCursor(encoded, out var decoded).Should().BeTrue();
+            decoded.Should().Be(seq);
+
+            // And through the full parse path.
+            var (f, err) = Parse(cursor: encoded);
+            err.Should().BeNull();
+            f!.Cursor.Should().Be(seq);
+        }
+    }
+
+    [Test]
+    public void Garbage_Cursor_Yields_Error()
+    {
+        var (f, err) = Parse(cursor: "!!!not-base64!!!");
+        f.Should().BeNull();
+        err.Should().Contain("cursor");
+    }
+
+    [Test]
+    public void ToAuditableShape_Contains_Applied_Filters_Only()
+    {
+        var (f, _) = Parse(category: "secret", severity: "critical", limit: 10);
+        var shape = f!.ToAuditableShape();
+        shape.Should().ContainKey("category");
+        shape.Should().ContainKey("severity");
+        shape.Should().ContainKey("limit");
+        shape.Should().NotContainKey("action");
+        shape.Should().NotContainKey("actorUserId");
+    }
+
+    [Test]
+    public void AppliedFilterKeys_Never_Leaks_Values()
+    {
+        var (f, _) = Parse(q: "sensitive@example.com", ipAddress: "10.0.0.1");
+        var keys = f!.AppliedFilterKeys();
+        keys.Should().Contain("q").And.Contain("ipAddress");
+        keys.Should().NotContain("sensitive@example.com");
+        keys.Should().NotContain("10.0.0.1");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs
@@ -1,0 +1,494 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-3 — end-to-end query tests for <see cref="AuditQueryService"/>
+/// against a real Postgres 17 container. Seeds curated <c>audit_records</c> rows
+/// directly (this story is read-only over the 37-1 read-model) into two tenant
+/// schemas + the control plane, then exercises every filter dimension, the
+/// <c>q</c> search, keyset pagination (incl. concurrent-insert stability), the
+/// per-mode scoping, the cross-tenant / cross-scope isolation walls, and the
+/// <c>AUDIT.QUERIED</c> meta-audit emission.
+/// </summary>
+[TestFixture]
+public class AuditQueryServiceTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private Guid _tenantA;
+    private Guid _tenantB;
+    private string _schemaA = null!;
+    private string _schemaB = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_query_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using (var cp = NewCp())
+            await cp.Database.MigrateAsync();
+
+        _tenantA = Guid.NewGuid();
+        _tenantB = Guid.NewGuid();
+        _schemaA = TenantNaming.SchemaName(_tenantA);
+        _schemaB = TenantNaming.SchemaName(_tenantB);
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaB));
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task Reset()
+    {
+        await using var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        await Exec(conn, "TRUNCATE audit_records, platform_events RESTART IDENTITY CASCADE;");
+        foreach (var schema in new[] { _schemaA, _schemaB })
+            await Exec(conn, $"TRUNCATE \"{schema}\".audit_records RESTART IDENTITY;");
+    }
+
+    // ════════════════════ per-dimension filters ════════════════════
+
+    [Test]
+    public async Task Each_Structured_Filter_Isolates_The_Expected_Subset()
+    {
+        var actor1 = Guid.NewGuid();
+        var actor2 = Guid.NewGuid();
+        await SeedTenant(_tenantA, s => s with
+        {
+            Category = "secret", ActionCode = "SECRET.REVEAL", ActorUserId = actor1,
+            TargetType = "secret", TargetId = "sec-1", Severity = "critical", Outcome = "success",
+            IpAddress = "10.0.0.1", OccurredAt = D(2026, 1, 10), Seq = 1,
+        });
+        await SeedTenant(_tenantA, s => s with
+        {
+            Category = "rbac", ActionCode = "TENANT.MEMBER_ROLE_CHANGED", ActorUserId = actor2,
+            TargetType = "user", TargetId = "usr-9", Severity = "warning", Outcome = "denied",
+            IpAddress = "10.0.0.2", OccurredAt = D(2026, 2, 10), Seq = 2,
+        });
+
+        var svc = NewService(out _, out _);
+
+        (await QueryTenant(svc, F(category: "secret"))).Records.Should().ContainSingle()
+            .Which.ActionCode.Should().Be("SECRET.REVEAL");
+        (await QueryTenant(svc, F(action: "TENANT.MEMBER_ROLE_CHANGED"))).Records.Should().ContainSingle();
+        (await QueryTenant(svc, F(actorUserId: actor1))).Records.Should().ContainSingle()
+            .Which.ActorUserId.Should().Be(actor1);
+        (await QueryTenant(svc, F(targetType: "user"))).Records.Should().ContainSingle();
+        (await QueryTenant(svc, F(targetId: "sec-1"))).Records.Should().ContainSingle();
+        (await QueryTenant(svc, F(severity: "critical"))).Records.Should().ContainSingle();
+        (await QueryTenant(svc, F(outcome: "denied"))).Records.Should().ContainSingle();
+        (await QueryTenant(svc, F(ipAddress: "10.0.0.2"))).Records.Should().ContainSingle();
+
+        // Half-open [from, to): Jan row only.
+        (await QueryTenant(svc, F(from: D(2026, 1, 1), to: D(2026, 2, 1))))
+            .Records.Should().ContainSingle().Which.OccurredAt.Should().Be(D(2026, 1, 10));
+    }
+
+    [Test]
+    public async Task Filters_AND_Combine()
+    {
+        var actor = Guid.NewGuid();
+        await SeedTenant(_tenantA, s => s with { Category = "secret", ActorUserId = actor, Severity = "critical", Seq = 1, TargetId = "a" });
+        await SeedTenant(_tenantA, s => s with { Category = "secret", ActorUserId = actor, Severity = "info", Seq = 2, TargetId = "b" });
+        await SeedTenant(_tenantA, s => s with { Category = "rbac", ActorUserId = actor, Severity = "critical", Seq = 3, TargetId = "c" });
+
+        var svc = NewService(out _, out _);
+        var result = await QueryTenant(svc, F(category: "secret", severity: "critical"));
+        result.Records.Should().ContainSingle().Which.TargetId.Should().Be("a");
+    }
+
+    // ════════════════════ search (q) ════════════════════
+
+    [Test]
+    public async Task Search_Matches_Actor_Target_And_Payload_CaseInsensitively()
+    {
+        await SeedTenant(_tenantA, s => s with { Seq = 1, ActorEmailSnapshot = "Alice@Example.com", TargetId = "t-1", PayloadJson = "{\"note\":\"routine\"}" });
+        await SeedTenant(_tenantA, s => s with { Seq = 2, ActorEmailSnapshot = "bob@example.com", TargetId = "NEEDLE-42", PayloadJson = "{\"note\":\"routine\"}" });
+        await SeedTenant(_tenantA, s => s with { Seq = 3, ActorEmailSnapshot = "carol@example.com", TargetId = "t-3", PayloadJson = "{\"secretName\":\"haystack-token\"}" });
+
+        var svc = NewService(out _, out _);
+
+        (await QueryTenant(svc, F(q: "alice"))).Records.Should().ContainSingle("actor email matched case-insensitively");
+        (await QueryTenant(svc, F(q: "needle"))).Records.Should().ContainSingle("target id matched case-insensitively");
+        (await QueryTenant(svc, F(q: "haystack"))).Records.Should().ContainSingle("payload json matched");
+    }
+
+    [Test]
+    public async Task Injection_Shaped_Search_Is_Inert()
+    {
+        await SeedTenant(_tenantA, s => s with { Seq = 1, ActorEmailSnapshot = "alice@example.com", TargetId = "t-1" });
+        await SeedTenant(_tenantA, s => s with { Seq = 2, ActorEmailSnapshot = "bob@example.com", TargetId = "t-2" });
+
+        var svc = NewService(out _, out _);
+        var result = await QueryTenant(svc, F(q: "' OR 1=1 --"));
+        result.Records.Should().BeEmpty("a parameterized ILIKE treats the injection string as a literal");
+    }
+
+    // ════════════════════ keyset pagination ════════════════════
+
+    [Test]
+    public async Task Keyset_Pages_Through_Without_Overlap_Or_Gap()
+    {
+        for (var i = 1; i <= 250; i++)
+            await SeedTenant(_tenantA, s => s with { Seq = i, TargetId = $"t-{i}" });
+
+        var svc = NewService(out _, out _);
+
+        var page1 = await QueryTenant(svc, F(limit: 100));
+        page1.Records.Should().HaveCount(100);
+        page1.Records[0].SourceSequenceNumber.Should().Be(250, "most-recent first");
+        page1.Records[^1].SourceSequenceNumber.Should().Be(151);
+        page1.NextCursor.Should().NotBeNull();
+
+        var page2 = await QueryTenant(svc, F(limit: 100, cursor: page1.NextCursor));
+        page2.Records.Should().HaveCount(100);
+        page2.Records[0].SourceSequenceNumber.Should().Be(150);
+        page2.Records[^1].SourceSequenceNumber.Should().Be(51);
+        page2.NextCursor.Should().NotBeNull();
+
+        var page3 = await QueryTenant(svc, F(limit: 100, cursor: page2.NextCursor));
+        page3.Records.Should().HaveCount(50);
+        page3.Records[^1].SourceSequenceNumber.Should().Be(1);
+        page3.NextCursor.Should().BeNull("last page");
+
+        // No overlap across pages.
+        var all = page1.Records.Concat(page2.Records).Concat(page3.Records)
+            .Select(r => r.SourceSequenceNumber).ToList();
+        all.Should().OnlyHaveUniqueItems();
+        all.Should().HaveCount(250);
+    }
+
+    [Test]
+    public async Task Keyset_Is_Stable_Under_Concurrent_Inserts()
+    {
+        for (var i = 1; i <= 250; i++)
+            await SeedTenant(_tenantA, s => s with { Seq = i, TargetId = $"t-{i}" });
+
+        var svc = NewService(out _, out _);
+        var page1 = await QueryTenant(svc, F(limit: 100));
+
+        // 10 NEWER rows appear between page 1 and page 2.
+        for (var i = 251; i <= 260; i++)
+            await SeedTenant(_tenantA, s => s with { Seq = i, TargetId = $"t-{i}" });
+
+        var page2 = await QueryTenant(svc, F(limit: 100, cursor: page1.NextCursor));
+        page2.Records[0].SourceSequenceNumber.Should().Be(150,
+            "the keyset cursor pins the boundary — newer rows never shift page 2");
+        page2.Records[^1].SourceSequenceNumber.Should().Be(51);
+        page2.Records.Select(r => r.SourceSequenceNumber)
+            .Should().NotContain(new long[] { 251, 252, 260 });
+    }
+
+    // ════════════════════ cross-tenant / cross-scope isolation ════════════════════
+
+    [Test]
+    public async Task Tenant_Query_Never_Returns_Another_Tenants_Rows()
+    {
+        await SeedTenant(_tenantA, s => s with { Seq = 1, TargetId = "A-only" });
+        await SeedTenant(_tenantB, s => s with { Seq = 1, TargetId = "B-only" });
+
+        var svc = NewService(out _, out _);
+        var a = await QueryTenant(svc, F(), _tenantA);
+        a.Records.Should().ContainSingle().Which.TargetId.Should().Be("A-only");
+        a.Records.Should().NotContain(r => r.TargetId == "B-only");
+    }
+
+    [Test]
+    public async Task Foreign_TenantId_Injected_Into_Filter_Returns_Zero_Foreign_Rows()
+    {
+        // Defence-in-depth: even if the explicit predicate targeted tenant B, the
+        // read opens tenant A's PHYSICAL schema — B's rows are unreachable.
+        await SeedTenant(_tenantA, s => s with { Seq = 1, TargetId = "A-only" });
+        await SeedTenant(_tenantB, s => s with { Seq = 1, TargetId = "B-only" });
+
+        var svc = NewService(out _, out _);
+        // Query tenant A but filter for B's target id — physically only A's schema
+        // is open, so zero rows (never B-only).
+        var result = await QueryTenant(svc, F(targetId: "B-only"), _tenantA);
+        result.Records.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Platform_Query_Reads_ControlPlane_Rows_Only_Never_Tenant_Rows()
+    {
+        // A tenant-scoped row lives in tenant A's schema; a platform row lives in CP.
+        await SeedTenant(_tenantA, s => s with { Seq = 1, TargetId = "tenant-row" });
+        await SeedControlPlane(s => s with { Seq = 1, TargetId = "platform-row", TenantId = null, UserId = null });
+
+        var svc = NewService(out _, out _);
+        var result = await svc.QueryPlatformAsync(null, F(), TammaMode.SaaS, default);
+
+        result.Records.Should().ContainSingle().Which.TargetId.Should().Be("platform-row");
+        result.Records.Should().NotContain(r => r.TargetId == "tenant-row");
+    }
+
+    // ════════════════════ per-mode scoping ════════════════════
+
+    [Test]
+    public async Task SingleUser_Tenant_Query_Reads_CP_Rows_Keyed_By_User()
+    {
+        var userX = Guid.NewGuid();
+        var userY = Guid.NewGuid();
+        await SeedControlPlane(s => s with { Seq = 1, TargetId = "mine", UserId = userX, TenantId = null });
+        await SeedControlPlane(s => s with { Seq = 2, TargetId = "theirs", UserId = userY, TenantId = null });
+
+        var svc = NewService(out _, out _);
+        var result = await svc.QueryTenantAsync(_tenantA, userX, F(), TammaMode.SingleUser, default);
+
+        result.Records.Should().ContainSingle().Which.TargetId.Should().Be("mine");
+        result.Records.Should().NotContain(r => r.TargetId == "theirs");
+    }
+
+    // ════════════════════ total (estimate) ════════════════════
+
+    [Test]
+    public async Task Total_Reflects_Filtered_Count_Not_Just_The_Page()
+    {
+        for (var i = 1; i <= 5; i++)
+            await SeedTenant(_tenantA, s => s with { Seq = i, Category = "secret" });
+        for (var i = 6; i <= 8; i++)
+            await SeedTenant(_tenantA, s => s with { Seq = i, Category = "rbac" });
+
+        var svc = NewService(out _, out _);
+        var result = await QueryTenant(svc, F(category: "secret", limit: 2));
+        result.Records.Should().HaveCount(2, "page is limited");
+        result.Total.Should().Be(5, "total counts the whole filtered set, not just the page");
+        result.TotalIsCapped.Should().BeFalse();
+    }
+
+    // ════════════════════ meta-audit (AUDIT.QUERIED) ════════════════════
+
+    [Test]
+    public async Task Successful_Tenant_Read_Emits_One_AuditQueried_Tenant_Event()
+    {
+        await SeedTenant(_tenantA, s => s with { Seq = 1 });
+        var svc = NewService(out var events, out var platform);
+
+        await svc.QueryTenantAsync(_tenantA, Guid.NewGuid(), F(category: "secret"), TammaMode.SaaS, default);
+
+        events.Appended.Should().ContainSingle();
+        var evt = events.Appended[0];
+        evt.Type.Should().Be(AuditQueryEventTypes.Queried);
+        evt.TenantId.Should().Be(_tenantA);
+        evt.Tags.Should().Contain("\"scope\":\"tenant\"");
+        platform.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Successful_Platform_Read_Emits_One_AuditQueried_Platform_Event()
+    {
+        await SeedControlPlane(s => s with { Seq = 1, TenantId = null, UserId = null });
+        var svc = NewService(out var events, out var platform);
+
+        await svc.QueryPlatformAsync(Guid.NewGuid(), F(), TammaMode.SaaS, default);
+
+        platform.Appended.Should().ContainSingle();
+        var evt = platform.Appended[0];
+        evt.Type.Should().Be(AuditQueryEventTypes.Queried);
+        evt.TenantId.Should().BeNull();
+        evt.Tags.Should().Contain("\"scope\":\"platform\"");
+        events.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task MetaAudit_Append_Failure_Does_Not_Fail_The_Read()
+    {
+        await SeedTenant(_tenantA, s => s with { Seq = 1 });
+        var svc = NewService(
+            new ThrowingEventRepository(), new RecordingPlatformEventRepository());
+
+        // The read still succeeds even though the meta-audit append throws.
+        var result = await svc.QueryTenantAsync(_tenantA, Guid.NewGuid(), F(), TammaMode.SaaS, default);
+        result.Records.Should().ContainSingle();
+    }
+
+    // ── service construction ──
+
+    private AuditQueryService NewService(
+        out RecordingEventRepository events, out RecordingPlatformEventRepository platform)
+    {
+        events = new RecordingEventRepository();
+        platform = new RecordingPlatformEventRepository();
+        return NewService(events, platform);
+    }
+
+    private AuditQueryService NewService(IEventRepository events, IPlatformEventRepository platform) =>
+        new(new SearchPathTenantFactory(_cs), NewCp(), events, platform,
+            new TestTenantContext(), TimeProvider.System, NullLogger<AuditQueryService>.Instance);
+
+    private Task<Tamma.Api.Dtos.Audit.AuditQueryResponse> QueryTenant(
+        AuditQueryService svc, AuditQueryFilter f, Guid? tenantId = null) =>
+        svc.QueryTenantAsync(tenantId ?? _tenantA, Guid.NewGuid(), f, TammaMode.SaaS, default);
+
+    private static AuditQueryFilter F(
+        string? category = null, string? action = null, Guid? actorUserId = null,
+        string? targetType = null, string? targetId = null, string? severity = null,
+        string? outcome = null, string? ipAddress = null, DateTime? from = null,
+        DateTime? to = null, string? q = null, int? limit = null, string? cursor = null)
+    {
+        var (filter, error) = AuditQueryFilter.TryParse(
+            category, action, actorUserId?.ToString(), targetType, targetId, severity,
+            outcome, ipAddress, from, to, q, limit, cursor);
+        error.Should().BeNull("test filters must be valid");
+        return filter!;
+    }
+
+    // ── seeding ──
+
+    private sealed record Seed(
+        long Seq, string Category, string ActionCode, Guid? ActorUserId,
+        string? ActorEmailSnapshot, string? TargetType, string? TargetId,
+        string Severity, string Outcome, string? IpAddress, DateTime OccurredAt,
+        string PayloadJson, Guid? TenantId, Guid? UserId);
+
+    private static Seed Default(Guid? tenantId, Guid? userId) => new(
+        Seq: 1, Category: "secret", ActionCode: "SECRET.REVEAL", ActorUserId: null,
+        ActorEmailSnapshot: null, TargetType: "secret", TargetId: "t-1",
+        Severity: "info", Outcome: "success", IpAddress: null, OccurredAt: D(2026, 1, 1),
+        PayloadJson: "{}", TenantId: tenantId, UserId: userId);
+
+    private async Task SeedTenant(Guid tenantId, Func<Seed, Seed> mutate)
+    {
+        var s = mutate(Default(tenantId, null));
+        await using var db = NewTenant(tenantId, TenantNaming.SchemaName(tenantId));
+        db.AuditRecords.Add(ToRecord(s));
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedControlPlane(Func<Seed, Seed> mutate)
+    {
+        var s = mutate(Default(null, null));
+        await using var cp = NewCp();
+        cp.AuditRecords.Add(ToRecord(s));
+        await cp.SaveChangesAsync();
+    }
+
+    private static AuditRecord ToRecord(Seed s) => new()
+    {
+        Id = Guid.NewGuid(),
+        Category = s.Category,
+        ActionCode = s.ActionCode,
+        Severity = s.Severity,
+        ActorUserId = s.ActorUserId,
+        ActorEmailSnapshot = s.ActorEmailSnapshot,
+        TargetType = s.TargetType,
+        TargetId = s.TargetId,
+        Outcome = s.Outcome,
+        IpAddress = s.IpAddress,
+        OccurredAt = s.OccurredAt,
+        SourceEventId = Guid.NewGuid(),
+        SourceSequenceNumber = s.Seq,
+        PayloadJson = s.PayloadJson,
+        TenantId = s.TenantId,
+        UserId = s.UserId,
+    };
+
+    private static DateTime D(int y, int m, int d) =>
+        new(y, m, d, 0, 0, 0, DateTimeKind.Utc);
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_cs) { SearchPath = schema }.ConnectionString;
+
+    private ControlPlaneDbContext NewCp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private TenantDbContext NewTenant(Guid tenantId, string schema) =>
+        new(new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options, tenantId);
+
+    private static async Task Exec(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    // ── test doubles ──
+
+    private sealed class TestTenantContext : ITenantContext
+    {
+        public Guid? TenantId { get; private set; }
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class SearchPathTenantFactory(string baseCs) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            var schema = TenantNaming.SchemaName(tenantId);
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options, tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public List<DomainEvent> Appended { get; } = new();
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Appended.Add(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+
+    private sealed class ThrowingEventRepository : IEventRepository
+    {
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) => throw new InvalidOperationException("boom");
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingPlatformEventRepository : IPlatformEventRepository
+    {
+        public List<PlatformEvent> Appended { get; } = new();
+
+        public Task<PlatformEvent?> AppendAsync(PlatformEvent evt, CancellationToken ct = default)
+        {
+            Appended.Add(evt);
+            return Task.FromResult<PlatformEvent?>(evt);
+        }
+
+        public Task<PlatformEvent?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<IReadOnlyList<PlatformEvent>> QueryAsync(Guid? tenantId = null, Guid? userId = null, string? typePrefix = null, DateTime? since = null, bool includePlatformWide = false, int limit = 100, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditQueryServiceTests.cs
@@ -186,6 +186,39 @@ public class AuditQueryServiceTests
     }
 
     [Test]
+    public async Task Keyset_Does_Not_Skip_Rows_That_Share_A_NonUnique_SourceSequenceNumber()
+    {
+        // The control-plane audit_records table is fed by TWO independent identity
+        // sequences (domain_events.SequenceNumber AND platform_events.SequenceNumber,
+        // both starting at 1), so source_sequence_number values COLLIDE — the table
+        // is unique only on source_event_id. A keyset that seeks on the sequence
+        // ALONE (cursor encodes seq=N; next page does `seq < N`) silently drops the
+        // OTHER row sharing the boundary sequence — a compliance completeness bug.
+        // Seed two platform rows with the SAME sequence (distinct id/source_event_id)
+        // and page one-at-a-time: BOTH must surface, none skipped, none duplicated.
+        await SeedControlPlane(s => s with { Seq = 7, TargetId = "collide-A", TenantId = null, UserId = null });
+        await SeedControlPlane(s => s with { Seq = 7, TargetId = "collide-B", TenantId = null, UserId = null });
+
+        var svc = NewService(out _, out _);
+
+        var page1 = await svc.QueryPlatformAsync(null, F(limit: 1), TammaMode.SaaS, default);
+        page1.Records.Should().HaveCount(1);
+        page1.NextCursor.Should().NotBeNull(
+            "a second row shares the boundary sequence and must not be skipped");
+
+        var page2 = await svc.QueryPlatformAsync(null, F(limit: 1, cursor: page1.NextCursor), TammaMode.SaaS, default);
+        page2.Records.Should().HaveCount(1,
+            "the OTHER row sharing source_sequence_number=7 surfaces on the next page "
+                + "(a single-key cursor skipped it)");
+        page2.NextCursor.Should().BeNull("both rows are now consumed");
+
+        var seen = page1.Records.Concat(page2.Records).Select(r => r.TargetId).ToList();
+        seen.Should().OnlyHaveUniqueItems("no row is duplicated across pages");
+        seen.Should().BeEquivalentTo(new[] { "collide-A", "collide-B" },
+            "both colliding-sequence rows surface across the pages — none skipped");
+    }
+
+    [Test]
     public async Task Keyset_Is_Stable_Under_Concurrent_Inserts()
     {
         for (var i = 1; i <= 250; i++)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/TenantAuditEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Orgs/TenantAuditEndpointTests.cs
@@ -2,20 +2,26 @@ using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Tamma.Api.Authorization;
-using Tamma.Api.Dtos.Orgs;
 using Tamma.Api.Endpoints;
-using Tamma.Data;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Tests.Orgs;
 
 /// <summary>
-/// Direct-handler tests for <see cref="OrgEndpoints.ListTenantAudit"/>
-/// (story 18-7 task 2). Covers the auth gate, tenant scoping, type-prefix
-/// filter, and pagination clamping.
+/// Story 37-3 — direct-handler tests for the rewritten
+/// <see cref="OrgEndpoints.ListTenantAudit"/> (rich query over the curated
+/// <c>audit_records</c> read-model) + <see cref="AdminEndpoints.ListPlatformAudit"/>.
+/// Covers the RBAC gate (member 403, admin 200, missing-role 403), invalid-filter
+/// 400, limit clamping, and the legacy <c>type</c>/<c>offset</c> compat shim.
+/// Filter/pagination/scoping correctness is proven in
+/// <c>AuditQueryServiceTests</c>.
 /// </summary>
 [TestFixture]
 public class TenantAuditEndpointTests
@@ -23,8 +29,9 @@ public class TenantAuditEndpointTests
     private IServiceScope _scope = null!;
     private ITenantRepository _tenantRepo = null!;
     private IUserRepository _userRepo = null!;
-    private IEventRepository _events = null!;
-    private ITenantContext _tenantContext = null!;
+    private IAuditQueryService _auditQuery = null!;
+    private ITammaModeProvider _mode = null!;
+    private static readonly ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
 
     [SetUp]
     public async Task Setup()
@@ -33,8 +40,8 @@ public class TenantAuditEndpointTests
         _scope = ApiTestFixture.Factory.Services.CreateScope();
         _tenantRepo = _scope.ServiceProvider.GetRequiredService<ITenantRepository>();
         _userRepo = _scope.ServiceProvider.GetRequiredService<IUserRepository>();
-        _events = _scope.ServiceProvider.GetRequiredService<IEventRepository>();
-        _tenantContext = _scope.ServiceProvider.GetRequiredService<ITenantContext>();
+        _auditQuery = _scope.ServiceProvider.GetRequiredService<IAuditQueryService>();
+        _mode = _scope.ServiceProvider.GetRequiredService<ITammaModeProvider>();
     }
 
     [TearDown]
@@ -44,11 +51,7 @@ public class TenantAuditEndpointTests
     public async Task ListTenantAudit_Returns403_WhenRequesterIsMember()
     {
         var (tenantId, _) = await SeedTenantAsync();
-        var ctx = HttpCtxWithRole(TenantRoleHierarchy.Member);
-
-        var result = await OrgEndpoints.ListTenantAudit(
-            tenantId, _events, _tenantContext, ctx, limit: null, offset: null, type: null);
-
+        var result = await Invoke(tenantId, HttpCtxWithRole(TenantRoleHierarchy.Member));
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status403Forbidden);
     }
 
@@ -56,111 +59,75 @@ public class TenantAuditEndpointTests
     public async Task ListTenantAudit_Returns403_WhenNoMembershipRoleSet()
     {
         var (tenantId, _) = await SeedTenantAsync();
-        // ctx without TenantRoleItemKey ⇒ filter chain misconfigured ⇒ 403.
-        var ctx = new DefaultHttpContext();
-
-        var result = await OrgEndpoints.ListTenantAudit(
-            tenantId, _events, _tenantContext, ctx, limit: null, offset: null, type: null);
-
+        var result = await Invoke(tenantId, new DefaultHttpContext());
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status403Forbidden);
     }
 
     [Test]
-    public async Task ListTenantAudit_Returns200_AndOnlyTenantScopedRows()
-    {
-        var (tenantA, _) = await SeedTenantAsync();
-        var (tenantB, _) = await SeedTenantAsync();
-
-        // Seed events for both tenants.
-        await SeedEventAsync(tenantA, "TENANT.MEMBER_INVITED.SUCCESS");
-        await SeedEventAsync(tenantA, "TENANT.MEMBER_JOINED.SUCCESS");
-        await SeedEventAsync(tenantB, "TENANT.MEMBER_INVITED.SUCCESS");
-
-        var ctx = HttpCtxWithRole(TenantRoleHierarchy.Admin);
-        var result = await OrgEndpoints.ListTenantAudit(
-            tenantA, _events, _tenantContext, ctx, limit: null, offset: null, type: null);
-
-        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
-
-        // Re-query directly to assert the row count we expect — the handler
-        // returned an opaque payload but the underlying state is observable.
-        var (rows, total) = await _events.ListByTenantAsync(tenantA, null, 50, 0);
-        rows.Should().HaveCount(2);
-        total.Should().Be(2);
-        rows.Should().OnlyContain(e => e.TenantId == tenantA);
-    }
-
-    [Test]
-    public async Task ListTenantAudit_FiltersByTypePrefix()
+    public async Task ListTenantAudit_Returns200_ForAdmin()
     {
         var (tenantId, _) = await SeedTenantAsync();
-        await SeedEventAsync(tenantId, "TENANT.MEMBER_INVITED.SUCCESS");
-        await SeedEventAsync(tenantId, "TENANT.MEMBER_ROLE_CHANGED.SUCCESS");
-        await SeedEventAsync(tenantId, "TENANT.OWNERSHIP_TRANSFERRED.SUCCESS");
-
-        var (members, totalMembers) = await _events.ListByTenantAsync(tenantId, "TENANT.MEMBER", 50, 0);
-        members.Should().HaveCount(2);
-        totalMembers.Should().Be(2);
-        members.Should().OnlyContain(e => e.Type.StartsWith("TENANT.MEMBER"));
-
-        var (transfers, totalTransfers) = await _events.ListByTenantAsync(tenantId, "TENANT.OWNERSHIP", 50, 0);
-        transfers.Should().HaveCount(1);
-        totalTransfers.Should().Be(1);
-        transfers[0].Type.Should().Be("TENANT.OWNERSHIP_TRANSFERRED.SUCCESS");
-    }
-
-    [Test]
-    public async Task ListTenantAudit_HonoursPagination()
-    {
-        var (tenantId, _) = await SeedTenantAsync();
-        for (var i = 0; i < 5; i++)
-            await SeedEventAsync(tenantId, "TENANT.MEMBER_INVITED.SUCCESS");
-
-        var (page1, total1) = await _events.ListByTenantAsync(tenantId, null, 2, 0);
-        page1.Should().HaveCount(2);
-        total1.Should().Be(5);
-
-        var (page2, total2) = await _events.ListByTenantAsync(tenantId, null, 2, 2);
-        page2.Should().HaveCount(2);
-        total2.Should().Be(5);
-
-        var (page3, total3) = await _events.ListByTenantAsync(tenantId, null, 2, 4);
-        page3.Should().HaveCount(1);
-        total3.Should().Be(5);
-    }
-
-    [Test]
-    public async Task ListTenantAudit_OrdersMostRecentFirst()
-    {
-        var (tenantId, _) = await SeedTenantAsync();
-        var older = await SeedEventAsync(tenantId, "TENANT.CREATED.SUCCESS");
-        // Force ordering with a tiny delay so created_at differs.
-        await Task.Delay(20);
-        var newer = await SeedEventAsync(tenantId, "TENANT.MEMBER_INVITED.SUCCESS");
-
-        var (rows, _) = await _events.ListByTenantAsync(tenantId, null, 10, 0);
-        rows[0].Id.Should().Be(newer.Id);
-        rows[1].Id.Should().Be(older.Id);
-    }
-
-    [Test]
-    public async Task ListTenantAudit_ClampsLimitTo200()
-    {
-        var (tenantId, _) = await SeedTenantAsync();
-        // Single event so we exercise the limit clamp without the test
-        // taking forever seeding 200 rows.
-        await SeedEventAsync(tenantId, "TENANT.CREATED.SUCCESS");
-
-        var ctx = HttpCtxWithRole(TenantRoleHierarchy.Admin);
-        // Caller asks for 5000 — handler must clamp to 200 internally.
-        var result = await OrgEndpoints.ListTenantAudit(
-            tenantId, _events, _tenantContext, ctx, limit: 5000, offset: -1, type: null);
-
-        // Status check is enough — the clamp is exercised, no 4xx/5xx.
+        var result = await Invoke(tenantId, HttpCtxWithRole(TenantRoleHierarchy.Admin));
         (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
     }
 
-    // ── Helpers ─────────────────────────────────────────────────────────────
+    [Test]
+    public async Task ListTenantAudit_Returns400_OnInvalidFilterValue()
+    {
+        var (tenantId, _) = await SeedTenantAsync();
+        var result = await Invoke(tenantId, HttpCtxWithRole(TenantRoleHierarchy.Admin), severity: "bogus");
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task ListTenantAudit_ClampsLimit_StillReturns200()
+    {
+        var (tenantId, _) = await SeedTenantAsync();
+        var result = await Invoke(tenantId, HttpCtxWithRole(TenantRoleHierarchy.Admin), limit: 5000);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Test]
+    public async Task ListTenantAudit_LegacyTypeAndOffset_StillReturns200()
+    {
+        var (tenantId, _) = await SeedTenantAsync();
+        var result = await Invoke(
+            tenantId, HttpCtxWithRole(TenantRoleHierarchy.Admin), type: "SECRET.REVEAL", offset: 20);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Test]
+    public async Task ListPlatformAudit_Returns200_OnValidQuery()
+    {
+        var result = await AdminEndpoints.ListPlatformAudit(
+            _auditQuery, _mode, EmptyPrincipal(), _loggerFactory,
+            category: null, action: null, actorUserId: null, targetType: null, targetId: null,
+            severity: null, outcome: null, ipAddress: null, from: null, to: null, q: null,
+            limit: null, cursor: null, type: null, offset: null, ct: default);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Test]
+    public async Task ListPlatformAudit_Returns400_OnInvalidFilterValue()
+    {
+        var result = await AdminEndpoints.ListPlatformAudit(
+            _auditQuery, _mode, EmptyPrincipal(), _loggerFactory,
+            category: "not-a-category", action: null, actorUserId: null, targetType: null, targetId: null,
+            severity: null, outcome: null, ipAddress: null, from: null, to: null, q: null,
+            limit: null, cursor: null, type: null, offset: null, ct: default);
+        (await ExecuteAndGetStatus(result)).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ── Helpers ──
+
+    private Task<IResult> Invoke(
+        Guid tenantId, HttpContext ctx, string? severity = null, int? limit = null,
+        string? type = null, int? offset = null)
+        => OrgEndpoints.ListTenantAudit(
+            tenantId, _auditQuery, _mode, EmptyPrincipal(), ctx, _loggerFactory,
+            category: null, action: null, actorUserId: null, targetType: null, targetId: null,
+            severity: severity, outcome: null, ipAddress: null, from: null, to: null, q: null,
+            limit: limit, cursor: null, type: type, offset: offset, ct: default);
 
     private async Task<(Guid TenantId, Guid OwnerId)> SeedTenantAsync()
     {
@@ -176,22 +143,11 @@ public class TenantAuditEndpointTests
             Type = "org",
             OwnerId = owner.Id,
         });
-        // Phase 3 -- tenant events live in the tenant store, which is only
-        // reachable for provisioned tenants.
         await ApiTestFixture.ProvisionTenantAsync(tenant.Id);
         return (tenant.Id, owner.Id);
     }
 
-    private async Task<DomainEvent> SeedEventAsync(Guid tenantId, string type)
-        => await _events.AppendAsync(new DomainEvent
-        {
-            Id = Guid.NewGuid(),
-            Type = type,
-            TenantId = tenantId,
-            Tags = $"{{\"tenantId\":\"{tenantId}\"}}",
-            Metadata = "{\"workflowVersion\":\"1.0.0\",\"eventSource\":\"system\"}",
-            Data = "{}",
-        });
+    private static ClaimsPrincipal EmptyPrincipal() => new(new ClaimsIdentity());
 
     private static HttpContext HttpCtxWithRole(string role)
     {


### PR DESCRIPTION
## What

Story 37-3 (P0). A read-only query API over the curated `audit_records` read-model (37-1): `GET /api/v1/orgs/{tenantId}/audit` (tenant **admin+**, membership-gated) and `GET /api/v1/admin/audit` (**PlatformOwnerAccess**). Filters (category/action/actor/target/severity/outcome/ip/time-range/`q` search), keyset pagination, capped total. Reads the materialized table only — never re-projects raw events. **No migration.**

- Corrected the spec's schema assumptions against real 37-1 (one `audit_records` table on both contexts; columns `Category`/`ActorEmailSnapshot`/`PayloadJson`).
- Parameterized `ILIKE` search (`FromSqlInterpolated`, injection-inert); opaque base64url cursor (malformed → 400).
- Isolation: physical per-tenant schema + explicit scope predicate on every path (SaaS `TenantId==tenantId`, single-user `UserId==caller`, platform `TenantId==null`). Best-effort `AUDIT.QUERIED` meta-audit.
- Legacy 18-7 endpoint rewritten in place (TS dashboard parse update flagged as a follow-up; no server-side consumer broke).

## Review outcome

Adversarial review verified RBAC (both routes), scope predicates on every path, cursor/search injection-safety, and meta-audit best-effort as SOLID. One Important finding fixed:
- **Compliance completeness bug (single-user):** the CP `audit_records` table is fed by two independent identity sequences (`domain_events` + `platform_events`), so `SourceSequenceNumber` collides and a single-key keyset cursor **silently dropped** a colliding row at page boundaries. Fixed with a total ordering `(SourceSequenceNumber DESC, Id DESC)` + compound cursor + a Postgres row-value seek (`(seq,id) < (c.seq,c.id)`). Collision test added (two same-seq rows both surface across pages).
- Folded in a Kind-aware `ToUtc` (treat Unspecified as UTC; convert Local) — heeds the repo's TZ-bug class.

Follow-ups noted: 36-3's `AnalyticsWindow.ToUtc` has the same latent Unspecified-drift; orphaned `AuditEventResponse`/`ListByTenantAsync` dead-code cleanup.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Audit tests: 149 passed (incl. Postgres testcontainer isolation + collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)