### PR TITLE
feat(epic-35): Story 35-5 — Stripe Webhook Ingestion, Idempotency & Billing Event Projection

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingWebhookAdminEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/BillingWebhookAdminEndpoints.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.Billing;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints.Billing;
+
+/// <summary>
+/// Story 35-5 (AC12) — platform-operator replay/inspect surface for stored
+/// Stripe webhook deliveries. Both routes are <c>PlatformOwnerAccess</c>-gated (a
+/// Stripe webhook is a platform-operator concern, never a tenant-scoped route —
+/// there is no path for one tenant to read another tenant's webhook rows).
+///
+/// <list type="bullet">
+///   <item><c>GET /api/v1/admin/billing/webhook-events</c> — recent rows,
+///     filterable by <c>status</c>/<c>eventType</c>/<c>tenantId</c>, paged
+///     (default 50, max 200).</item>
+///   <item><c>POST /api/v1/admin/billing/webhook-events/{id}/replay</c> —
+///     re-dispatch a stored payload (idempotent; a <c>projected</c> row is a
+///     no-op).</item>
+/// </list>
+/// </summary>
+public static class BillingWebhookAdminEndpoints
+{
+    private const int DefaultLimit = 50;
+    private const int MaxLimit = 200;
+
+    public static async Task<IResult> List(
+        [FromServices] ControlPlaneDbContext db,
+        [FromServices] ILoggerFactory loggerFactory,
+        string? status = null,
+        string? eventType = null,
+        Guid? tenantId = null,
+        int limit = DefaultLimit,
+        int offset = 0)
+    {
+        var logger = loggerFactory.CreateLogger("BillingWebhookAdminEndpoints");
+        limit = Math.Clamp(limit, 1, MaxLimit);
+        offset = Math.Max(offset, 0);
+
+        var query = db.BillingWebhookEvents.AsNoTracking().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(e => e.Status == status);
+        if (!string.IsNullOrWhiteSpace(eventType))
+            query = query.Where(e => e.EventType == eventType);
+        if (tenantId is not null)
+            query = query.Where(e => e.TenantId == tenantId);
+
+        var total = await query.CountAsync();
+        var items = await query
+            .OrderByDescending(e => e.ReceivedAt)
+            .Skip(offset)
+            .Take(limit)
+            .Select(e => new
+            {
+                e.Id,
+                e.StripeEventId,
+                e.EventType,
+                e.TenantId,
+                e.StripeObjectId,
+                e.Status,
+                e.Attempts,
+                e.LastError,
+                e.ReceivedAt,
+                e.ProcessedAt,
+            })
+            .ToListAsync();
+
+        logger.LogInformation(
+            "Admin listed {Count} billing webhook events (status={Status}, eventType={EventType}, "
+            + "tenantId={TenantId}, total={Total}).",
+            items.Count, status, eventType, tenantId, total);
+
+        return Results.Ok(new { items, total, limit, offset });
+    }
+
+    public static async Task<IResult> Replay(
+        Guid id,
+        [FromServices] IStripeWebhookProcessor processor,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("BillingWebhookAdminEndpoints");
+        logger.LogInformation("Admin replay requested for billing webhook event {Id}.", id);
+
+        var result = await processor.ReplayAsync(id);
+        if (result is null)
+        {
+            return Results.NotFound(new { error = "webhook event not found", id });
+        }
+
+        return Results.Ok(new { replayed = true, id, status = result.Status });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/StripeWebhookEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/StripeWebhookEndpoint.cs
@@ -1,0 +1,77 @@
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Endpoints.Billing;
+
+/// <summary>
+/// Story 35-5 — <c>POST /api/v1/billing/stripe/webhook</c>. Anonymous at the
+/// app-auth layer (Stripe calls it), signature-gated instead. Mirrors
+/// <c>GitHubEndpoints.Webhooks</c>: <c>EnableBuffering()</c> + a leave-open
+/// <see cref="StreamReader"/> to capture the RAW body (any body re-serialization
+/// would break signature verification), then verify with the Stripe SDK before
+/// any processing.
+///
+/// <para>Status discipline (AC1–AC3, AC11): missing signature → <c>400</c>;
+/// unresolvable secret → <c>503</c> (never fail open); invalid signature →
+/// <c>400</c> (WARN, never the raw body); everything else acks <c>200</c> — so a
+/// permanently-unprojectable event never triggers a Stripe retry storm.</para>
+/// </summary>
+public static class StripeWebhookEndpoint
+{
+    public static async Task<IResult> Receive(
+        HttpContext context,
+        [FromServices] IStripeSigningSecretSource secretSource,
+        [FromServices] IStripeEventVerifier verifier,
+        [FromServices] IStripeWebhookProcessor processor,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("StripeWebhookEndpoint");
+
+        var signature = context.Request.Headers["Stripe-Signature"].FirstOrDefault();
+        if (string.IsNullOrEmpty(signature))
+        {
+            logger.LogWarning("Stripe webhook rejected: missing Stripe-Signature header.");
+            return Results.BadRequest(new { error = "missing signature" });
+        }
+
+        // Capture the raw body without consuming it for any later middleware.
+        context.Request.EnableBuffering();
+        string rawBody;
+        using (var reader = new StreamReader(
+            context.Request.Body, Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: false, bufferSize: 1024, leaveOpen: true))
+        {
+            rawBody = await reader.ReadToEndAsync(context.RequestAborted);
+            context.Request.Body.Position = 0;
+        }
+
+        // Secret from the Epic 29 cabinet — never IConfiguration. Fail CLOSED.
+        var signingSecret = await secretSource
+            .GetSigningSecretAsync(context.RequestAborted);
+        if (string.IsNullOrEmpty(signingSecret))
+        {
+            logger.LogError(
+                "Stripe webhook secret unresolvable from the cabinet; returning 503 "
+                + "(fail closed — never fail open on a missing secret).");
+            return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+        }
+
+        Stripe.Event stripeEvent;
+        try
+        {
+            stripeEvent = verifier.Construct(rawBody, signature, signingSecret);
+        }
+        catch (Stripe.StripeException ex)
+        {
+            // Never log the raw body or the signature header.
+            logger.LogWarning(
+                "Stripe webhook signature rejected: {Reason}", ex.StripeError?.Message ?? ex.Message);
+            return Results.BadRequest(new { error = "invalid signature" });
+        }
+
+        var result = await processor
+            .ProcessAsync(stripeEvent, rawBody, context.RequestAborted);
+        return Results.Ok(new { received = true, status = result.Status });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Handlers;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.PromptStore;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 35-5 — mode-gated DI for the Stripe webhook ingestion pipeline. Wired
+/// only when <see cref="ITammaModeProvider.Mode"/> is <c>SaaS</c> (single-user's
+/// <c>NullBillingProvider</c> means zero Stripe surface — 35-1 AC7 / 35-5 AC13).
+///
+/// <para>Registers the processor, the handler registry + the four default
+/// DCB-emitting handlers, the <see cref="NullBillingEventHandler"/> fallthrough,
+/// the signing-secret source, the Stripe event verifier, and the fast-ack
+/// follow-up <see cref="IPlatformTaskHandler"/>. Mirrors
+/// <c>PlatformTaskServiceCollectionExtensions</c>.</para>
+/// </summary>
+public static class BillingWebhookServiceCollectionExtensions
+{
+    /// <summary>Register the webhook pipeline when the process runs in SaaS mode.</summary>
+    public static IServiceCollection AddBillingWebhookIngestion(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var mode = ResolveMode(services, configuration);
+        if (mode != TammaMode.SaaS)
+        {
+            // Single-user: no Stripe surface. Route mapping is skipped in Program.cs.
+            return services;
+        }
+
+        services.TryAddSingleton<TimeProvider>(TimeProvider.System);
+
+        // Signing-secret source + verifier are stateless singletons.
+        services.TryAddSingleton<IStripeSigningSecretSource, CabinetStripeSigningSecretSource>();
+        services.TryAddSingleton<IStripeEventVerifier, StripeEventVerifier>();
+
+        // The processor + registry are Scoped (they take ControlPlaneDbContext +
+        // scoped repositories), mirroring PlatformTaskHandlerRegistry.
+        services.TryAddScoped<IBillingEventHandlerRegistry, BillingEventHandlerRegistry>();
+        services.TryAddScoped<IStripeWebhookProcessor, StripeWebhookProcessor>();
+
+        // The fallthrough handler is resolved directly by the processor (NOT via
+        // the IEnumerable<IBillingEventHandler> registry set), so register the
+        // concrete type.
+        services.TryAddScoped<NullBillingEventHandler>();
+
+        // 35-5's default DCB-emitting handlers. Sibling stories add their own via
+        // AddBillingEventHandler<T>(); duplicate-claim detection supersedes these
+        // cleanly when 35-4/35-7/35-8 land.
+        services.AddBillingEventHandler<SubscriptionWebhookHandler>();
+        services.AddBillingEventHandler<InvoiceWebhookHandler>();
+        services.AddBillingEventHandler<PaymentWebhookHandler>();
+        services.AddBillingEventHandler<DisputeWebhookHandler>();
+
+        // Fast-ack follow-up worker task handler (AC10).
+        services.AddPlatformTaskHandler<BillingWebhookFollowupTaskHandler>();
+
+        return services;
+    }
+
+    /// <summary>Register one <see cref="IBillingEventHandler"/> (scoped).</summary>
+    public static IServiceCollection AddBillingEventHandler<THandler>(
+        this IServiceCollection services)
+        where THandler : class, IBillingEventHandler
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        services.AddScoped<IBillingEventHandler, THandler>();
+        return services;
+    }
+
+    private static TammaMode ResolveMode(
+        IServiceCollection services, IConfiguration configuration)
+    {
+        var registered = services
+            .FirstOrDefault(d => d.ServiceType == typeof(ITammaModeProvider))?
+            .ImplementationInstance as ITammaModeProvider;
+        return registered?.Mode ?? TammaModeProvider.Resolve(configuration);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1169,6 +1169,14 @@ builder.Services.AddPlatformTaskWorker(builder.Configuration);
 // resolves through the Epic 29 cabinet — never raw env in production (AC5).
 builder.Services.AddTammaBilling(builder.Configuration);
 
+// Story 35-5 — Stripe webhook ingestion pipeline (SaaS only). Registers the
+// processor, the pluggable IBillingEventHandler registry + 35-5's default
+// DCB-emitting handlers, the cabinet-resolving signing-secret source, the
+// Stripe event verifier, and the fast-ack billing.webhook.followup task handler.
+// Single-user is a no-op (NullBillingProvider — zero Stripe surface); the routes
+// below are mapped only in SaaS mode.
+builder.Services.AddBillingWebhookIngestion(builder.Configuration);
+
 // Unified-tenancy Phase 4 — `tenant.move` platform-task handler. Drives
 // ITenantMoveService.MoveAsync for tasks enqueued by
 // POST /api/admin/tenants/{tenantId}/move; on failure it stamps the
@@ -2414,6 +2422,27 @@ github.MapPost("/webhooks", GitHubEndpoints.Webhooks)
 app.MapPost("/api/webhooks/{platform}", WebhookEndpoints.Receive)
     .RequireRateLimiting("GitHubWebhook"); // reuse the 300/min budget
 
+// ── Story 35-5 — Stripe billing webhook (SaaS only; signature-gated, no JWT) ──
+// Mapped only in SaaS mode: single-user has no Stripe surface (NullBillingProvider,
+// 35-1 AC7 / 35-5 AC13), so the webhook + admin routes stay unmapped (→ 404). The
+// webhook route is anonymous at the app-auth layer (Stripe calls it) and gated by
+// the Stripe signature instead; the admin routes are PlatformOwnerAccess (a Stripe
+// webhook is a platform-operator concern, never a tenant-scoped route).
+if (app.Services.GetRequiredService<Tamma.Api.Services.PromptStore.ITammaModeProvider>()
+        .Mode == Tamma.Api.Services.PromptStore.TammaMode.SaaS)
+{
+    app.MapPost("/api/v1/billing/stripe/webhook",
+            Tamma.Api.Endpoints.Billing.StripeWebhookEndpoint.Receive)
+        .RequireRateLimiting("GitHubWebhook"); // reuse the 300/min webhook budget
+
+    app.MapGet("/api/v1/admin/billing/webhook-events",
+            Tamma.Api.Endpoints.Billing.BillingWebhookAdminEndpoints.List)
+        .RequireAuthorization("PlatformOwnerAccess");
+    app.MapPost("/api/v1/admin/billing/webhook-events/{id:guid}/replay",
+            Tamma.Api.Endpoints.Billing.BillingWebhookAdminEndpoints.Replay)
+        .RequireAuthorization("PlatformOwnerAccess");
+}
+
 // ── SaaS (API key auth) ──
 app.MapPost("/api/v1/llm/chat", SaaSEndpoints.LlmChat).RequireAuthorization();
 
@@ -2628,6 +2657,7 @@ using (var scope = app.Services.CreateScope())
                     tenant_agent_enablements,
                     audit_records, audit_projector_cursor,
                     billing_customers, billing_plan_prices,
+                    billing_webhook_events,
                     alert_delivery_attempts, alert_channels, alerts,
                     alert_evaluator_cursor, alert_rules,
                     api_keys, agent_configs, budget_configs, domain_events,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEventHandlerRegistry.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEventHandlerRegistry.cs
@@ -1,0 +1,62 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — resolves an <see cref="IBillingEventHandler"/> for a Stripe
+/// event type. Mirrors <c>PlatformTaskHandlerRegistry</c>: a per-scope snapshot
+/// dictionary keyed by event type, with duplicate-claim detection at
+/// construction. An unclaimed type returns <c>null</c> (the processor then uses
+/// <see cref="NullBillingEventHandler"/>).
+/// </summary>
+public interface IBillingEventHandlerRegistry
+{
+    /// <summary>Resolve a handler for <paramref name="eventType"/>, or <c>null</c>.</summary>
+    IBillingEventHandler? Resolve(string eventType);
+
+    /// <summary>All claimed Stripe event types (admin diagnostics).</summary>
+    IReadOnlyCollection<string> RegisteredEventTypes { get; }
+}
+
+/// <summary>
+/// Default <see cref="IBillingEventHandlerRegistry"/> backed by a snapshot
+/// dictionary built per scope from every registered
+/// <see cref="IBillingEventHandler"/>. Two handlers claiming the same event type
+/// throw at construction so a misconfiguration is caught on the first claim
+/// (mirrors <c>PlatformTaskHandlerRegistry</c>).
+///
+/// <para><see cref="NullBillingEventHandler"/> is excluded from the registry —
+/// it is the explicit fallthrough the processor applies when
+/// <see cref="Resolve"/> is null, never a registered claimant.</para>
+/// </summary>
+public sealed class BillingEventHandlerRegistry : IBillingEventHandlerRegistry
+{
+    private readonly IReadOnlyDictionary<string, IBillingEventHandler> _byType;
+
+    public BillingEventHandlerRegistry(IEnumerable<IBillingEventHandler> handlers)
+    {
+        ArgumentNullException.ThrowIfNull(handlers);
+        var dict = new Dictionary<string, IBillingEventHandler>(StringComparer.Ordinal);
+        foreach (var handler in handlers)
+        {
+            if (handler is NullBillingEventHandler) continue;
+            foreach (var type in handler.HandledEventTypes)
+            {
+                if (string.IsNullOrWhiteSpace(type))
+                    throw new InvalidOperationException(
+                        $"IBillingEventHandler '{handler.GetType().FullName}' "
+                        + "claimed an empty event type.");
+                if (dict.TryGetValue(type, out var existing))
+                    throw new InvalidOperationException(
+                        $"Duplicate IBillingEventHandler registration for Stripe "
+                        + $"event type '{type}': {existing.GetType().FullName} vs "
+                        + $"{handler.GetType().FullName}.");
+                dict[type] = handler;
+            }
+        }
+        _byType = dict;
+    }
+
+    public IBillingEventHandler? Resolve(string eventType) =>
+        _byType.TryGetValue(eventType ?? string.Empty, out var h) ? h : null;
+
+    public IReadOnlyCollection<string> RegisteredEventTypes => _byType.Keys.ToArray();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookContext.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — the per-event context handed to an <see cref="IBillingEventHandler"/>.
+/// The processor has already verified the signature, deduped the delivery, and
+/// resolved the tenant; the handler only projects + emits its <c>BILLING.*</c>
+/// DCB event.
+///
+/// <para>The primary Stripe object id (<see cref="StripeObjectId"/>) and the
+/// customer id are extracted from the raw payload's <c>data.object</c> by the
+/// processor — deterministic and Stripe-SDK-shape-independent — so handlers
+/// never re-parse the body. The typed <see cref="StripeEvent"/> is still
+/// supplied for handlers that want the strongly-typed object.</para>
+/// </summary>
+public sealed record BillingWebhookContext(
+    Stripe.Event StripeEvent,
+    Guid TenantId,
+    string EventType,
+    string StripeEventId,
+    string? StripeObjectId,
+    string RawPayload);
+
+/// <summary>
+/// A follow-up work item a handler wants run asynchronously (dunning
+/// escalation, email, Stripe round-trips) rather than inline — enqueued by the
+/// processor as a <c>billing.webhook.followup</c> <c>PlatformQueuedTask</c>
+/// (AC10). <see cref="Payload"/> is the JSON payload for that task.
+/// </summary>
+public sealed record BillingFollowup(string Subtype, string Payload);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookDcbEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookDcbEvents.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using Tamma.Data.Entities;
 
@@ -11,11 +13,28 @@ namespace Tamma.Api.Services.Billing;
 /// event carries the resolved <see cref="DomainEvent.TenantId"/> so tenant
 /// isolation is structural (AC14) and <c>IEventRepository.AppendAsync</c> routes
 /// it to the tenant's stream.
+///
+/// <para><b>Exactly-once on replay.</b> The <see cref="DomainEvent.Id"/> is
+/// DETERMINISTIC — derived from <c>(dcbType, stripeEventId)</c> via
+/// <see cref="DeterministicId"/> — so re-dispatching the same fact (admin replay
+/// of a non-terminal row, or a crash between the DCB emit and the terminal status
+/// save) mints the SAME Id. <c>IEventRepository.AppendAsync</c> (tenant stream)
+/// and <c>IPlatformEventRepository.AppendAsync</c> (platform stream, PK collision)
+/// both dedup on that Id, so a re-dispatch is idempotent and money events
+/// (<c>BILLING.INVOICE.PAID</c>, <c>BILLING.PAYMENT.SUCCEEDED</c>) are never
+/// double-counted. A random <c>Guid.NewGuid()</c> here would defeat that dedup.</para>
 /// </summary>
 public static class BillingWebhookDcbEvents
 {
     private const string SystemMetadata =
         """{"workflowVersion":"1.0.0","eventSource":"system"}""";
+
+    /// <summary>
+    /// Fixed namespace for the name-based (UUIDv5-style) deterministic Id. Not
+    /// security-sensitive — it only namespaces the SHA-1 name hash so unrelated
+    /// deterministic-Guid schemes cannot collide.
+    /// </summary>
+    private static readonly Guid IdNamespace = new("a3f1c2d4-5b6e-4788-9a0b-1c2d3e4f5a6b");
 
     /// <summary>
     /// A projection event (<c>BILLING.SUBSCRIPTION.*</c>, <c>BILLING.INVOICE.*</c>,
@@ -26,7 +45,7 @@ public static class BillingWebhookDcbEvents
         string dcbType, BillingWebhookContext ctx, object? data = null) =>
         new()
         {
-            Id = Guid.NewGuid(),
+            Id = DeterministicId(dcbType, ctx.StripeEventId),
             Type = dcbType,
             TenantId = ctx.TenantId,
             Tags = JsonSerializer.Serialize(new
@@ -55,7 +74,7 @@ public static class BillingWebhookDcbEvents
         string? stripeObjectId, string reason) =>
         new()
         {
-            Id = Guid.NewGuid(),
+            Id = DeterministicId(dcbType, stripeEventId),
             Type = dcbType,
             TenantId = tenantId,
             Tags = JsonSerializer.Serialize(new
@@ -69,4 +88,43 @@ public static class BillingWebhookDcbEvents
             Data = JsonSerializer.Serialize(new { reason }),
             CreatedAt = DateTime.UtcNow,
         };
+
+    /// <summary>
+    /// Deterministic, name-based (RFC 4122 §4.3 UUIDv5) Guid over
+    /// <c>(dcbType, stripeEventId)</c>. Same inputs → same Guid, so a re-dispatch
+    /// of the same DCB fact is deduped by the event store on its Id. Different
+    /// dcbTypes for the same Stripe event (e.g. a projection vs a
+    /// <c>BILLING.WEBHOOK.SKIPPED</c>) are DISTINCT facts and get distinct Ids.
+    /// </summary>
+    internal static Guid DeterministicId(string dcbType, string stripeEventId)
+    {
+        // Length-prefix dcbType so ("A","BC") and ("AB","C") can never hash to the
+        // same name (unambiguous, no separator/control chars).
+        var name = Encoding.UTF8.GetBytes(
+            $"{(dcbType ?? string.Empty).Length}:{dcbType}{stripeEventId}");
+        var ns = IdNamespace.ToByteArray();
+        SwapGuidByteOrder(ns); // Guid stores the first 3 fields little-endian; UUIDv5 hashes network order.
+
+        var buffer = new byte[ns.Length + name.Length];
+        Buffer.BlockCopy(ns, 0, buffer, 0, ns.Length);
+        Buffer.BlockCopy(name, 0, buffer, ns.Length, name.Length);
+
+        var hash = SHA1.HashData(buffer); // 20 bytes; take the first 16.
+        var guidBytes = new byte[16];
+        Array.Copy(hash, guidBytes, 16);
+        guidBytes[6] = (byte)((guidBytes[6] & 0x0F) | 0x50); // version 5
+        guidBytes[8] = (byte)((guidBytes[8] & 0x3F) | 0x80); // RFC 4122 variant
+
+        SwapGuidByteOrder(guidBytes); // back to Guid's mixed-endian layout
+        return new Guid(guidBytes);
+    }
+
+    /// <summary>Swap the byte order of a Guid's first three fields (endianness bridge).</summary>
+    private static void SwapGuidByteOrder(byte[] g)
+    {
+        (g[0], g[3]) = (g[3], g[0]);
+        (g[1], g[2]) = (g[2], g[1]);
+        (g[4], g[5]) = (g[5], g[4]);
+        (g[6], g[7]) = (g[7], g[6]);
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookDcbEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookDcbEvents.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 (AC8) — builds the <c>BILLING.*</c> DCB <see cref="DomainEvent"/>
+/// rows for webhook projections, in the same shape as <c>BillingEvents</c>:
+/// Metadata <c>{"workflowVersion":"1.0.0","eventSource":"system"}</c>; Tags
+/// <c>{ tenantId, stripeEventId, eventType, stripeObjectId }</c>. Every projected
+/// event carries the resolved <see cref="DomainEvent.TenantId"/> so tenant
+/// isolation is structural (AC14) and <c>IEventRepository.AppendAsync</c> routes
+/// it to the tenant's stream.
+/// </summary>
+public static class BillingWebhookDcbEvents
+{
+    private const string SystemMetadata =
+        """{"workflowVersion":"1.0.0","eventSource":"system"}""";
+
+    /// <summary>
+    /// A projection event (<c>BILLING.SUBSCRIPTION.*</c>, <c>BILLING.INVOICE.*</c>,
+    /// <c>BILLING.PAYMENT.*</c>, <c>BILLING.DISPUTE.OPENED</c>) for a resolved
+    /// tenant. <paramref name="data"/> is an optional extra data bag.
+    /// </summary>
+    public static DomainEvent Projection(
+        string dcbType, BillingWebhookContext ctx, object? data = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Type = dcbType,
+            TenantId = ctx.TenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = ctx.TenantId.ToString("D"),
+                stripeEventId = ctx.StripeEventId,
+                eventType = ctx.EventType,
+                stripeObjectId = ctx.StripeObjectId,
+            }),
+            Metadata = SystemMetadata,
+            Data = JsonSerializer.Serialize(data ?? new
+            {
+                stripeObjectId = ctx.StripeObjectId,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+    /// <summary>
+    /// An operational event (<c>BILLING.WEBHOOK.SKIPPED</c> /
+    /// <c>BILLING.WEBHOOK.FAILED</c>). <paramref name="tenantId"/> is null for a
+    /// no-customer-match skip (platform-scoped); the tags carry the raw Stripe id
+    /// for forensics without leaking the body.
+    /// </summary>
+    public static DomainEvent Operational(
+        string dcbType, Guid? tenantId, string stripeEventId, string eventType,
+        string? stripeObjectId, string reason) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Type = dcbType,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId?.ToString("D"),
+                stripeEventId,
+                eventType,
+                stripeObjectId,
+            }),
+            Metadata = SystemMetadata,
+            Data = JsonSerializer.Serialize(new { reason }),
+            CreatedAt = DateTime.UtcNow,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookEventTypes.cs
@@ -1,0 +1,49 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — canonical constants for the Stripe event types 35-5's default
+/// handlers claim, and the <c>BILLING.*</c> DCB event types they emit
+/// (<c>AGGREGATE.ACTION.STATUS</c> convention). Kept as constants so the
+/// handlers, the registry, and the tests cannot drift.
+/// </summary>
+public static class BillingWebhookEventTypes
+{
+    // ── Inbound Stripe event types ──
+    public const string SubscriptionCreated = "customer.subscription.created";
+    public const string SubscriptionUpdated = "customer.subscription.updated";
+    public const string SubscriptionDeleted = "customer.subscription.deleted";
+    public const string SubscriptionTrialWillEnd = "customer.subscription.trial_will_end";
+
+    public const string InvoiceCreated = "invoice.created";
+    public const string InvoiceFinalized = "invoice.finalized";
+    public const string InvoicePaid = "invoice.paid";
+    public const string InvoicePaymentFailed = "invoice.payment_failed";
+
+    public const string PaymentIntentSucceeded = "payment_intent.succeeded";
+    public const string PaymentIntentPaymentFailed = "payment_intent.payment_failed";
+
+    public const string ChargeDisputeCreated = "charge.dispute.created";
+
+    // ── Emitted BILLING.* DCB event types ──
+    public const string DcbSubscriptionCreated = "BILLING.SUBSCRIPTION.CREATED";
+    public const string DcbSubscriptionUpdated = "BILLING.SUBSCRIPTION.UPDATED";
+    public const string DcbSubscriptionDeleted = "BILLING.SUBSCRIPTION.DELETED";
+    public const string DcbSubscriptionTrialEnding = "BILLING.SUBSCRIPTION.TRIAL_ENDING";
+
+    public const string DcbInvoiceCreated = "BILLING.INVOICE.CREATED";
+    public const string DcbInvoiceFinalized = "BILLING.INVOICE.FINALIZED";
+    public const string DcbInvoicePaid = "BILLING.INVOICE.PAID";
+    public const string DcbInvoicePaymentFailed = "BILLING.INVOICE.PAYMENT_FAILED";
+
+    public const string DcbPaymentSucceeded = "BILLING.PAYMENT.SUCCEEDED";
+    public const string DcbPaymentFailed = "BILLING.PAYMENT.FAILED";
+
+    public const string DcbDisputeOpened = "BILLING.DISPUTE.OPENED";
+
+    // ── Operational (system) DCB event types ──
+    public const string DcbWebhookSkipped = "BILLING.WEBHOOK.SKIPPED";
+    public const string DcbWebhookFailed = "BILLING.WEBHOOK.FAILED";
+
+    /// <summary>The <c>PlatformQueuedTask.Type</c> for fast-ack follow-up work (AC10).</summary>
+    public const string FollowupTaskType = "billing.webhook.followup";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookFollowupTaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingWebhookFollowupTaskHandler.cs
@@ -1,0 +1,35 @@
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 (AC10) — processes the fast-ack <c>billing.webhook.followup</c>
+/// tasks the processor enqueues (dunning escalation, dispute response, email).
+/// This is a thin v1: it logs the follow-up and completes so the queue drains
+/// without dead-lettering. Story 35-8 (dunning) replaces the body with the real
+/// escalation logic; unknown follow-up subtypes are logged and acked rather than
+/// thrown so a future subtype never dead-letters here.
+/// </summary>
+public sealed class BillingWebhookFollowupTaskHandler : IPlatformTaskHandler
+{
+    private readonly ILogger<BillingWebhookFollowupTaskHandler> _logger;
+
+    public BillingWebhookFollowupTaskHandler(ILogger<BillingWebhookFollowupTaskHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    public string TaskType => BillingWebhookEventTypes.FollowupTaskType;
+
+    public Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        _logger.LogInformation(
+            "Processing billing.webhook.followup task {TaskId} for tenant {TenantId} "
+            + "(v1 no-op sink; Story 35-8 dunning replaces this).",
+            task.Id, task.TenantId);
+        return Task.CompletedTask;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/DisputeWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/DisputeWebhookHandler.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing.Handlers;
+
+/// <summary>
+/// Story 35-5 — default handler for <c>charge.dispute.created</c>. Emits
+/// <c>BILLING.DISPUTE.OPENED</c> and returns a <see cref="BillingFollowup"/> so
+/// the (heavy) dispute-response workflow — evidence gathering, notification —
+/// runs async on the <c>billing.webhook.followup</c> queue rather than inline
+/// (fast-ack, AC10). A dispute is a platform-operator concern; the mirror/response
+/// automation is owned by a later story.
+/// </summary>
+public sealed class DisputeWebhookHandler : IBillingEventHandler
+{
+    private readonly IEventRepository _events;
+
+    public DisputeWebhookHandler(IEventRepository events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        _events = events;
+    }
+
+    public IReadOnlyCollection<string> HandledEventTypes => new[]
+    {
+        BillingWebhookEventTypes.ChargeDisputeCreated,
+    };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        await _events.AppendAsync(
+            BillingWebhookDcbEvents.Projection(BillingWebhookEventTypes.DcbDisputeOpened, ctx))
+            .ConfigureAwait(false);
+
+        return new BillingFollowup(
+            "charge.dispute.created",
+            JsonSerializer.Serialize(new
+            {
+                reason = "dispute_opened",
+                stripeEventId = ctx.StripeEventId,
+                stripeObjectId = ctx.StripeObjectId,
+            }));
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/InvoiceWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/InvoiceWebhookHandler.cs
@@ -1,0 +1,65 @@
+using System.Text.Json;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing.Handlers;
+
+/// <summary>
+/// Story 35-5 — default handler for the invoice lifecycle. Emits the canonical
+/// <c>BILLING.INVOICE.*</c> DCB event per Stripe invoice event. The
+/// <c>BillingInvoice</c> mirror + dunning are owned by Story 35-8. A
+/// <c>invoice.payment_failed</c> returns a <see cref="BillingFollowup"/> so the
+/// (heavy) dunning escalation runs async on the <c>billing.webhook.followup</c>
+/// queue rather than inline (fast-ack, AC10); <c>paid</c>/<c>created</c>/
+/// <c>finalized</c> need no follow-up.
+/// </summary>
+public sealed class InvoiceWebhookHandler : IBillingEventHandler
+{
+    private readonly IEventRepository _events;
+
+    public InvoiceWebhookHandler(IEventRepository events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        _events = events;
+    }
+
+    public IReadOnlyCollection<string> HandledEventTypes => new[]
+    {
+        BillingWebhookEventTypes.InvoiceCreated,
+        BillingWebhookEventTypes.InvoiceFinalized,
+        BillingWebhookEventTypes.InvoicePaid,
+        BillingWebhookEventTypes.InvoicePaymentFailed,
+    };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        var dcbType = ctx.EventType switch
+        {
+            BillingWebhookEventTypes.InvoiceCreated => BillingWebhookEventTypes.DcbInvoiceCreated,
+            BillingWebhookEventTypes.InvoiceFinalized => BillingWebhookEventTypes.DcbInvoiceFinalized,
+            BillingWebhookEventTypes.InvoicePaid => BillingWebhookEventTypes.DcbInvoicePaid,
+            BillingWebhookEventTypes.InvoicePaymentFailed => BillingWebhookEventTypes.DcbInvoicePaymentFailed,
+            _ => throw new InvalidOperationException(
+                $"InvoiceWebhookHandler received unclaimed type '{ctx.EventType}'."),
+        };
+
+        await _events.AppendAsync(BillingWebhookDcbEvents.Projection(dcbType, ctx))
+            .ConfigureAwait(false);
+
+        // Dunning escalation is heavy (Stripe round-trips, email) — Story 35-8
+        // owns the actual work; 35-5 only enqueues the fast-ack follow-up so
+        // recovery never runs inline (AC10).
+        if (ctx.EventType == BillingWebhookEventTypes.InvoicePaymentFailed)
+        {
+            return new BillingFollowup(
+                "invoice.payment_failed",
+                JsonSerializer.Serialize(new
+                {
+                    reason = "invoice_payment_failed",
+                    stripeEventId = ctx.StripeEventId,
+                    stripeObjectId = ctx.StripeObjectId,
+                }));
+        }
+
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/PaymentWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/PaymentWebhookHandler.cs
@@ -1,0 +1,43 @@
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing.Handlers;
+
+/// <summary>
+/// Story 35-5 — default handler for payment-intent lifecycle. Emits the
+/// canonical <c>BILLING.PAYMENT.*</c> DCB event per Stripe payment_intent event.
+/// The <c>BillingPaymentMethod</c> mirror + portal are owned by Story 35-7. No
+/// follow-up: a failed payment_intent is surfaced through the DCB trail and (for
+/// invoices) the invoice.payment_failed dunning follow-up — a payment_intent
+/// failure alone needs no async escalation here.
+/// </summary>
+public sealed class PaymentWebhookHandler : IBillingEventHandler
+{
+    private readonly IEventRepository _events;
+
+    public PaymentWebhookHandler(IEventRepository events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        _events = events;
+    }
+
+    public IReadOnlyCollection<string> HandledEventTypes => new[]
+    {
+        BillingWebhookEventTypes.PaymentIntentSucceeded,
+        BillingWebhookEventTypes.PaymentIntentPaymentFailed,
+    };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        var dcbType = ctx.EventType switch
+        {
+            BillingWebhookEventTypes.PaymentIntentSucceeded => BillingWebhookEventTypes.DcbPaymentSucceeded,
+            BillingWebhookEventTypes.PaymentIntentPaymentFailed => BillingWebhookEventTypes.DcbPaymentFailed,
+            _ => throw new InvalidOperationException(
+                $"PaymentWebhookHandler received unclaimed type '{ctx.EventType}'."),
+        };
+
+        await _events.AppendAsync(BillingWebhookDcbEvents.Projection(dcbType, ctx))
+            .ConfigureAwait(false);
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/SubscriptionWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/Handlers/SubscriptionWebhookHandler.cs
@@ -1,0 +1,47 @@
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing.Handlers;
+
+/// <summary>
+/// Story 35-5 — default handler for the subscription lifecycle. Emits the
+/// canonical <c>BILLING.SUBSCRIPTION.*</c> DCB event per Stripe subscription
+/// event. The <c>BillingSubscription</c> mirror is owned by Story 35-4, which
+/// registers its own <see cref="IBillingEventHandler"/> — 35-5 only guarantees
+/// the DCB audit trail is complete from day one (35-4 supersedes this claim once
+/// it lands, since duplicate-claim detection forbids both). No follow-up work.
+/// </summary>
+public sealed class SubscriptionWebhookHandler : IBillingEventHandler
+{
+    private readonly IEventRepository _events;
+
+    public SubscriptionWebhookHandler(IEventRepository events)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        _events = events;
+    }
+
+    public IReadOnlyCollection<string> HandledEventTypes => new[]
+    {
+        BillingWebhookEventTypes.SubscriptionCreated,
+        BillingWebhookEventTypes.SubscriptionUpdated,
+        BillingWebhookEventTypes.SubscriptionDeleted,
+        BillingWebhookEventTypes.SubscriptionTrialWillEnd,
+    };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        var dcbType = ctx.EventType switch
+        {
+            BillingWebhookEventTypes.SubscriptionCreated => BillingWebhookEventTypes.DcbSubscriptionCreated,
+            BillingWebhookEventTypes.SubscriptionUpdated => BillingWebhookEventTypes.DcbSubscriptionUpdated,
+            BillingWebhookEventTypes.SubscriptionDeleted => BillingWebhookEventTypes.DcbSubscriptionDeleted,
+            BillingWebhookEventTypes.SubscriptionTrialWillEnd => BillingWebhookEventTypes.DcbSubscriptionTrialEnding,
+            _ => throw new InvalidOperationException(
+                $"SubscriptionWebhookHandler received unclaimed type '{ctx.EventType}'."),
+        };
+
+        await _events.AppendAsync(BillingWebhookDcbEvents.Projection(dcbType, ctx))
+            .ConfigureAwait(false);
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingEventHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingEventHandler.cs
@@ -1,0 +1,31 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — pluggable projection handler for one or more Stripe event types.
+/// 35-5 ships the dispatch seam + DCB-emitting default handlers; sibling stories
+/// (35-4 subscription mirror, 35-7 payment-method mirror, 35-8 invoice/dunning
+/// mirror, 35-10 wallet) register their own handlers that own their mirror
+/// entities — 35-5 never creates <c>BillingSubscription</c>/<c>BillingInvoice</c>/
+/// <c>BillingPaymentMethod</c>.
+///
+/// <para>Registered via <c>services.AddBillingEventHandler&lt;T&gt;()</c> and
+/// resolved by <see cref="IBillingEventHandlerRegistry"/> on the event type. An
+/// unclaimed type falls through to <see cref="NullBillingEventHandler"/>.</para>
+///
+/// <para><b>Idempotency contract</b>: <see cref="HandleAsync"/> must be safe to
+/// re-run — re-dispatching an already-projected event is a no-op (the processor
+/// short-circuits a <c>projected</c> row on replay; handlers stay side-effect-light).</para>
+/// </summary>
+public interface IBillingEventHandler
+{
+    /// <summary>Stripe event types this handler claims (e.g. <c>invoice.paid</c>).</summary>
+    IReadOnlyCollection<string> HandledEventTypes { get; }
+
+    /// <summary>
+    /// Project the event (mirror write in sibling handlers) + emit the
+    /// <c>BILLING.*</c> DCB event. Returns a <see cref="BillingFollowup"/> when
+    /// heavy async work is needed (enqueued as a <c>PlatformQueuedTask</c> by the
+    /// processor), or <c>null</c> for none.
+    /// </summary>
+    Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeEventVerifier.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeEventVerifier.cs
@@ -1,0 +1,41 @@
+using Stripe;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — thin seam over <see cref="Stripe.EventUtility"/> so the endpoint
+/// is testable without re-implementing Stripe's <c>t=</c>/<c>v1=</c> HMAC scheme,
+/// and so a test can compute a real signature against a test <c>whsec_</c>. The
+/// default implementation delegates to the SDK — we NEVER hand-roll the HMAC
+/// (story Dev Note 4).
+/// </summary>
+public interface IStripeEventVerifier
+{
+    /// <summary>
+    /// Verify + parse a signed delivery. Throws <see cref="StripeException"/>
+    /// when the signature is invalid, missing, or outside the tolerance window.
+    /// </summary>
+    Event Construct(string rawBody, string signatureHeader, string signingSecret);
+
+    /// <summary>
+    /// Parse a stored (already-verified) payload back into a
+    /// <see cref="Stripe.Event"/> for admin replay — no signature check.
+    /// </summary>
+    Event Parse(string rawBody);
+}
+
+/// <inheritdoc />
+public sealed class StripeEventVerifier : IStripeEventVerifier
+{
+    public Event Construct(string rawBody, string signatureHeader, string signingSecret) =>
+        // throwOnApiVersionMismatch:false — a Stripe account whose default API
+        // version differs from the SDK's pinned version must NOT be rejected as a
+        // bad signature (that would 400 valid events); we only care that the HMAC
+        // verifies. tolerance:300 = Stripe's default replay window.
+        EventUtility.ConstructEvent(
+            rawBody, signatureHeader, signingSecret,
+            tolerance: 300, throwOnApiVersionMismatch: false);
+
+    public Event Parse(string rawBody) =>
+        EventUtility.ParseEvent(rawBody, throwOnApiVersionMismatch: false);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeSigningSecretSource.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeSigningSecretSource.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Tamma.Api.Services.Secrets.Stopgap;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 (AC2) — resolves the Stripe webhook SIGNING secret through the
+/// Epic 29 cabinet exactly as Story 35-1 wires the Stripe API key: the
+/// <see cref="IRuntimeSecretResolver"/> by the cabinet name on
+/// <see cref="BillingOptions.StripeWebhookSecretCabinetName"/>
+/// (<c>SecretScope.Platform</c>). NEVER a raw <c>IConfiguration</c> read.
+///
+/// <para>Returns <c>null</c> when the secret is unresolvable so the endpoint can
+/// fail closed with <c>503</c> (never fail open — GitHub audit finding 001).</para>
+/// </summary>
+public interface IStripeSigningSecretSource
+{
+    Task<string?> GetSigningSecretAsync(CancellationToken ct = default);
+}
+
+/// <inheritdoc />
+public sealed class CabinetStripeSigningSecretSource : IStripeSigningSecretSource
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly BillingOptions _options;
+    private readonly ILogger<CabinetStripeSigningSecretSource> _logger;
+
+    public CabinetStripeSigningSecretSource(
+        IServiceProvider serviceProvider,
+        IOptions<BillingOptions> options,
+        ILogger<CabinetStripeSigningSecretSource> logger)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+        // The runtime secret resolver is resolved lazily (mirrors 35-1's
+        // StripeClientFactory) so the DI graph validates in hosts that don't wire
+        // the Epic 29 cabinet (test fixtures, single-user dev). An absent resolver
+        // → null → the endpoint fails CLOSED with 503, never open.
+        _serviceProvider = serviceProvider;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task<string?> GetSigningSecretAsync(CancellationToken ct = default)
+    {
+        var resolver = _serviceProvider.GetService<IRuntimeSecretResolver>();
+        if (resolver is null)
+        {
+            _logger.LogError(
+                "Stripe webhook signing secret cannot be resolved: the Epic 29 runtime "
+                + "secret resolver is not registered. Failing closed (503).");
+            return null;
+        }
+
+        try
+        {
+            var secret = await resolver
+                .GetAsync(_options.StripeWebhookSecretCabinetName, ct)
+                .ConfigureAwait(false);
+            return string.IsNullOrWhiteSpace(secret) ? null : secret;
+        }
+        catch (MissingSecretException)
+        {
+            // Story 29-10 fail-fast mode: the cabinet row is absent. Treat as
+            // unresolvable → the endpoint returns 503 (fail closed), never open.
+            _logger.LogError(
+                "Stripe webhook signing secret absent from cabinet '{CabinetName}'; "
+                + "failing closed (503).",
+                _options.StripeWebhookSecretCabinetName);
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeWebhookProcessor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeWebhookProcessor.cs
@@ -1,0 +1,49 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — the dedupe + tenant-resolve + dispatch + DCB-emit + fast-ack
+/// core of the webhook pipeline. The endpoint verifies the Stripe signature and
+/// hands the parsed <see cref="Stripe.Event"/> + raw body here; the processor
+/// owns everything after verification. Split from the endpoint so it is unit
+/// testable with an in-memory CP context and mocked repositories.
+/// </summary>
+public interface IStripeWebhookProcessor
+{
+    /// <summary>
+    /// Process a freshly-verified webhook delivery. Inserts the dedup row,
+    /// resolves the tenant, dispatches the handler, emits the <c>BILLING.*</c>
+    /// DCB event, and enqueues any follow-up. Never throws for a projection
+    /// failure (records <c>failed</c> + acks) — only a CP dedup-row WRITE failure
+    /// bubbles (so the endpoint returns 503 and Stripe retries the one case where
+    /// retry is wanted).
+    /// </summary>
+    Task<WebhookProcessResult> ProcessAsync(
+        Stripe.Event stripeEvent, string rawPayload, CancellationToken ct = default);
+
+    /// <summary>
+    /// Admin replay (AC12) — re-dispatch a stored <c>BillingWebhookEvent</c> by
+    /// id. Re-running an already-<c>projected</c>/<c>enqueued</c> row is a no-op
+    /// (idempotent). Returns <c>null</c> when the row does not exist.
+    /// </summary>
+    Task<WebhookProcessResult?> ReplayAsync(Guid webhookEventId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Outcome of a webhook process/replay. <see cref="Status"/> mirrors the terminal
+/// <c>BillingWebhookEvent.Status</c> (or <c>duplicate</c> for a deduped
+/// redelivery). The endpoint echoes it in the <c>200</c> ack body.
+/// </summary>
+public sealed record WebhookProcessResult(string Status)
+{
+    public const string DuplicateStatus = "duplicate";
+    public const string SkippedStatus = "skipped";
+    public const string ProjectedStatus = "projected";
+    public const string EnqueuedStatus = "enqueued";
+    public const string FailedStatus = "failed";
+
+    public static WebhookProcessResult Duplicate { get; } = new(DuplicateStatus);
+    public static WebhookProcessResult Skipped { get; } = new(SkippedStatus);
+    public static WebhookProcessResult Projected { get; } = new(ProjectedStatus);
+    public static WebhookProcessResult Enqueued { get; } = new(EnqueuedStatus);
+    public static WebhookProcessResult Failed { get; } = new(FailedStatus);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingEventHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingEventHandler.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 (AC7, AC11) — the logging default handler. Used by the processor
+/// for any Stripe event type NO registered <see cref="IBillingEventHandler"/>
+/// claims. Emits no <c>BILLING.*</c> projection event and returns no follow-up;
+/// the processor records the row <c>Status = skipped</c> and acks <c>200</c> so
+/// an unknown/irrelevant event never triggers a Stripe retry storm.
+///
+/// <para>Excluded from <see cref="BillingEventHandlerRegistry"/> (it claims no
+/// event types) — it is the explicit fallthrough, never a registered claimant.</para>
+/// </summary>
+public sealed class NullBillingEventHandler : IBillingEventHandler
+{
+    private readonly ILogger<NullBillingEventHandler> _logger;
+
+    public NullBillingEventHandler(ILogger<NullBillingEventHandler> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    /// <summary>Claims nothing — the registry skips it; the processor uses it as fallthrough.</summary>
+    public IReadOnlyCollection<string> HandledEventTypes => Array.Empty<string>();
+
+    public Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        _logger.LogInformation(
+            "No billing handler for Stripe event type {EventType} "
+            + "(stripeEventId={StripeEventId}, tenantId={TenantId}); recording skipped.",
+            ctx.EventType, ctx.StripeEventId, ctx.TenantId);
+        return Task.FromResult<BillingFollowup?>(null);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeWebhookProcessor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeWebhookProcessor.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Redaction;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-5 — the webhook ingestion core. Flow (fresh delivery):
+/// <list type="number">
+///   <item>Insert <c>BillingWebhookEvent{received}</c>; a <c>UNIQUE(StripeEventId)</c>
+///     collision → <c>Duplicate</c> (idempotent ack — AC5).</item>
+///   <item>Resolve tenant via <c>BillingCustomer.StripeCustomerId</c>; no match →
+///     <c>skipped</c> (AC6).</item>
+///   <item>Resolve handler (or <see cref="NullBillingEventHandler"/> for unknown
+///     types → <c>skipped</c>, AC11); run it (mirror write in sibling handlers +
+///     <c>BILLING.*</c> DCB emit, AC8).</item>
+///   <item>Any returned <see cref="BillingFollowup"/> → enqueue a
+///     <c>billing.webhook.followup</c> <c>PlatformQueuedTask</c> (fast-ack, AC10);
+///     stamp <c>enqueued</c>, else <c>projected</c>.</item>
+///   <item>Handler exception → <c>failed</c> + scrubbed <c>LastError</c>, still
+///     ack (recovery via admin replay, not Stripe retries).</item>
+/// </list>
+///
+/// <para><b>Idempotency / atomicity.</b> The dedup row is inserted FIRST, so a
+/// concurrent redelivery collides on the unique index and never re-projects.
+/// The <c>BILLING.*</c> DCB event routes through <see cref="IEventRepository"/>
+/// (a tenant-routed store), so a single cross-DB transaction is not possible;
+/// the guarantee instead is "insert-first dedup + admin replay" — a crash after
+/// insert leaves a non-<c>projected</c> row that replay re-dispatches, and a
+/// redelivery is deduped. This is the <c>PlatformWebhookDelivery</c> precedent.</para>
+/// </summary>
+public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly IEventRepository _events;
+    private readonly IPlatformQueuedTaskRepository _tasks;
+    private readonly IBillingEventHandlerRegistry _registry;
+    private readonly NullBillingEventHandler _nullHandler;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<StripeWebhookProcessor> _logger;
+
+    public StripeWebhookProcessor(
+        ControlPlaneDbContext db,
+        IEventRepository events,
+        IPlatformQueuedTaskRepository tasks,
+        IBillingEventHandlerRegistry registry,
+        NullBillingEventHandler nullHandler,
+        TimeProvider clock,
+        ILogger<StripeWebhookProcessor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(tasks);
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(nullHandler);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _db = db;
+        _events = events;
+        _tasks = tasks;
+        _registry = registry;
+        _nullHandler = nullHandler;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<WebhookProcessResult> ProcessAsync(
+        Stripe.Event stripeEvent, string rawPayload, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stripeEvent);
+        ArgumentNullException.ThrowIfNull(rawPayload);
+
+        var stripeEventId = stripeEvent.Id ?? string.Empty;
+        var eventType = stripeEvent.Type ?? string.Empty;
+        var (objectId, customerId) = ExtractIds(rawPayload);
+        var now = _clock.GetUtcNow().UtcDateTime;
+
+        _logger.LogInformation(
+            "Stripe webhook received: {EventType} (stripeEventId={StripeEventId}, "
+            + "stripeObjectId={StripeObjectId}).",
+            eventType, stripeEventId, objectId);
+
+        // ── 1. Dedup. Pre-check is a cheap fast-path (and the only guard EF
+        // InMemory can enforce in unit tests); the unique-index catch below is
+        // the authoritative, race-safe guard under concurrent Stripe retries. ──
+        var already = await _db.BillingWebhookEvents
+            .AsNoTracking()
+            .AnyAsync(e => e.StripeEventId == stripeEventId, ct)
+            .ConfigureAwait(false);
+        if (already)
+        {
+            _logger.LogDebug(
+                "Duplicate Stripe delivery {StripeEventId}; acking without reprocessing.",
+                stripeEventId);
+            return WebhookProcessResult.Duplicate;
+        }
+
+        var row = new BillingWebhookEvent
+        {
+            Id = Guid.NewGuid(),
+            StripeEventId = stripeEventId,
+            EventType = eventType,
+            StripeObjectId = objectId,
+            Status = "received",
+            Attempts = 1,
+            Payload = string.IsNullOrWhiteSpace(rawPayload) ? "{}" : rawPayload,
+            ReceivedAt = now,
+        };
+        _db.BillingWebhookEvents.Add(row);
+        try
+        {
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateException)
+        {
+            // Race: a concurrent delivery of the same event won the unique index.
+            _db.Entry(row).State = EntityState.Detached;
+            _logger.LogDebug(
+                "Duplicate Stripe delivery {StripeEventId} (unique-index race); acking.",
+                stripeEventId);
+            return WebhookProcessResult.Duplicate;
+        }
+
+        return await DispatchAsync(row, stripeEvent, customerId, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<WebhookProcessResult?> ReplayAsync(
+        Guid webhookEventId, CancellationToken ct = default)
+    {
+        var row = await _db.BillingWebhookEvents
+            .FirstOrDefaultAsync(e => e.Id == webhookEventId, ct)
+            .ConfigureAwait(false);
+        if (row is null) return null;
+
+        // Idempotent: a terminal projected/enqueued row is a no-op on replay (AC12).
+        if (row.Status is "projected" or "enqueued")
+        {
+            _logger.LogInformation(
+                "Replay of {StripeEventId} is a no-op — already {Status}.",
+                row.StripeEventId, row.Status);
+            return new WebhookProcessResult(row.Status);
+        }
+
+        Stripe.Event stripeEvent;
+        try
+        {
+            stripeEvent = new StripeEventVerifier().Parse(row.Payload);
+        }
+        catch (Exception ex)
+        {
+            row.Attempts += 1;
+            row.Status = "failed";
+            row.LastError = CredentialRedactor.Clean(ex.Message);
+            row.ProcessedAt = _clock.GetUtcNow().UtcDateTime;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogError(ex,
+                "Replay of {StripeEventId} failed to parse stored payload.", row.StripeEventId);
+            return WebhookProcessResult.Failed;
+        }
+
+        var (_, customerId) = ExtractIds(row.Payload);
+        row.Attempts += 1;
+        _logger.LogInformation(
+            "Admin replay of Stripe webhook {StripeEventId} (attempt {Attempts}).",
+            row.StripeEventId, row.Attempts);
+        return await DispatchAsync(row, stripeEvent, customerId, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Shared dispatch (tenant-resolve → handler → DCB emit → follow-up enqueue →
+    /// status stamp). Operates on an already-persisted <paramref name="row"/>.
+    /// </summary>
+    private async Task<WebhookProcessResult> DispatchAsync(
+        BillingWebhookEvent row, Stripe.Event stripeEvent, string? customerId, CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow().UtcDateTime;
+
+        // ── 2. Tenant resolution (AC6). ──
+        var tenantId = await ResolveTenantAsync(customerId, ct).ConfigureAwait(false);
+        if (tenantId is null)
+        {
+            row.TenantId = null;
+            row.Status = "skipped";
+            row.ProcessedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Stripe webhook {StripeEventId} ({EventType}) maps to no BillingCustomer "
+                + "(stripeCustomerId={StripeCustomerId}); recording skipped.",
+                row.StripeEventId, row.EventType, customerId);
+            return WebhookProcessResult.Skipped;
+        }
+
+        row.TenantId = tenantId;
+        var ctx = new BillingWebhookContext(
+            stripeEvent, tenantId.Value, row.EventType, row.StripeEventId, row.StripeObjectId, row.Payload);
+
+        // ── 3. Handler resolution. Unknown type → NullBillingEventHandler → skipped (AC11). ──
+        var handler = _registry.Resolve(row.EventType);
+        if (handler is null)
+        {
+            await _nullHandler.HandleAsync(ctx, ct).ConfigureAwait(false);
+            row.Status = "skipped";
+            row.ProcessedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            return WebhookProcessResult.Skipped;
+        }
+
+        row.Status = "processing";
+
+        // ── 4. Project + emit + fast-ack. ──
+        BillingFollowup? followup;
+        try
+        {
+            followup = await handler.HandleAsync(ctx, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            row.Status = "failed";
+            row.LastError = CredentialRedactor.Clean(ex.Message);
+            row.ProcessedAt = _clock.GetUtcNow().UtcDateTime;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            // Audit the failure (tenant-scoped) but STILL ack 200 — recovery is
+            // our own admin replay + follow-up queue, not Stripe retries.
+            await SafeEmitAsync(BillingWebhookDcbEvents.Operational(
+                BillingWebhookEventTypes.DcbWebhookFailed, tenantId, row.StripeEventId,
+                row.EventType, row.StripeObjectId, "handler_exception")).ConfigureAwait(false);
+            _logger.LogError(ex,
+                "Billing handler {Handler} threw for {StripeEventId} ({EventType}); "
+                + "recorded failed, acked.",
+                handler.GetType().Name, row.StripeEventId, row.EventType);
+            return WebhookProcessResult.Failed;
+        }
+
+        if (followup is not null)
+        {
+            await _tasks.EnqueueAsync(new PlatformQueuedTask
+            {
+                Id = Guid.NewGuid(),
+                Type = BillingWebhookEventTypes.FollowupTaskType,
+                TenantId = tenantId,
+                Payload = followup.Payload,
+                Status = "pending",
+                CreatedAt = now,
+                UpdatedAt = now,
+            }, ct).ConfigureAwait(false);
+            row.Status = "enqueued";
+            row.ProcessedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogDebug(
+                "Enqueued billing.webhook.followup ({Subtype}) for {StripeEventId}.",
+                followup.Subtype, row.StripeEventId);
+            return WebhookProcessResult.Enqueued;
+        }
+
+        row.Status = "projected";
+        row.ProcessedAt = now;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        _logger.LogInformation(
+            "Projected Stripe webhook {StripeEventId} ({EventType}) for tenant {TenantId}.",
+            row.StripeEventId, row.EventType, tenantId);
+        return WebhookProcessResult.Projected;
+    }
+
+    private async Task<Guid?> ResolveTenantAsync(string? customerId, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(customerId)) return null;
+        return await _db.BillingCustomers
+            .AsNoTracking()
+            .Where(c => c.StripeCustomerId == customerId)
+            .Select(c => (Guid?)c.TenantId)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task SafeEmitAsync(DomainEvent evt)
+    {
+        try
+        {
+            await _events.AppendAsync(evt).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A failed audit-event append must never mask the original outcome.
+            _logger.LogWarning(ex,
+                "Failed to append operational billing event {Type}.", evt.Type);
+        }
+    }
+
+    /// <summary>
+    /// Extract <c>data.object.id</c> (the primary Stripe object id) and
+    /// <c>data.object.customer</c> (a <c>cus_...</c> string, or the id of an
+    /// expanded customer object) from the raw event JSON. Deterministic and
+    /// SDK-shape-independent — never re-parses through the typed model. Returns
+    /// <c>(null, null)</c> when the JSON is malformed or lacks the fields.
+    /// </summary>
+    internal static (string? ObjectId, string? CustomerId) ExtractIds(string rawPayload)
+    {
+        if (string.IsNullOrWhiteSpace(rawPayload)) return (null, null);
+        try
+        {
+            using var doc = JsonDocument.Parse(rawPayload);
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("object", out var obj)
+                || obj.ValueKind != JsonValueKind.Object)
+            {
+                return (null, null);
+            }
+
+            string? objectId = obj.TryGetProperty("id", out var idEl)
+                && idEl.ValueKind == JsonValueKind.String
+                ? idEl.GetString()
+                : null;
+
+            string? customerId = null;
+            if (obj.TryGetProperty("customer", out var custEl))
+            {
+                customerId = custEl.ValueKind switch
+                {
+                    JsonValueKind.String => custEl.GetString(),
+                    JsonValueKind.Object when custEl.TryGetProperty("id", out var cid)
+                        && cid.ValueKind == JsonValueKind.String => cid.GetString(),
+                    _ => null,
+                };
+            }
+
+            return (objectId, customerId);
+        }
+        catch (JsonException)
+        {
+            return (null, null);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeWebhookProcessor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/StripeWebhookProcessor.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Tamma.Core.Redaction;
 using Tamma.Data;
 using Tamma.Data.Entities;
@@ -116,9 +117,14 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
         {
             await _db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
-        catch (DbUpdateException)
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
         {
-            // Race: a concurrent delivery of the same event won the unique index.
+            // Race: a concurrent delivery of the same event won the UNIQUE index
+            // (SqlState 23505). ONLY that is a duplicate; any other DbUpdateException
+            // (deadlock, timeout, connection reset, NOT-NULL/FK violation, …) is a
+            // transient/real write failure that MUST bubble so the endpoint returns
+            // a non-2xx and Stripe retries — swallowing it as "duplicate" would lose
+            // the billing event forever (IStripeWebhookProcessor contract).
             _db.Entry(row).State = EntityState.Detached;
             _logger.LogDebug(
                 "Duplicate Stripe delivery {StripeEventId} (unique-index race); acking.",
@@ -185,15 +191,11 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
         var tenantId = await ResolveTenantAsync(customerId, ct).ConfigureAwait(false);
         if (tenantId is null)
         {
-            row.TenantId = null;
-            row.Status = "skipped";
-            row.ProcessedAt = now;
-            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
-            _logger.LogWarning(
-                "Stripe webhook {StripeEventId} ({EventType}) maps to no BillingCustomer "
-                + "(stripeCustomerId={StripeCustomerId}); recording skipped.",
-                row.StripeEventId, row.EventType, customerId);
-            return WebhookProcessResult.Skipped;
+            // A verified event we cannot tenant-resolve must NEVER disappear
+            // without a trace. In particular a real charge.dispute.created has NO
+            // top-level `customer` on its Dispute object, so it always lands here —
+            // it must be audited AND followed up, not silently skipped.
+            return await HandleUnresolvedTenantAsync(row, now, ct).ConfigureAwait(false);
         }
 
         row.TenantId = tenantId;
@@ -213,11 +215,28 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
 
         row.Status = "processing";
 
-        // ── 4. Project + emit + fast-ack. ──
+        // ── 4. Project + emit + follow-up enqueue + fast-ack, as ONE fallible unit. ──
+        // The follow-up enqueue lives INSIDE the try so an enqueue/commit failure
+        // stamps the row `failed` (deliberately re-drivable via admin replay)
+        // instead of leaving a non-terminal `received`/`processing` row that a
+        // Stripe redelivery would dedup away — which would drop the follow-up while
+        // the projection had already emitted.
         BillingFollowup? followup;
         try
         {
             followup = await handler.HandleAsync(ctx, ct).ConfigureAwait(false);
+
+            if (followup is not null)
+            {
+                await EnqueueFollowupAsync(followup.Payload, tenantId, now, ct).ConfigureAwait(false);
+                row.Status = "enqueued";
+            }
+            else
+            {
+                row.Status = "projected";
+            }
+            row.ProcessedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -240,33 +259,118 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
 
         if (followup is not null)
         {
-            await _tasks.EnqueueAsync(new PlatformQueuedTask
-            {
-                Id = Guid.NewGuid(),
-                Type = BillingWebhookEventTypes.FollowupTaskType,
-                TenantId = tenantId,
-                Payload = followup.Payload,
-                Status = "pending",
-                CreatedAt = now,
-                UpdatedAt = now,
-            }, ct).ConfigureAwait(false);
-            row.Status = "enqueued";
-            row.ProcessedAt = now;
-            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
             _logger.LogDebug(
                 "Enqueued billing.webhook.followup ({Subtype}) for {StripeEventId}.",
                 followup.Subtype, row.StripeEventId);
             return WebhookProcessResult.Enqueued;
         }
 
-        row.Status = "projected";
-        row.ProcessedAt = now;
-        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
         _logger.LogInformation(
             "Projected Stripe webhook {StripeEventId} ({EventType}) for tenant {TenantId}.",
             row.StripeEventId, row.EventType, tenantId);
         return WebhookProcessResult.Projected;
     }
+
+    /// <summary>
+    /// A verified event that could not be tenant-resolved. Two cases:
+    /// <list type="bullet">
+    ///   <item><b>Known-relevant type</b> (a handler claims this Stripe type) but no
+    ///     tenant — e.g. a real <c>charge.dispute.created</c> whose Dispute object
+    ///     carries NO top-level <c>customer</c>. Emit a platform-scope
+    ///     <c>BILLING.WEBHOOK.SKIPPED</c> audit event so the event is never lost,
+    ///     and for a dispute ALSO enqueue a <c>billing.webhook.followup</c>
+    ///     (carrying the charge / payment_intent ids) so the chargeback is resolved
+    ///     out-of-band (the follow-up handler can later map charge → customer →
+    ///     tenant via a Stripe lookup, or an operator does). The invariant: a
+    ///     verified dispute NEVER disappears without an audit trail + a follow-up.</item>
+    ///   <item><b>Unknown type</b> (no handler claims it) with no tenant — a benign
+    ///     irrelevant delivery; recorded <c>skipped</c> with no audit-event spam.</item>
+    /// </list>
+    /// </summary>
+    private async Task<WebhookProcessResult> HandleUnresolvedTenantAsync(
+        BillingWebhookEvent row, DateTime now, CancellationToken ct)
+    {
+        row.TenantId = null;
+        row.ProcessedAt = now;
+
+        var isKnownRelevant = _registry.Resolve(row.EventType) is not null;
+        if (!isKnownRelevant)
+        {
+            // Unknown/irrelevant Stripe type + no tenant: nothing to project and
+            // nothing worth auditing on the DCB stream (avoid SKIPPED spam).
+            row.Status = "skipped";
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Stripe webhook {StripeEventId} ({EventType}) has no tenant and no "
+                + "handler; recording skipped.",
+                row.StripeEventId, row.EventType);
+            return WebhookProcessResult.Skipped;
+        }
+
+        // Platform-scope audit: a KNOWN-relevant event we could not tenant-resolve.
+        await SafeEmitAsync(BillingWebhookDcbEvents.Operational(
+            BillingWebhookEventTypes.DcbWebhookSkipped, tenantId: null, row.StripeEventId,
+            row.EventType, row.StripeObjectId, "tenant_unresolved")).ConfigureAwait(false);
+
+        // A dispute MUST also get a follow-up so the chargeback is not dropped.
+        if (row.EventType == BillingWebhookEventTypes.ChargeDisputeCreated)
+        {
+            var (charge, paymentIntent) = ExtractDisputeRefs(row.Payload);
+            var followupPayload = JsonSerializer.Serialize(new
+            {
+                reason = "dispute_unresolved_tenant",
+                stripeEventId = row.StripeEventId,
+                disputeId = row.StripeObjectId,
+                charge,
+                paymentIntent,
+            });
+            try
+            {
+                await EnqueueFollowupAsync(followupPayload, tenantId: null, now, ct).ConfigureAwait(false);
+                row.Status = "enqueued";
+                await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                row.Status = "failed";
+                row.LastError = CredentialRedactor.Clean(ex.Message);
+                await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+                _logger.LogError(ex,
+                    "Dispute {StripeEventId} follow-up enqueue failed after SKIPPED audit; "
+                    + "recorded failed (re-drivable via replay).",
+                    row.StripeEventId);
+                return WebhookProcessResult.Failed;
+            }
+            _logger.LogWarning(
+                "Dispute {StripeEventId} (charge={Charge}, paymentIntent={PaymentIntent}) could "
+                + "not be tenant-resolved; emitted BILLING.WEBHOOK.SKIPPED + enqueued follow-up "
+                + "for out-of-band resolution.",
+                row.StripeEventId, charge, paymentIntent);
+            return WebhookProcessResult.Enqueued;
+        }
+
+        // Other known-relevant types with no tenant: audited, then skipped.
+        row.Status = "skipped";
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        _logger.LogWarning(
+            "Stripe webhook {StripeEventId} ({EventType}) maps to no BillingCustomer; "
+            + "emitted BILLING.WEBHOOK.SKIPPED (platform audit), recording skipped.",
+            row.StripeEventId, row.EventType);
+        return WebhookProcessResult.Skipped;
+    }
+
+    private async Task EnqueueFollowupAsync(
+        string payload, Guid? tenantId, DateTime now, CancellationToken ct) =>
+        await _tasks.EnqueueAsync(new PlatformQueuedTask
+        {
+            Id = Guid.NewGuid(),
+            Type = BillingWebhookEventTypes.FollowupTaskType,
+            TenantId = tenantId,
+            Payload = payload,
+            Status = "pending",
+            CreatedAt = now,
+            UpdatedAt = now,
+        }, ct).ConfigureAwait(false);
 
     private async Task<Guid?> ResolveTenantAsync(string? customerId, CancellationToken ct)
     {
@@ -278,6 +382,16 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
             .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// A <see cref="DbUpdateException"/> is a unique-violation (23505) only — the
+    /// idempotent-dedup case. Mirrors <c>EventRepository.AppendAsync</c>. Any other
+    /// DbUpdateException is a transient/real failure that must not be masked as a
+    /// duplicate ack.
+    /// </summary>
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is PostgresException pg &&
+        pg.SqlState == PostgresErrorCodes.UniqueViolation;
 
     private async Task SafeEmitAsync(DomainEvent evt)
     {
@@ -318,23 +432,56 @@ public sealed class StripeWebhookProcessor : IStripeWebhookProcessor
                 ? idEl.GetString()
                 : null;
 
-            string? customerId = null;
-            if (obj.TryGetProperty("customer", out var custEl))
-            {
-                customerId = custEl.ValueKind switch
-                {
-                    JsonValueKind.String => custEl.GetString(),
-                    JsonValueKind.Object when custEl.TryGetProperty("id", out var cid)
-                        && cid.ValueKind == JsonValueKind.String => cid.GetString(),
-                    _ => null,
-                };
-            }
-
-            return (objectId, customerId);
+            return (objectId, ReadIdOrString(obj, "customer"));
         }
         catch (JsonException)
         {
             return (null, null);
         }
     }
+
+    /// <summary>
+    /// Extract a Dispute object's <c>charge</c> and <c>payment_intent</c> reference
+    /// ids from the raw event JSON. A real Stripe Dispute has NO top-level
+    /// <c>customer</c>, so these are the only handles back to the tenant — the
+    /// dispute follow-up carries them for out-of-band resolution (e.g. a Stripe
+    /// charge lookup). Each may be a bare id string or an expanded object with an
+    /// <c>id</c>. Returns <c>(null, null)</c> for malformed JSON or missing fields.
+    /// </summary>
+    internal static (string? Charge, string? PaymentIntent) ExtractDisputeRefs(string rawPayload)
+    {
+        if (string.IsNullOrWhiteSpace(rawPayload)) return (null, null);
+        try
+        {
+            using var doc = JsonDocument.Parse(rawPayload);
+            if (!doc.RootElement.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("object", out var obj)
+                || obj.ValueKind != JsonValueKind.Object)
+            {
+                return (null, null);
+            }
+
+            return (ReadIdOrString(obj, "charge"), ReadIdOrString(obj, "payment_intent"));
+        }
+        catch (JsonException)
+        {
+            return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Read <paramref name="prop"/> from <paramref name="obj"/> as either a bare id
+    /// string (<c>"cus_…"</c>/<c>"ch_…"</c>) or the <c>id</c> of an expanded object.
+    /// Returns <c>null</c> when absent or of any other shape.
+    /// </summary>
+    private static string? ReadIdOrString(JsonElement obj, string prop) =>
+        obj.TryGetProperty(prop, out var el)
+            ? el.ValueKind switch
+            {
+                JsonValueKind.String => el.GetString(),
+                JsonValueKind.Object when el.TryGetProperty("id", out var id)
+                    && id.ValueKind == JsonValueKind.String => id.GetString(),
+                _ => null,
+            }
+            : null;
 }

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -659,6 +659,13 @@ public class ControlPlaneDbContext : DbContext
     public DbSet<BillingPlanPrice> BillingPlanPrices => Set<BillingPlanPrice>();
 
     /// <summary>
+    /// Story 35-5 — Stripe webhook dedup + audit journal. Unique
+    /// <c>StripeEventId</c> makes at-least-once redelivery a no-op ack. See
+    /// <see cref="Entities.BillingWebhookEvent"/>.
+    /// </summary>
+    public DbSet<BillingWebhookEvent> BillingWebhookEvents => Set<BillingWebhookEvent>();
+
+    /// <summary>
     /// Story 37-1 — platform-scope curated audit trail. Tenant-scope rows live
     /// in the per-tenant schema's <c>audit_records</c>; these are the
     /// platform/lifecycle rows (impersonation, tenant provision/move, etc.).

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/BillingWebhookEvent.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/BillingWebhookEvent.cs
@@ -1,0 +1,63 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-5 — control-plane dedup + audit row for one inbound Stripe webhook
+/// delivery. Stripe delivers at-least-once; the <c>UNIQUE</c> index on
+/// <see cref="StripeEventId"/> makes reprocessing safe — a duplicate insert
+/// collision is treated as an idempotent ack. Mirrors the
+/// <see cref="PlatformWebhookDelivery"/> / <see cref="GitHubWebhookDelivery"/>
+/// idempotency-journal pattern.
+///
+/// <para>CP-resident (control plane): billing is a cross-cutting platform
+/// concern and the webhook arrives with no tenant context — the tenant is
+/// resolved from <see cref="BillingCustomer.StripeCustomerId"/> and stamped on
+/// <see cref="TenantId"/>. SaaS only — single-user never registers the webhook
+/// route (35-1 <c>NullBillingProvider</c>).</para>
+/// </summary>
+public class BillingWebhookEvent
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Stripe event id (<c>evt_...</c>). UNIQUE — the dedup key.</summary>
+    public string StripeEventId { get; set; } = null!;
+
+    /// <summary>Stripe event type, e.g. <c>invoice.paid</c>.</summary>
+    public string EventType { get; set; } = null!;
+
+    /// <summary>
+    /// Owning tenant, resolved from the event's Stripe customer id via
+    /// <see cref="BillingCustomer"/>. Nullable — an event whose customer maps to
+    /// no <see cref="BillingCustomer"/> is recorded <see cref="Status"/> =
+    /// <c>skipped</c> with a null tenant (AC6).
+    /// </summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>
+    /// The primary Stripe object id carried by the event
+    /// (<c>sub_...</c>/<c>in_...</c>/<c>pi_...</c>/<c>dp_...</c>), extracted from
+    /// <c>data.object.id</c>. Stamped on the DCB event's <c>stripeObjectId</c> tag.
+    /// </summary>
+    public string? StripeObjectId { get; set; }
+
+    /// <summary>
+    /// Processing status:
+    /// <c>received | processing | projected | enqueued | failed | skipped</c>.
+    /// </summary>
+    public string Status { get; set; } = "received";
+
+    /// <summary>Processing-attempt counter (incremented on each admin replay).</summary>
+    public int Attempts { get; set; }
+
+    /// <summary>
+    /// Raw Stripe event JSON as delivered (already verified). Kept for admin
+    /// replay/inspect. Stripe's own redaction applies; we add nothing PII-sensitive.
+    /// </summary>
+    public string Payload { get; set; } = "{}";
+
+    /// <summary>Last handler error, scrubbed via <c>CredentialRedactor.Clean</c>.</summary>
+    public string? LastError { get; set; }
+
+    public DateTime ReceivedAt { get; set; }
+    public DateTime? ProcessedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702172018_BillingWebhookEvents.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702172018_BillingWebhookEvents.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702172018_BillingWebhookEvents")]
+    partial class BillingWebhookEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702172018_BillingWebhookEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702172018_BillingWebhookEvents.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class BillingWebhookEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "billing_webhook_events",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    StripeEventId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    EventType = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    StripeObjectId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "received"),
+                    Attempts = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    Payload = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    LastError = table.Column<string>(type: "text", nullable: true),
+                    ReceivedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    ProcessedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_billing_webhook_events", x => x.Id);
+                    table.CheckConstraint("ck_billing_webhook_events_status", "\"Status\" IN ('received','processing','projected','enqueued','failed','skipped')");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_billing_webhook_events_Status_ReceivedAt",
+                table: "billing_webhook_events",
+                columns: new[] { "Status", "ReceivedAt" },
+                descending: new[] { false, true });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_billing_webhook_events_TenantId",
+                table: "billing_webhook_events",
+                column: "TenantId",
+                filter: "\"TenantId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_webhook_events_StripeEventId",
+                table: "billing_webhook_events",
+                column: "StripeEventId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "billing_webhook_events");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1040,6 +1040,45 @@ internal static class TammaModelConfiguration
                 .HasDatabaseName("UX_billing_plan_prices_PlanSlug")
                 .IsUnique();
         });
+
+        // ── BillingWebhookEvent (Story 35-5 — Stripe webhook dedup journal) ──
+        modelBuilder.Entity<BillingWebhookEvent>(entity =>
+        {
+            entity.ToTable("billing_webhook_events", t =>
+            {
+                // Text domain for the processing status.
+                t.HasCheckConstraint(
+                    "ck_billing_webhook_events_status",
+                    "\"Status\" IN ('received','processing','projected','enqueued','failed','skipped')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.StripeEventId).IsRequired().HasMaxLength(255);
+            entity.Property(e => e.EventType).IsRequired().HasMaxLength(255);
+            entity.Property(e => e.StripeObjectId).HasMaxLength(255);
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(20).HasDefaultValue("received");
+            entity.Property(e => e.Attempts).HasDefaultValue(0);
+            entity.Property(e => e.Payload)
+                .IsRequired().HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+            entity.Property(e => e.ReceivedAt).HasDefaultValueSql("now()");
+
+            // Dedup key — Stripe delivers at-least-once; the unique insert
+            // collision is the authoritative idempotency guard (AC5).
+            entity.HasIndex(e => e.StripeEventId)
+                .HasDatabaseName("UX_billing_webhook_events_StripeEventId")
+                .IsUnique();
+
+            // Admin list — recent rows by status (AC12).
+            entity.HasIndex(e => new { e.Status, e.ReceivedAt })
+                .HasDatabaseName("IX_billing_webhook_events_Status_ReceivedAt")
+                .IsDescending(false, true);
+
+            // Tenant-scoped filter for the admin list (partial — most rows resolve).
+            entity.HasIndex(e => e.TenantId)
+                .HasDatabaseName("IX_billing_webhook_events_TenantId")
+                .HasFilter("\"TenantId\" IS NOT NULL");
+        });
     }
 
     /// <summary>

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddBillingWebhookIngestionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddBillingWebhookIngestionTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Extensions;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC13) — mode-gated webhook DI. In SaaS the processor, registry,
+/// default handlers, secret source, verifier, and follow-up task handler are
+/// registered; in single-user NONE are (zero Stripe surface — the routes in
+/// Program.cs are likewise unmapped).
+/// </summary>
+[TestFixture]
+public class AddBillingWebhookIngestionTests
+{
+    private static ServiceProvider BuildProvider(string mode)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Tamma:Mode"] = mode })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<ITammaModeProvider, TammaModeProvider>();
+        services.TryAddSingletonDoubles();
+        services.AddPlatformTaskWorker(configuration);
+        services.AddBillingWebhookIngestion(configuration);
+        return services.BuildServiceProvider();
+    }
+
+    [Test]
+    public void Saas_Registers_Processor_Handlers_And_Followup()
+    {
+        using var sp = BuildProvider("saas");
+        using var scope = sp.CreateScope();
+        var s = scope.ServiceProvider;
+
+        s.GetService<IStripeWebhookProcessor>().Should().NotBeNull();
+        s.GetService<IBillingEventHandlerRegistry>().Should().NotBeNull();
+        s.GetService<IStripeSigningSecretSource>().Should().NotBeNull();
+        s.GetService<IStripeEventVerifier>().Should().NotBeNull();
+        s.GetService<NullBillingEventHandler>().Should().NotBeNull();
+
+        s.GetServices<IBillingEventHandler>().Select(h => h.GetType().Name)
+            .Should().Contain(new[]
+            {
+                "SubscriptionWebhookHandler", "InvoiceWebhookHandler",
+                "PaymentWebhookHandler", "DisputeWebhookHandler",
+            });
+        s.GetServices<IPlatformTaskHandler>()
+            .Should().Contain(h => h is BillingWebhookFollowupTaskHandler);
+    }
+
+    [Test]
+    public void SingleUser_Registers_Nothing()
+    {
+        using var sp = BuildProvider("single-user");
+        using var scope = sp.CreateScope();
+        var s = scope.ServiceProvider;
+
+        s.GetService<IStripeWebhookProcessor>().Should().BeNull("single-user has zero Stripe surface");
+        s.GetService<IStripeSigningSecretSource>().Should().BeNull();
+        s.GetServices<IBillingEventHandler>().Should().BeEmpty();
+        s.GetServices<IPlatformTaskHandler>()
+            .Should().NotContain(h => h is BillingWebhookFollowupTaskHandler);
+    }
+}
+
+internal static class BillingWebhookTestServiceExtensions
+{
+    /// <summary>Register the lightweight doubles the SaaS processor graph needs to resolve.</summary>
+    public static IServiceCollection TryAddSingletonDoubles(this IServiceCollection services)
+    {
+        services.AddDbContextFactory<ControlPlaneDbContext>(
+            o => o.UseInMemoryDatabase($"webhook-di-{Guid.NewGuid():N}"));
+        services.AddScoped(sp =>
+            sp.GetRequiredService<IDbContextFactory<ControlPlaneDbContext>>().CreateDbContext());
+        services.AddScoped(_ => Moq.Mock.Of<IEventRepository>());
+        services.AddScoped(_ => Moq.Mock.Of<IPlatformQueuedTaskRepository>());
+        services.AddScoped(_ => Moq.Mock.Of<IRuntimeSecretResolver>());
+        services.AddOptions<BillingOptions>();
+        return services;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingEventHandlerRegistryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingEventHandlerRegistryTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC7) — <see cref="BillingEventHandlerRegistry"/> resolves a
+/// registered handler by event type, returns null for an unclaimed type, and
+/// throws at construction when two handlers claim the same type (mirrors
+/// <c>PlatformTaskHandlerRegistry</c>). <see cref="NullBillingEventHandler"/> is
+/// excluded from the registered set.
+/// </summary>
+[TestFixture]
+public class BillingEventHandlerRegistryTests
+{
+    private sealed class FakeHandler : IBillingEventHandler
+    {
+        public FakeHandler(params string[] types) => HandledEventTypes = types;
+        public IReadOnlyCollection<string> HandledEventTypes { get; }
+        public Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+            => Task.FromResult<BillingFollowup?>(null);
+    }
+
+    [Test]
+    public void Resolves_Registered_Handler_By_EventType()
+    {
+        var handler = new FakeHandler("invoice.paid", "invoice.created");
+        var registry = new BillingEventHandlerRegistry(new[] { handler });
+
+        registry.Resolve("invoice.paid").Should().BeSameAs(handler);
+        registry.Resolve("invoice.created").Should().BeSameAs(handler);
+        registry.RegisteredEventTypes.Should().BeEquivalentTo("invoice.paid", "invoice.created");
+    }
+
+    [Test]
+    public void Returns_Null_For_Unclaimed_Type()
+    {
+        var registry = new BillingEventHandlerRegistry(new[] { new FakeHandler("invoice.paid") });
+        registry.Resolve("foo.bar.baz").Should().BeNull();
+    }
+
+    [Test]
+    public void Throws_On_Duplicate_EventType_Claim()
+    {
+        var a = new FakeHandler("invoice.paid");
+        var b = new FakeHandler("invoice.paid");
+
+        var act = () => new BillingEventHandlerRegistry(new IBillingEventHandler[] { a, b });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Duplicate*invoice.paid*");
+    }
+
+    [Test]
+    public void Excludes_NullBillingEventHandler_From_Registered_Set()
+    {
+        var nullHandler = new NullBillingEventHandler(NullLogger<NullBillingEventHandler>.Instance);
+        var real = new FakeHandler("invoice.paid");
+
+        var registry = new BillingEventHandlerRegistry(
+            new IBillingEventHandler[] { nullHandler, real });
+
+        registry.Resolve("invoice.paid").Should().BeSameAs(real);
+        registry.RegisteredEventTypes.Should().BeEquivalentTo("invoice.paid");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingWebhookEventModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingWebhookEventModelTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC4) — model-shape assertions for <see cref="BillingWebhookEvent"/>.
+/// Pure design-time metadata inspection (no Postgres). Confirms the table maps,
+/// the dedup unique index on <c>StripeEventId</c>, the status CHECK constraint,
+/// and the column defaults.
+/// </summary>
+[TestFixture]
+public class BillingWebhookEventModelTests
+{
+    private static ControlPlaneDbContext CreateContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseNpgsql("Host=localhost;Database=cp_test;Username=tamma;Password=tamma")
+            .Options);
+
+    [Test]
+    public void Table_Is_Mapped()
+    {
+        using var ctx = CreateContext();
+        ctx.Model.GetEntityTypes().Select(t => t.GetTableName())
+            .Should().Contain("billing_webhook_events");
+    }
+
+    [Test]
+    public void StripeEventId_Is_Unique_Dedup_Index()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingWebhookEvent))!;
+        var idx = entity.GetIndexes()
+            .Single(i => i.GetDatabaseName() == "UX_billing_webhook_events_StripeEventId");
+
+        idx.IsUnique.Should().BeTrue("at-least-once redelivery is deduped on the unique index (AC5)");
+        idx.Properties.Select(p => p.Name).Should().Equal(nameof(BillingWebhookEvent.StripeEventId));
+    }
+
+    [Test]
+    public void Has_Status_Check_Constraint()
+    {
+        using var ctx = CreateContext();
+        var model = ctx.GetService<IDesignTimeModel>().Model;
+        var entity = model.FindEntityType(typeof(BillingWebhookEvent))!;
+        entity.GetCheckConstraints().Select(c => c.Name)
+            .Should().Contain("ck_billing_webhook_events_status");
+    }
+
+    [Test]
+    public void Has_Column_Defaults()
+    {
+        using var ctx = CreateContext();
+        var entity = ctx.Model.FindEntityType(typeof(BillingWebhookEvent))!;
+
+        entity.FindProperty(nameof(BillingWebhookEvent.Status))!
+            .GetDefaultValue().Should().Be("received");
+        entity.FindProperty(nameof(BillingWebhookEvent.Attempts))!
+            .GetDefaultValue().Should().Be(0);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingWebhookRoutesTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingWebhookRoutesTests.cs
@@ -1,0 +1,188 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.IdentityModel.Tokens;
+using NUnit.Framework;
+using Tamma.Api.Tests.Infrastructure;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC1, AC2, AC12, AC13) — route wiring under a real host. A SaaS
+/// (Production) factory maps the webhook + admin routes; the webhook route is
+/// anonymous + signature-gated (missing signature → 400; a signature present but
+/// no cabinet secret → 503 fail-closed), and the admin routes are
+/// <c>PlatformOwnerAccess</c>-gated. Boots a standalone factory against the shared
+/// Postgres container, mirroring <c>PlatformOwnerAccessPolicyTests</c>.
+/// </summary>
+[TestFixture]
+public class BillingWebhookRoutesTests
+{
+    private const string JwtSecret = "billing-webhook-test-secret-32-chars-min";
+    private static readonly SymmetricSecurityKey SigningKey =
+        new(Encoding.UTF8.GetBytes(JwtSecret));
+
+    private WebApplicationFactory<Program> _factory = null!;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        Environment.SetEnvironmentVariable("Jwt__Secret", JwtSecret);
+        Environment.SetEnvironmentVariable("Jwt__Issuer", "tamma");
+        Environment.SetEnvironmentVariable("Jwt__Audience", "tamma-api");
+        Environment.SetEnvironmentVariable("Cranl__ApiKey", null);
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__DefaultConnection", ApiTestFixture.Postgres.GetConnectionString());
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__TammaDb", ApiTestFixture.Postgres.GetConnectionString());
+        // Production boot supplies ConnectionStrings:ControlPlane → SaaS mode → the
+        // billing webhook + admin routes are mapped.
+        Environment.SetEnvironmentVariable(
+            "ConnectionStrings__ControlPlane", ApiTestFixture.Postgres.GetConnectionString());
+        Environment.SetEnvironmentVariable(
+            "Cranl__EncryptionKey", Convert.ToBase64String(new byte[32]));
+
+        _factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b =>
+            {
+                b.UseEnvironment("Production");
+                b.DisableAlertHostedServices();
+            });
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _factory?.Dispose();
+        Environment.SetEnvironmentVariable("Jwt__Secret", null);
+        Environment.SetEnvironmentVariable("Jwt__Issuer", null);
+        Environment.SetEnvironmentVariable("Jwt__Audience", null);
+        Environment.SetEnvironmentVariable("ConnectionStrings__ControlPlane", null);
+        Environment.SetEnvironmentVariable("Cranl__EncryptionKey", null);
+    }
+
+    private static string MintToken(string role, string platformRole)
+    {
+        var jwt = new JwtSecurityToken(
+            issuer: "tamma", audience: "tamma-api",
+            claims: new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, Guid.NewGuid().ToString()),
+                new Claim("tenantId", Guid.NewGuid().ToString()),
+                new Claim("role", role),
+                new Claim("platformRole", platformRole),
+                new Claim(JwtRegisteredClaimNames.Email, "actor@example.com"),
+                new Claim("name", "Actor"),
+                new Claim("authMethod", "email"),
+                new Claim("tenants", "[]"),
+            },
+            expires: DateTime.UtcNow.AddMinutes(15),
+            signingCredentials: new SigningCredentials(SigningKey, SecurityAlgorithms.HmacSha256));
+        return new JwtSecurityTokenHandler().WriteToken(jwt);
+    }
+
+    // ── AC1/AC3 — signature-gated, anonymous ──
+
+    [Test]
+    public async Task Webhook_Without_Signature_Is_Mapped_And_Returns_400()
+    {
+        using var client = _factory.CreateClient();
+        var resp = await client.PostAsync(
+            "/api/v1/billing/stripe/webhook",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        // 400 (not 404) proves the route is mapped in SaaS AND anonymous (no 401)
+        // AND signature-gated (missing Stripe-Signature → 400).
+        resp.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ── AC2 — unresolvable secret → 503 (fail closed) ──
+
+    [Test]
+    public async Task Webhook_With_Signature_But_No_Cabinet_Secret_Returns_503()
+    {
+        using var client = _factory.CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Post, "/api/v1/billing/stripe/webhook")
+        {
+            Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+        };
+        req.Headers.TryAddWithoutValidation("Stripe-Signature", "t=1,v1=deadbeef");
+
+        var resp = await client.SendAsync(req);
+
+        resp.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
+            "no signing secret in the cabinet → fail closed with 503, never open");
+    }
+
+    // ── AC12 — admin RBAC ──
+
+    [Test]
+    public async Task Admin_List_Rejects_NonPlatformAdmin()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", MintToken("owner", "user"));
+
+        var resp = await client.GetAsync("/api/v1/admin/billing/webhook-events");
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Admin_List_Admits_PlatformAdmin()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", MintToken("member", "platform_admin"));
+
+        var resp = await client.GetAsync("/api/v1/admin/billing/webhook-events");
+        resp.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        resp.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Admin_Replay_Rejects_NonPlatformAdmin()
+    {
+        using var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", MintToken("owner", "user"));
+
+        var resp = await client.PostAsync(
+            $"/api/v1/admin/billing/webhook-events/{Guid.NewGuid()}/replay", content: null);
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+}
+
+/// <summary>
+/// Story 35-5 (AC13) — in single-user mode the webhook + admin routes are NOT
+/// mapped. The shared <see cref="ApiTestFixture"/> boots without a ControlPlane
+/// connection string / TenantSharedSecret ⇒ SingleUser ⇒ the routes 404.
+/// </summary>
+[TestFixture]
+public class BillingWebhookSingleUserModeTests
+{
+    [Test]
+    public async Task Webhook_Route_Is_Unmapped_In_SingleUser()
+    {
+        using var client = ApiTestFixture.CreateClient();
+        var resp = await client.PostAsync(
+            "/api/v1/billing/stripe/webhook",
+            new StringContent("{}", Encoding.UTF8, "application/json"));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "single-user mode maps no Stripe surface (NullBillingProvider)");
+    }
+
+    [Test]
+    public async Task Admin_List_Route_Is_Unmapped_In_SingleUser()
+    {
+        using var client = ApiTestFixture.CreateClient();
+        var resp = await client.GetAsync("/api/v1/admin/billing/webhook-events");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookEndpointTests.cs
@@ -1,0 +1,117 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints.Billing;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC1–AC3) — <see cref="StripeWebhookEndpoint"/> control flow, tested
+/// directly against a <see cref="DefaultHttpContext"/> with mocked services (no
+/// host/docker): missing signature → 400; unresolvable secret → 503 (fail closed);
+/// invalid signature → 400 (never projects); valid → 200 + processor invoked once.
+/// </summary>
+[TestFixture]
+public class StripeWebhookEndpointTests
+{
+    private static readonly ILoggerFactory Loggers = NullLoggerFactory.Instance;
+
+    private static DefaultHttpContext MakeContext(string body, string? signature)
+    {
+        var ctx = new DefaultHttpContext();
+        var bytes = Encoding.UTF8.GetBytes(body);
+        ctx.Request.Body = new MemoryStream(bytes);
+        ctx.Request.ContentLength = bytes.Length;
+        if (signature is not null)
+            ctx.Request.Headers["Stripe-Signature"] = signature;
+        return ctx;
+    }
+
+    private static int StatusOf(IResult result) =>
+        ((IStatusCodeHttpResult)result).StatusCode ?? 0;
+
+    [Test]
+    public async Task Missing_Signature_Returns_400_And_Never_Processes()
+    {
+        var secret = new Mock<IStripeSigningSecretSource>();
+        var verifier = new Mock<IStripeEventVerifier>();
+        var processor = new Mock<IStripeWebhookProcessor>();
+
+        var result = await StripeWebhookEndpoint.Receive(
+            MakeContext("{}", signature: null),
+            secret.Object, verifier.Object, processor.Object, Loggers);
+
+        StatusOf(result).Should().Be(400);
+        processor.Verify(p => p.ProcessAsync(
+            It.IsAny<Stripe.Event>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Unresolvable_Secret_Returns_503_And_Never_Processes()
+    {
+        var secret = new Mock<IStripeSigningSecretSource>();
+        secret.Setup(s => s.GetSigningSecretAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var verifier = new Mock<IStripeEventVerifier>();
+        var processor = new Mock<IStripeWebhookProcessor>();
+
+        var result = await StripeWebhookEndpoint.Receive(
+            MakeContext("{}", signature: "t=1,v1=abc"),
+            secret.Object, verifier.Object, processor.Object, Loggers);
+
+        StatusOf(result).Should().Be(503);
+        verifier.Verify(v => v.Construct(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never, "never verify (or process) when the secret is unresolvable");
+        processor.Verify(p => p.ProcessAsync(
+            It.IsAny<Stripe.Event>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Invalid_Signature_Returns_400_And_Never_Processes()
+    {
+        var secret = new Mock<IStripeSigningSecretSource>();
+        secret.Setup(s => s.GetSigningSecretAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("whsec_test");
+        var verifier = new Mock<IStripeEventVerifier>();
+        verifier.Setup(v => v.Construct(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Stripe.StripeException("signature verification failed"));
+        var processor = new Mock<IStripeWebhookProcessor>();
+
+        var result = await StripeWebhookEndpoint.Receive(
+            MakeContext("{}", signature: "t=1,v1=bad"),
+            secret.Object, verifier.Object, processor.Object, Loggers);
+
+        StatusOf(result).Should().Be(400);
+        processor.Verify(p => p.ProcessAsync(
+            It.IsAny<Stripe.Event>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an invalid signature never projects");
+    }
+
+    [Test]
+    public async Task Valid_Signature_Returns_200_And_Processes_Once()
+    {
+        var secret = new Mock<IStripeSigningSecretSource>();
+        secret.Setup(s => s.GetSigningSecretAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync("whsec_test");
+        var evt = new Stripe.Event { Id = "evt_ok", Type = "invoice.paid" };
+        var verifier = new Mock<IStripeEventVerifier>();
+        verifier.Setup(v => v.Construct(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(evt);
+        var processor = new Mock<IStripeWebhookProcessor>();
+        processor.Setup(p => p.ProcessAsync(evt, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WebhookProcessResult.Projected);
+
+        var result = await StripeWebhookEndpoint.Receive(
+            MakeContext("""{"id":"evt_ok"}""", signature: "t=1,v1=good"),
+            secret.Object, verifier.Object, processor.Object, Loggers);
+
+        StatusOf(result).Should().Be(200);
+        processor.Verify(p => p.ProcessAsync(evt, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookProcessorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookProcessorTests.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Billing.Handlers;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-5 (AC5, AC6, AC7, AC8, AC10, AC11, AC14) — the
+/// <see cref="StripeWebhookProcessor"/> dedupe + tenant-resolve + dispatch + DCB
+/// emit + fast-ack pipeline. EF InMemory CP context; <see cref="IEventRepository"/>
+/// and <see cref="IPlatformQueuedTaskRepository"/> mocked; the four real default
+/// handlers exercise the exact <c>BILLING.*</c> emission.
+/// </summary>
+[TestFixture]
+public class StripeWebhookProcessorTests
+{
+    private const string Cus = "cus_tenantA";
+
+    private static ControlPlaneDbContext NewDb(string name) =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(name).Options);
+
+    private sealed class Harness
+    {
+        public required StripeWebhookProcessor Processor { get; init; }
+        public required ControlPlaneDbContext Db { get; init; }
+        public required Mock<IEventRepository> Events { get; init; }
+        public required Mock<IPlatformQueuedTaskRepository> Tasks { get; init; }
+        public required List<DomainEvent> Appended { get; init; }
+    }
+
+    private static Harness Build(
+        string dbName, Guid tenantId,
+        IEnumerable<IBillingEventHandler>? handlers = null,
+        string customerId = Cus)
+    {
+        var db = NewDb(dbName);
+        db.BillingCustomers.Add(new BillingCustomer
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            StripeCustomerId = customerId,
+            BillingMode = "PlatformProvided",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        db.SaveChanges();
+
+        var appended = new List<DomainEvent>();
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d)
+            .Callback<DomainEvent>(appended.Add);
+
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+        tasks.Setup(t => t.EnqueueAsync(It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformQueuedTask t, CancellationToken _) => t);
+
+        var handlerList = (handlers ?? DefaultHandlers(events.Object)).ToList();
+        var registry = new BillingEventHandlerRegistry(handlerList);
+        var nullHandler = new NullBillingEventHandler(NullLogger<NullBillingEventHandler>.Instance);
+
+        var processor = new StripeWebhookProcessor(
+            db, events.Object, tasks.Object, registry, nullHandler,
+            TimeProvider.System, NullLogger<StripeWebhookProcessor>.Instance);
+
+        return new Harness
+        {
+            Processor = processor, Db = db, Events = events, Tasks = tasks, Appended = appended,
+        };
+    }
+
+    private static IEnumerable<IBillingEventHandler> DefaultHandlers(IEventRepository events) =>
+        new IBillingEventHandler[]
+        {
+            new SubscriptionWebhookHandler(events),
+            new InvoiceWebhookHandler(events),
+            new PaymentWebhookHandler(events),
+            new DisputeWebhookHandler(events),
+        };
+
+    private static Stripe.Event Evt(string type, string id) => new() { Id = id, Type = type };
+
+    private static string Payload(string objectId, string? customer)
+    {
+        var cust = customer is null ? string.Empty : ",\"customer\":\"" + customer + "\"";
+        return "{\"data\":{\"object\":{\"id\":\"" + objectId + "\"" + cust + "}}}";
+    }
+
+    private static (string? tenantId, string? stripeEventId, string? eventType, string? stripeObjectId)
+        ReadTags(DomainEvent e)
+    {
+        using var doc = JsonDocument.Parse(e.Tags);
+        var r = doc.RootElement;
+        string? S(string k) => r.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() : null;
+        return (S("tenantId"), S("stripeEventId"), S("eventType"), S("stripeObjectId"));
+    }
+
+    // ── AC5 — dedupe ──
+
+    [Test]
+    public async Task Duplicate_Delivery_Projects_Once()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Duplicate_Delivery_Projects_Once), tid);
+        var evt = Evt(BillingWebhookEventTypes.SubscriptionCreated, "evt_dup");
+        var payload = Payload("sub_1", Cus);
+
+        var first = await h.Processor.ProcessAsync(evt, payload);
+        var second = await h.Processor.ProcessAsync(evt, payload);
+
+        first.Status.Should().Be(WebhookProcessResult.ProjectedStatus);
+        second.Status.Should().Be(WebhookProcessResult.DuplicateStatus);
+        (await h.Db.BillingWebhookEvents.CountAsync()).Should().Be(1, "one dedup row per event id");
+        h.Events.Verify(e => e.AppendAsync(It.Is<DomainEvent>(
+            d => d.Type == BillingWebhookEventTypes.DcbSubscriptionCreated)), Times.Once,
+            "the second delivery does not re-project");
+    }
+
+    // ── AC6 — tenant resolution ──
+
+    [Test]
+    public async Task No_Customer_Match_Is_Skipped_200_No_Projection()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(No_Customer_Match_Is_Skipped_200_No_Projection), tid);
+        var evt = Evt(BillingWebhookEventTypes.InvoicePaid, "evt_nocust");
+
+        var result = await h.Processor.ProcessAsync(evt, Payload("in_1", "cus_unknown"));
+
+        result.Status.Should().Be(WebhookProcessResult.SkippedStatus);
+        var row = await h.Db.BillingWebhookEvents.SingleAsync();
+        row.Status.Should().Be("skipped");
+        row.TenantId.Should().BeNull();
+        h.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never,
+            "a no-customer-match emits no projection event");
+    }
+
+    [Test]
+    public async Task Resolves_Tenant_And_Stamps_It_On_Row_And_Event()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Resolves_Tenant_And_Stamps_It_On_Row_And_Event), tid);
+
+        await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.SubscriptionUpdated, "evt_t"), Payload("sub_9", Cus));
+
+        var row = await h.Db.BillingWebhookEvents.SingleAsync();
+        row.TenantId.Should().Be(tid);
+        row.StripeObjectId.Should().Be("sub_9");
+
+        var (tenantTag, eventIdTag, typeTag, objTag) = ReadTags(h.Appended.Single());
+        tenantTag.Should().Be(tid.ToString("D"));
+        eventIdTag.Should().Be("evt_t");
+        typeTag.Should().Be(BillingWebhookEventTypes.SubscriptionUpdated);
+        objTag.Should().Be("sub_9");
+    }
+
+    // ── AC7 / AC8 — per default-handler DCB type ──
+
+    [TestCase(BillingWebhookEventTypes.SubscriptionCreated, "sub_1", BillingWebhookEventTypes.DcbSubscriptionCreated)]
+    [TestCase(BillingWebhookEventTypes.SubscriptionUpdated, "sub_1", BillingWebhookEventTypes.DcbSubscriptionUpdated)]
+    [TestCase(BillingWebhookEventTypes.SubscriptionDeleted, "sub_1", BillingWebhookEventTypes.DcbSubscriptionDeleted)]
+    [TestCase(BillingWebhookEventTypes.SubscriptionTrialWillEnd, "sub_1", BillingWebhookEventTypes.DcbSubscriptionTrialEnding)]
+    [TestCase(BillingWebhookEventTypes.InvoiceCreated, "in_1", BillingWebhookEventTypes.DcbInvoiceCreated)]
+    [TestCase(BillingWebhookEventTypes.InvoiceFinalized, "in_1", BillingWebhookEventTypes.DcbInvoiceFinalized)]
+    [TestCase(BillingWebhookEventTypes.InvoicePaid, "in_1", BillingWebhookEventTypes.DcbInvoicePaid)]
+    [TestCase(BillingWebhookEventTypes.PaymentIntentSucceeded, "pi_1", BillingWebhookEventTypes.DcbPaymentSucceeded)]
+    [TestCase(BillingWebhookEventTypes.PaymentIntentPaymentFailed, "pi_1", BillingWebhookEventTypes.DcbPaymentFailed)]
+    [TestCase(BillingWebhookEventTypes.ChargeDisputeCreated, "dp_1", BillingWebhookEventTypes.DcbDisputeOpened)]
+    public async Task Default_Handler_Emits_Expected_Dcb_Type(
+        string stripeType, string objectId, string expectedDcbType)
+    {
+        var tid = Guid.NewGuid();
+        var h = Build($"perhandler_{stripeType}", tid);
+
+        await h.Processor.ProcessAsync(Evt(stripeType, "evt_" + objectId), Payload(objectId, Cus));
+
+        h.Appended.Should().ContainSingle()
+            .Which.Type.Should().Be(expectedDcbType);
+    }
+
+    // ── AC11 — unknown type ──
+
+    [Test]
+    public async Task Unknown_Type_Is_Skipped_200_No_Projection()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Unknown_Type_Is_Skipped_200_No_Projection), tid);
+
+        var result = await h.Processor.ProcessAsync(Evt("foo.bar.baz", "evt_unknown"), Payload("x_1", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.SkippedStatus);
+        (await h.Db.BillingWebhookEvents.SingleAsync()).Status.Should().Be("skipped");
+        h.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    // ── AC10 — fast-ack enqueue ──
+
+    [Test]
+    public async Task Invoice_Payment_Failed_Enqueues_Followup_Task()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Invoice_Payment_Failed_Enqueues_Followup_Task), tid);
+
+        var result = await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.InvoicePaymentFailed, "evt_pf"), Payload("in_pf", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.EnqueuedStatus);
+        (await h.Db.BillingWebhookEvents.SingleAsync()).Status.Should().Be("enqueued");
+        h.Tasks.Verify(t => t.EnqueueAsync(
+            It.Is<PlatformQueuedTask>(p =>
+                p.Type == BillingWebhookEventTypes.FollowupTaskType && p.TenantId == tid),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Invoice_Paid_Does_Not_Enqueue_Followup()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Invoice_Paid_Does_Not_Enqueue_Followup), tid);
+
+        var result = await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.InvoicePaid, "evt_paid"), Payload("in_paid", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.ProjectedStatus);
+        h.Tasks.Verify(t => t.EnqueueAsync(It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Handler failure ──
+
+    private sealed class ThrowingHandler : IBillingEventHandler
+    {
+        public IReadOnlyCollection<string> HandledEventTypes => new[] { "invoice.paid" };
+        public Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+            => throw new InvalidOperationException("boom Bearer sk_live_ABCDEF1234567890 leak");
+    }
+
+    [Test]
+    public async Task Handler_Exception_Records_Failed_Scrubbed_And_Acks()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Handler_Exception_Records_Failed_Scrubbed_And_Acks), tid,
+            handlers: new IBillingEventHandler[] { new ThrowingHandler() });
+
+        var result = await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.InvoicePaid, "evt_boom"), Payload("in_boom", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.FailedStatus);
+        var row = await h.Db.BillingWebhookEvents.SingleAsync();
+        row.Status.Should().Be("failed");
+        row.LastError.Should().NotBeNullOrEmpty();
+        row.LastError.Should().NotContain("sk_live_", "the error must be credential-scrubbed");
+        row.LastError.Should().Contain("[REDACTED]");
+    }
+
+    // ── AC14 — tenant isolation ──
+
+    [Test]
+    public async Task Interleaved_Deliveries_Tag_Correct_Tenant()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var h = Build(nameof(Interleaved_Deliveries_Tag_Correct_Tenant), tenantA);
+        // second customer → tenant B
+        h.Db.BillingCustomers.Add(new BillingCustomer
+        {
+            Id = Guid.NewGuid(), TenantId = tenantB, StripeCustomerId = "cus_tenantB",
+            BillingMode = "PlatformProvided", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        });
+        await h.Db.SaveChangesAsync();
+
+        await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.SubscriptionCreated, "evt_A"), Payload("sub_A", Cus));
+        await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.SubscriptionCreated, "evt_B"), Payload("sub_B", "cus_tenantB"));
+
+        var rowA = await h.Db.BillingWebhookEvents.SingleAsync(e => e.StripeEventId == "evt_A");
+        var rowB = await h.Db.BillingWebhookEvents.SingleAsync(e => e.StripeEventId == "evt_B");
+        rowA.TenantId.Should().Be(tenantA);
+        rowB.TenantId.Should().Be(tenantB);
+
+        h.Appended.Should().OnlyContain(e => e.TenantId == tenantA || e.TenantId == tenantB);
+        h.Appended.Should().Contain(e => e.TenantId == tenantA);
+        h.Appended.Should().Contain(e => e.TenantId == tenantB);
+        // No event tagged tenant A carries tenant B's object and vice versa.
+        var evA = h.Appended.Single(e => e.TenantId == tenantA);
+        ReadTags(evA).stripeObjectId.Should().Be("sub_A");
+    }
+
+    // ── AC12 — replay idempotency ──
+
+    [Test]
+    public async Task Replay_Of_Projected_Row_Is_NoOp()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Replay_Of_Projected_Row_Is_NoOp), tid);
+        await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.SubscriptionCreated, "evt_rp"), Payload("sub_rp", Cus));
+        var row = await h.Db.BillingWebhookEvents.SingleAsync();
+        h.Appended.Clear();
+
+        var result = await h.Processor.ReplayAsync(row.Id);
+
+        result!.Status.Should().Be("projected");
+        h.Appended.Should().BeEmpty("re-running a projected event emits no new DCB event");
+    }
+
+    [Test]
+    public async Task Replay_Of_Missing_Row_Returns_Null()
+    {
+        var h = Build(nameof(Replay_Of_Missing_Row_Returns_Null), Guid.NewGuid());
+        (await h.Processor.ReplayAsync(Guid.NewGuid())).Should().BeNull();
+    }
+
+    // ── Id extraction ──
+
+    [Test]
+    public void ExtractIds_Reads_Object_And_Customer()
+    {
+        var (obj, cust) = StripeWebhookProcessor.ExtractIds(Payload("sub_x", "cus_x"));
+        obj.Should().Be("sub_x");
+        cust.Should().Be("cus_x");
+    }
+
+    [Test]
+    public void ExtractIds_Handles_Missing_Customer_And_Malformed()
+    {
+        StripeWebhookProcessor.ExtractIds(Payload("dp_1", null)).CustomerId.Should().BeNull();
+        StripeWebhookProcessor.ExtractIds("not json").Should().Be((null, null));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookProcessorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/StripeWebhookProcessorTests.cs
@@ -3,6 +3,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Npgsql;
 using NUnit.Framework;
 using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Billing.Handlers;
@@ -129,10 +130,14 @@ public class StripeWebhookProcessorTests
     // ── AC6 — tenant resolution ──
 
     [Test]
-    public async Task No_Customer_Match_Is_Skipped_200_No_Projection()
+    public async Task No_Customer_Match_Known_Type_Skips_But_Emits_Skipped_Audit()
     {
+        // Finding 1(b): a KNOWN-relevant type (invoice.paid has a handler) that
+        // cannot be tenant-resolved must be AUDITED at platform scope
+        // (BILLING.WEBHOOK.SKIPPED), not left as zero trace. It still emits no
+        // money/projection event and acks 200 (no Stripe retry storm).
         var tid = Guid.NewGuid();
-        var h = Build(nameof(No_Customer_Match_Is_Skipped_200_No_Projection), tid);
+        var h = Build(nameof(No_Customer_Match_Known_Type_Skips_But_Emits_Skipped_Audit), tid);
         var evt = Evt(BillingWebhookEventTypes.InvoicePaid, "evt_nocust");
 
         var result = await h.Processor.ProcessAsync(evt, Payload("in_1", "cus_unknown"));
@@ -141,8 +146,31 @@ public class StripeWebhookProcessorTests
         var row = await h.Db.BillingWebhookEvents.SingleAsync();
         row.Status.Should().Be("skipped");
         row.TenantId.Should().BeNull();
+
+        var audit = h.Appended.Should().ContainSingle().Subject;
+        audit.Type.Should().Be(BillingWebhookEventTypes.DcbWebhookSkipped,
+            "a known-relevant unresolvable event is audited, not silently dropped");
+        audit.TenantId.Should().BeNull("the skip is platform-scoped");
+        h.Appended.Should().NotContain(e => e.Type == BillingWebhookEventTypes.DcbInvoicePaid,
+            "no money/projection event is emitted for an unknown tenant");
+    }
+
+    [Test]
+    public async Task Unknown_Type_No_Tenant_Skips_Without_Audit_Spam()
+    {
+        // The flip side of 1(b): an UNKNOWN type with no tenant is a benign,
+        // irrelevant delivery — it must NOT emit a BILLING.WEBHOOK.SKIPPED audit
+        // (that would spam the platform stream for every stray Stripe event type).
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Unknown_Type_No_Tenant_Skips_Without_Audit_Spam), tid);
+
+        var result = await h.Processor.ProcessAsync(
+            Evt("foo.bar.baz", "evt_unk_notenant"), Payload("x_1", "cus_unknown"));
+
+        result.Status.Should().Be(WebhookProcessResult.SkippedStatus);
+        (await h.Db.BillingWebhookEvents.SingleAsync()).Status.Should().Be("skipped");
         h.Events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never,
-            "a no-customer-match emits no projection event");
+            "an unknown type with no tenant emits no audit event (no spam)");
     }
 
     [Test]
@@ -176,7 +204,10 @@ public class StripeWebhookProcessorTests
     [TestCase(BillingWebhookEventTypes.InvoicePaid, "in_1", BillingWebhookEventTypes.DcbInvoicePaid)]
     [TestCase(BillingWebhookEventTypes.PaymentIntentSucceeded, "pi_1", BillingWebhookEventTypes.DcbPaymentSucceeded)]
     [TestCase(BillingWebhookEventTypes.PaymentIntentPaymentFailed, "pi_1", BillingWebhookEventTypes.DcbPaymentFailed)]
-    [TestCase(BillingWebhookEventTypes.ChargeDisputeCreated, "dp_1", BillingWebhookEventTypes.DcbDisputeOpened)]
+    // NB: charge.dispute.created is intentionally NOT here — a realistic Dispute
+    // object has NO top-level `customer`, so it never resolves inline. Its two
+    // paths (resolvable-via-expanded-customer → projects; unresolvable → SKIPPED +
+    // follow-up) are covered by the dedicated dispute tests below.
     public async Task Default_Handler_Emits_Expected_Dcb_Type(
         string stripeType, string objectId, string expectedDcbType)
     {
@@ -187,6 +218,77 @@ public class StripeWebhookProcessorTests
 
         h.Appended.Should().ContainSingle()
             .Which.Type.Should().Be(expectedDcbType);
+    }
+
+    // ── Disputes (Finding 1) — a verified dispute must NEVER vanish silently ──
+
+    /// <summary>
+    /// A realistic <c>charge.dispute.created</c>: the Dispute object has NO
+    /// top-level <c>customer</c> — only <c>charge</c>/<c>payment_intent</c>. Under
+    /// the old code this resolved tenant=null and was stamped <c>skipped</c> with
+    /// zero trace: the dispute silently vanished. It must instead emit
+    /// <c>BILLING.WEBHOOK.SKIPPED</c> (platform audit) AND enqueue the dispute
+    /// follow-up carrying the charge/payment_intent ids.
+    /// </summary>
+    [Test]
+    public async Task Realistic_Dispute_No_Customer_Emits_Skipped_And_Enqueues_Followup()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Realistic_Dispute_No_Customer_Emits_Skipped_And_Enqueues_Followup), tid);
+
+        // Real Stripe dispute shape: no `customer`, has `charge` + `payment_intent`.
+        var payload =
+            "{\"data\":{\"object\":{\"id\":\"dp_1\",\"object\":\"dispute\","
+            + "\"charge\":\"ch_123\",\"payment_intent\":\"pi_456\"}}}";
+
+        var result = await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.ChargeDisputeCreated, "evt_dispute_real"), payload);
+
+        // NOT silently skipped — a follow-up exists so it is handled out-of-band.
+        result.Status.Should().Be(WebhookProcessResult.EnqueuedStatus);
+        var row = await h.Db.BillingWebhookEvents.SingleAsync();
+        row.Status.Should().Be("enqueued");
+        row.TenantId.Should().BeNull();
+
+        // (i) audited at platform scope
+        var audit = h.Appended.Should().ContainSingle().Subject;
+        audit.Type.Should().Be(BillingWebhookEventTypes.DcbWebhookSkipped);
+        audit.TenantId.Should().BeNull();
+        h.Appended.Should().NotContain(e => e.Type == BillingWebhookEventTypes.DcbDisputeOpened,
+            "an unresolvable dispute does not project BILLING.DISPUTE.OPENED");
+
+        // (ii) follow-up carries the charge/payment_intent + stripe event id
+        h.Tasks.Verify(t => t.EnqueueAsync(
+            It.Is<PlatformQueuedTask>(p =>
+                p.Type == BillingWebhookEventTypes.FollowupTaskType
+                && p.TenantId == null
+                && p.Payload.Contains("ch_123")
+                && p.Payload.Contains("pi_456")
+                && p.Payload.Contains("evt_dispute_real")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// A dispute CAN arrive with an expanded <c>customer</c> (SDK expansion). Then
+    /// it resolves inline and projects <c>BILLING.DISPUTE.OPENED</c> + enqueues the
+    /// dispute-response follow-up. Keeps <see cref="DisputeWebhookHandler"/>'s
+    /// happy path covered without a fake customer on a realistic payload.
+    /// </summary>
+    [Test]
+    public async Task Dispute_With_Expanded_Customer_Projects_Dispute_Opened()
+    {
+        var tid = Guid.NewGuid();
+        var h = Build(nameof(Dispute_With_Expanded_Customer_Projects_Dispute_Opened), tid);
+
+        var result = await h.Processor.ProcessAsync(
+            Evt(BillingWebhookEventTypes.ChargeDisputeCreated, "evt_dp_cust"),
+            Payload("dp_1", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.EnqueuedStatus);
+        h.Appended.Should().ContainSingle()
+            .Which.Type.Should().Be(BillingWebhookEventTypes.DcbDisputeOpened);
+        h.Tasks.Verify(t => t.EnqueueAsync(
+            It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // ── AC11 — unknown type ──
@@ -323,6 +425,99 @@ public class StripeWebhookProcessorTests
         (await h.Processor.ReplayAsync(Guid.NewGuid())).Should().BeNull();
     }
 
+    // ── Finding 2 — the dedup-insert catch is unique-violation-ONLY ──
+
+    [Test]
+    public async Task Insert_Unique_Violation_Is_Acked_As_Duplicate()
+    {
+        // A 23505 collision on the dedup insert is the idempotent-redelivery case
+        // → Duplicate/200 (Stripe stops retrying).
+        var db = new ThrowOnSaveCpDb(
+            InMemoryOptions(nameof(Insert_Unique_Violation_Is_Acked_As_Duplicate)),
+            new DbUpdateException("dup",
+                new PostgresException(
+                    "duplicate key value violates unique constraint", "ERROR", "ERROR", "23505")));
+        var proc = NewProcessorFor(db);
+
+        var result = await proc.ProcessAsync(
+            Evt(BillingWebhookEventTypes.InvoicePaid, "evt_uv"), Payload("in_uv", Cus));
+
+        result.Status.Should().Be(WebhookProcessResult.DuplicateStatus);
+    }
+
+    [Test]
+    public async Task Insert_Transient_DbUpdateException_Bubbles_Not_Swallowed()
+    {
+        // A deadlock/timeout/connection-reset during the dedup insert is NOT a
+        // duplicate — it must BUBBLE (→ endpoint non-2xx → Stripe retries) rather
+        // than be swallowed as Duplicate/200 (which would lose the billing event).
+        var db = new ThrowOnSaveCpDb(
+            InMemoryOptions(nameof(Insert_Transient_DbUpdateException_Bubbles_Not_Swallowed)),
+            new DbUpdateException("deadlock",
+                new PostgresException("deadlock detected", "ERROR", "ERROR", "40P01")));
+        var proc = NewProcessorFor(db);
+
+        var act = async () => await proc.ProcessAsync(
+            Evt(BillingWebhookEventTypes.InvoicePaid, "evt_deadlock"), Payload("in_dl", Cus));
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    // ── Finding 3 — deterministic DCB Id makes replay idempotent ──
+
+    [Test]
+    public async Task Replay_Of_NonTerminal_Row_Does_Not_Double_Emit_Money_Event()
+    {
+        var tid = Guid.NewGuid();
+
+        // Dedup-aware event store (mirrors EventRepository / PlatformEventRepository
+        // dedup-on-Id). A deterministic DCB Id makes a re-dispatch a no-op here.
+        var byId = new Dictionary<Guid, DomainEvent>();
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d)
+            .Callback<DomainEvent>(d => byId.TryAdd(d.Id, d));
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+        tasks.Setup(t => t.EnqueueAsync(It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformQueuedTask t, CancellationToken _) => t);
+
+        var db = NewDb(nameof(Replay_Of_NonTerminal_Row_Does_Not_Double_Emit_Money_Event));
+        db.BillingCustomers.Add(new BillingCustomer
+        {
+            Id = Guid.NewGuid(), TenantId = tid, StripeCustomerId = Cus,
+            BillingMode = "PlatformProvided", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        });
+        db.SaveChanges();
+
+        var proc = new StripeWebhookProcessor(
+            db, events.Object, tasks.Object,
+            new BillingEventHandlerRegistry(DefaultHandlers(events.Object).ToList()),
+            new NullBillingEventHandler(NullLogger<NullBillingEventHandler>.Instance),
+            TimeProvider.System, NullLogger<StripeWebhookProcessor>.Instance);
+
+        // Full Stripe-shaped payload so admin replay's EventUtility.ParseEvent is happy.
+        var payload =
+            "{\"id\":\"evt_det\",\"type\":\"payment_intent.succeeded\","
+            + "\"data\":{\"object\":{\"id\":\"pi_det\",\"customer\":\"" + Cus + "\"}}}";
+
+        await proc.ProcessAsync(Evt(BillingWebhookEventTypes.PaymentIntentSucceeded, "evt_det"), payload);
+        byId.Values.Count(e => e.Type == BillingWebhookEventTypes.DcbPaymentSucceeded)
+            .Should().Be(1, "one money event on first delivery");
+
+        // Simulate a crash between the DCB emit and the terminal status save: the
+        // row is left non-terminal, so admin replay re-dispatches it.
+        var row = await db.BillingWebhookEvents.SingleAsync();
+        row.Status = "received";
+        row.ProcessedAt = null;
+        await db.SaveChangesAsync();
+
+        await proc.ReplayAsync(row.Id);
+
+        byId.Values.Count(e => e.Type == BillingWebhookEventTypes.DcbPaymentSucceeded)
+            .Should().Be(1,
+                "a deterministic DCB Id lets the store dedup the replay — money events never double-count");
+    }
+
     // ── Id extraction ──
 
     [Test]
@@ -338,5 +533,69 @@ public class StripeWebhookProcessorTests
     {
         StripeWebhookProcessor.ExtractIds(Payload("dp_1", null)).CustomerId.Should().BeNull();
         StripeWebhookProcessor.ExtractIds("not json").Should().Be((null, null));
+    }
+
+    [Test]
+    public void ExtractDisputeRefs_Reads_Charge_And_PaymentIntent()
+    {
+        var payload =
+            "{\"data\":{\"object\":{\"id\":\"dp_1\",\"charge\":\"ch_9\",\"payment_intent\":\"pi_9\"}}}";
+        var (charge, pi) = StripeWebhookProcessor.ExtractDisputeRefs(payload);
+        charge.Should().Be("ch_9");
+        pi.Should().Be("pi_9");
+
+        StripeWebhookProcessor.ExtractDisputeRefs("not json").Should().Be((null, null));
+    }
+
+    [Test]
+    public void DeterministicId_Is_Stable_Per_Type_And_Event_And_Distinct_Across_Them()
+    {
+        var a1 = BillingWebhookDcbEvents.DeterministicId("BILLING.PAYMENT.SUCCEEDED", "evt_1");
+        var a2 = BillingWebhookDcbEvents.DeterministicId("BILLING.PAYMENT.SUCCEEDED", "evt_1");
+        a1.Should().Be(a2, "same (dcbType, stripeEventId) → same Id (dedup key)");
+        a1.Should().NotBe(Guid.Empty);
+
+        BillingWebhookDcbEvents.DeterministicId("BILLING.PAYMENT.SUCCEEDED", "evt_2")
+            .Should().NotBe(a1, "a different event id is a different fact");
+        BillingWebhookDcbEvents.DeterministicId("BILLING.WEBHOOK.SKIPPED", "evt_1")
+            .Should().NotBe(a1, "a different dcb type is a different fact");
+    }
+
+    // ── helpers for Finding 2 ──
+
+    private static DbContextOptions<ControlPlaneDbContext> InMemoryOptions(string name) =>
+        new DbContextOptionsBuilder<ControlPlaneDbContext>().UseInMemoryDatabase(name).Options;
+
+    private static StripeWebhookProcessor NewProcessorFor(ControlPlaneDbContext db)
+    {
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d);
+        var tasks = new Mock<IPlatformQueuedTaskRepository>();
+        tasks.Setup(t => t.EnqueueAsync(It.IsAny<PlatformQueuedTask>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlatformQueuedTask t, CancellationToken _) => t);
+        return new StripeWebhookProcessor(
+            db, events.Object, tasks.Object,
+            new BillingEventHandlerRegistry(DefaultHandlers(events.Object).ToList()),
+            new NullBillingEventHandler(NullLogger<NullBillingEventHandler>.Instance),
+            TimeProvider.System, NullLogger<StripeWebhookProcessor>.Instance);
+    }
+
+    /// <summary>
+    /// A <see cref="ControlPlaneDbContext"/> whose async SaveChanges always throws
+    /// a supplied exception — used to simulate a specific
+    /// <see cref="DbUpdateException"/> on the dedup insert. The synchronous
+    /// <c>SaveChanges</c> used by test seeding is untouched.
+    /// </summary>
+    private sealed class ThrowOnSaveCpDb : ControlPlaneDbContext
+    {
+        private readonly Exception _toThrow;
+
+        public ThrowOnSaveCpDb(DbContextOptions<ControlPlaneDbContext> opts, Exception toThrow)
+            : base(opts) => _toThrow = toThrow;
+
+        public override Task<int> SaveChangesAsync(
+            bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+            => throw _toThrow;
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -121,6 +121,10 @@ public class ControlPlaneDbContextModelTests
             // only — usage/metering data is owned by later Epic 35 stories.
             "billing_customers",
             "billing_plan_prices",
+            // Story 35-5 — Stripe webhook dedup + audit journal. CP-resident:
+            // billing is a cross-cutting platform concern; the webhook arrives
+            // with no tenant context (tenant resolved from the Stripe customer).
+            "billing_webhook_events",
             // Story 37-1 — curated audit-record read-model + the per-(projector,
             // tenant) cursor. audit_records is mapped on BOTH contexts (the CP
             // build materializes platform-scope + single-user rows); the cursor
@@ -148,6 +152,7 @@ public class ControlPlaneDbContextModelTests
             + "Story 32-16 adds tenant_agent_enablements. "
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
+            + "Story 35-5 adds billing_webhook_events. "
             + "Story 37-1 adds audit_records + audit_projector_cursor. "
             + "Story 34-11 adds providers + provider_model_prices. "
             + "Story 34-5 adds margin_policies. "


### PR DESCRIPTION
## What

Story 35-5 (P0). `POST /api/v1/billing/stripe/webhook` (anonymous, **signature-gated**) — verifies the Stripe signature (secret from the Epic 29 cabinet via `IRuntimeSecretResolver`, **fail-closed 503** if unresolvable), dedups by Stripe event id (`billing_webhook_events` UNIQUE), resolves tenant via `BillingCustomer.StripeCustomerId → TenantId`, and projects `BILLING.*` DCB events through a pluggable handler registry. Admin `GET .../webhook-events` + `POST .../{id}/replay` (**PlatformOwnerAccess**). SaaS-mode-gated routes. New `BillingWebhookEvents` migration on ControlPlaneDbContext (all three CP-table places updated: DROP-list, model test, migration).

## Review outcome

Adversarial security review verified signature verification (no bypass, no prod no-op verifier), fail-closed secret, dedup race-safety, tenant-resolution uniqueness, admin RBAC/replay, and SaaS gating as SOLID. **Three real findings fixed** (all had green tests before):
- **Critical — dead dispute path:** a real Stripe Dispute has no top-level `customer` (only `charge`/`payment_intent`), so every `charge.dispute.created` resolved to no tenant and was **silently skipped** (masked by a test injecting a fake `customer`). Now: a known-relevant type that can't be tenant-resolved emits the platform-scope `BILLING.WEBHOOK.SKIPPED` audit **and** (for disputes) enqueues the follow-up task with the charge/PI ref — a verified dispute never vanishes. (No schema needed — no charge→customer table exists; resolved via existing data + follow-up.)
- **Important — silent billing-event loss:** the dedup catch swallowed *any* `DbUpdateException` as a "duplicate" (200), so transient failures (deadlock/timeout) were lost with no Stripe retry. Narrowed to the 23505 unique-violation only; all else bubbles → 503 → Stripe retries.
- **Important — replay double-projects money:** the DCB event Id was `Guid.NewGuid()` per dispatch, so an admin replay re-emitted `INVOICE.PAID`/`PAYMENT.SUCCEEDED` uncdeduped. Now a **deterministic UUIDv5** from `(dcbType, stripeEventId)` makes re-dispatch idempotent; the follow-up enqueue moved inside the handler try so a failure marks the row `failed`, not silently re-drivable.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Tests: 127 passed (Stripe|Billing|CP-model, incl. Postgres testcontainer; fail-before/pass-after verified for all three fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)