### PR TITLE
fix(epic-2): durable SLA timer on the SingleIssueCycle merge wait (no more indefinite hang)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
@@ -1,25 +1,58 @@
 using System.Text.Json.Serialization;
 using Elsa.Extensions;
 using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.Core;
 
 namespace Tamma.Activities.ADL;
 
 /// <summary>
-/// Bookmark-based activity that blocks until a PR is merged.
-/// Resumed by a GitHub webhook (pull_request.closed with merged=true).
+/// Bookmark-based activity that blocks until a PR is merged — OR a durable SLA deadline
+/// elapses, whichever happens first. Resumed by a GitHub webhook (pull_request.closed with
+/// merged=true) → <c>Merged</c>; or by the durable SLA timer → <c>TimedOut</c>.
+///
+/// <para><b>Durable merge SLA timeout (SingleIssueCycle.md §Missing #6 — the tracked
+/// follow-up; landed 2026-07-02).</b> The merge is approved + performed synchronously inside
+/// the merge-approval gate, so the <c>pr-merged-{pr}</c> webhook should arrive within
+/// moments. But if that webhook is never delivered (a lost/failed delivery, or a merge that
+/// silently didn't complete) the cycle would otherwise wait on the bookmark forever with no
+/// escalation. Two resume paths are now armed when the activity suspends:</para>
+/// <list type="number">
+///   <item><description>the merge bookmark (<c>pr-merged-{pr}</c>) resumed by the GitHub
+///     webhook → <c>Merged</c> outcome (the unchanged happy path); and</description></item>
+///   <item><description>a DURABLE delay bookmark via
+///     <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+///     at the SLA (<c>Adl:PrMergeTimeoutMinutes</c>, default 720 = 12h) → <c>TimedOut</c>
+///     outcome, on which the parent cycle escalates to a human handoff instead of hanging.</description></item>
+/// </list>
+/// <para>The Delay bookmark is EF-persisted and re-armed by <c>Elsa.Scheduling</c>'s startup
+/// task on rehydration (mirrors <see cref="Tamma.Activities.Blocker.EscalateToSeniorActivity"/>
+/// and <see cref="Tamma.Activities.Testing.WaitForCIResultsActivity"/>), so a host restart mid-wait
+/// does NOT drop the SLA. Whichever path resumes first completes the activity; Elsa burns the
+/// remaining bookmark, so there is no orphaned timer / stale double-resume.</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",
     "Wait for PR Merged",
-    "Block until the pull request is merged",
+    "Block until the pull request is merged, or escalate when the merge SLA elapses",
     Kind = ActivityKind.Task
 )]
+[FlowNode("Merged", "TimedOut")]
 public class WaitForPRMergedActivity : TammaOutcomeActivity
 {
+    /// <summary>
+    /// Default merge-webhook SLA (minutes) when <c>Adl:PrMergeTimeoutMinutes</c> is unset.
+    /// 12h — generous enough to absorb a delayed / retried webhook delivery, short enough
+    /// that an unattended loop never stalls indefinitely on a lost merge webhook.
+    /// </summary>
+    public const int DefaultTimeoutMinutes = 720;
+
+    private readonly IConfiguration? _configuration;
+
     public override string? EventType => "CYCLE.PR.MERGE.WAIT";
 
     [Input(Description = "Repository (owner/repo)")]
@@ -34,24 +67,43 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
     [JsonConstructor]
     public WaitForPRMergedActivity() { }
 
-    public WaitForPRMergedActivity(ILogger<WaitForPRMergedActivity> logger)
+    public WaitForPRMergedActivity(ILogger<WaitForPRMergedActivity> logger, IConfiguration configuration)
     {
         Logger = logger;
+        _configuration = configuration;
     }
 
-    protected override async Task RunAsync(ActivityExecutionContext context)
+    protected override Task RunAsync(ActivityExecutionContext context)
     {
         var prNumber = PRNumber.Get(context);
-        Logger?.LogInformation("Waiting for PR #{PRNumber} to be merged...", prNumber);
 
+        // 1) Merge bookmark — resumed by the GitHub pull_request.closed(merged=true) webhook.
         context.CreateBookmark(new CreateBookmarkArgs
         {
             Callback = OnMerged,
             BookmarkName = $"pr-merged-{prNumber}",
             IncludeActivityInstanceId = false,
         });
+
+        // 2) Durable merge SLA — a DelayFor (Delay) bookmark that Elsa.Scheduling's startup
+        //    background task RE-ARMS after a host restart (EF-persisted, not an in-memory
+        //    timer). A never-delivered merge webhook now escalates to a real TimedOut terminal
+        //    even across a VPS restart inside the (default 12h) SLA window instead of hanging.
+        var slaMinutes = _configuration?.GetValue<int?>("Adl:PrMergeTimeoutMinutes") ?? DefaultTimeoutMinutes;
+        slaMinutes = Math.Max(1, slaMinutes);
+        context.DelayFor(TimeSpan.FromMinutes(slaMinutes), OnTimeoutAsync);
+
+        Logger?.LogInformation(
+            "Waiting for PR #{PRNumber} to be merged; durable SLA timeout armed at +{SlaMinutes}min",
+            prNumber, slaMinutes);
+
+        return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Merge webhook resume path (happy path): the PR was merged. Elsa burns the still-armed
+    /// SLA Delay bookmark on completion (no orphaned timer).
+    /// </summary>
     private async ValueTask OnMerged(ActivityExecutionContext context)
     {
         var sha = context.WorkflowInput.GetValueOrDefault("mergeSha")?.ToString();
@@ -60,7 +112,24 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
         Logger?.LogInformation("PR #{PRNumber} merged. SHA: {MergeSha}",
             PRNumber.Get(context), sha ?? "unknown");
 
-        await context.CompleteActivityAsync();
+        await context.CompleteActivityWithOutcomesAsync("Merged");
+    }
+
+    /// <summary>
+    /// Durable timeout path: the merge SLA elapsed with no merge webhook. The Delay bookmark
+    /// scheduler resumes the activity here (and re-arms across a host restart). Takes the
+    /// deterministic <c>TimedOut</c> edge so the cycle escalates to a human handoff instead of
+    /// suspending forever; the still-armed merge bookmark is burned on completion.
+    /// </summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        MergeSha.Set(context, null);
+
+        Logger?.LogWarning(
+            "Merge SLA expired (durable timeout) for PR #{PRNumber} — taking the TimedOut edge",
+            PRNumber.Get(context));
+
+        await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 
     public override Dictionary<string, object?> BuildEndData(ActivityExecutionContext context) => new()

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -687,6 +687,12 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         var notifyMergeEscalated = NotifyIssue("NotifyMergeEscalated", repository, issueNumber,
             "⚠️ Merge-approval gate escalated (failed merge / invalid decision). Needs human attention.",
             new[] { "tamma-error", "needs-human" }, new[] { "tamma-processing" });
+        // Durable merge-SLA escalation (§Missing #6): the merge was approved but the
+        // `pr-merged` webhook never arrived within the SLA. A human must check the PR /
+        // merge status — a needs-human handoff, not a cycle error.
+        var notifyMergeTimeout = NotifyIssue("NotifyMergeTimeout", repository, issueNumber,
+            "⏰ Merge approved but not confirmed within the SLA (no merge webhook). Needs human attention.",
+            new[] { "needs-human" }, new[] { "tamma-processing" });
 
         // ================================================================
         // 13. Wait for PR Merged (bookmark — blocks until merged)
@@ -903,13 +909,15 @@ public class SingleIssueCycleWorkflow : WorkflowBase
             ctx => HasTasks(tasksJson.Get(ctx)),
             failedStepId, failedDetail, "task-creation",
             _ => "task-creation returned no tasks (empty or unparseable task list)");
-        // NOTE (honestly-DEFERRED follow-up, SingleIssueCycle.md §Missing #6):
-        // WaitForPRMergedActivity / WaitForPRApprovalActivity create unbounded
-        // `pr-merged-{pr}` / `pr-approval-{pr}` bookmarks with NO SLA timeout. If a
-        // merge/approval webhook never arrives the loop hangs. This is NOT a
-        // regression (the real merge now runs synchronously inside merge-approval),
-        // but before this cycle runs in a live unattended loop a durable
-        // `context.DelayFor` SLA timer must be added to those waits. Tracked follow-up.
+        // RESOLVED (SingleIssueCycle.md §Missing #6 — was a DEFERRED follow-up):
+        // WaitForPRMerged is the ONLY unbounded human/webhook wait left in the cycle
+        // (the old binary WaitForPRApprovalActivity was retired for the merge-approval
+        // gate). It now arms a DURABLE `context.DelayFor` merge SLA alongside its
+        // `pr-merged-{pr}` bookmark (Adl:PrMergeTimeoutMinutes, default 12h) and exposes
+        // a `TimedOut` outcome — so a never-delivered merge webhook escalates to the
+        // needs-human terminal (notifyMergeTimeout → reportNeedsHuman) instead of
+        // hanging the loop forever. See the WaitForPRMerged wiring below and the
+        // durable-timer precedents (WaitForCIResultsActivity / EscalateToSeniorActivity).
 
         var prOk = StepGate("PrOk", "PR OK?",
             ctx => prNumber.Get(ctx) > 0,
@@ -1029,7 +1037,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ciGate, ciOk, notifyCiPassed,
                 dispatchCodeReview, mergeApprovalGate,
                 extractGateOutcome, gateOutcomeSwitch,
-                notifyMergeRejected, notifyMergeEscalated,
+                notifyMergeRejected, notifyMergeEscalated, notifyMergeTimeout,
                 waitForMerged, closeIssue, deploymentPipeline, deployOk,
                 emitCycleCompleted,
                 // Notifications (fire-and-forget)
@@ -1216,9 +1224,18 @@ public class SingleIssueCycleWorkflow : WorkflowBase
                 ConnectOutcome(gateOutcomeSwitch, "Escalated", notifyMergeEscalated),
                 ConnectOutcome(gateOutcomeSwitch, "Escalated", reportError),
 
-                // 13. Merged → Close Issue + Deployment Pipeline (parallel)
-                Connect(waitForMerged, closeIssue),
-                Connect(waitForMerged, deploymentPipeline),
+                // 13. Merged → Close Issue + Deployment Pipeline (parallel) — the
+                //      happy path, now gated on the explicit "Merged" outcome so the
+                //      durable merge-SLA "TimedOut" outcome can escalate separately.
+                ConnectOutcome(waitForMerged, "Merged", closeIssue),
+                ConnectOutcome(waitForMerged, "Merged", deploymentPipeline),
+
+                // 13b. Merge SLA elapsed with no merge webhook (§Missing #6) → the
+                //      durable timer fires the "TimedOut" outcome: notify + needs-human
+                //      handoff terminal. The loop can NEVER wait on the merge webhook
+                //      forever — a lost/failed merge webhook now escalates deterministically.
+                ConnectOutcome(waitForMerged, "TimedOut", notifyMergeTimeout),
+                ConnectOutcome(waitForMerged, "TimedOut", reportNeedsHuman),
 
                 // 15. Deployment done → GATE on the deploy result (§Missing #11).
                 //     A deployment failure must NOT report success — it routes to the

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/WaitForPRMergedDurableTimeoutTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/WaitForPRMergedDurableTimeoutTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// SingleIssueCycle.md §Missing #6 (landed 2026-07-02) — the durable merge-wait-timeout
+/// invariant for <c>WaitForPRMergedActivity</c>.
+///
+/// <para>The cycle's last unbounded human/webhook wait (the <c>pr-merged-{pr}</c> bookmark)
+/// now arms a durable SLA alongside it. The SLA MUST use <c>context.DelayFor(...)</c> — the
+/// EF-persisted Delay bookmark that <c>Elsa.Scheduling</c>'s startup task RE-ARMS after a host
+/// restart — NOT the in-memory <c>IWorkflowScheduler.ScheduleAtAsync</c> timer (lost on any
+/// restart within the SLA window, which is the exact hang this closes). These source-scan
+/// invariants guard against regression to the in-memory scheduler and mirror the
+/// <c>BlockerDurableTimeoutTests</c> / <c>ReviewDurableTimeoutTests</c> precedents. A live
+/// resume/rehydration test would need the full Elsa runtime + EF store, which this activity has
+/// no unit harness for; the escalation-on-timeout branch is proved structurally in
+/// <c>SingleIssueCycleMergeSlaTests</c>.</para>
+/// </summary>
+[TestFixture]
+public class WaitForPRMergedDurableTimeoutTests
+{
+    [Test]
+    public void WaitForPRMerged_ArmsDurableDelayBookmark_WithATimeoutHandler()
+    {
+        var src = ReadAdlActivity("WaitForPRMergedActivity.cs");
+
+        // The durable primitive — DelayFor (the Delay bookmark) — must be armed, and a
+        // dedicated timeout callback must exist to take the TimedOut edge.
+        src.Should().Contain("context.DelayFor(",
+            "WaitForPRMerged must arm the durable DelayFor (Delay) bookmark so the SLA survives a host restart");
+        src.Should().Contain("OnTimeoutAsync",
+            "WaitForPRMerged must resume into a dedicated durable-timeout handler");
+        src.Should().Contain("CompleteActivityWithOutcomesAsync(\"TimedOut\")",
+            "the durable timeout must take the deterministic TimedOut outcome");
+    }
+
+    [Test]
+    public void WaitForPRMerged_StillArmsTheMergeWebhookBookmark()
+    {
+        var src = ReadAdlActivity("WaitForPRMergedActivity.cs");
+
+        // Dual-arm: the merge bookmark must remain so a real merge webhook can resume (only
+        // the timeout primitive was added, not a change to the resume path).
+        src.Should().Contain("pr-merged-",
+            "the merge-webhook bookmark must remain so a real merge resumes the wait");
+        src.Should().Contain("CompleteActivityWithOutcomesAsync(\"Merged\")",
+            "a delivered merge webhook must take the Merged outcome (the unchanged happy path)");
+    }
+
+    [Test]
+    public void WaitForPRMerged_DoesNotUseTheInMemoryScheduler()
+    {
+        var src = ReadAdlActivity("WaitForPRMergedActivity.cs");
+
+        src.Should().NotContain("ScheduleAtAsync(",
+            "WaitForPRMerged must NOT schedule via IWorkflowScheduler.ScheduleAtAsync (in-memory timer lost on restart)");
+        src.Should().NotContain("GetService<IWorkflowScheduler>",
+            "WaitForPRMerged must not resolve the in-memory IWorkflowScheduler");
+    }
+
+    // ---------------------------------------------------------------------
+    // Source-tree helper (mirrors BlockerDurableTimeoutTests' worktree locator).
+    // ---------------------------------------------------------------------
+
+    private static string ReadAdlActivity(string fileName)
+    {
+        var path = Path.Combine(TammaElsaSrcRoot(), "Tamma.Activities", "ADL", fileName);
+        File.Exists(path).Should().BeTrue($"expected ADL activity source at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string TammaElsaSrcRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "Tamma.Activities");
+            if (Directory.Exists(candidate))
+                return Path.Combine(dir.FullName, "src");
+
+            var nested = Path.Combine(dir.FullName, "apps", "tamma-elsa", "src", "Tamma.Activities");
+            if (Directory.Exists(nested))
+                return Path.Combine(dir.FullName, "apps", "tamma-elsa", "src");
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate apps/tamma-elsa/src by walking up from "
+            + AppContext.BaseDirectory + " — the durable-timeout invariant test needs the source tree.");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleMergeSlaTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleIssueCycleMergeSlaTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// SingleIssueCycle.md §Missing #6 (the tracked DEFERRED follow-up, landed 2026-07-02) —
+/// the durable merge-SLA timer on the cycle's last unbounded human/webhook wait
+/// (<c>WaitForPRMerged</c>). Two invariants:
+///
+/// <list type="bullet">
+///   <item>the happy path is UNCHANGED — a merge webhook resumes via the <c>Merged</c> outcome
+///     and still flows to CloseIssue + the deployment pipeline + the success terminal;</item>
+///   <item>exceeding the SLA fires the durable <c>context.DelayFor</c> timer, which takes the
+///     <c>TimedOut</c> outcome and escalates to the needs-human terminal (never ReportSuccess),
+///     terminating at Finish — the loop can NEVER wait on the merge webhook indefinitely.</item>
+/// </list>
+///
+/// <para>These are the structural proofs (the established test style for this workflow — see
+/// <see cref="SingleIssueCycleRoutingTests"/> / <see cref="SingleIssueCycleSafetyTests"/>). The
+/// durable-primitive proof (that the timer survives a host restart) is the source-scan invariant
+/// in <see cref="WaitForPRMergedDurableTimeoutTests"/>, mirroring the Blocker/Review precedents.
+/// A live resume/rehydration test would need the full Elsa runtime + EF store, which these
+/// activities have no unit harness for.</para>
+/// </summary>
+[TestFixture]
+public class SingleIssueCycleMergeSlaTests
+{
+    private Flowchart _flowchart = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new SingleIssueCycleWorkflow());
+        _flowchart = WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    // ── The activity declares the two typed outcomes the cycle branches on ──
+
+    [Test]
+    public void WaitForPRMerged_DeclaresMergedAndTimedOutOutcomes()
+    {
+        var flowNode = typeof(WaitForPRMergedActivity).GetCustomAttribute<FlowNodeAttribute>();
+        flowNode.Should().NotBeNull(
+            "WaitForPRMerged must declare typed outcomes so the cycle can branch merge vs. SLA-timeout");
+        flowNode!.Outcomes.Should().Contain("Merged", "the merge webhook resumes on the Merged outcome");
+        flowNode.Outcomes.Should().Contain("TimedOut", "the durable SLA timer resumes on the TimedOut outcome");
+    }
+
+    [Test]
+    public void WaitForPRMerged_HasASaneDefaultSla()
+    {
+        // A configurable timeout with a sane default (Adl:PrMergeTimeoutMinutes) — never zero /
+        // never "wait forever". 12h absorbs a delayed/retried webhook without stalling a loop.
+        WaitForPRMergedActivity.DefaultTimeoutMinutes.Should().BeGreaterThan(0,
+            "the merge wait must have a positive default SLA — a non-positive value would wait forever");
+        WaitForPRMergedActivity.DefaultTimeoutMinutes.Should().Be(720, "12h is the documented default");
+    }
+
+    // ── (a) Happy path UNCHANGED: Merged → CloseIssue + DeploymentPipeline → success ──
+
+    [Test]
+    public void MergedOutcome_StillReachesCloseIssueDeploymentAndSuccess()
+    {
+        HasEdge("WaitForPRMerged", "CloseIssue", "Merged").Should().BeTrue(
+            "a merged PR must still close the issue (happy path unchanged)");
+        HasEdge("WaitForPRMerged", "DeploymentPipeline", "Merged").Should().BeTrue(
+            "a merged PR must still trigger the deployment pipeline (happy path unchanged)");
+
+        var reach = ReachableFromPort("WaitForPRMerged", "Merged");
+        reach.Should().Contain("ReportSuccess",
+            "the merge happy path must still be able to report success");
+        reach.Should().Contain("Finish", "the merge happy path must terminate at Finish");
+    }
+
+    [Test]
+    public void WaitForPRMerged_HasNoUnconditionalFallthrough()
+    {
+        // Every edge out of WaitForPRMerged must be outcome-qualified (Merged / TimedOut).
+        // A portless edge would let the happy-path successors also fire on a timeout.
+        var outgoing = _flowchart.Connections
+            .Where(c => c.Source.Activity.Id == "WaitForPRMerged")
+            .ToList();
+
+        outgoing.Should().NotBeEmpty();
+        outgoing.Should().OnlyContain(c => c.Source.Port == "Merged" || c.Source.Port == "TimedOut",
+            "every WaitForPRMerged edge must be qualified by the Merged or TimedOut outcome");
+    }
+
+    // ── (b) SLA exceeded → durable timer → escalation terminal, never an indefinite wait ──
+
+    [Test]
+    public void TimedOutOutcome_EscalatesToNeedsHuman_AndTerminates()
+    {
+        HasEdge("WaitForPRMerged", "NotifyMergeTimeout", "TimedOut").Should().BeTrue(
+            "an SLA timeout must notify that the merge was not confirmed in time");
+        HasEdge("WaitForPRMerged", "ReportNeedsHuman", "TimedOut").Should().BeTrue(
+            "an SLA timeout must escalate to the needs-human handoff terminal");
+
+        var reach = ReachableFromPort("WaitForPRMerged", "TimedOut");
+        reach.Should().Contain("Finish",
+            "the SLA-timeout path must terminate at Finish (no dangling edge / no indefinite wait)");
+        reach.Should().NotContain("ReportSuccess",
+            "an unconfirmed merge must NEVER report success (no false success on a timeout)");
+        reach.Should().NotContain("CloseIssue",
+            "an unconfirmed merge must NOT close the issue as resolved");
+    }
+
+    [Test]
+    public void NotifyMergeTimeout_IsWiredIntoTheFlowchart()
+    {
+        _flowchart.Activities.Any(a => a.Id == "NotifyMergeTimeout")
+            .Should().BeTrue("the SLA-timeout notify must be present in the flowchart");
+        _flowchart.Connections.Any(c => c.Target.Activity.Id == "NotifyMergeTimeout")
+            .Should().BeTrue("NotifyMergeTimeout must be reachable (not an orphaned node)");
+    }
+
+    // ── Helpers (local — mirror the SafetyTests helpers) ──
+
+    private bool HasEdge(string sourceId, string targetId, string? port = null)
+        => _flowchart.Connections.Any(c =>
+            c.Source.Activity.Id == sourceId &&
+            c.Target.Activity.Id == targetId &&
+            (port == null || c.Source.Port == port));
+
+    private HashSet<string> ReachableFromPort(string sourceId, string port)
+    {
+        var seen = new HashSet<string>();
+        var queue = new Queue<string>();
+        foreach (var c in _flowchart.Connections.Where(c =>
+            c.Source.Activity.Id == sourceId && c.Source.Port == port))
+        {
+            if (seen.Add(c.Target.Activity.Id)) queue.Enqueue(c.Target.Activity.Id);
+        }
+        while (queue.Count > 0)
+        {
+            var id = queue.Dequeue();
+            foreach (var c in _flowchart.Connections.Where(c => c.Source.Activity.Id == id))
+            {
+                if (c.Target.Activity.Id is { } t && seen.Add(t)) queue.Enqueue(t);
+            }
+        }
+        return seen;
+    }
+}


### PR DESCRIPTION
## What

Resolves the tracked `SingleIssueCycle §Missing #6` follow-up: the central cycle's post-approval merge wait (`WaitForPRMerged`) armed a `pr-merged-{pr}` bookmark with **no SLA**, so a run could wait forever if the merge webhook never arrived.

Adds a durable `context.DelayFor` SLA timer racing the merge bookmark (pattern copied from `WaitForCIResultsActivity` + the `IConfiguration` SLA convention from `EscalateToSeniorActivity` — EF-persisted, re-armed across host restart by `Elsa.Scheduling`; no new mechanism).

- New `TimedOut` outcome (`[FlowNode("Merged","TimedOut")]`); on expiry the workflow routes `notifyMergeTimeout → reportNeedsHuman → Finish` (a human handoff, not a code error).
- SLA configurable via `Adl:PrMergeTimeoutMinutes`, default **720** (12h — between CI's 30m machine wait and the 24h human-escalation).
- The DEFERRED comment (~906-912) replaced with the real wiring. (The comment also named `WaitForPRApprovalActivity`, but that node was retired from the merge-approval gate — confirmed by an existing test — so only `WaitForPRMerged` needed the timer.)

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both; workflow logic only). No `Program.cs` change.
- Tests: 9 new (happy path `Merged` unchanged → success terminal; `TimedOut` → needs-human, never success; no portless fall-through; source-scan durable-timer invariant) + full Workflows+ADL suite 926 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)