### PR TITLE
feat(epic-34): Story 34-6 — Entitlement & Quota Resolution Service

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/EntitlementDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/EntitlementDtos.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Api.Dtos.Pricing;
+
+/// <summary>
+/// Story 34-6 — wire shape for <c>GET /api/pricing/entitlements</c> and
+/// <c>GET /api/admin/tenants/{id}/entitlements</c>. Embeds per-metric headroom
+/// inline (currentUsage / remaining / isOver) so dashboards get resolution +
+/// live headroom in ONE call.
+/// </summary>
+public sealed record ResolvedEntitlementsDto(
+    string TenantId,
+    string PlanId,
+    int PlanVersion,
+    bool IsCustom,
+    IReadOnlyList<ResolvedEntitlementDto> Limits);
+
+/// <summary>
+/// Story 34-6 — one metric line: the resolved limit + the live headroom.
+/// <c>limitValue</c>/<c>remaining</c> null = unlimited; <c>currentUsage</c> null
+/// = usage unavailable (metering-only metric until Epic 35).
+/// </summary>
+public sealed record ResolvedEntitlementDto(
+    string MetricKey,
+    long? LimitValue,
+    string Period,
+    string OverageMode,
+    long? CurrentUsage,
+    long? Remaining,
+    bool IsOver,
+    double? OveragePercent);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -5,7 +5,9 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Dtos.Admin;
+using Tamma.Api.Services.Pricing;
 using Tamma.Api.Services.TenantStatus;
+using Tamma.Core;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -88,6 +90,43 @@ public static class AdminTenantsEndpoints
         StatusDeleting,
         StatusDeleted,
     };
+
+    // ── GET /api/admin/tenants/{tenantId}/entitlements ──
+
+    /// <summary>
+    /// Story 34-6 (AC5) — the platform-owner read seam for any tenant's
+    /// resolved entitlement set + live headroom. <c>PlatformOwnerAccess</c>
+    /// only; the tenant is taken from the route. An unknown tenant OR a tenant
+    /// with no active assignment → 404 (the <c>NO_ASSIGNMENT</c> error mapped,
+    /// never a 500). Same body shape as the member self-read
+    /// (<c>GET /api/pricing/entitlements</c>).
+    /// </summary>
+    public static async Task<IResult> GetTenantEntitlements(
+        Guid tenantId,
+        IEntitlementService entitlements,
+        IEntitlementUsageReader usageReader,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger(
+            "Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints");
+
+        try
+        {
+            var dto = await EntitlementResponseBuilder.BuildAsync(
+                entitlements, usageReader,
+                EntitlementPrincipal.ForTenant(tenantId), logger, ct);
+
+            logger.LogInformation(
+                "Admin entitlement read: tenant {TenantId}", tenantId);
+            return Results.Ok(dto);
+        }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT")
+        {
+            // Unknown tenant OR no active assignment — both 404 (AC5).
+            return Results.NotFound(new { error = "no_active_assignment" });
+        }
+    }
 
     // ── GET /api/admin/tenants ──
 

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -126,6 +126,26 @@ public static class AdminTenantsEndpoints
             // Unknown tenant OR no active assignment — both 404 (AC5).
             return Results.NotFound(new { error = "no_active_assignment" });
         }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE")
+        {
+            // A pinned plan whose catalog snapshot vanished — a transient/config
+            // fault (the snapshot SHOULD exist), not "no plan". Fail loud as 503
+            // (typed ProblemDetails), never a bare 500 and never a permissive 200.
+            logger.LogError(
+                "Admin entitlement read failed — tenant {TenantId} pinned plan has no catalog snapshot",
+                tenantId);
+            return Results.Problem(
+                title: ex.Code, detail: ex.Message,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.NO_PRINCIPAL")
+        {
+            // Defensive — the admin route always supplies a tenant id, so a
+            // malformed principal reaching here is a bad request, not a 500.
+            return Results.Problem(
+                title: ex.Code, detail: ex.Message,
+                statusCode: StatusCodes.Status400BadRequest);
+        }
     }
 
     // ── GET /api/admin/tenants ──

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Tamma.Api.Auth;
 using Tamma.Api.Services.Pricing;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Core;
@@ -108,6 +110,60 @@ public static class PricingEndpoints
                 provider, planSlug ?? "");
             return Results.Problem(
                 title: ex.Code, detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    // ── GET /api/pricing/entitlements ─────────────────────────────────────
+    // Story 34-6 (AC4/AC11) — the caller's OWN resolved entitlement set +
+    // live headroom. MemberAccess: any authenticated tenant member reads their
+    // own tenant (read is unprivileged — mirrors the PromptStore "GET resolved
+    // = any member" RBAC). Tenant is taken from ITenantContext (SaaS) / the
+    // sole user (single-user); a request body/param NEVER selects the tenant,
+    // so a member can never read another tenant's entitlements.
+    public static async Task<IResult> GetEntitlements(
+        ClaimsPrincipal user,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider,
+        IEntitlementService entitlements,
+        IEntitlementUsageReader usageReader,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.PricingEndpoints");
+
+        // Per-mode principal (CLAUDE.md two-scoping-model rule):
+        //  - single-user → the sole user → their personal tenant (ForUser)
+        //  - SaaS        → the caller's ambient tenant (ForTenant)
+        EntitlementPrincipal principal;
+        if (modeProvider.Mode == TammaMode.SingleUser)
+        {
+            if (user.GetUserId() is not Guid userId)
+            {
+                return Results.Unauthorized();
+            }
+
+            principal = EntitlementPrincipal.ForUser(userId);
+        }
+        else
+        {
+            if (tenantContext.TenantId is not Guid tenantId)
+            {
+                return Results.NotFound(new { error = "no_active_tenant" });
+            }
+
+            principal = EntitlementPrincipal.ForTenant(tenantId);
+        }
+
+        try
+        {
+            var dto = await EntitlementResponseBuilder.BuildAsync(
+                entitlements, usageReader, principal, logger, ct);
+            return Results.Ok(dto);
+        }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT")
+        {
+            // No active plan assignment — a 404, never a 500 (AC4/AC5).
+            return Results.NotFound(new { error = "no_active_assignment" });
         }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -165,5 +165,25 @@ public static class PricingEndpoints
             // No active plan assignment — a 404, never a 500 (AC4/AC5).
             return Results.NotFound(new { error = "no_active_assignment" });
         }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE")
+        {
+            // A pinned plan whose catalog snapshot vanished — a transient/config
+            // fault (the snapshot SHOULD exist), NOT "no plan". Fail loud as 503
+            // (typed ProblemDetails) so the caller retries; never a permissive
+            // 200 and never a bare 500.
+            logger.LogError(
+                "Entitlement read failed — pinned plan has no catalog snapshot (member self-read)");
+            return Results.Problem(
+                title: ex.Code, detail: ex.Message,
+                statusCode: StatusCodes.Status503ServiceUnavailable);
+        }
+        catch (TammaError ex) when (ex.Code == "ENTITLEMENT.RESOLVE.NO_PRINCIPAL")
+        {
+            // Resolver got a principal with neither a tenant nor a user id — for
+            // the member self-read that is a missing/invalid identity → 401.
+            return Results.Problem(
+                title: ex.Code, detail: ex.Message,
+                statusCode: StatusCodes.Status401Unauthorized);
+        }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Tamma.Api.Services.Pricing;
 
@@ -46,6 +47,47 @@ public static class PricingServiceCollectionExtensions
         services.TryAddSingleton<IUsagePricingEngine, UsagePricingEngine>();
         services.TryAddScoped<IMarginPolicyResolver, MarginPolicyResolver>();
         services.TryAddScoped<ITenantProviderPricingModeResolver, BillingCustomerPricingModeResolver>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Story 34-6 — the entitlement &amp; quota resolution service + its
+    /// per-tenant snapshot cache, gauge-metric usage reader, and event-driven
+    /// cache-invalidation listener.
+    ///
+    /// <list type="bullet">
+    ///   <item><description><see cref="IEntitlementSnapshotCache"/> — singleton
+    ///     (one cache shared across requests + the invalidation listener).</description></item>
+    ///   <item><description><see cref="IEntitlementService"/>,
+    ///     <see cref="IActivePlanAssignmentSource"/>,
+    ///     <see cref="IEntitlementUsageReader"/> — scoped (depend on the scoped
+    ///     <c>ControlPlaneDbContext</c> / catalog service).</description></item>
+    ///   <item><description><see cref="EntitlementCacheInvalidationListener"/> —
+    ///     hosted service subscribing the in-process event bus.</description></item>
+    /// </list>
+    ///
+    /// <para><b>34-4 interim:</b> the default
+    /// <see cref="IActivePlanAssignmentSource"/> reads the tenant's Epic-28
+    /// <c>PlanId</c> shadow column. Swap in a 34-4
+    /// <c>IPlanAssignmentService</c> adapter under this same seam once that
+    /// story lands — no resolver change required.</para>
+    /// </summary>
+    public static IServiceCollection AddEntitlementResolution(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        // One shared cache across requests + the invalidation listener.
+        services.TryAddSingleton<IEntitlementSnapshotCache>(sp =>
+            new EntitlementSnapshotCache(sp.GetRequiredService<TimeProvider>()));
+
+        services.TryAddScoped<IActivePlanAssignmentSource, TenantShadowColumnPlanAssignmentSource>();
+        services.TryAddScoped<IEntitlementUsageReader, ControlPlaneEntitlementUsageReader>();
+        services.TryAddScoped<IEntitlementService, EntitlementService>();
+
+        services.AddHostedService<EntitlementCacheInvalidationListener>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1035,6 +1035,12 @@ builder.Services.AddPlanCatalog();
 // resolver. CP-resident; platform-owned margin policies in both modes.
 builder.Services.AddUsagePricingEngine();
 
+// Story 34-6 — entitlement & quota resolution: the single read seam turning a
+// tenant's pinned plan assignment into a closed ResolvedEntitlements map, plus
+// the per-tenant snapshot cache, gauge-metric usage reader, and event-driven
+// cache-invalidation listener. Read-only; fails loud on no assignment.
+builder.Services.AddEntitlementResolution();
+
 // Wave C.4 §4 — per-process health monitor for TammaApiClient.
 // Singleton so the rolling 5-min failure window is shared across every
 // call site. Fires PLATFORM.API.UNHEALTHY via IAlertEventEmitter when
@@ -1739,6 +1745,10 @@ admin.MapGet("/tenants", Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.ListTen
 admin.MapGet("/tenants/{tenantId:guid}/detail",
         Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.GetTenantDetail)
     .RequireAuthorization("PlatformOwnerAccess");
+// Story 34-6 (AC5) — platform-owner read of any tenant's resolved entitlements.
+admin.MapGet("/tenants/{tenantId:guid}/entitlements",
+        Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.GetTenantEntitlements)
+    .RequireAuthorization("PlatformOwnerAccess");
 admin.MapPost("/tenants/{tenantId:guid}/actions/retry",
         Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.RetryTenant)
     .RequireAuthorization("PlatformOwnerAccess");
@@ -1905,6 +1915,10 @@ admin.MapPost("/secrets/{id:guid}/retire-version/{versionNumber:int}",
 // (/api/admin/pricing/*). Powers the upgrade/cost UI in packages/dashboard-user.
 var pricing = app.MapGroup("/api/pricing").RequireAuthorization("MemberAccess");
 pricing.MapGet("/estimate", Tamma.Api.Endpoints.PricingEndpoints.GetEstimate);
+// Story 34-6 — the caller's OWN resolved entitlements + live headroom. Read is
+// unprivileged (any authenticated member); tenant is taken from ITenantContext
+// (SaaS) / the sole user (single-user), never from a request param.
+pricing.MapGet("/entitlements", Tamma.Api.Endpoints.PricingEndpoints.GetEntitlements);
 
 var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");
 orgs.MapPost("/", OrgEndpoints.CreateOrg);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ControlPlaneEntitlementUsageReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ControlPlaneEntitlementUsageReader.cs
@@ -14,8 +14,10 @@ namespace Tamma.Api.Services.Pricing;
 ///   <item><term><see cref="EntitlementMetricKey.Seats"/></term>
 ///     <description><c>TenantMembership</c> count</description></item>
 ///   <item><term><see cref="EntitlementMetricKey.Agents"/></term>
-///     <description>Epic-32 tenant-owned <c>Agent</c> identities
-///       (<c>OwnerTenantId == tenantId</c>)</description></item>
+///     <description>Epic-32 owned <c>Agent</c> identities — SaaS:
+///       <c>OwnerTenantId == tenantId</c>; single-user:
+///       <c>OwnerUserId == userId</c> (mode-scoped ownership, see
+///       <c>AgentsAsync</c>)</description></item>
 ///   <item><term><see cref="EntitlementMetricKey.Repos"/></term>
 ///     <description>active <c>GitHubInstallationRepo</c> for the tenant's installation</description></item>
 /// </list>
@@ -47,12 +49,12 @@ public sealed class ControlPlaneEntitlementUsageReader : IEntitlementUsageReader
     }
 
     public async Task<long?> GetCurrentAsync(
-        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default)
+        Guid tenantId, Guid? userId, EntitlementMetricKey metric, CancellationToken ct = default)
     {
         long? value = metric switch
         {
             EntitlementMetricKey.Seats => await SeatsAsync(tenantId, ct),
-            EntitlementMetricKey.Agents => await AgentsAsync(tenantId, ct),
+            EntitlementMetricKey.Agents => await AgentsAsync(tenantId, userId, ct),
             EntitlementMetricKey.Repos => await ReposAsync(tenantId, ct),
 
             // Metering-backed — Epic 35 reader answers these.
@@ -60,8 +62,8 @@ public sealed class ControlPlaneEntitlementUsageReader : IEntitlementUsageReader
         };
 
         _logger.LogDebug(
-            "Usage reader: tenant {TenantId} metric {Metric} → {Value}",
-            tenantId, metric.ToMetricString(), value?.ToString() ?? "unavailable");
+            "Usage reader: tenant {TenantId} user {UserId} metric {Metric} → {Value}",
+            tenantId, userId, metric.ToMetricString(), value?.ToString() ?? "unavailable");
 
         return value;
     }
@@ -74,13 +76,24 @@ public sealed class ControlPlaneEntitlementUsageReader : IEntitlementUsageReader
         return total;
     }
 
-    private Task<int> AgentsAsync(Guid tenantId, CancellationToken ct) =>
-        // Tenant agent identities: private Agent rows owned by this tenant
-        // (public/system agents have OwnerTenantId == null and aren't "owned").
+    private Task<int> AgentsAsync(Guid tenantId, Guid? userId, CancellationToken ct) =>
+        // Agent identities owned by this principal. Ownership is mode-scoped
+        // (Agent entity: OwnerTenantId XOR OwnerUserId), so mirror
+        // AgentRepository.ListVisibleAsync's ownership predicate:
+        //   • SaaS         → OwnerTenantId == the (resolved) tenant.
+        //   • single-user  → OwnerUserId  == the sole user (userId != null);
+        //                     the resolved personal tenant owns no agents, so
+        //                     the tenant clause contributes 0 and the user
+        //                     clause carries the count.
+        // Public/system agents (both owner columns NULL) are never counted; the
+        // userId guard keeps them out of the SaaS count (userId == null there).
         _db.Agents
             .AsNoTracking()
             .IgnoreQueryFilters()
-            .CountAsync(a => a.OwnerTenantId == tenantId, ct);
+            .CountAsync(
+                a => a.OwnerTenantId == tenantId
+                     || (userId != null && a.OwnerUserId == userId),
+                ct);
 
     private Task<int> ReposAsync(Guid tenantId, CancellationToken ct) =>
         // Active connected repos across the tenant's GitHub installation(s).

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ControlPlaneEntitlementUsageReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ControlPlaneEntitlementUsageReader.cs
@@ -1,0 +1,95 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — control-plane-backed default <see cref="IEntitlementUsageReader"/>
+/// answering the three CP-resident gauge counts and returning <c>null</c> for
+/// everything metering-backed (Epic 35 supplies that reader):
+/// <list type="table">
+///   <item><term><see cref="EntitlementMetricKey.Seats"/></term>
+///     <description><c>TenantMembership</c> count</description></item>
+///   <item><term><see cref="EntitlementMetricKey.Agents"/></term>
+///     <description>Epic-32 tenant-owned <c>Agent</c> identities
+///       (<c>OwnerTenantId == tenantId</c>)</description></item>
+///   <item><term><see cref="EntitlementMetricKey.Repos"/></term>
+///     <description>active <c>GitHubInstallationRepo</c> for the tenant's installation</description></item>
+/// </list>
+/// Scoped (depends on the scoped <see cref="ControlPlaneDbContext"/> +
+/// <see cref="ITenantMembershipRepository"/>). Read-only.
+///
+/// <para><b>Spec deviation (documented):</b> Story 34-6 §AC9 named
+/// <c>AgentConfig</c> as the <c>Agents</c> source, but that is the deprecated,
+/// anonymous, TENANT-resident (unique-per-tenant) config blob — it is not
+/// control-plane-resident and cannot be counted here. The canonical Epic-32
+/// agent-IDENTITY entity is <c>Agent</c> (control-plane-resident, owned via
+/// <c>OwnerTenantId</c>), which is what "number of agent identities a tenant may
+/// own" actually means, so the reader counts tenant-owned <c>Agent</c> rows.</para>
+/// </summary>
+public sealed class ControlPlaneEntitlementUsageReader : IEntitlementUsageReader
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly ITenantMembershipRepository _memberships;
+    private readonly ILogger<ControlPlaneEntitlementUsageReader> _logger;
+
+    public ControlPlaneEntitlementUsageReader(
+        ControlPlaneDbContext db,
+        ITenantMembershipRepository memberships,
+        ILogger<ControlPlaneEntitlementUsageReader> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _memberships = memberships ?? throw new ArgumentNullException(nameof(memberships));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<long?> GetCurrentAsync(
+        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default)
+    {
+        long? value = metric switch
+        {
+            EntitlementMetricKey.Seats => await SeatsAsync(tenantId, ct),
+            EntitlementMetricKey.Agents => await AgentsAsync(tenantId, ct),
+            EntitlementMetricKey.Repos => await ReposAsync(tenantId, ct),
+
+            // Metering-backed — Epic 35 reader answers these.
+            _ => null,
+        };
+
+        _logger.LogDebug(
+            "Usage reader: tenant {TenantId} metric {Metric} → {Value}",
+            tenantId, metric.ToMetricString(), value?.ToString() ?? "unavailable");
+
+        return value;
+    }
+
+    private async Task<long> SeatsAsync(Guid tenantId, CancellationToken ct)
+    {
+        // ListByTenantAsync returns (Members, Total); Total is the seat count.
+        // limit=1/offset=0 keeps the materialised page tiny — we only want Total.
+        var (_, total) = await _memberships.ListByTenantAsync(tenantId, 1, 0);
+        return total;
+    }
+
+    private Task<int> AgentsAsync(Guid tenantId, CancellationToken ct) =>
+        // Tenant agent identities: private Agent rows owned by this tenant
+        // (public/system agents have OwnerTenantId == null and aren't "owned").
+        _db.Agents
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .CountAsync(a => a.OwnerTenantId == tenantId, ct);
+
+    private Task<int> ReposAsync(Guid tenantId, CancellationToken ct) =>
+        // Active connected repos across the tenant's GitHub installation(s).
+        _db.GitHubInstallationRepos
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .CountAsync(
+                r => r.IsActive
+                     && _db.GitHubInstallations
+                         .Any(i => i.Id == r.InstallationEntityId && i.TenantId == tenantId),
+                ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementCacheInvalidationListener.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementCacheInvalidationListener.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PlatformEvents;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — evicts cached entitlement snapshots in reaction to plan /
+/// catalog changes. Subscribes the in-process <see cref="IPlatformEventBus"/>
+/// (the same bus <c>TenantStatusInvalidationListener</c> /
+/// <c>NotificationDispatcher</c> use) — a near-clone of that listener but
+/// SIMPLER: no Postgres LISTEN/NOTIFY, no connection management, no shutdown
+/// drain (the bus is in-process).
+///
+/// <list type="bullet">
+///   <item><description><c>TENANT.PLAN.CHANGED</c> (34-4) for tenant T ⇒
+///     evict exactly T's snapshot.</description></item>
+///   <item><description>A catalog edit (<c>PLAN.VERSION.CREATED</c> /
+///     <c>PLAN.DEPRECATED</c>) ⇒ flush the whole cache (cheap; pinned snapshots
+///     re-read correctly on the next miss).</description></item>
+/// </list>
+///
+/// <para>Handlers are best-effort and never throw back into the bus (the bus
+/// already catches, but a malformed event must evict NOTHING rather than flush
+/// everything — see <see cref="OnTenantPlanChangedAsync"/>).</para>
+/// </summary>
+public sealed class EntitlementCacheInvalidationListener : BackgroundService
+{
+    private readonly IPlatformEventBus _bus;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly ILogger<EntitlementCacheInvalidationListener> _logger;
+
+    private IDisposable? _tenantPlanSub;
+    private IDisposable? _catalogSub;
+
+    public EntitlementCacheInvalidationListener(
+        IPlatformEventBus bus,
+        IEntitlementSnapshotCache cache,
+        ILogger<EntitlementCacheInvalidationListener> logger)
+    {
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Subscribe once at startup; the returned tokens are disposed on stop.
+        _tenantPlanSub = _bus.Subscribe(
+            EntitlementEventTypes.TenantPlanChangedPrefix, OnTenantPlanChangedAsync);
+        _catalogSub = _bus.Subscribe(
+            EntitlementEventTypes.PlanCatalogPrefix, OnCatalogChangedAsync);
+
+        _logger.LogInformation(
+            "EntitlementCacheInvalidationListener subscribed ({TenantPrefix} → evict, {CatalogPrefix} → flush)",
+            EntitlementEventTypes.TenantPlanChangedPrefix,
+            EntitlementEventTypes.PlanCatalogPrefix);
+
+        return Task.CompletedTask;
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _tenantPlanSub?.Dispose();
+        _catalogSub?.Dispose();
+        _tenantPlanSub = null;
+        _catalogSub = null;
+        return base.StopAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Per-tenant eviction on a <c>TENANT.PLAN.*</c> event. Reads the tenant id
+    /// from the event's <c>TenantId</c> column, falling back to the
+    /// <c>tenantId</c> tag. A malformed event (no resolvable tenant) evicts
+    /// NOTHING — never a blanket flush.
+    /// </summary>
+    private Task OnTenantPlanChangedAsync(PlatformEvent evt, CancellationToken ct)
+    {
+        try
+        {
+            var tenantId = ResolveTenantId(evt);
+            if (tenantId is null)
+            {
+                _logger.LogWarning(
+                    "Entitlement invalidation: {Type} carried no resolvable tenantId; evicting nothing",
+                    evt.Type);
+                return Task.CompletedTask;
+            }
+
+            _cache.Invalidate(tenantId.Value);
+            _logger.LogDebug(
+                "Entitlement invalidation: evicted tenant {TenantId} snapshot on {Type}",
+                tenantId, evt.Type);
+        }
+        catch (Exception ex)
+        {
+            // Belt-and-suspenders — the bus already swallows, but keep the
+            // cache untouched for unrelated tenants on a handler fault.
+            _logger.LogWarning(
+                ex, "Entitlement invalidation handler threw on {Type}; ignored", evt.Type);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Full flush on any catalog edit (<c>PLAN.*</c>).</summary>
+    private Task OnCatalogChangedAsync(PlatformEvent evt, CancellationToken ct)
+    {
+        try
+        {
+            _cache.Flush();
+            _logger.LogInformation(
+                "Entitlement invalidation: flushed all snapshots on catalog event {Type}", evt.Type);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex, "Entitlement invalidation flush threw on {Type}; ignored", evt.Type);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Guid? ResolveTenantId(PlatformEvent evt)
+    {
+        if (evt.TenantId is Guid fromColumn && fromColumn != Guid.Empty)
+        {
+            return fromColumn;
+        }
+
+        if (string.IsNullOrWhiteSpace(evt.Tags))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(evt.Tags);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("tenantId", out var el)
+                && el.ValueKind == JsonValueKind.String
+                && Guid.TryParse(el.GetString(), out var fromTag))
+            {
+                return fromTag;
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed tags → no tenant → evict nothing.
+        }
+
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementEventTypes.cs
@@ -1,0 +1,36 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — DCB event type names emitted by <see cref="EntitlementService"/>
+/// to the control-plane <c>platform_events</c> store (CP-resident, same home as
+/// the <see cref="PlanCatalogEventTypes"/> catalog events). Pattern:
+/// <c>AGGREGATE.ACTION.STATUS</c>.
+///
+/// <para>Emitted on cache-miss resolve / admin read (SUCCESS) and on a
+/// resolution failure (FAILED) — NOT on every cache hit (AC10).</para>
+/// </summary>
+public static class EntitlementEventTypes
+{
+    /// <summary>A tenant's entitlement set was resolved (cache-miss or admin read).</summary>
+    public const string ResolvedSuccess = "ENTITLEMENT.RESOLVED.SUCCESS";
+
+    /// <summary>Resolution failed (no active assignment / catalog unavailable).</summary>
+    public const string ResolvedFailed = "ENTITLEMENT.RESOLVED.FAILED";
+
+    // ── Consumed (not emitted here) — cache-invalidation triggers. ──
+
+    /// <summary>
+    /// Type-prefix the cache-invalidation listener subscribes for per-tenant
+    /// eviction. Story 34-4 emits <c>TENANT.PLAN.CHANGED</c> under this prefix
+    /// on (re)assignment; the listener evicts exactly that tenant's snapshot.
+    /// </summary>
+    public const string TenantPlanChangedPrefix = "TENANT.PLAN.";
+
+    /// <summary>
+    /// Type-prefix the cache-invalidation listener subscribes for a full flush.
+    /// Catches the 34-1/34-2 catalog-edit events (<c>PLAN.VERSION.CREATED</c>,
+    /// <c>PLAN.DEPRECATED</c>) — a catalog change flushes the whole cache
+    /// (cheap, and pinned snapshots re-read correctly on the next miss).
+    /// </summary>
+    public const string PlanCatalogPrefix = "PLAN.";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementModels.cs
@@ -1,0 +1,184 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — who we're resolving entitlements for. SaaS →
+/// <see cref="ForTenant"/>; single-user → <see cref="ForUser"/> (the sole
+/// user, resolved to their personal tenant). Mirrors the
+/// <c>(userId | tenantId)</c> XOR principal of the prompt store: exactly one
+/// of the two ids is set. A <see cref="EntitlementPrincipal"/> is a value.
+/// </summary>
+public readonly record struct EntitlementPrincipal
+{
+    /// <summary>SaaS principal — the tenant that owns the entitlements.</summary>
+    public Guid? TenantId { get; private init; }
+
+    /// <summary>single-user principal — the sole user (→ personal tenant).</summary>
+    public Guid? UserId { get; private init; }
+
+    /// <summary>SaaS: resolve directly by tenant id (from <c>ITenantContext</c>).</summary>
+    public static EntitlementPrincipal ForTenant(Guid tenantId) => new() { TenantId = tenantId };
+
+    /// <summary>single-user: resolve the sole user's personal tenant.</summary>
+    public static EntitlementPrincipal ForUser(Guid userId) => new() { UserId = userId };
+}
+
+/// <summary>
+/// Story 34-6 — one resolved quota line. <see cref="LimitValue"/> <c>null</c> =
+/// unlimited. <see cref="Period"/> is <c>monthly</c> | <c>total</c>;
+/// <see cref="OverageMode"/> is <c>block</c> | <c>allow</c> | <c>meter</c>
+/// (mirrors <c>PlanEntitlement</c>'s domains verbatim).
+/// </summary>
+public sealed record ResolvedEntitlement(
+    EntitlementMetricKey MetricKey,
+    long? LimitValue,
+    string Period,
+    string OverageMode);
+
+/// <summary>
+/// Story 34-6 — the complete, closed entitlement map: EVERY
+/// <see cref="EntitlementMetricKey"/> member is present (a missing catalog row
+/// backfills the documented default, so consumers can index any metric without
+/// a null-check). Carries the pinned plan coordinates
+/// (<see cref="PlanId"/>/<see cref="PlanVersion"/>/<see cref="IsCustom"/>) so
+/// callers can audit the source. Immutable value.
+/// </summary>
+public sealed record ResolvedEntitlements(
+    Guid TenantId,
+    Guid PlanId,
+    int PlanVersion,
+    bool IsCustom,
+    IReadOnlyDictionary<EntitlementMetricKey, ResolvedEntitlement> Limits)
+{
+    /// <summary>
+    /// Indexer over the closed map. Never throws for a valid enum member — the
+    /// map is complete by construction (see
+    /// <see cref="EntitlementDefaults.BuildClosedMap"/>).
+    /// </summary>
+    public ResolvedEntitlement Get(EntitlementMetricKey key) => Limits[key];
+}
+
+/// <summary>
+/// Story 34-6 — non-enforcing headroom calc. The single shared over/remaining
+/// computation the sibling Enforcement epic and both dashboards consume so the
+/// math can never diverge. <see cref="Remaining"/> <c>null</c> = unlimited;
+/// <see cref="CurrentUsage"/> <c>null</c> = usage unavailable (metering-only
+/// metric until Epic 35 supplies its reader).
+/// </summary>
+public sealed record EntitlementHeadroom(
+    EntitlementMetricKey MetricKey,
+    long? LimitValue,
+    long? CurrentUsage,
+    long? Remaining,
+    bool IsOver,
+    double? OveragePercent);
+
+/// <summary>
+/// Story 34-6 — code-owned defaults + the closed-map builder. Centralised so
+/// the documented "missing entitlement row ⇒ most-restrictive default" rule
+/// lives in exactly one place (AC2). A missing metric row NEVER produces an
+/// empty/absent entry — it produces a <c>limit 0 / monthly / block</c> line.
+/// </summary>
+public static class EntitlementDefaults
+{
+    /// <summary>Documented per-metric default reset window when the plan omits a row.</summary>
+    public const string DefaultPeriod = "monthly";
+
+    /// <summary>Documented per-metric default overage behaviour when the plan omits a row.</summary>
+    public const string DefaultOverageMode = "block";
+
+    /// <summary>Documented per-metric default limit when the plan omits a row (most restrictive).</summary>
+    public const long DefaultLimit = 0;
+
+    /// <summary>The closed set of every metric key — the map is always exactly this set.</summary>
+    public static IReadOnlyList<EntitlementMetricKey> AllMetrics { get; } =
+        Enum.GetValues<EntitlementMetricKey>();
+
+    /// <summary>The documented default line for a metric with no catalog row.</summary>
+    public static ResolvedEntitlement DefaultFor(EntitlementMetricKey metric) =>
+        new(metric, DefaultLimit, DefaultPeriod, DefaultOverageMode);
+
+    /// <summary>
+    /// Build the complete, closed map from a plan version's entitlement rows.
+    /// Present rows win verbatim (including <c>LimitValue == null</c> ⇒
+    /// unlimited); absent metrics backfill <see cref="DefaultFor"/>. Guarantees
+    /// AC2: exactly the closed enum, never a subset.
+    /// </summary>
+    /// <param name="rows">The pinned plan version's entitlement projections.</param>
+    /// <param name="onBackfill">
+    /// Optional callback invoked once per backfilled (missing) metric — used by
+    /// the resolver to WARN-log the default backfill.
+    /// </param>
+    public static IReadOnlyDictionary<EntitlementMetricKey, ResolvedEntitlement> BuildClosedMap(
+        IEnumerable<PlanEntitlementView> rows,
+        Action<EntitlementMetricKey>? onBackfill = null)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+
+        var byMetric = new Dictionary<EntitlementMetricKey, PlanEntitlementView>();
+        foreach (var row in rows)
+        {
+            // Last write wins if the catalog ever produced a duplicate — the
+            // catalog's own unique index prevents this, but be defensive.
+            byMetric[row.MetricKey] = row;
+        }
+
+        var map = new Dictionary<EntitlementMetricKey, ResolvedEntitlement>(AllMetrics.Count);
+        foreach (var metric in AllMetrics)
+        {
+            if (byMetric.TryGetValue(metric, out var row))
+            {
+                map[metric] = new ResolvedEntitlement(
+                    metric, row.LimitValue, row.Period, row.OverageMode);
+            }
+            else
+            {
+                onBackfill?.Invoke(metric);
+                map[metric] = DefaultFor(metric);
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Pure, non-enforcing headroom calc shared by the resolver, the endpoints,
+    /// the sibling Enforcement epic, and both dashboards. Unlimited
+    /// (<paramref name="limitValue"/> <c>null</c>) short-circuits to
+    /// <c>Remaining = null, IsOver = false</c> regardless of usage. A zero limit
+    /// yields <c>OveragePercent = null</c> (division guard) but still flags
+    /// <c>IsOver</c> when usage &gt; 0.
+    /// </summary>
+    public static EntitlementHeadroom ComputeHeadroom(
+        EntitlementMetricKey metric, long? limitValue, long? currentUsage)
+    {
+        // Unlimited: no ceiling, never over, remaining is meaningless (null).
+        if (limitValue is null)
+        {
+            return new EntitlementHeadroom(
+                metric, LimitValue: null, CurrentUsage: currentUsage,
+                Remaining: null, IsOver: false, OveragePercent: null);
+        }
+
+        var limit = limitValue.Value;
+
+        // Usage unavailable (metering-only metric, Epic 35): report the limit
+        // but no over/remaining math — CurrentUsage/Remaining/OveragePercent null.
+        if (currentUsage is null)
+        {
+            return new EntitlementHeadroom(
+                metric, LimitValue: limit, CurrentUsage: null,
+                Remaining: null, IsOver: false, OveragePercent: null);
+        }
+
+        var usage = currentUsage.Value;
+        var remaining = Math.Max(0, limit - usage);
+        var isOver = usage > limit;
+        double? overagePercent = limit > 0 ? (double)usage / limit * 100 : null;
+
+        return new EntitlementHeadroom(
+            metric, LimitValue: limit, CurrentUsage: usage,
+            Remaining: remaining, IsOver: isOver, OveragePercent: overagePercent);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementResponseBuilder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementResponseBuilder.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — composes the wire response for both entitlement read endpoints:
+/// resolve the closed map, then per-metric live usage + shared headroom calc.
+/// Shared so the member self-read and the admin cross-tenant read produce an
+/// identical body shape (AC4/AC5).
+///
+/// <para>Per-metric usage read is best-effort: a reader that throws for one
+/// metric degrades that line to <c>CurrentUsage = null</c> (WARN-logged) — the
+/// rest of the set still resolves (edge case in the story).</para>
+/// </summary>
+public static class EntitlementResponseBuilder
+{
+    public static async Task<ResolvedEntitlementsDto> BuildAsync(
+        IEntitlementService service,
+        IEntitlementUsageReader usageReader,
+        EntitlementPrincipal principal,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentNullException.ThrowIfNull(usageReader);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var resolved = await service.ResolveAsync(principal, ct);
+
+        var lines = new List<ResolvedEntitlementDto>(resolved.Limits.Count);
+        foreach (var metric in EntitlementDefaults.AllMetrics)
+        {
+            var line = resolved.Get(metric);
+
+            long? usage = null;
+            try
+            {
+                usage = await usageReader.GetCurrentAsync(resolved.TenantId, metric, ct);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Usage reader threw for tenant {TenantId} metric {Metric}; degrading to unavailable",
+                    resolved.TenantId, metric.ToMetricString());
+            }
+
+            var headroom = EntitlementDefaults.ComputeHeadroom(metric, line.LimitValue, usage);
+
+            lines.Add(new ResolvedEntitlementDto(
+                MetricKey: metric.ToMetricString(),
+                LimitValue: line.LimitValue,
+                Period: line.Period,
+                OverageMode: line.OverageMode,
+                CurrentUsage: headroom.CurrentUsage,
+                Remaining: headroom.Remaining,
+                IsOver: headroom.IsOver,
+                OveragePercent: headroom.OveragePercent));
+        }
+
+        return new ResolvedEntitlementsDto(
+            TenantId: resolved.TenantId.ToString(),
+            PlanId: resolved.PlanId.ToString(),
+            PlanVersion: resolved.PlanVersion,
+            IsCustom: resolved.IsCustom,
+            Limits: lines);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementResponseBuilder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementResponseBuilder.cs
@@ -37,7 +37,12 @@ public static class EntitlementResponseBuilder
             long? usage = null;
             try
             {
-                usage = await usageReader.GetCurrentAsync(resolved.TenantId, metric, ct);
+                // Pass BOTH the resolved tenant (SaaS + single-user personal
+                // tenant scope) AND the single-user principal's user id, so
+                // USER-owned counts (Agents) resolve in single-user mode where
+                // the owner is a user, not the personal tenant.
+                usage = await usageReader.GetCurrentAsync(
+                    resolved.TenantId, principal.UserId, metric, ct);
             }
             catch (Exception ex)
             {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementService.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — core <see cref="IEntitlementService"/>: resolve a principal to
+/// the complete, closed <see cref="ResolvedEntitlements"/> map (cache-first) and
+/// compute non-enforcing headroom. Read-only; fails loud on a missing
+/// assignment (never an empty/plain fallback — mirrors the prompt/convention
+/// contract, <c>feedback_resolution_no_empty_fallback</c>).
+///
+/// <para>Resolution: principal → tenantId (per-mode) → cache → active pinned
+/// assignment (<see cref="IActivePlanAssignmentSource"/>) → catalog snapshot
+/// (<see cref="IPlanCatalogService.GetByIdAsync"/>) → closed 7-key map (missing
+/// rows backfill the documented default) → cache + emit
+/// <c>ENTITLEMENT.RESOLVED.SUCCESS</c> on the miss.</para>
+/// </summary>
+public sealed class EntitlementService : IEntitlementService
+{
+    private readonly IActivePlanAssignmentSource _assignments;
+    private readonly IPlanCatalogService _catalog;
+    private readonly IEntitlementSnapshotCache _cache;
+    private readonly ITammaModeProvider _mode;
+    private readonly IUserRepository _users;
+    private readonly IPlatformEventPublisher _events;
+    private readonly ILogger<EntitlementService> _logger;
+
+    public EntitlementService(
+        IActivePlanAssignmentSource assignments,
+        IPlanCatalogService catalog,
+        IEntitlementSnapshotCache cache,
+        ITammaModeProvider mode,
+        IUserRepository users,
+        IPlatformEventPublisher events,
+        ILogger<EntitlementService> logger)
+    {
+        _assignments = assignments ?? throw new ArgumentNullException(nameof(assignments));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _users = users ?? throw new ArgumentNullException(nameof(users));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ResolvedEntitlements> ResolveAsync(
+        EntitlementPrincipal principal, CancellationToken ct = default)
+    {
+        var tenantId = await ResolvePrincipalTenantAsync(principal, ct);
+
+        // 2. Cache-first — a hit skips the assignment + catalog reads and emits
+        //    no event.
+        var cached = _cache.TryGet(tenantId);
+        if (cached is not null)
+        {
+            _logger.LogDebug("Entitlements cache hit for tenant {TenantId}", tenantId);
+            return cached;
+        }
+
+        // 3. Active pinned assignment. Null ⇒ NO_ASSIGNMENT fail-loud.
+        var assignment = await _assignments.GetActiveAsync(tenantId, ct);
+        if (assignment is null)
+        {
+            await EmitFailedAsync(tenantId, reason: "no_assignment", ct);
+            _logger.LogError(
+                "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT — tenant {TenantId} has no active plan assignment",
+                tenantId);
+            throw new TammaError(
+                "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT",
+                $"Tenant '{tenantId}' has no active plan assignment.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId.ToString(),
+                    ["mode"] = _mode.Mode.ToString(),
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        // 4. Pinned catalog snapshot (immutable for deprecated versions, so a
+        //    later deprecation cannot retro-mutate). Null ⇒ CATALOG_UNAVAILABLE.
+        var snapshot = await _catalog.GetByIdAsync(assignment.PlanId, ct);
+        if (snapshot is null)
+        {
+            await EmitFailedAsync(tenantId, reason: "catalog_unavailable", ct);
+            _logger.LogError(
+                "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE — tenant {TenantId} pinned plan {PlanId} has no catalog snapshot",
+                tenantId, assignment.PlanId);
+            throw new TammaError(
+                "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE",
+                $"Pinned plan '{assignment.PlanId}' for tenant '{tenantId}' has no catalog snapshot.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId.ToString(),
+                    ["planId"] = assignment.PlanId.ToString(),
+                    ["mode"] = _mode.Mode.ToString(),
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        // 5. Build the complete, closed map (missing rows backfill the default).
+        var limits = EntitlementDefaults.BuildClosedMap(
+            snapshot.Entitlements,
+            onBackfill: metric => _logger.LogWarning(
+                "Entitlement backfill: tenant {TenantId} plan {PlanId} v{Version} missing metric {Metric} → default (limit {Limit}, {Period}, {Overage})",
+                tenantId, snapshot.PlanId, snapshot.Version, metric.ToMetricString(),
+                EntitlementDefaults.DefaultLimit, EntitlementDefaults.DefaultPeriod,
+                EntitlementDefaults.DefaultOverageMode));
+
+        var resolved = new ResolvedEntitlements(
+            tenantId, snapshot.PlanId, snapshot.Version, snapshot.IsCustom, limits);
+
+        // 6. Cache + emit success (cache-miss only).
+        _cache.Set(tenantId, resolved);
+        await EmitSuccessAsync(resolved, source: "cache-miss", ct);
+
+        _logger.LogInformation(
+            "Entitlements resolved (cache miss): tenant {TenantId} plan {PlanId} v{Version} (custom={IsCustom}) mode {Mode}",
+            tenantId, snapshot.PlanId, snapshot.Version, snapshot.IsCustom, _mode.Mode);
+
+        return resolved;
+    }
+
+    public EntitlementHeadroom CheckHeadroom(
+        ResolvedEntitlements resolved, EntitlementMetricKey metric, long currentUsage)
+    {
+        ArgumentNullException.ThrowIfNull(resolved);
+        var line = resolved.Get(metric);
+        return EntitlementDefaults.ComputeHeadroom(metric, line.LimitValue, currentUsage);
+    }
+
+    /// <summary>
+    /// Per-mode principal → tenantId. SaaS keys by tenant id; single-user keys
+    /// by the sole user → their personal/active tenant (<c>User.TenantId</c>).
+    /// A user with no active tenant is a <c>NO_ASSIGNMENT</c> case (the
+    /// personal-tenant invariant should prevent it).
+    /// </summary>
+    private async Task<Guid> ResolvePrincipalTenantAsync(
+        EntitlementPrincipal principal, CancellationToken ct)
+    {
+        if (principal.TenantId is Guid tenantId)
+        {
+            return tenantId;
+        }
+
+        if (principal.UserId is Guid userId)
+        {
+            var user = await _users.GetByIdAsync(userId);
+            if (user?.TenantId is Guid personalTenant)
+            {
+                return personalTenant;
+            }
+
+            await EmitFailedAsync(tenantId: null, reason: "no_assignment", ct);
+            _logger.LogError(
+                "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT — user {UserId} has no active/personal tenant",
+                userId);
+            throw new TammaError(
+                "ENTITLEMENT.RESOLVE.NO_ASSIGNMENT",
+                $"User '{userId}' has no active tenant to resolve entitlements for.",
+                new Dictionary<string, object?>
+                {
+                    ["userId"] = userId.ToString(),
+                    ["mode"] = _mode.Mode.ToString(),
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        // Neither id set — a malformed principal (defensive; the factory
+        // methods always set exactly one).
+        throw new TammaError(
+            "ENTITLEMENT.RESOLVE.NO_PRINCIPAL",
+            "EntitlementPrincipal has neither a tenant id nor a user id.",
+            new Dictionary<string, object?> { ["mode"] = _mode.Mode.ToString() },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    private Task EmitSuccessAsync(ResolvedEntitlements resolved, string source, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = resolved.TenantId.ToString(),
+            ["planId"] = resolved.PlanId.ToString(),
+            ["planVersion"] = resolved.PlanVersion.ToString(),
+            ["mode"] = _mode.Mode.ToString(),
+            ["source"] = source,
+        };
+        return EmitAsync(EntitlementEventTypes.ResolvedSuccess, resolved.TenantId, tags, ct);
+    }
+
+    private Task EmitFailedAsync(Guid? tenantId, string reason, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = tenantId?.ToString(),
+            ["mode"] = _mode.Mode.ToString(),
+            ["reason"] = reason,
+        };
+        return EmitAsync(EntitlementEventTypes.ResolvedFailed, tenantId, tags, ct);
+    }
+
+    /// <summary>
+    /// Emit an entitlement DCB event to the CP <c>platform_events</c> store +
+    /// the in-process bus (same home as the catalog events; matches
+    /// <c>PlanVersionEditor</c>). Best-effort: an emission failure is
+    /// WARN-logged, never thrown back into the resolve path.
+    /// </summary>
+    private async Task EmitAsync(
+        string type, Guid? tenantId, Dictionary<string, string?> tags, CancellationToken ct)
+    {
+        var data = new Dictionary<string, object?>(
+            tags.ToDictionary(kv => kv.Key, kv => (object?)kv.Value));
+
+        var evt = new PlatformEvent
+        {
+            Type = type,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        };
+
+        try
+        {
+            await _events.AppendAndPublishAsync(evt, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex, "Failed to emit entitlement event {Type} for tenant {TenantId}",
+                type, tenantId);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementSnapshotCache.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/EntitlementSnapshotCache.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — in-memory <see cref="IEntitlementSnapshotCache"/> over a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> keyed by tenant id (precedent
+/// <c>InMemoryBudgetConfigProvider</c>). A plain dictionary (rather than
+/// <c>IMemoryCache</c>) gives O(1) <see cref="Flush"/> + per-tenant
+/// <see cref="Invalidate"/> without the "IMemoryCache can't enumerate keys"
+/// dance, and a deterministic <see cref="TimeProvider"/>-driven TTL that tests
+/// can drive with a fake clock.
+///
+/// <para>Singleton lifetime: one cache shared across requests + the
+/// invalidation listener. The default TTL is a belt-and-suspenders memory bound
+/// behind event-driven invalidation, not a correctness mechanism (pinned plan
+/// versions are immutable).</para>
+/// </summary>
+public sealed class EntitlementSnapshotCache : IEntitlementSnapshotCache
+{
+    /// <summary>Default TTL — a memory bound behind event invalidation.</summary>
+    public static readonly TimeSpan DefaultTtl = TimeSpan.FromMinutes(5);
+
+    private readonly ConcurrentDictionary<Guid, Entry> _entries = new();
+    private readonly TimeProvider _time;
+    private readonly TimeSpan _ttl;
+
+    private readonly record struct Entry(ResolvedEntitlements Value, DateTimeOffset ExpiresAt);
+
+    public EntitlementSnapshotCache(TimeProvider time)
+        : this(time, DefaultTtl)
+    {
+    }
+
+    /// <summary>Test-friendly ctor with an explicit TTL.</summary>
+    public EntitlementSnapshotCache(TimeProvider time, TimeSpan ttl)
+    {
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        if (ttl <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(ttl), ttl, "TTL must be positive.");
+        }
+
+        _ttl = ttl;
+    }
+
+    public int Count => _entries.Count;
+
+    public ResolvedEntitlements? TryGet(Guid tenantId)
+    {
+        if (!_entries.TryGetValue(tenantId, out var entry))
+        {
+            return null;
+        }
+
+        if (_time.GetUtcNow() >= entry.ExpiresAt)
+        {
+            // Lazy eviction on read. TryRemove(KeyValuePair) only removes when
+            // the slot still holds the expired entry — a concurrent Set that
+            // refreshed the entry is preserved.
+            _entries.TryRemove(new KeyValuePair<Guid, Entry>(tenantId, entry));
+            return null;
+        }
+
+        return entry.Value;
+    }
+
+    public void Set(Guid tenantId, ResolvedEntitlements resolved)
+    {
+        ArgumentNullException.ThrowIfNull(resolved);
+        _entries[tenantId] = new Entry(resolved, _time.GetUtcNow().Add(_ttl));
+    }
+
+    public void Invalidate(Guid tenantId) => _entries.TryRemove(tenantId, out _);
+
+    public void Flush() => _entries.Clear();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IActivePlanAssignmentSource.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IActivePlanAssignmentSource.cs
@@ -1,0 +1,88 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — the pinned <c>(PlanId, PlanVersion)</c> a tenant is currently
+/// assigned. This is the seam the resolver reads BEFORE snapshotting the
+/// catalog (<see cref="IPlanCatalogService.GetByIdAsync"/>), so a
+/// <c>null</c> return means "no active assignment" (a hard
+/// <c>NO_ASSIGNMENT</c> fail-loud) while a non-null id that fails to snapshot
+/// means "catalog unavailable" — two distinct failure reasons.
+///
+/// <para><b>34-4 dependency (interim wiring):</b> Story 34-4
+/// (<c>IPlanAssignmentService.GetActiveAsync</c> + the <c>TenantPlanAssignment</c>
+/// table) is NOT yet implemented. Until it lands, the default implementation
+/// (<see cref="TenantShadowColumnPlanAssignmentSource"/>) reads the tenant's
+/// EXISTING Epic-28 <c>PlanId</c> shadow column — the same pinned column
+/// <see cref="PlanCatalogService.GetForTenantAsync"/> already resolves. When
+/// 34-4 lands, register an adapter over its <c>GetActiveAsync</c> under this
+/// same interface — a one-line DI change in
+/// <c>PricingServiceCollectionExtensions</c> — with no resolver code change.
+/// This story invents NO new assignment table; it reads what exists.</para>
+/// </summary>
+public interface IActivePlanAssignmentSource
+{
+    /// <summary>
+    /// The tenant's active pinned plan reference, or <c>null</c> when the
+    /// tenant has no assignment (or does not exist). Read-only.
+    /// </summary>
+    Task<ActivePlanAssignment?> GetActiveAsync(Guid tenantId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Story 34-6 — the pinned plan coordinates a tenant is assigned. Immutable
+/// value. <see cref="PlanVersion"/> is <c>null</c> in the interim shadow-column
+/// path (the version is read from the snapshot); 34-4 will supply it directly.
+/// </summary>
+public sealed record ActivePlanAssignment(Guid PlanId, int? PlanVersion);
+
+/// <summary>
+/// Story 34-6 — interim default: resolves the pinned plan from the Epic-28
+/// <c>PlanId</c> shadow column on the tenant row. Scoped (depends on the scoped
+/// <see cref="ControlPlaneDbContext"/>). Read-only projection of a single
+/// column; never mutates. Replaced by a 34-4 <c>IPlanAssignmentService</c>
+/// adapter behind the same seam once that story lands.
+/// </summary>
+public sealed class TenantShadowColumnPlanAssignmentSource : IActivePlanAssignmentSource
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly ILogger<TenantShadowColumnPlanAssignmentSource> _logger;
+
+    public TenantShadowColumnPlanAssignmentSource(
+        ControlPlaneDbContext db,
+        ILogger<TenantShadowColumnPlanAssignmentSource> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ActivePlanAssignment?> GetActiveAsync(
+        Guid tenantId, CancellationToken ct = default)
+    {
+        // Read the pinned PlanId shadow column (Guid? pointing at a specific
+        // plan version row). IgnoreQueryFilters + explicit DeletedAt guard so
+        // the admin cross-tenant read path is not blocked by the ambient
+        // tenant filter — same projection PlanCatalogService.GetForTenantAsync
+        // uses.
+        var planId = await _db.Tenants
+            .IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId && t.DeletedAt == null)
+            .Select(t => EF.Property<Guid?>(t, "PlanId"))
+            .FirstOrDefaultAsync(ct);
+
+        if (planId is null || planId == Guid.Empty)
+        {
+            _logger.LogDebug(
+                "No active plan assignment for tenant {TenantId} (PlanId shadow column empty)",
+                tenantId);
+            return null;
+        }
+
+        // Version comes from the snapshot in the interim path (the shadow
+        // column pins the version-row id, not the version number).
+        return new ActivePlanAssignment(planId.Value, PlanVersion: null);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementService.cs
@@ -1,0 +1,40 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — the single read seam that turns a tenant's pinned plan
+/// assignment into a concrete, closed <see cref="ResolvedEntitlements"/> map,
+/// plus a pure non-enforcing <see cref="CheckHeadroom"/> calc. The sibling
+/// Enforcement epic, Billing (Epic 35), and both dashboards all answer
+/// "what is this tenant allowed?" from this one calculation so limits never
+/// drift.
+///
+/// <para>Read-only and non-mutating: it never writes catalog / assignment
+/// rows, never charges, never meters, and never blocks a workflow.</para>
+/// </summary>
+public interface IEntitlementService
+{
+    /// <summary>
+    /// Resolve the complete entitlement set for a principal (cache-first).
+    /// Every <see cref="EntitlementMetricKey"/> member is present in the
+    /// returned map (missing catalog rows backfill the documented default).
+    ///
+    /// <para>Throws <see cref="Tamma.Core.TammaError"/>
+    /// (<c>ENTITLEMENT.RESOLVE.NO_ASSIGNMENT</c>, severity High) when the
+    /// principal has no active plan assignment — it NEVER returns an
+    /// empty/plain set (mirrors the prompt/convention fail-loud contract).
+    /// Throws <c>ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE</c> when a pinned
+    /// plan id no longer resolves to a catalog snapshot.</para>
+    /// </summary>
+    Task<ResolvedEntitlements> ResolveAsync(
+        EntitlementPrincipal principal, CancellationToken ct = default);
+
+    /// <summary>
+    /// Pure, non-enforcing headroom calc shared by enforcement + dashboards.
+    /// Unlimited (<c>LimitValue == null</c>) ⇒ <c>Remaining = null,
+    /// IsOver = false</c> regardless of usage.
+    /// </summary>
+    EntitlementHeadroom CheckHeadroom(
+        ResolvedEntitlements resolved, EntitlementMetricKey metric, long currentUsage);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementSnapshotCache.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementSnapshotCache.cs
@@ -1,0 +1,30 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — per-tenant entitlement snapshot cache. Keyed by the resolved
+/// <c>tenant_id</c>. A cached snapshot is a memory optimisation only, never a
+/// correctness mechanism: a pinned plan version is immutable, so a stale entry
+/// can never be WRONG — only outdated if a tenant was re-assigned, which the
+/// <c>TENANT.PLAN.CHANGED</c> event invalidates instantly. The TTL is a memory
+/// bound.
+/// </summary>
+public interface IEntitlementSnapshotCache
+{
+    /// <summary>
+    /// Return the cached snapshot for a tenant, or <c>null</c> on miss or
+    /// expiry. Expired entries are evicted lazily on read.
+    /// </summary>
+    ResolvedEntitlements? TryGet(Guid tenantId);
+
+    /// <summary>Cache (or overwrite) a tenant's snapshot with the default TTL.</summary>
+    void Set(Guid tenantId, ResolvedEntitlements resolved);
+
+    /// <summary>Evict exactly one tenant's snapshot (on <c>TENANT.PLAN.CHANGED</c>).</summary>
+    void Invalidate(Guid tenantId);
+
+    /// <summary>Clear the whole cache (on a catalog-wide edit).</summary>
+    void Flush();
+
+    /// <summary>Current entry count — exposed for tests + diagnostics.</summary>
+    int Count { get; }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementUsageReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementUsageReader.cs
@@ -18,6 +18,18 @@ public interface IEntitlementUsageReader
     /// reader cannot answer the metric (headroom degrades to
     /// <c>CurrentUsage = null</c> for those).
     /// </summary>
+    /// <param name="tenantId">
+    /// The resolved tenant id (SaaS: the ambient tenant; single-user: the sole
+    /// user's personal tenant). Tenant-scoped counts (<c>Seats</c>, <c>Repos</c>)
+    /// key off this in both modes.
+    /// </param>
+    /// <param name="userId">
+    /// The single-user principal's user id (<c>null</c> in SaaS). Needed for
+    /// USER-owned counts: an <c>Agent</c> owned in single-user mode carries
+    /// <c>OwnerUserId</c> (not <c>OwnerTenantId</c>), so without this the
+    /// <c>Agents</c> count is silently 0 in single-user (CLAUDE.md
+    /// "design two scoping models, not one").
+    /// </param>
     Task<long?> GetCurrentAsync(
-        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default);
+        Guid tenantId, Guid? userId, EntitlementMetricKey metric, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementUsageReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IEntitlementUsageReader.cs
@@ -1,0 +1,23 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-6 — current value for gauge-style metrics, so headroom on the read
+/// API reflects live counts without the caller wiring three repositories.
+/// Returns <c>null</c> for metrics this reader can't answer (metering-only
+/// <see cref="EntitlementMetricKey.LlmTokens"/> /
+/// <see cref="EntitlementMetricKey.WorkflowRuns"/> until Epic 35 supplies its
+/// metering reader; also <see cref="EntitlementMetricKey.RagStorageMb"/> /
+/// <see cref="EntitlementMetricKey.BenchmarkRetentionDays"/>).
+/// </summary>
+public interface IEntitlementUsageReader
+{
+    /// <summary>
+    /// The live current value for a gauge metric, or <c>null</c> when this
+    /// reader cannot answer the metric (headroom degrades to
+    /// <c>CurrentUsage = null</c> for those).
+    /// </summary>
+    Task<long?> GetCurrentAsync(
+        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/CheckHeadroomTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/CheckHeadroomTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC8, AC13) — the pure, non-enforcing headroom calc shared by
+/// enforcement + both dashboards. Covers under / at-limit / over / unlimited /
+/// zero-limit / usage-unavailable matrix so the one shared computation can never
+/// diverge between consumers.
+/// </summary>
+[TestFixture]
+public class CheckHeadroomTests
+{
+    private const EntitlementMetricKey Metric = EntitlementMetricKey.WorkflowRuns;
+
+    [Test]
+    public void Under_Limit_HasRemaining_NotOver()
+    {
+        var h = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 100, currentUsage: 40);
+
+        h.LimitValue.Should().Be(100);
+        h.CurrentUsage.Should().Be(40);
+        h.Remaining.Should().Be(60);
+        h.IsOver.Should().BeFalse();
+        h.OveragePercent.Should().BeApproximately(40d, 0.0001);
+    }
+
+    [Test]
+    public void At_Limit_ZeroRemaining_NotOver()
+    {
+        var h = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 100, currentUsage: 100);
+
+        h.Remaining.Should().Be(0);
+        h.IsOver.Should().BeFalse();
+        h.OveragePercent.Should().BeApproximately(100d, 0.0001);
+    }
+
+    [Test]
+    public void Over_Limit_ClampsRemainingToZero_IsOver()
+    {
+        var h = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 100, currentUsage: 130);
+
+        h.Remaining.Should().Be(0, "remaining never goes negative");
+        h.IsOver.Should().BeTrue();
+        h.OveragePercent.Should().BeApproximately(130d, 0.0001);
+    }
+
+    [Test]
+    public void Unlimited_NullLimit_NeverOver_RemainingNull_EvenAtHugeUsage()
+    {
+        var h = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: null, currentUsage: long.MaxValue);
+
+        h.LimitValue.Should().BeNull();
+        h.Remaining.Should().BeNull();
+        h.IsOver.Should().BeFalse();
+        h.OveragePercent.Should().BeNull();
+        h.CurrentUsage.Should().Be(long.MaxValue);
+    }
+
+    [Test]
+    public void ZeroLimit_OveragePercentNull_ButIsOverWhenUsagePositive()
+    {
+        var over = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 0, currentUsage: 5);
+        over.OveragePercent.Should().BeNull("division-by-zero guard");
+        over.IsOver.Should().BeTrue();
+        over.Remaining.Should().Be(0);
+
+        var atZero = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 0, currentUsage: 0);
+        atZero.IsOver.Should().BeFalse();
+        atZero.OveragePercent.Should().BeNull();
+    }
+
+    [Test]
+    public void UsageUnavailable_NullUsage_DegradesGracefully()
+    {
+        var h = EntitlementDefaults.ComputeHeadroom(Metric, limitValue: 100, currentUsage: null);
+
+        h.LimitValue.Should().Be(100);
+        h.CurrentUsage.Should().BeNull();
+        h.Remaining.Should().BeNull();
+        h.IsOver.Should().BeFalse();
+        h.OveragePercent.Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/ControlPlaneEntitlementUsageReaderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/ControlPlaneEntitlementUsageReaderTests.cs
@@ -115,16 +115,16 @@ public class ControlPlaneEntitlementUsageReaderTests
         await using var ctx = NewContext();
         var reader = BuildReader(ctx, memberships.Object);
 
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Seats)).Should().Be(4);
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Agents)).Should().Be(2,
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.Seats)).Should().Be(4);
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.Agents)).Should().Be(2,
             "only tenant-owned private agents count, not the public system agent");
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Repos)).Should().Be(2,
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.Repos)).Should().Be(2,
             "only active repos count");
 
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.LlmTokens)).Should().BeNull();
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.WorkflowRuns)).Should().BeNull();
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.RagStorageMb)).Should().BeNull();
-        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.BenchmarkRetentionDays)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.LlmTokens)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.WorkflowRuns)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.RagStorageMb)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, null, EntitlementMetricKey.BenchmarkRetentionDays)).Should().BeNull();
     }
 
     [Test]
@@ -156,9 +156,55 @@ public class ControlPlaneEntitlementUsageReaderTests
         await using var ctx = NewContext();
         var reader = BuildReader(ctx, memberships.Object);
 
-        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Agents)).Should().Be(0);
-        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Repos)).Should().Be(0);
-        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Seats)).Should().Be(0);
+        (await reader.GetCurrentAsync(tenantB, null, EntitlementMetricKey.Agents)).Should().Be(0);
+        (await reader.GetCurrentAsync(tenantB, null, EntitlementMetricKey.Repos)).Should().Be(0);
+        (await reader.GetCurrentAsync(tenantB, null, EntitlementMetricKey.Seats)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task Agents_SingleUserOwned_CountedByUserId_TenantOwnedStillByTenant()
+    {
+        // single-user: agents are USER-owned (OwnerUserId set, OwnerTenantId
+        // NULL) and the sole user resolves through their personal tenant, which
+        // owns no agents. Counting Agents by OwnerTenantId alone is therefore
+        // always 0 in single-user — the two-scoping-models gap. The reader must
+        // count the user's own agents when given the single-user user id.
+        var personalTenant = Guid.NewGuid();  // the sole user's personal tenant
+        var user = Guid.NewGuid();             // single-user principal
+        var saasTenant = Guid.NewGuid();       // an unrelated SaaS tenant
+
+        await using (var setup = NewContext())
+        {
+            setup.Tenants.Add(NewTenant(personalTenant));
+            setup.Tenants.Add(NewTenant(saasTenant));
+
+            // 2 single-user-owned agents (OwnerUserId == user, OwnerTenantId NULL).
+            setup.Agents.Add(UserOwnedAgent(user, "atlas"));
+            setup.Agents.Add(UserOwnedAgent(user, "nova"));
+            // A different user's agent — must NOT be counted for `user`.
+            setup.Agents.Add(UserOwnedAgent(Guid.NewGuid(), "someone-else"));
+            // A tenant-owned (SaaS) agent — must NOT leak into the user count,
+            // and must still be counted by its tenant.
+            setup.Agents.Add(OwnedAgent(saasTenant, "team-bot"));
+            // A public/system agent — owned by nobody, never counted.
+            setup.Agents.Add(PublicAgent("claude"));
+
+            await setup.SaveChangesAsync();
+        }
+
+        var memberships = new Mock<ITenantMembershipRepository>();
+
+        await using var ctx = NewContext();
+        var reader = BuildReader(ctx, memberships.Object);
+
+        // single-user: resolved tenant = personal tenant (owns 0 agents), userId
+        // = the sole user → their 2 agents are counted.
+        (await reader.GetCurrentAsync(personalTenant, user, EntitlementMetricKey.Agents))
+            .Should().Be(2, "single-user-owned agents (OwnerUserId) must be counted for the sole user");
+
+        // SaaS path (userId == null) still counts strictly by owner tenant.
+        (await reader.GetCurrentAsync(saasTenant, null, EntitlementMetricKey.Agents))
+            .Should().Be(1, "tenant-owned agents are still counted by OwnerTenantId in SaaS");
     }
 
     [Test]
@@ -204,6 +250,17 @@ public class ControlPlaneEntitlementUsageReaderTests
         Name = name,
         Visibility = AgentVisibility.Private,
         OwnerTenantId = tenantId,
+        Status = AgentStatus.Active,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    private static Agent UserOwnedAgent(Guid userId, string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Visibility = AgentVisibility.Private,
+        OwnerUserId = userId,
         Status = AgentStatus.Active,
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow,

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/ControlPlaneEntitlementUsageReaderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/ControlPlaneEntitlementUsageReaderTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC9, AC13) — the control-plane gauge-metric usage reader against
+/// a real Postgres testcontainer (so the FK + partial unique index behave like
+/// production): <c>Seats</c> = membership Total, <c>Agents</c> = tenant
+/// <c>AgentConfig</c> count, <c>Repos</c> = active <c>GitHubInstallationRepo</c>
+/// count, metering-only metrics = <c>null</c>, plus tenant isolation. Also
+/// covers the interim <see cref="TenantShadowColumnPlanAssignmentSource"/>
+/// (34-4 seam) reading the Epic-28 <c>PlanId</c> shadow column.
+/// </summary>
+[TestFixture]
+public class ControlPlaneEntitlementUsageReaderTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("entitlement_usage_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE agents, github_installation_repos, github_installations, plans, tenants CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static Tenant NewTenant(Guid id) => new()
+    {
+        Id = id,
+        Name = "T-" + id.ToString("N")[..6],
+        Slug = "t-" + id.ToString("N")[..6],
+        Type = "team",
+        Plan = "free",
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    private ControlPlaneEntitlementUsageReader BuildReader(
+        ControlPlaneDbContext ctx, ITenantMembershipRepository memberships) =>
+        new(ctx, memberships, NullLogger<ControlPlaneEntitlementUsageReader>.Instance);
+
+    [Test]
+    public async Task Reads_Seats_Agents_Repos_And_Nulls_MeteringMetrics()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var installA = Guid.NewGuid();
+
+        await using (var setup = NewContext())
+        {
+            setup.Tenants.Add(NewTenant(tenantA));
+            setup.Tenants.Add(NewTenant(tenantB));
+
+            // Tenant A: 2 private (tenant-owned) agent identities.
+            setup.Agents.Add(OwnedAgent(tenantA, "atlas"));
+            setup.Agents.Add(OwnedAgent(tenantA, "nova"));
+            // A public/system agent is NOT owned by any tenant → not counted.
+            setup.Agents.Add(PublicAgent("claude"));
+
+            // Tenant A: 1 installation with 3 repos (2 active, 1 inactive).
+            setup.GitHubInstallations.Add(new GitHubInstallation
+            {
+                Id = installA, InstallationId = 111, AccountLogin = "acme",
+                AccountType = "Organization", AppId = 1, TenantId = tenantA,
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+            setup.GitHubInstallationRepos.AddRange(
+                Repo(installA, 1, "acme/a", active: true),
+                Repo(installA, 2, "acme/b", active: true),
+                Repo(installA, 3, "acme/c", active: false));
+
+            await setup.SaveChangesAsync();
+        }
+
+        var memberships = new Mock<ITenantMembershipRepository>();
+        memberships.Setup(m => m.ListByTenantAsync(tenantA, It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync((new List<TenantMembership>(), 4));
+
+        await using var ctx = NewContext();
+        var reader = BuildReader(ctx, memberships.Object);
+
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Seats)).Should().Be(4);
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Agents)).Should().Be(2,
+            "only tenant-owned private agents count, not the public system agent");
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.Repos)).Should().Be(2,
+            "only active repos count");
+
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.LlmTokens)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.WorkflowRuns)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.RagStorageMb)).Should().BeNull();
+        (await reader.GetCurrentAsync(tenantA, EntitlementMetricKey.BenchmarkRetentionDays)).Should().BeNull();
+    }
+
+    [Test]
+    public async Task TenantIsolation_OtherTenant_HasZeroCounts()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var installA = Guid.NewGuid();
+
+        await using (var setup = NewContext())
+        {
+            setup.Tenants.Add(NewTenant(tenantA));
+            setup.Tenants.Add(NewTenant(tenantB));
+            setup.Agents.Add(OwnedAgent(tenantA, "atlas"));
+            setup.GitHubInstallations.Add(new GitHubInstallation
+            {
+                Id = installA, InstallationId = 222, AccountLogin = "acme",
+                AccountType = "Organization", AppId = 1, TenantId = tenantA,
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+            setup.GitHubInstallationRepos.Add(Repo(installA, 9, "acme/z", active: true));
+            await setup.SaveChangesAsync();
+        }
+
+        var memberships = new Mock<ITenantMembershipRepository>();
+        memberships.Setup(m => m.ListByTenantAsync(tenantB, It.IsAny<int>(), It.IsAny<int>()))
+            .ReturnsAsync((new List<TenantMembership>(), 0));
+
+        await using var ctx = NewContext();
+        var reader = BuildReader(ctx, memberships.Object);
+
+        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Agents)).Should().Be(0);
+        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Repos)).Should().Be(0);
+        (await reader.GetCurrentAsync(tenantB, EntitlementMetricKey.Seats)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task ShadowColumnAssignmentSource_ReadsPlanId_And_NullWhenUnset()
+    {
+        var withPlan = Guid.NewGuid();
+        var withoutPlan = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+
+        await using (var setup = NewContext())
+        {
+            // A plan row for the FK (plans.Id) the shadow column points at.
+            setup.Plans.Add(new Plan
+            {
+                Id = planId, Slug = "team", DisplayName = "Team", Version = 1,
+                Status = "active", IsCustom = false, BillingInterval = "monthly",
+                CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+            });
+
+            var t1 = NewTenant(withPlan);
+            var t2 = NewTenant(withoutPlan);
+            setup.Tenants.Add(t1);
+            setup.Tenants.Add(t2);
+            setup.Entry(t1).Property("PlanId").CurrentValue = planId;
+            await setup.SaveChangesAsync();
+        }
+
+        await using var ctx = NewContext();
+        var source = new TenantShadowColumnPlanAssignmentSource(
+            ctx, NullLogger<TenantShadowColumnPlanAssignmentSource>.Instance);
+
+        var active = await source.GetActiveAsync(withPlan);
+        active.Should().NotBeNull();
+        active!.PlanId.Should().Be(planId);
+
+        (await source.GetActiveAsync(withoutPlan)).Should().BeNull("no PlanId shadow value → no assignment");
+        (await source.GetActiveAsync(Guid.NewGuid())).Should().BeNull("unknown tenant → no assignment");
+    }
+
+    private static Agent OwnedAgent(Guid tenantId, string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Visibility = AgentVisibility.Private,
+        OwnerTenantId = tenantId,
+        Status = AgentStatus.Active,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    private static Agent PublicAgent(string name) => new()
+    {
+        Id = Guid.NewGuid(),
+        Name = name,
+        Visibility = AgentVisibility.Public,
+        Status = AgentStatus.Active,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    private static GitHubInstallationRepo Repo(Guid installId, long repoId, string full, bool active) => new()
+    {
+        Id = Guid.NewGuid(),
+        InstallationEntityId = installId,
+        RepoId = repoId,
+        Owner = full.Split('/')[0],
+        Name = full.Split('/')[1],
+        RepoFullName = full,
+        IsActive = active,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementCacheInvalidationListenerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementCacheInvalidationListenerTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.PlatformEvents;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC6, AC13) — the event-driven cache-invalidation listener over
+/// the real in-process <see cref="InMemoryPlatformEventBus"/>:
+/// <c>TENANT.PLAN.CHANGED</c> evicts exactly one tenant, a catalog edit flushes
+/// all, and a malformed event evicts NOTHING (never a blanket flush).
+/// </summary>
+[TestFixture]
+public class EntitlementCacheInvalidationListenerTests
+{
+    private static ResolvedEntitlements Sample(Guid t) =>
+        new(t, Guid.NewGuid(), 1, false,
+            new Dictionary<EntitlementMetricKey, ResolvedEntitlement>
+            {
+                [EntitlementMetricKey.Seats] = new(EntitlementMetricKey.Seats, 1, "monthly", "block"),
+            });
+
+    private static (InMemoryPlatformEventBus bus, EntitlementSnapshotCache cache,
+        EntitlementCacheInvalidationListener listener) NewHarness()
+    {
+        var bus = new InMemoryPlatformEventBus(NullLogger<InMemoryPlatformEventBus>.Instance);
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        var listener = new EntitlementCacheInvalidationListener(
+            bus, cache, NullLogger<EntitlementCacheInvalidationListener>.Instance);
+        return (bus, cache, listener);
+    }
+
+    [Test]
+    public async Task TenantPlanChanged_EvictsExactlyThatTenant_ViaColumn()
+    {
+        var (bus, cache, listener) = NewHarness();
+        await listener.StartAsync(CancellationToken.None);
+
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+        cache.Set(b, Sample(b));
+
+        await bus.PublishAsync(new PlatformEvent { Type = "TENANT.PLAN.CHANGED", TenantId = a });
+
+        cache.TryGet(a).Should().BeNull("tenant A's plan changed → evicted");
+        cache.TryGet(b).Should().NotBeNull("tenant B untouched");
+
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TenantPlanChanged_EvictsViaTenantIdTag_WhenColumnEmpty()
+    {
+        var (bus, cache, listener) = NewHarness();
+        await listener.StartAsync(CancellationToken.None);
+
+        var a = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+
+        await bus.PublishAsync(new PlatformEvent
+        {
+            Type = "TENANT.PLAN.CHANGED",
+            TenantId = null,
+            Tags = JsonSerializer.Serialize(new { tenantId = a.ToString() }),
+        });
+
+        cache.TryGet(a).Should().BeNull("tenantId read from the tag fallback");
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task CatalogEdit_FlushesAll()
+    {
+        var (bus, cache, listener) = NewHarness();
+        await listener.StartAsync(CancellationToken.None);
+
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+        cache.Set(b, Sample(b));
+
+        await bus.PublishAsync(new PlatformEvent { Type = "PLAN.VERSION.CREATED" });
+
+        cache.Count.Should().Be(0, "a catalog edit flushes the whole cache");
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task MalformedTenantPlanEvent_EvictsNothing()
+    {
+        var (bus, cache, listener) = NewHarness();
+        await listener.StartAsync(CancellationToken.None);
+
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+        cache.Set(b, Sample(b));
+
+        // No TenantId column, no tenantId tag → resolves to nothing.
+        await bus.PublishAsync(new PlatformEvent
+        {
+            Type = "TENANT.PLAN.CHANGED",
+            TenantId = null,
+            Tags = "{}",
+        });
+
+        cache.Count.Should().Be(2, "a malformed event evicts nothing — never a blanket flush");
+        await listener.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task EntitlementResolvedEvents_DoNotTriggerInvalidation()
+    {
+        var (bus, cache, listener) = NewHarness();
+        await listener.StartAsync(CancellationToken.None);
+
+        var a = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+
+        // ENTITLEMENT.* is neither TENANT.PLAN.* nor PLAN.* — no feedback loop.
+        await bus.PublishAsync(new PlatformEvent
+        {
+            Type = EntitlementEventTypes.ResolvedSuccess, TenantId = a,
+        });
+
+        cache.TryGet(a).Should().NotBeNull("resolve events must not evict");
+        await listener.StopAsync(CancellationToken.None);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementEndpointsTests.cs
@@ -1,0 +1,211 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC4, AC5, AC11, AC13) — the two entitlement read endpoints via
+/// direct handler invocation (the project's endpoint-test convention): member
+/// self-read (per-mode principal, tenant from ITenantContext / sole user),
+/// admin read-by-route, <c>NO_ASSIGNMENT</c> → 404, and tenant isolation (the
+/// member route resolves the ambient tenant, never a request param).
+/// </summary>
+[TestFixture]
+public class EntitlementEndpointsTests
+{
+    private sealed class FakeMode : ITammaModeProvider
+    {
+        public TammaMode Mode { get; init; }
+    }
+
+    private static ResolvedEntitlements ResolvedFor(Guid tenantId, long? seatLimit = 10) =>
+        new(tenantId, Guid.NewGuid(), 1, false,
+            EntitlementDefaults.AllMetrics.ToDictionary(
+                m => m,
+                m => new ResolvedEntitlement(
+                    m,
+                    m == EntitlementMetricKey.Seats ? seatLimit : 100,
+                    "monthly", "block")));
+
+    private static (Mock<IEntitlementService> svc, Mock<IEntitlementUsageReader> usage) Mocks(
+        Guid tenantId, ResolvedEntitlements? resolved = null)
+    {
+        var svc = new Mock<IEntitlementService>();
+        svc.Setup(s => s.ResolveAsync(It.IsAny<EntitlementPrincipal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolved ?? ResolvedFor(tenantId));
+
+        var usage = new Mock<IEntitlementUsageReader>();
+        usage.Setup(u => u.GetCurrentAsync(tenantId, EntitlementMetricKey.Seats, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(3);
+        usage.Setup(u => u.GetCurrentAsync(It.IsAny<Guid>(), It.Is<EntitlementMetricKey>(
+                m => m != EntitlementMetricKey.Seats), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((long?)null);
+        return (svc, usage);
+    }
+
+    private static ClaimsPrincipal UserPrincipal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(
+            new[] { new Claim(ClaimTypes.NameIdentifier, userId.ToString()) }, "Test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static ResolvedEntitlementsDto DtoOf(IResult result)
+    {
+        result.Should().BeAssignableTo<IValueHttpResult>();
+        return (ResolvedEntitlementsDto)((IValueHttpResult)result).Value!;
+    }
+
+    private static int StatusOf(IResult result)
+    {
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        return ((IStatusCodeHttpResult)result).StatusCode!.Value;
+    }
+
+    [Test]
+    public async Task Member_SaaS_ReadsOwnTenant_FromContext_WithLiveCounts()
+    {
+        var tenant = Guid.NewGuid();
+        var (svc, usage) = Mocks(tenant);
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(tenant);
+
+        var result = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()),
+            tenantContext,
+            new FakeMode { Mode = TammaMode.SaaS },
+            svc.Object, usage.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status200OK);
+        var dto = DtoOf(result);
+        dto.TenantId.Should().Be(tenant.ToString());
+        dto.Limits.Should().HaveCount(EntitlementDefaults.AllMetrics.Count);
+        dto.Limits.Single(l => l.MetricKey == "seats").CurrentUsage.Should().Be(3);
+        dto.Limits.Single(l => l.MetricKey == "seats").Remaining.Should().Be(7);
+
+        // Isolation: the tenant is taken from ITenantContext, never a param.
+        svc.Verify(s => s.ResolveAsync(
+            It.Is<EntitlementPrincipal>(p => p.TenantId == tenant && p.UserId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Member_SingleUser_ResolvesByUserPrincipal()
+    {
+        var user = Guid.NewGuid();
+        var tenant = Guid.NewGuid();
+        var (svc, usage) = Mocks(tenant);
+
+        var result = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(user),
+            new TenantContext(),
+            new FakeMode { Mode = TammaMode.SingleUser },
+            svc.Object, usage.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status200OK);
+        svc.Verify(s => s.ResolveAsync(
+            It.Is<EntitlementPrincipal>(p => p.UserId == user && p.TenantId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Member_NoAssignment_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var svc = new Mock<IEntitlementService>();
+        svc.Setup(s => s.ResolveAsync(It.IsAny<EntitlementPrincipal>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TammaError("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT", "no plan"));
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(tenant);
+
+        var result = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()),
+            tenantContext,
+            new FakeMode { Mode = TammaMode.SaaS },
+            svc.Object, Mock.Of<IEntitlementUsageReader>(),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task Member_SaaS_NoTenant_Returns404()
+    {
+        var result = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()),
+            new TenantContext(), // no tenant set
+            new FakeMode { Mode = TammaMode.SaaS },
+            Mock.Of<IEntitlementService>(), Mock.Of<IEntitlementUsageReader>(),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task Admin_ReadsByRoute()
+    {
+        var tenant = Guid.NewGuid();
+        var (svc, usage) = Mocks(tenant);
+
+        var result = await AdminTenantsEndpoints.GetTenantEntitlements(
+            tenant, svc.Object, usage.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status200OK);
+        DtoOf(result).TenantId.Should().Be(tenant.ToString());
+        svc.Verify(s => s.ResolveAsync(
+            It.Is<EntitlementPrincipal>(p => p.TenantId == tenant),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Admin_UnknownOrNoAssignment_Returns404()
+    {
+        var svc = new Mock<IEntitlementService>();
+        svc.Setup(s => s.ResolveAsync(It.IsAny<EntitlementPrincipal>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TammaError("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT", "no plan"));
+
+        var result = await AdminTenantsEndpoints.GetTenantEntitlements(
+            Guid.NewGuid(), svc.Object, Mock.Of<IEntitlementUsageReader>(),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task Isolation_TwoTenants_EachSeesOwnSet()
+    {
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var (svcA, usageA) = Mocks(a, ResolvedFor(a, seatLimit: 5));
+        var (svcB, usageB) = Mocks(b, ResolvedFor(b, seatLimit: 50));
+
+        var ctxA = new TenantContext(); ctxA.SetTenantId(a);
+        var ctxB = new TenantContext(); ctxB.SetTenantId(b);
+
+        var resA = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()), ctxA, new FakeMode { Mode = TammaMode.SaaS },
+            svcA.Object, usageA.Object, NullLoggerFactory.Instance, CancellationToken.None);
+        var resB = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()), ctxB, new FakeMode { Mode = TammaMode.SaaS },
+            svcB.Object, usageB.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+        DtoOf(resA).TenantId.Should().Be(a.ToString());
+        DtoOf(resA).Limits.Single(l => l.MetricKey == "seats").LimitValue.Should().Be(5);
+        DtoOf(resB).TenantId.Should().Be(b.ToString());
+        DtoOf(resB).Limits.Single(l => l.MetricKey == "seats").LimitValue.Should().Be(50);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementEndpointsTests.cs
@@ -49,9 +49,10 @@ public class EntitlementEndpointsTests
             .ReturnsAsync(resolved ?? ResolvedFor(tenantId));
 
         var usage = new Mock<IEntitlementUsageReader>();
-        usage.Setup(u => u.GetCurrentAsync(tenantId, EntitlementMetricKey.Seats, It.IsAny<CancellationToken>()))
+        usage.Setup(u => u.GetCurrentAsync(
+                tenantId, It.IsAny<Guid?>(), EntitlementMetricKey.Seats, It.IsAny<CancellationToken>()))
             .ReturnsAsync(3);
-        usage.Setup(u => u.GetCurrentAsync(It.IsAny<Guid>(), It.Is<EntitlementMetricKey>(
+        usage.Setup(u => u.GetCurrentAsync(It.IsAny<Guid>(), It.IsAny<Guid?>(), It.Is<EntitlementMetricKey>(
                 m => m != EntitlementMetricKey.Seats), It.IsAny<CancellationToken>()))
             .ReturnsAsync((long?)null);
         return (svc, usage);
@@ -183,6 +184,45 @@ public class EntitlementEndpointsTests
             NullLoggerFactory.Instance, CancellationToken.None);
 
         StatusOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task Member_CatalogUnavailable_Returns503()
+    {
+        // A pinned plan with no catalog snapshot throws CATALOG_UNAVAILABLE.
+        // Without an explicit map it would surface as a bare 500 (no global
+        // TammaError→ProblemDetails middleware); it must be a fail-loud 503.
+        var tenant = Guid.NewGuid();
+        var svc = new Mock<IEntitlementService>();
+        svc.Setup(s => s.ResolveAsync(It.IsAny<EntitlementPrincipal>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TammaError(
+                "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE", "pinned plan snapshot missing"));
+        var tenantContext = new TenantContext();
+        tenantContext.SetTenantId(tenant);
+
+        var result = await PricingEndpoints.GetEntitlements(
+            UserPrincipal(Guid.NewGuid()),
+            tenantContext,
+            new FakeMode { Mode = TammaMode.SaaS },
+            svc.Object, Mock.Of<IEntitlementUsageReader>(),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    [Test]
+    public async Task Admin_CatalogUnavailable_Returns503()
+    {
+        var svc = new Mock<IEntitlementService>();
+        svc.Setup(s => s.ResolveAsync(It.IsAny<EntitlementPrincipal>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TammaError(
+                "ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE", "pinned plan snapshot missing"));
+
+        var result = await AdminTenantsEndpoints.GetTenantEntitlements(
+            Guid.NewGuid(), svc.Object, Mock.Of<IEntitlementUsageReader>(),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusOf(result).Should().Be(StatusCodes.Status503ServiceUnavailable);
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementServiceTests.cs
@@ -1,0 +1,299 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC1-3, AC7, AC10, AC13) — core resolution: per-mode principal,
+/// complete closed map + default backfill, unlimited, custom-plan override,
+/// fail-loud on no assignment / catalog-unavailable (never an empty set), and
+/// cache hit/miss + event emission. All sibling contracts (34-1 catalog, 34-4
+/// interim assignment source) are mocked.
+/// </summary>
+[TestFixture]
+public class EntitlementServiceTests
+{
+    private sealed class FakeMode : ITammaModeProvider
+    {
+        public TammaMode Mode { get; init; }
+    }
+
+    private static PlanSnapshot Snapshot(
+        Guid planId, int version, bool isCustom, params PlanEntitlementView[] ents) =>
+        new(planId, "team", "Team", version, "active", isCustom, "month", null,
+            Array.Empty<PlanFeatureView>(), ents, Array.Empty<PlanPriceView>());
+
+    private static PlanEntitlementView[] AllSeven() =>
+        EntitlementDefaults.AllMetrics
+            .Select((m, i) => new PlanEntitlementView(m, 10 + i, "monthly", "block"))
+            .ToArray();
+
+    private static EntitlementService Build(
+        TammaMode mode,
+        Mock<IActivePlanAssignmentSource> assignments,
+        Mock<IPlanCatalogService> catalog,
+        RecordingPlatformEventPublisher events,
+        EntitlementSnapshotCache cache,
+        Mock<IUserRepository>? users = null)
+    {
+        users ??= new Mock<IUserRepository>();
+        return new EntitlementService(
+            assignments.Object,
+            catalog.Object,
+            cache,
+            new FakeMode { Mode = mode },
+            users.Object,
+            events,
+            NullLogger<EntitlementService>.Instance);
+    }
+
+    private static EntitlementSnapshotCache NewCache() =>
+        new(new PricingTestClock());
+
+    [Test]
+    public async Task Resolve_SaaS_ByTenantId_ReturnsCompleteMap_EmitsSuccess()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 3, false, AllSeven()));
+        var events = new RecordingPlatformEventPublisher();
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog, events, NewCache());
+
+        var resolved = await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        resolved.TenantId.Should().Be(tenant);
+        resolved.PlanId.Should().Be(planId);
+        resolved.PlanVersion.Should().Be(3);
+        resolved.Limits.Should().HaveCount(EntitlementDefaults.AllMetrics.Count);
+        foreach (var m in EntitlementDefaults.AllMetrics)
+        {
+            resolved.Limits.Should().ContainKey(m);
+        }
+
+        events.Events.Should().ContainSingle(e => e.Type == EntitlementEventTypes.ResolvedSuccess);
+        var evt = events.Events.Single(e => e.Type == EntitlementEventTypes.ResolvedSuccess);
+        evt.Tags.Should().Contain("cache-miss");
+        evt.TenantId.Should().Be(tenant);
+    }
+
+    [Test]
+    public async Task Resolve_SingleUser_ByUserId_ResolvesPersonalTenant()
+    {
+        var user = Guid.NewGuid();
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetByIdAsync(user)).ReturnsAsync(new User { Id = user, TenantId = tenant });
+
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 1, false, AllSeven()));
+
+        var svc = Build(TammaMode.SingleUser, assignments, catalog,
+            new RecordingPlatformEventPublisher(), NewCache(), users);
+
+        var resolved = await svc.ResolveAsync(EntitlementPrincipal.ForUser(user));
+
+        resolved.TenantId.Should().Be(tenant);
+        assignments.Verify(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resolve_CompleteSevenKeys_BackfillsMissingWithDocumentedDefault()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        // Only 3 of 7 rows present.
+        var present = new[]
+        {
+            new PlanEntitlementView(EntitlementMetricKey.Seats, 5, "monthly", "block"),
+            new PlanEntitlementView(EntitlementMetricKey.Agents, 3, "total", "allow"),
+            new PlanEntitlementView(EntitlementMetricKey.LlmTokens, null, "monthly", "meter"),
+        };
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 1, false, present));
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog,
+            new RecordingPlatformEventPublisher(), NewCache());
+
+        var resolved = await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        resolved.Limits.Should().HaveCount(EntitlementDefaults.AllMetrics.Count);
+        // Present rows win verbatim.
+        resolved.Get(EntitlementMetricKey.Seats).LimitValue.Should().Be(5);
+        resolved.Get(EntitlementMetricKey.Agents).Period.Should().Be("total");
+        // Missing rows backfill the documented default (0, monthly, block).
+        var repos = resolved.Get(EntitlementMetricKey.Repos);
+        repos.LimitValue.Should().Be(EntitlementDefaults.DefaultLimit);
+        repos.Period.Should().Be(EntitlementDefaults.DefaultPeriod);
+        repos.OverageMode.Should().Be(EntitlementDefaults.DefaultOverageMode);
+    }
+
+    [Test]
+    public async Task Resolve_Unlimited_NullLimit_FlowsThroughHeadroom()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var ents = new[]
+        {
+            new PlanEntitlementView(EntitlementMetricKey.LlmTokens, null, "monthly", "meter"),
+        };
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 1, false, ents));
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog,
+            new RecordingPlatformEventPublisher(), NewCache());
+
+        var resolved = await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        resolved.Get(EntitlementMetricKey.LlmTokens).LimitValue.Should().BeNull();
+        var h = svc.CheckHeadroom(resolved, EntitlementMetricKey.LlmTokens, currentUsage: 9_999_999);
+        h.Remaining.Should().BeNull();
+        h.IsOver.Should().BeFalse();
+    }
+
+    [Test]
+    public void Resolve_NoAssignment_FailsLoud_EmitsFailed_NeverEmptySet()
+    {
+        var tenant = Guid.NewGuid();
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ActivePlanAssignment?)null);
+        var catalog = new Mock<IPlanCatalogService>();
+        var events = new RecordingPlatformEventPublisher();
+        var cache = NewCache();
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog, events, cache);
+
+        var act = async () => await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        var err = act.Should().ThrowAsync<TammaError>().Result;
+        err.Which.Code.Should().Be("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT");
+        err.Which.Severity.Should().Be(TammaErrorSeverity.High);
+
+        events.Events.Should().ContainSingle(e => e.Type == EntitlementEventTypes.ResolvedFailed);
+        events.Events.Single(e => e.Type == EntitlementEventTypes.ResolvedFailed)
+            .Tags.Should().Contain("no_assignment");
+        cache.Count.Should().Be(0, "a failed resolve never caches an empty set");
+        catalog.Verify(c => c.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public void Resolve_CatalogUnavailable_FailsLoud_EmitsFailed()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PlanSnapshot?)null);
+        var events = new RecordingPlatformEventPublisher();
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog, events, NewCache());
+
+        var act = async () => await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        act.Should().ThrowAsync<TammaError>()
+            .Result.Which.Code.Should().Be("ENTITLEMENT.RESOLVE.CATALOG_UNAVAILABLE");
+        events.Events.Single(e => e.Type == EntitlementEventTypes.ResolvedFailed)
+            .Tags.Should().Contain("catalog_unavailable");
+    }
+
+    [Test]
+    public async Task Resolve_CustomPlan_Overrides_PublicDefaults()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        // Bespoke enterprise plan: unlimited agents, huge seats.
+        var ents = new[]
+        {
+            new PlanEntitlementView(EntitlementMetricKey.Agents, null, "monthly", "allow"),
+            new PlanEntitlementView(EntitlementMetricKey.Seats, 5000, "monthly", "allow"),
+        };
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 2, isCustom: true, ents));
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog,
+            new RecordingPlatformEventPublisher(), NewCache());
+
+        var resolved = await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        resolved.IsCustom.Should().BeTrue();
+        resolved.Get(EntitlementMetricKey.Agents).LimitValue.Should().BeNull("custom unlimited");
+        resolved.Get(EntitlementMetricKey.Seats).LimitValue.Should().Be(5000);
+    }
+
+    [Test]
+    public async Task Resolve_CacheHit_SkipsReads_AndEmitsNoSecondEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var planId = Guid.NewGuid();
+        var assignments = new Mock<IActivePlanAssignmentSource>();
+        assignments.Setup(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ActivePlanAssignment(planId, null));
+        var catalog = new Mock<IPlanCatalogService>();
+        catalog.Setup(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Snapshot(planId, 1, false, AllSeven()));
+        var events = new RecordingPlatformEventPublisher();
+
+        var svc = Build(TammaMode.SaaS, assignments, catalog, events, NewCache());
+
+        await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+        await svc.ResolveAsync(EntitlementPrincipal.ForTenant(tenant));
+
+        assignments.Verify(a => a.GetActiveAsync(tenant, It.IsAny<CancellationToken>()), Times.Once);
+        catalog.Verify(c => c.GetByIdAsync(planId, It.IsAny<CancellationToken>()), Times.Once);
+        events.Events.Count(e => e.Type == EntitlementEventTypes.ResolvedSuccess).Should().Be(1);
+    }
+
+    [Test]
+    public void Resolve_SingleUser_NoActiveTenant_FailsLoud()
+    {
+        var user = Guid.NewGuid();
+        var users = new Mock<IUserRepository>();
+        users.Setup(u => u.GetByIdAsync(user)).ReturnsAsync(new User { Id = user, TenantId = null });
+
+        var svc = Build(TammaMode.SingleUser,
+            new Mock<IActivePlanAssignmentSource>(), new Mock<IPlanCatalogService>(),
+            new RecordingPlatformEventPublisher(), NewCache(), users);
+
+        var act = async () => await svc.ResolveAsync(EntitlementPrincipal.ForUser(user));
+        act.Should().ThrowAsync<TammaError>()
+            .Result.Which.Code.Should().Be("ENTITLEMENT.RESOLVE.NO_ASSIGNMENT");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementSnapshotCacheTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/EntitlementSnapshotCacheTests.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 (AC6, AC13) — the per-tenant snapshot cache: round-trip, evict
+/// exactly one, flush all, deterministic TTL expiry (fake clock), and
+/// two-tenant no-collision.
+/// </summary>
+[TestFixture]
+public class EntitlementSnapshotCacheTests
+{
+    private static ResolvedEntitlements Sample(Guid tenantId) =>
+        new(tenantId, Guid.NewGuid(), 1, false,
+            new Dictionary<EntitlementMetricKey, ResolvedEntitlement>
+            {
+                [EntitlementMetricKey.Seats] = new(EntitlementMetricKey.Seats, 5, "monthly", "block"),
+            });
+
+    [Test]
+    public void Set_TryGet_RoundTrips_PerTenant()
+    {
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        var t = Guid.NewGuid();
+        var snap = Sample(t);
+
+        cache.Set(t, snap);
+
+        cache.TryGet(t).Should().BeSameAs(snap);
+        cache.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void TryGet_Miss_ReturnsNull()
+    {
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        cache.TryGet(Guid.NewGuid()).Should().BeNull();
+    }
+
+    [Test]
+    public void Invalidate_EvictsExactlyOne()
+    {
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+        cache.Set(b, Sample(b));
+
+        cache.Invalidate(a);
+
+        cache.TryGet(a).Should().BeNull();
+        cache.TryGet(b).Should().NotBeNull("only tenant A was evicted");
+        cache.Count.Should().Be(1);
+    }
+
+    [Test]
+    public void Flush_ClearsAll()
+    {
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        cache.Set(a, Sample(a));
+        cache.Set(b, Sample(b));
+
+        cache.Flush();
+
+        cache.Count.Should().Be(0);
+        cache.TryGet(a).Should().BeNull();
+        cache.TryGet(b).Should().BeNull();
+    }
+
+    [Test]
+    public void Ttl_Expiry_EvictsOnRead()
+    {
+        var clock = new PricingTestClock();
+        var cache = new EntitlementSnapshotCache(clock, TimeSpan.FromMinutes(5));
+        var t = Guid.NewGuid();
+        cache.Set(t, Sample(t));
+
+        clock.Advance(TimeSpan.FromMinutes(4));
+        cache.TryGet(t).Should().NotBeNull("still within TTL");
+
+        clock.Advance(TimeSpan.FromMinutes(1) + TimeSpan.FromSeconds(1));
+        cache.TryGet(t).Should().BeNull("TTL elapsed");
+        cache.Count.Should().Be(0, "expired entry evicted lazily on read");
+    }
+
+    [Test]
+    public void TwoTenants_DoNotCollide()
+    {
+        var cache = new EntitlementSnapshotCache(new PricingTestClock());
+        var a = Guid.NewGuid();
+        var b = Guid.NewGuid();
+        var snapA = Sample(a);
+        var snapB = Sample(b);
+        cache.Set(a, snapA);
+        cache.Set(b, snapB);
+
+        cache.TryGet(a).Should().BeSameAs(snapA);
+        cache.TryGet(b).Should().BeSameAs(snapB);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingTestClock.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingTestClock.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-6 — minimal controllable <see cref="TimeProvider"/> for the
+/// entitlement cache TTL tests. The <c>Tamma.Api.Tests</c> project does not
+/// reference <c>Microsoft.Extensions.Time.Testing</c>, so (matching the Alerts /
+/// Epic-28 analytics tests) we hand-roll the tiny surface we need.
+/// </summary>
+internal sealed class PricingTestClock : TimeProvider
+{
+    private DateTimeOffset _now;
+
+    public PricingTestClock(DateTimeOffset? start = null)
+    {
+        _now = start ?? new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    }
+
+    public override DateTimeOffset GetUtcNow() => _now;
+
+    public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+}


### PR DESCRIPTION
## What

Story 34-6 (P0). `IEntitlementService.ResolveAsync` produces the resolved per-tenant entitlement/quota map across 7 metric keys (Agents, WorkflowRuns, LlmTokens, Seats, Repos, RagStorageMb, BenchmarkRetentionDays) over the 34-1 plan catalog, with live-usage headroom. Consumed by 35-6 enforcement + 34-10 pricing contract.

- `GET /api/pricing/entitlements` (MemberAccess, tenant from context) + `GET /api/admin/tenants/{id}/entitlements` (**PlatformOwnerAccess**).
- **Fails loud** — no active assignment → `NO_ASSIGNMENT` (404), missing catalog snapshot → `CATALOG_UNAVAILABLE` (503); never a silent-permissive empty/unlimited set. `null` (unlimited) never conflated with `0` (blocked); missing metric backfills most-restrictive (`limit 0 / block`).
- Per-tenant limit cache (5-min TTL, evict on `TENANT.PLAN.`/`PLAN.` events). **No migration** (pure resolver over 34-1).
- **34-4 (tenant→plan assignment) is not implemented yet** — interim `IActivePlanAssignmentSource` reads the Epic-28 tenant `PlanId` shadow column; swaps to 34-4's `GetActiveAsync` via one DI line when it lands (the invalidation listener already subscribes `TENANT.PLAN.`).

## Review outcome

Adversarial review verified SaaS per-tenant count scoping, RBAC (both routes), fail-loud semantics, null-vs-zero backfill, and cache correctness as SOLID. One Important finding fixed:
- **Single-user `Agents` count was always 0** (counted only `OwnerTenantId==tenantId`, but single-user agents carry `OwnerUserId`) → would fail-permissive under 35-6. Fixed: thread the principal `UserId`, count `OwnerTenantId==tenantId || OwnerUserId==userId`. Audited the other counts (Seats/Repos genuinely tenant-keyed, correct). Also mapped `CATALOG_UNAVAILABLE`→503 / `NO_PRINCIPAL`→401/400 instead of a raw 500.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Entitlement tests: 34 passed (incl. single-user count red→green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)