### PR TITLE
feat(epic-35): Story 35-4 — Subscription Lifecycle (create/upgrade/downgrade/cancel/trial/seats)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/SubscriptionEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Billing/SubscriptionEndpoints.cs
@@ -1,0 +1,138 @@
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Authorization;
+using Tamma.Api.Services.Billing;
+using Tamma.Core;
+
+namespace Tamma.Api.Endpoints.Billing;
+
+/// <summary>
+/// Story 35-4 — tenant-scoped subscription lifecycle endpoints under
+/// <c>/api/v1/orgs/{tenantId}/billing/subscription</c>. Mounted (SaaS only) with
+/// the <see cref="RequireTenantMembershipFilter"/> (cross-tenant access → 403).
+/// Every mutation additionally requires <c>tenant_owner</c>/<c>tenant_admin</c>
+/// (read from the membership-filter item key); a <c>member</c> caller gets 403
+/// BEFORE any Stripe call (AC2). GET is allowed for any member (AC9).
+/// </summary>
+public static class SubscriptionEndpoints
+{
+    public sealed record CheckoutRequest(string PlanSlug, int? Seats, int? TrialDays);
+    public sealed record ChangePlanRequest(string PlanSlug);
+    public sealed record CancelRequest(bool AtPeriodEnd);
+    public sealed record SeatsRequest(int Seats);
+
+    public static IEndpointRouteBuilder MapSubscriptionEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/v1/orgs/{tenantId:guid}/billing/subscription")
+            .RequireAuthorization("MemberAccess")
+            .AddEndpointFilter<RequireTenantMembershipFilter>();
+
+        group.MapGet("/", GetSubscription);
+        group.MapPost("/checkout", Checkout);
+        group.MapPost("/change", ChangePlan);
+        group.MapPost("/cancel", Cancel);
+        group.MapPost("/seats", ChangeSeats);
+        return app;
+    }
+
+    internal static async Task<IResult> GetSubscription(
+        Guid tenantId, HttpContext http, ISubscriptionService svc, CancellationToken ct)
+    {
+        var projection = await svc.GetAsync(tenantId, ct);
+        return Results.Ok(projection);
+    }
+
+    internal static async Task<IResult> Checkout(
+        Guid tenantId, CheckoutRequest req, HttpContext http, ISubscriptionService svc,
+        ILoggerFactory logs, CancellationToken ct)
+    {
+        if (RequireAdmin(http) is { } forbidden) return forbidden;
+        if (string.IsNullOrWhiteSpace(req?.PlanSlug))
+            return Results.BadRequest(new { error = "plan_slug_required" });
+
+        return await Guarded(logs, tenantId, "checkout", async () =>
+        {
+            var result = await svc.CreateCheckoutSessionAsync(
+                tenantId, req.PlanSlug, req.Seats, req.TrialDays, ct);
+            return Results.Ok(result);
+        });
+    }
+
+    internal static async Task<IResult> ChangePlan(
+        Guid tenantId, ChangePlanRequest req, HttpContext http, ISubscriptionService svc,
+        ILoggerFactory logs, CancellationToken ct)
+    {
+        if (RequireAdmin(http) is { } forbidden) return forbidden;
+        if (string.IsNullOrWhiteSpace(req?.PlanSlug))
+            return Results.BadRequest(new { error = "plan_slug_required" });
+
+        return await Guarded(logs, tenantId, "change", async () =>
+            Results.Ok(await svc.ChangePlanAsync(tenantId, req.PlanSlug, ct)));
+    }
+
+    internal static async Task<IResult> Cancel(
+        Guid tenantId, CancelRequest req, HttpContext http, ISubscriptionService svc,
+        ILoggerFactory logs, CancellationToken ct)
+    {
+        if (RequireAdmin(http) is { } forbidden) return forbidden;
+
+        return await Guarded(logs, tenantId, "cancel", async () =>
+            Results.Ok(await svc.CancelAsync(tenantId, req?.AtPeriodEnd ?? false, ct)));
+    }
+
+    internal static async Task<IResult> ChangeSeats(
+        Guid tenantId, SeatsRequest req, HttpContext http, ISubscriptionService svc,
+        ILoggerFactory logs, CancellationToken ct)
+    {
+        if (RequireAdmin(http) is { } forbidden) return forbidden;
+        if (req is null)
+            return Results.BadRequest(new { error = "seats_required" });
+
+        return await Guarded(logs, tenantId, "seats", async () =>
+            Results.Ok(await svc.ChangeSeatsAsync(tenantId, req.Seats, ct)));
+    }
+
+    /// <summary>
+    /// 403 unless the membership-filter role is <c>tenant_admin</c> or higher.
+    /// Returns null when the caller is authorized (mutations proceed).
+    /// </summary>
+    private static IResult? RequireAdmin(HttpContext http)
+    {
+        var role = http.Items[RequireTenantMembershipFilter.TenantRoleItemKey] as string;
+        if (TenantRoleHierarchy.IsAtLeast(role, TenantRoleHierarchy.Admin)) return null;
+        return Results.Json(
+            new { error = "forbidden", message = "Requires tenant owner or admin." },
+            statusCode: StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>Run the service call, mapping <see cref="TammaError"/> codes + Stripe failures to HTTP.</summary>
+    private static async Task<IResult> Guarded(
+        ILoggerFactory logs, Guid tenantId, string op, Func<Task<IResult>> action)
+    {
+        try
+        {
+            return await action();
+        }
+        catch (TammaError err)
+        {
+            var status = err.Code switch
+            {
+                SubscriptionService.SeatsBelowActiveMembersCode => StatusCodes.Status409Conflict,
+                SubscriptionService.NoActiveSubscriptionCode => StatusCodes.Status409Conflict,
+                SubscriptionService.NoCustomerCode => StatusCodes.Status409Conflict,
+                SubscriptionService.SaasOnlyCode => StatusCodes.Status404NotFound,
+                _ => StatusCodes.Status400BadRequest,
+            };
+            return Results.Json(new { error = err.Code, message = err.Message }, statusCode: status);
+        }
+        catch (Stripe.StripeException ex)
+        {
+            // Never log the Stripe key or customer payment details — only the class.
+            logs.CreateLogger("Billing.Subscription").LogWarning(
+                "Stripe {Op} failed for tenant {TenantId}: {ErrorClass}. Surfaced as 502; the 35-5 "
+                + "webhook reconciles the confirmed state.", op, tenantId, ex.GetType().Name);
+            return Results.Json(
+                new { error = "BILLING.STRIPE.CALL_FAILED", message = "Stripe call failed; please retry." },
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Billing.Tasks;
 using Tamma.Api.Services.PlatformTasks;
 using Tamma.Api.Services.PromptStore;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Extensions;
 
@@ -59,6 +60,15 @@ public static class BillingServiceCollectionExtensions
         // both modes — in single-user it dead-letters cleanly (handler guards on
         // IsEnabled) but the hook never enqueues a task there anyway.
         services.AddPlatformTaskHandler<CreateBillingCustomerTaskHandler>();
+
+        // Story 35-4 — subscription lifecycle seam. Registered in BOTH modes so the
+        // service resolves the NullBillingProvider in single-user and short-circuits
+        // every mutating call (zero Stripe — AC11); the endpoints are mapped only in
+        // SaaS (Program.cs). The mirror updater is ALSO consumed by the 35-5 webhook
+        // handler (SubscriptionMirrorWebhookHandler) so the mirror logic lives once.
+        services.AddScoped<IBillingSubscriptionRepository, BillingSubscriptionRepository>();
+        services.AddScoped<SubscriptionMirrorUpdater>();
+        services.AddScoped<ISubscriptionService, SubscriptionService>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingWebhookServiceCollectionExtensions.cs
@@ -52,7 +52,16 @@ public static class BillingWebhookServiceCollectionExtensions
         // 35-5's default DCB-emitting handlers. Sibling stories add their own via
         // AddBillingEventHandler<T>(); duplicate-claim detection supersedes these
         // cleanly when 35-4/35-7/35-8 land.
-        services.AddBillingEventHandler<SubscriptionWebhookHandler>();
+        //
+        // Story 35-4 SUPERSEDES the audit-only SubscriptionWebhookHandler with
+        // SubscriptionMirrorWebhookHandler, which drives the shared
+        // SubscriptionMirrorUpdater (mirror + Tenant.Plan lockstep + the
+        // BILLING.SUBSCRIPTION.* DCB event). Its dependency graph is registered by
+        // AddTammaBilling, which Program.cs calls before this. Registry
+        // duplicate-claim detection forbids BOTH claiming the subscription types, so
+        // the 35-5 handler is no longer registered (its class stays for its own unit
+        // tests).
+        services.AddBillingEventHandler<SubscriptionMirrorWebhookHandler>();
         services.AddBillingEventHandler<InvoiceWebhookHandler>();
         services.AddBillingEventHandler<PaymentWebhookHandler>();
         services.AddBillingEventHandler<DisputeWebhookHandler>();

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2458,6 +2458,13 @@ if (app.Services.GetRequiredService<Tamma.Api.Services.PromptStore.ITammaModePro
     app.MapPost("/api/v1/admin/billing/webhook-events/{id:guid}/replay",
             Tamma.Api.Endpoints.Billing.BillingWebhookAdminEndpoints.Replay)
         .RequireAuthorization("PlatformOwnerAccess");
+
+    // ── Story 35-4 — tenant-scoped subscription lifecycle (SaaS only) ──
+    // /api/v1/orgs/{tenantId}/billing/subscription/{checkout,change,cancel,seats}
+    // + GET. Membership-gated (RequireTenantMembershipFilter); mutations require
+    // tenant owner/admin (checked in-handler). Single-user leaves these unmapped
+    // (NullBillingProvider, zero Stripe — AC11).
+    Tamma.Api.Endpoints.Billing.SubscriptionEndpoints.MapSubscriptionEndpoints(app);
 }
 
 // ── SaaS (API key auth) ──
@@ -2674,7 +2681,7 @@ using (var scope = app.Services.CreateScope())
                     tenant_agent_enablements,
                     audit_records, audit_projector_cursor,
                     billing_customers, billing_plan_prices,
-                    billing_webhook_events,
+                    billing_webhook_events, billing_subscriptions,
                     alert_delivery_attempts, alert_channels, alerts,
                     alert_evaluator_cursor, alert_rules,
                     api_keys, agent_configs, budget_configs, domain_events,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
@@ -27,7 +27,13 @@ public static class BillingEvents
     public const string SubscriptionCreatedType = "BILLING.SUBSCRIPTION.CREATED";
     public const string SubscriptionUpdatedType = "BILLING.SUBSCRIPTION.UPDATED";
     public const string SubscriptionCanceledType = "BILLING.SUBSCRIPTION.CANCELED";
-    public const string SubscriptionTrialEndedType = "BILLING.SUBSCRIPTION.TRIAL_ENDED";
+
+    // The Stripe `customer.subscription.trial_will_end` event fires BEFORE the
+    // trial ends (the subscription is still `trialing`), so the DCB type is the
+    // semantically-correct TRIAL_ENDING — matching Story 35-5's
+    // <c>BillingWebhookEventTypes.DcbSubscriptionTrialEnding</c> (they must not
+    // drift; a rename here would orphan any consumer of the 35-5 string).
+    public const string SubscriptionTrialEndingType = "BILLING.SUBSCRIPTION.TRIAL_ENDING";
 
     private const string SystemMetadata =
         """{"workflowVersion":"1.0.0","eventSource":"system"}""";

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingEvents.cs
@@ -21,6 +21,14 @@ public static class BillingEvents
     public const string CustomerCreatedType = "BILLING.CUSTOMER.CREATED";
     public const string PlanCatalogSyncedType = "BILLING.PLAN_CATALOG.SYNCED";
 
+    // ── Story 35-4 — subscription lifecycle DCB event types (AC8). Emitted by
+    //    SubscriptionMirrorUpdater on every transition; tags { tenantId, planSlug,
+    //    status }. Names follow the AGGREGATE.ACTION.STATUS convention. ──
+    public const string SubscriptionCreatedType = "BILLING.SUBSCRIPTION.CREATED";
+    public const string SubscriptionUpdatedType = "BILLING.SUBSCRIPTION.UPDATED";
+    public const string SubscriptionCanceledType = "BILLING.SUBSCRIPTION.CANCELED";
+    public const string SubscriptionTrialEndedType = "BILLING.SUBSCRIPTION.TRIAL_ENDED";
+
     private const string SystemMetadata =
         """{"workflowVersion":"1.0.0","eventSource":"system"}""";
 
@@ -47,6 +55,38 @@ public static class BillingEvents
             {
                 stripeCustomerId,
                 billingMode,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        };
+
+    /// <summary>
+    /// Story 35-4 (AC8) — a subscription-lifecycle DCB event. <paramref name="type"/>
+    /// is one of the <c>Subscription*Type</c> constants; tags are
+    /// <c>{ tenantId, planSlug, status }</c> (plus optional
+    /// <paramref name="scheduledPlanSlug"/> on a scheduled downgrade). Tenant-scoped
+    /// (<c>TenantId</c> set) so <c>IEventRepository.AppendAsync</c> routes it to the
+    /// tenant's own <c>DomainEvents</c> store.
+    /// </summary>
+    public static DomainEvent Subscription(
+        string type, Guid tenantId, string planSlug, string status,
+        string? scheduledPlanSlug = null) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId.ToString("D"),
+                planSlug,
+                status,
+            }),
+            Metadata = SystemMetadata,
+            Data = JsonSerializer.Serialize(new
+            {
+                planSlug,
+                status,
+                scheduledPlanSlug,
             }),
             CreatedAt = DateTime.UtcNow,
         };

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingOptions.cs
@@ -30,4 +30,16 @@ public sealed class BillingOptions
 
     /// <summary>Default ISO-4217 settlement currency for new customers/prices.</summary>
     public string DefaultCurrency { get; set; } = "usd";
+
+    /// <summary>
+    /// Story 35-4 — the URL Stripe Checkout redirects to on success. Non-secret;
+    /// binds from config (<c>Billing:CheckoutSuccessUrl</c>).
+    /// </summary>
+    public string CheckoutSuccessUrl { get; set; } = "https://app.tamma.dev/billing/success";
+
+    /// <summary>
+    /// Story 35-4 — the URL Stripe Checkout redirects to on cancel. Non-secret;
+    /// binds from config (<c>Billing:CheckoutCancelUrl</c>).
+    /// </summary>
+    public string CheckoutCancelUrl { get; set; } = "https://app.tamma.dev/billing/cancel";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeServices.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IStripeServices.cs
@@ -22,9 +22,22 @@ public interface IStripeServices
     ProductService Products { get; }
     PriceService Prices { get; }
     MeterService Meters { get; }
+
+    // ── Story 35-4 — subscription lifecycle surface ──
+    // These service classes are non-sealed with virtual *Async methods, so tests
+    // mock them directly with Moq (same pattern as Customers above).
+
+    /// <summary>Stripe subscription CRUD (create/update/cancel) — Story 35-4.</summary>
+    Stripe.SubscriptionService Subscriptions { get; }
+
+    /// <summary>Stripe subscription schedules (scheduled downgrade at period end) — Story 35-4.</summary>
+    Stripe.SubscriptionScheduleService SubscriptionSchedules { get; }
+
+    /// <summary>Stripe Checkout sessions (mode=subscription) — Story 35-4.</summary>
+    Stripe.Checkout.SessionService CheckoutSessions { get; }
 }
 
-/// <summary>Concrete bundle wrapping the four service classes over one client.</summary>
+/// <summary>Concrete bundle wrapping the Stripe service classes over one client.</summary>
 public sealed class StripeServices : IStripeServices
 {
     public StripeServices(IStripeClient client)
@@ -34,10 +47,16 @@ public sealed class StripeServices : IStripeServices
         Products = new ProductService(client);
         Prices = new PriceService(client);
         Meters = new MeterService(client);
+        Subscriptions = new Stripe.SubscriptionService(client);
+        SubscriptionSchedules = new Stripe.SubscriptionScheduleService(client);
+        CheckoutSessions = new Stripe.Checkout.SessionService(client);
     }
 
     public CustomerService Customers { get; }
     public ProductService Products { get; }
     public PriceService Prices { get; }
     public MeterService Meters { get; }
+    public Stripe.SubscriptionService Subscriptions { get; }
+    public Stripe.SubscriptionScheduleService SubscriptionSchedules { get; }
+    public Stripe.Checkout.SessionService CheckoutSessions { get; }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/ISubscriptionService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/ISubscriptionService.cs
@@ -1,0 +1,44 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-4 — the subscription lifecycle seam. Orchestrates Stripe (via the
+/// 35-1 client factory) + the local mirror (<see cref="SubscriptionMirrorUpdater"/>)
+/// + DCB events for checkout / plan change / cancel / seats / read. SaaS only —
+/// in single-user the 35-1 <c>NullBillingProvider</c> (<c>IsEnabled = false</c>)
+/// makes every mutating call a hard SaaS-only error and zero Stripe calls (AC11).
+/// </summary>
+public interface ISubscriptionService
+{
+    /// <summary>
+    /// AC2 — build a Stripe Checkout Session (<c>mode=subscription</c>) for the
+    /// slug (+ optional seats/trial). NO local row is created — the mirror is
+    /// materialized by the Story 35-5 <c>customer.subscription.created</c> webhook.
+    /// </summary>
+    Task<CheckoutResult> CreateCheckoutSessionAsync(
+        Guid tenantId, string planSlug, int? seats, int? trialDays, CancellationToken ct = default);
+
+    /// <summary>
+    /// AC3 — upgrade (immediate proration) when the target plan's monthly price ≥
+    /// the current plan's; schedule a downgrade at period end otherwise.
+    /// </summary>
+    Task<SubscriptionProjection> ChangePlanAsync(
+        Guid tenantId, string newPlanSlug, CancellationToken ct = default);
+
+    /// <summary>AC4 — cancel immediately (status→canceled, plan→free now) or at period end.</summary>
+    Task<SubscriptionProjection> CancelAsync(
+        Guid tenantId, bool atPeriodEnd, CancellationToken ct = default);
+
+    /// <summary>
+    /// AC6 — change the seat quantity. Rejected with a <c>seats_below_active_members</c>
+    /// conflict (→ 409) when below the tenant's active-membership count, before any
+    /// Stripe call.
+    /// </summary>
+    Task<SubscriptionProjection> ChangeSeatsAsync(
+        Guid tenantId, int seats, CancellationToken ct = default);
+
+    /// <summary>AC9 — the current subscription projection; free-tier default when none.</summary>
+    Task<SubscriptionProjection> GetAsync(Guid tenantId, CancellationToken ct = default);
+}
+
+/// <summary>The checkout-session result returned to the tenant owner/admin (AC2).</summary>
+public sealed record CheckoutResult(string CheckoutUrl, string StripeSessionId);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Tamma.Core;
 using Tamma.Data;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
@@ -30,7 +31,21 @@ public sealed class SubscriptionMirrorUpdater
     public const string TransitionSeatsChanged = "seats_changed";
     public const string TransitionCanceledAtPeriodEnd = "canceled_at_period_end";
     public const string TransitionCanceled = "canceled";
-    public const string TransitionTrialEnded = "trial_ended";
+
+    /// <summary>
+    /// The <c>customer.subscription.trial_will_end</c> transition — fires ~3 days
+    /// BEFORE the trial ends (the subscription is still <c>trialing</c>), so it
+    /// emits <c>BILLING.SUBSCRIPTION.TRIAL_ENDING</c> (not <c>..._ENDED</c>).
+    /// </summary>
+    public const string TransitionTrialWillEnd = "trial_will_end";
+
+    /// <summary>
+    /// Raised when the effective plan slug has no active <c>Plan</c> row to lock
+    /// <c>Tenant.Plan</c>/<c>PlanId</c> onto (e.g. a cancel to free with no seeded
+    /// <c>free</c> plan). Fails LOUD so the transition surfaces/retries rather than
+    /// silently leaving the tenant entitled to the old higher plan.
+    /// </summary>
+    public const string LockstepPlanMissingCode = "BILLING.SUBSCRIPTION.LOCKSTEP_PLAN_MISSING";
 
     private static readonly HashSet<string> AllowedStatuses = new(StringComparer.Ordinal)
     {
@@ -116,6 +131,14 @@ public sealed class SubscriptionMirrorUpdater
         var status = MapStatus(stripeSub.Status);
         var (periodStart, periodEnd) = ExtractPeriod(stripeSub);
 
+        // Snapshot the mirror BEFORE mutation so the DCB event is emitted only when
+        // the applied Stripe state actually changes the mirror (AC — no double
+        // count). An API-initiated change applies once (emits here), then the
+        // resulting Stripe webhook re-applies the SAME state; without this guard the
+        // second apply would emit an identical BILLING.SUBSCRIPTION.* event and
+        // double-count in Epic 36/37. The mirror write itself stays idempotent.
+        var before = new MirrorSnapshot(mirror);
+
         mirror.StripeSubscriptionId = stripeSub.Id ?? mirror.StripeSubscriptionId;
         mirror.Status = status;
         if (periodStart is not null) mirror.CurrentPeriodStart = periodStart.Value;
@@ -148,12 +171,20 @@ public sealed class SubscriptionMirrorUpdater
         await ApplyTenantPlanLockstepAsync(tenantId, effectiveSlug, now, ct).ConfigureAwait(false);
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-        await EmitAsync(EventTypeFor(transition), tenantId, effectiveSlug, status, null).ConfigureAwait(false);
+        // Emit the DCB event ONLY when the applied Stripe state changed the mirror
+        // (a brand-new mirror always counts as a change). A pure replay (webhook
+        // echoing an already-applied API change) is a no-op emit.
+        var changed = isNew || before.DiffersFrom(mirror);
+        if (changed)
+        {
+            await EmitAsync(EventTypeFor(transition), tenantId, effectiveSlug, status, null)
+                .ConfigureAwait(false);
+        }
 
         _logger.LogInformation(
             "Subscription {Transition} for tenant {TenantId}: planSlug={PlanSlug}, status={Status}, "
-            + "seats={Seats} (new={IsNew}).",
-            transition, tenantId, effectiveSlug, status, mirror.Seats, isNew);
+            + "seats={Seats} (new={IsNew}, emitted={Emitted}).",
+            transition, tenantId, effectiveSlug, status, mirror.Seats, isNew, changed);
 
         return SubscriptionProjection.From(mirror);
     }
@@ -195,7 +226,7 @@ public sealed class SubscriptionMirrorUpdater
     {
         TransitionCreated => BillingEvents.SubscriptionCreatedType,
         TransitionCanceled or TransitionCanceledAtPeriodEnd => BillingEvents.SubscriptionCanceledType,
-        TransitionTrialEnded => BillingEvents.SubscriptionTrialEndedType,
+        TransitionTrialWillEnd => BillingEvents.SubscriptionTrialEndingType,
         _ => BillingEvents.SubscriptionUpdatedType, // upgraded / updated / seats_changed
     };
 
@@ -287,10 +318,25 @@ public sealed class SubscriptionMirrorUpdater
             .ConfigureAwait(false);
         if (plan is null)
         {
+            // Fail LOUD (no silent fallback): a missing target plan row on a
+            // money-critical transition would otherwise leave the tenant entitled
+            // to the OLD (higher) plan — 34-6 reads the shadow PlanId. A `free`
+            // plan must always be seeded; a gap must abort the transition so it
+            // surfaces/retries rather than drift silently.
             _logger.LogError(
-                "Subscription lockstep skipped: no active Plan row for slug '{Slug}' — "
-                + "Tenant.Plan not updated for tenant {TenantId}.", effectiveSlug, tenantId);
-            return;
+                "Subscription lockstep failed: no active Plan row for slug '{Slug}' — "
+                + "aborting the transition for tenant {TenantId} (would drift entitlement).",
+                effectiveSlug, tenantId);
+            throw new TammaError(
+                LockstepPlanMissingCode,
+                $"No active Plan row for effective slug '{effectiveSlug}' — cannot lock "
+                + $"Tenant.Plan for tenant {tenantId:D}. Seed the plan catalog.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId.ToString("D"),
+                    ["effectiveSlug"] = effectiveSlug,
+                },
+                retryable: false, severity: TammaErrorSeverity.Critical);
         }
 
         _db.Entry(tenant).Property("PlanId").CurrentValue = plan.Id;
@@ -315,5 +361,34 @@ public sealed class SubscriptionMirrorUpdater
                 "Failed to append {Type} for tenant {TenantId} (mirror already saved).",
                 type, tenantId);
         }
+    }
+
+    /// <summary>
+    /// Immutable snapshot of the mirror fields that decide whether a transition is
+    /// a real state change (drives the emit-once guard — Finding 3). Compared
+    /// field-for-field against the mutated mirror; equal ⇒ pure replay ⇒ no emit.
+    /// </summary>
+    private readonly record struct MirrorSnapshot(
+        string? StripeSubscriptionId,
+        string? PlanSlug,
+        string Status,
+        DateTime CurrentPeriodStart,
+        DateTime CurrentPeriodEnd,
+        bool CancelAtPeriodEnd,
+        DateTime? TrialEnd,
+        int Seats,
+        string? ScheduledPlanSlug,
+        DateTime? ScheduledEffectiveAt,
+        string? StripeScheduleId)
+    {
+        public MirrorSnapshot(BillingSubscription m) : this(
+            m.StripeSubscriptionId, m.PlanSlug, m.Status, m.CurrentPeriodStart,
+            m.CurrentPeriodEnd, m.CancelAtPeriodEnd, m.TrialEnd, m.Seats,
+            m.ScheduledPlanSlug, m.ScheduledEffectiveAt, m.StripeScheduleId)
+        {
+        }
+
+        /// <summary>True when any tracked field differs from the (mutated) mirror.</summary>
+        public bool DiffersFrom(BillingSubscription m) => this != new MirrorSnapshot(m);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorUpdater.cs
@@ -1,0 +1,319 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-4 — the SINGLE place a Stripe <see cref="Stripe.Subscription"/> is
+/// turned into the local <see cref="BillingSubscription"/> mirror + the
+/// <c>Tenant.Plan</c>/<c>Tenant.PlanId</c> lockstep + the
+/// <c>BILLING.SUBSCRIPTION.*</c> DCB event. Shared by BOTH the synchronous API
+/// path (<see cref="SubscriptionService"/>) and the asynchronous webhook path
+/// (<see cref="SubscriptionMirrorWebhookHandler"/>, called by the Story 35-5
+/// processor) so the mirror logic and the no-drift lockstep exist in exactly one
+/// place — the webhook reconciles, it never re-implements.
+///
+/// <para><b>Stripe is the state source of truth (AC13).</b> Status, period, and
+/// trial end are copied from the Stripe object, never inferred from the API
+/// request, so a stale request can never overwrite a newer Stripe-confirmed
+/// state. The effective plan slug is reverse-resolved from the subscription's
+/// base price id via the <c>billing_plan_prices</c> catalog.</para>
+/// </summary>
+public sealed class SubscriptionMirrorUpdater
+{
+    // ── Transition markers (drive the DCB event type + the lockstep rules) ──
+    public const string TransitionCreated = "created";
+    public const string TransitionUpgraded = "upgraded";
+    public const string TransitionUpdated = "updated";
+    public const string TransitionSeatsChanged = "seats_changed";
+    public const string TransitionCanceledAtPeriodEnd = "canceled_at_period_end";
+    public const string TransitionCanceled = "canceled";
+    public const string TransitionTrialEnded = "trial_ended";
+
+    private static readonly HashSet<string> AllowedStatuses = new(StringComparer.Ordinal)
+    {
+        "trialing", "active", "past_due", "canceled",
+        "incomplete", "incomplete_expired", "unpaid",
+    };
+
+    // Terminal / non-entitling statuses fall back to the free plan for the
+    // Tenant.Plan lockstep (immediate cancel / trial-expiry recompute quota to
+    // free now — AC4/AC5). past_due keeps the plan live through dunning; incomplete
+    // keeps the resolved plan (the initial charge is still in flight).
+    private static readonly HashSet<string> FreeFallbackStatuses = new(StringComparer.Ordinal)
+    {
+        "canceled", "incomplete_expired", "unpaid",
+    };
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IBillingSubscriptionRepository _repo;
+    private readonly IEventRepository _events;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<SubscriptionMirrorUpdater> _logger;
+
+    public SubscriptionMirrorUpdater(
+        ControlPlaneDbContext db,
+        IBillingSubscriptionRepository repo,
+        IEventRepository events,
+        TimeProvider clock,
+        ILogger<SubscriptionMirrorUpdater> logger)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(repo);
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _db = db;
+        _repo = repo;
+        _events = events;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Apply a Stripe subscription object onto the tenant's mirror + the
+    /// <c>Tenant.Plan</c>/<c>Tenant.PlanId</c> lockstep in one control-plane
+    /// transaction, then emit the transition's <c>BILLING.SUBSCRIPTION.*</c> DCB
+    /// event and return the projection. Status/period/trialEnd/seats come from
+    /// <paramref name="stripeSub"/> (AC13).
+    /// </summary>
+    public async Task<SubscriptionProjection> ApplyAsync(
+        Guid tenantId, Stripe.Subscription stripeSub, string transition, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(stripeSub);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transition);
+
+        var now = _clock.GetUtcNow().UtcDateTime;
+
+        // Resolve the mirror: prefer the Stripe-id match (webhook reconcile), else
+        // the tenant's active row (first API materialization).
+        BillingSubscription? mirror = null;
+        if (!string.IsNullOrEmpty(stripeSub.Id))
+        {
+            mirror = await _repo.GetByStripeSubscriptionIdAsync(stripeSub.Id, ct).ConfigureAwait(false);
+        }
+        mirror ??= await _repo.GetActiveByTenantAsync(tenantId, ct).ConfigureAwait(false);
+
+        var isNew = mirror is null;
+        if (mirror is null)
+        {
+            mirror = new BillingSubscription
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                CreatedAt = now,
+                Seats = 1,
+            };
+            await _repo.AddAsync(mirror, ct).ConfigureAwait(false);
+        }
+
+        var (resolvedSlug, resolvedSeats) = await ResolveSlugAndSeatsAsync(stripeSub, ct)
+            .ConfigureAwait(false);
+
+        var status = MapStatus(stripeSub.Status);
+        var (periodStart, periodEnd) = ExtractPeriod(stripeSub);
+
+        mirror.StripeSubscriptionId = stripeSub.Id ?? mirror.StripeSubscriptionId;
+        mirror.Status = status;
+        if (periodStart is not null) mirror.CurrentPeriodStart = periodStart.Value;
+        if (periodEnd is not null) mirror.CurrentPeriodEnd = periodEnd.Value;
+        mirror.CancelAtPeriodEnd = stripeSub.CancelAtPeriodEnd;
+        mirror.TrialEnd = stripeSub.TrialEnd;
+        if (resolvedSeats is not null) mirror.Seats = resolvedSeats.Value;
+
+        // The mirror's PlanSlug tracks the current EFFECTIVE plan (never the
+        // scheduled downgrade target — that lives in ScheduledPlanSlug). A live
+        // plan uses the resolved slug; a terminal/unpaid status collapses to free.
+        var effectiveSlug = FreeFallbackStatuses.Contains(status)
+            ? "free"
+            : resolvedSlug ?? mirror.PlanSlug ?? "free";
+        mirror.PlanSlug = effectiveSlug;
+
+        // Clear a pending downgrade once it has rolled over (effective == scheduled)
+        // or the subscription reached a terminal state.
+        if (mirror.ScheduledPlanSlug is not null
+            && (string.Equals(mirror.ScheduledPlanSlug, effectiveSlug, StringComparison.Ordinal)
+                || FreeFallbackStatuses.Contains(status)))
+        {
+            mirror.ScheduledPlanSlug = null;
+            mirror.ScheduledEffectiveAt = null;
+            mirror.StripeScheduleId = null;
+        }
+
+        mirror.UpdatedAt = now;
+
+        await ApplyTenantPlanLockstepAsync(tenantId, effectiveSlug, now, ct).ConfigureAwait(false);
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await EmitAsync(EventTypeFor(transition), tenantId, effectiveSlug, status, null).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Subscription {Transition} for tenant {TenantId}: planSlug={PlanSlug}, status={Status}, "
+            + "seats={Seats} (new={IsNew}).",
+            transition, tenantId, effectiveSlug, status, mirror.Seats, isNew);
+
+        return SubscriptionProjection.From(mirror);
+    }
+
+    /// <summary>
+    /// Record a scheduled downgrade on the mirror WITHOUT changing the live
+    /// <see cref="BillingSubscription.PlanSlug"/> or <c>Tenant.Plan</c> (the
+    /// higher plan's quota stays live until the rollover webhook — AC3). Emits
+    /// <c>BILLING.SUBSCRIPTION.UPDATED</c> carrying the <c>scheduledPlanSlug</c> tag.
+    /// </summary>
+    public async Task<SubscriptionProjection> RecordScheduledDowngradeAsync(
+        BillingSubscription mirror, string scheduledSlug, DateTime effectiveAt,
+        string stripeScheduleId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(mirror);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scheduledSlug);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stripeScheduleId);
+
+        mirror.ScheduledPlanSlug = scheduledSlug;
+        mirror.ScheduledEffectiveAt = effectiveAt;
+        mirror.StripeScheduleId = stripeScheduleId;
+        mirror.UpdatedAt = _clock.GetUtcNow().UtcDateTime;
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        await EmitAsync(
+            BillingEvents.SubscriptionUpdatedType, mirror.TenantId,
+            mirror.PlanSlug, mirror.Status, scheduledSlug).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Subscription downgrade scheduled for tenant {TenantId}: {CurrentSlug} → {ScheduledSlug} "
+            + "at {EffectiveAt:o} (planSlug/quota unchanged until rollover).",
+            mirror.TenantId, mirror.PlanSlug, scheduledSlug, effectiveAt);
+
+        return SubscriptionProjection.From(mirror);
+    }
+
+    /// <summary>Map the transition marker to the DCB event type (AC8).</summary>
+    private static string EventTypeFor(string transition) => transition switch
+    {
+        TransitionCreated => BillingEvents.SubscriptionCreatedType,
+        TransitionCanceled or TransitionCanceledAtPeriodEnd => BillingEvents.SubscriptionCanceledType,
+        TransitionTrialEnded => BillingEvents.SubscriptionTrialEndedType,
+        _ => BillingEvents.SubscriptionUpdatedType, // upgraded / updated / seats_changed
+    };
+
+    private static string MapStatus(string? stripeStatus) =>
+        stripeStatus is not null && AllowedStatuses.Contains(stripeStatus) ? stripeStatus : "active";
+
+    private static (DateTime? Start, DateTime? End) ExtractPeriod(Stripe.Subscription sub)
+    {
+        // Stripe.net 51.x moved current_period_* off the Subscription object onto
+        // each SubscriptionItem. Use the first item's window (the base price item).
+        var item = sub.Items?.Data?.FirstOrDefault();
+        if (item is null) return (null, null);
+        return (item.CurrentPeriodStart, item.CurrentPeriodEnd);
+    }
+
+    /// <summary>
+    /// Reverse-resolve the effective plan slug (from the base price id) and the
+    /// seat count (from the seats price id) using the <c>billing_plan_prices</c>
+    /// catalog. Returns <c>(null, null)</c> when no catalog row matches — the
+    /// caller then preserves the existing mirror slug/seats.
+    /// </summary>
+    private async Task<(string? Slug, int? Seats)> ResolveSlugAndSeatsAsync(
+        Stripe.Subscription sub, CancellationToken ct)
+    {
+        var items = sub.Items?.Data;
+        if (items is null || items.Count == 0) return (null, null);
+
+        var priceIds = items
+            .Select(i => i.Price?.Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct()
+            .ToList();
+        if (priceIds.Count == 0) return (null, null);
+
+        var catalog = await _db.BillingPlanPrices
+            .AsNoTracking()
+            .Where(p => (p.StripePriceId != null && priceIds.Contains(p.StripePriceId))
+                || (p.SeatsPriceId != null && priceIds.Contains(p.SeatsPriceId)))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        if (catalog.Count == 0) return (null, null);
+
+        // Effective slug = the catalog row whose BASE price id is on the sub.
+        var basePriceIds = new HashSet<string>(items
+            .Select(i => i.Price?.Id).Where(id => id is not null)!, StringComparer.Ordinal);
+        var slugRow = catalog.FirstOrDefault(
+            p => p.StripePriceId is not null && basePriceIds.Contains(p.StripePriceId));
+        var slug = slugRow?.PlanSlug;
+
+        // Seats = quantity of the item whose price id matches the slug's seats price.
+        int? seats = null;
+        if (slugRow?.SeatsPriceId is not null)
+        {
+            var seatItem = items.FirstOrDefault(
+                i => string.Equals(i.Price?.Id, slugRow.SeatsPriceId, StringComparison.Ordinal));
+            if (seatItem is not null) seats = (int)seatItem.Quantity;
+        }
+
+        return (slug, seats);
+    }
+
+    /// <summary>
+    /// No-drift lockstep (AC7) — mirror <c>Tenant.Plan</c> (legacy string) and the
+    /// shadow <c>Tenant.PlanId</c> FK to the effective slug, exactly as
+    /// <c>AdminTenantsEndpoints.UpdateTenantPlan</c> does. No-op when the tenant is
+    /// already on that slug. Logged (not thrown) if the plan row is missing so a
+    /// catalog gap never blocks the mirror save.
+    /// </summary>
+    private async Task ApplyTenantPlanLockstepAsync(
+        Guid tenantId, string effectiveSlug, DateTime now, CancellationToken ct)
+    {
+        var tenant = await _db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId && t.DeletedAt == null, ct)
+            .ConfigureAwait(false);
+        if (tenant is null)
+        {
+            _logger.LogError(
+                "Subscription lockstep skipped: tenant {TenantId} not found — mirror/Tenant.Plan "
+                + "may drift until the next webhook reconcile.", tenantId);
+            return;
+        }
+
+        if (string.Equals(tenant.Plan, effectiveSlug, StringComparison.Ordinal)) return;
+
+        var plan = await _db.Plans
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Slug == effectiveSlug && p.Status == "active", ct)
+            .ConfigureAwait(false);
+        if (plan is null)
+        {
+            _logger.LogError(
+                "Subscription lockstep skipped: no active Plan row for slug '{Slug}' — "
+                + "Tenant.Plan not updated for tenant {TenantId}.", effectiveSlug, tenantId);
+            return;
+        }
+
+        _db.Entry(tenant).Property("PlanId").CurrentValue = plan.Id;
+        tenant.Plan = plan.Slug;
+        tenant.UpdatedAt = now;
+    }
+
+    private async Task EmitAsync(
+        string type, Guid tenantId, string planSlug, string status, string? scheduledPlanSlug)
+    {
+        try
+        {
+            await _events.AppendAsync(
+                BillingEvents.Subscription(type, tenantId, planSlug, status, scheduledPlanSlug))
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A DCB append failure must not undo the already-committed mirror; the
+            // webhook reconciles state and an operator can replay the audit event.
+            _logger.LogError(ex,
+                "Failed to append {Type} for tenant {TenantId} (mirror already saved).",
+                type, tenantId);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorWebhookHandler.cs
@@ -1,0 +1,60 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-4 — the subscription webhook handler that SUPERSEDES the 35-5
+/// audit-only <c>SubscriptionWebhookHandler</c> (whose own doc anticipates this:
+/// "the <c>BillingSubscription</c> mirror is owned by Story 35-4 … 35-4
+/// supersedes this claim once it lands"). Registered in place of it so the
+/// registry's duplicate-claim guard is satisfied (exactly one handler per Stripe
+/// type).
+///
+/// <para>It drives the SHARED <see cref="SubscriptionMirrorUpdater"/> — the same
+/// entry point the API path uses — so a webhook reconciles the mirror +
+/// <c>Tenant.Plan</c> lockstep + emits the <c>BILLING.SUBSCRIPTION.*</c> DCB
+/// event without re-implementing any of it. No follow-up work (the updater is
+/// synchronous and cheap).</para>
+/// </summary>
+public sealed class SubscriptionMirrorWebhookHandler : IBillingEventHandler
+{
+    private readonly SubscriptionMirrorUpdater _mirror;
+
+    public SubscriptionMirrorWebhookHandler(SubscriptionMirrorUpdater mirror)
+    {
+        ArgumentNullException.ThrowIfNull(mirror);
+        _mirror = mirror;
+    }
+
+    public IReadOnlyCollection<string> HandledEventTypes => new[]
+    {
+        BillingWebhookEventTypes.SubscriptionCreated,
+        BillingWebhookEventTypes.SubscriptionUpdated,
+        BillingWebhookEventTypes.SubscriptionDeleted,
+        BillingWebhookEventTypes.SubscriptionTrialWillEnd,
+    };
+
+    public async Task<BillingFollowup?> HandleAsync(BillingWebhookContext ctx, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        if (ctx.StripeEvent.Data?.Object is not Stripe.Subscription stripeSub)
+        {
+            throw new InvalidOperationException(
+                $"SubscriptionMirrorWebhookHandler could not read a Stripe.Subscription from "
+                + $"event '{ctx.StripeEventId}' ({ctx.EventType}).");
+        }
+
+        var transition = ctx.EventType switch
+        {
+            BillingWebhookEventTypes.SubscriptionCreated => SubscriptionMirrorUpdater.TransitionCreated,
+            BillingWebhookEventTypes.SubscriptionUpdated => SubscriptionMirrorUpdater.TransitionUpdated,
+            BillingWebhookEventTypes.SubscriptionDeleted => SubscriptionMirrorUpdater.TransitionCanceled,
+            BillingWebhookEventTypes.SubscriptionTrialWillEnd =>
+                SubscriptionMirrorUpdater.TransitionTrialEnded,
+            _ => throw new InvalidOperationException(
+                $"SubscriptionMirrorWebhookHandler received unclaimed type '{ctx.EventType}'."),
+        };
+
+        await _mirror.ApplyAsync(ctx.TenantId, stripeSub, transition, ct).ConfigureAwait(false);
+        return null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorWebhookHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionMirrorWebhookHandler.cs
@@ -49,7 +49,7 @@ public sealed class SubscriptionMirrorWebhookHandler : IBillingEventHandler
             BillingWebhookEventTypes.SubscriptionUpdated => SubscriptionMirrorUpdater.TransitionUpdated,
             BillingWebhookEventTypes.SubscriptionDeleted => SubscriptionMirrorUpdater.TransitionCanceled,
             BillingWebhookEventTypes.SubscriptionTrialWillEnd =>
-                SubscriptionMirrorUpdater.TransitionTrialEnded,
+                SubscriptionMirrorUpdater.TransitionTrialWillEnd,
             _ => throw new InvalidOperationException(
                 $"SubscriptionMirrorWebhookHandler received unclaimed type '{ctx.EventType}'."),
         };

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionProjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionProjection.cs
@@ -1,0 +1,37 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-4 — the read DTO returned by <c>GET /billing/subscription</c> and by
+/// every lifecycle mutation. A tenant with no mirror row resolves to
+/// <see cref="FreeDefault"/> (free tier, active, one seat).
+/// </summary>
+public sealed record SubscriptionProjection(
+    string PlanSlug,
+    string Status,
+    DateTime? CurrentPeriodStart,
+    DateTime? CurrentPeriodEnd,
+    bool CancelAtPeriodEnd,
+    DateTime? TrialEnd,
+    int Seats,
+    string? ScheduledPlanSlug,
+    DateTime? ScheduledEffectiveAt)
+{
+    /// <summary>The free-tier default projection for a tenant with no subscription (AC9).</summary>
+    public static SubscriptionProjection FreeDefault() =>
+        new("free", "active", null, null, false, null, 1, null, null);
+
+    /// <summary>Project a persisted mirror row onto the wire shape.</summary>
+    public static SubscriptionProjection From(BillingSubscription s) =>
+        new(
+            s.PlanSlug,
+            s.Status,
+            s.CurrentPeriodStart == default ? null : s.CurrentPeriodStart,
+            s.CurrentPeriodEnd == default ? null : s.CurrentPeriodEnd,
+            s.CancelAtPeriodEnd,
+            s.TrialEnd,
+            s.Seats,
+            s.ScheduledPlanSlug,
+            s.ScheduledEffectiveAt);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs
@@ -1,0 +1,387 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Stripe;
+using Tamma.Core;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-4 — the subscription lifecycle orchestrator. Calls Stripe via the
+/// 35-1 client factory, then funnels every Stripe result through the shared
+/// <see cref="SubscriptionMirrorUpdater"/> so the mirror + <c>Tenant.Plan</c>
+/// lockstep + DCB event live in one place (also shared with the 35-5 webhook).
+///
+/// <para>Idempotency: every mutating Stripe call carries a deterministic
+/// <see cref="RequestOptions.IdempotencyKey"/> so a retry never double-applies
+/// proration or mints a duplicate schedule (AC10). Single-user short-circuits on
+/// <see cref="IBillingProvider.IsEnabled"/> — zero Stripe calls (AC11).</para>
+/// </summary>
+public sealed class SubscriptionService : ISubscriptionService
+{
+    /// <summary>Stable code for the seat-floor conflict (AC6) — surfaced as 409.</summary>
+    public const string SeatsBelowActiveMembersCode = "seats_below_active_members";
+
+    public const string SaasOnlyCode = "BILLING.SUBSCRIPTION.SAAS_ONLY";
+    public const string NoActiveSubscriptionCode = "BILLING.SUBSCRIPTION.NO_ACTIVE_SUBSCRIPTION";
+    public const string NoCustomerCode = "BILLING.SUBSCRIPTION.NO_CUSTOMER";
+
+    private readonly IBillingProvider _provider;
+    private readonly IStripeServicesFactory _stripeFactory;
+    private readonly IBillingCatalog _catalog;
+    private readonly IBillingSubscriptionRepository _repo;
+    private readonly SubscriptionMirrorUpdater _mirror;
+    private readonly ControlPlaneDbContext _db;
+    private readonly ITenantMembershipRepository _memberships;
+    private readonly BillingOptions _options;
+    private readonly ILogger<SubscriptionService> _logger;
+
+    public SubscriptionService(
+        IBillingProvider provider,
+        IStripeServicesFactory stripeFactory,
+        IBillingCatalog catalog,
+        IBillingSubscriptionRepository repo,
+        SubscriptionMirrorUpdater mirror,
+        ControlPlaneDbContext db,
+        ITenantMembershipRepository memberships,
+        IOptions<BillingOptions> options,
+        ILogger<SubscriptionService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+        ArgumentNullException.ThrowIfNull(stripeFactory);
+        ArgumentNullException.ThrowIfNull(catalog);
+        ArgumentNullException.ThrowIfNull(repo);
+        ArgumentNullException.ThrowIfNull(mirror);
+        ArgumentNullException.ThrowIfNull(db);
+        ArgumentNullException.ThrowIfNull(memberships);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _provider = provider;
+        _stripeFactory = stripeFactory;
+        _catalog = catalog;
+        _repo = repo;
+        _mirror = mirror;
+        _db = db;
+        _memberships = memberships;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<CheckoutResult> CreateCheckoutSessionAsync(
+        Guid tenantId, string planSlug, int? seats, int? trialDays, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(planSlug);
+        EnsureSaas();
+
+        var customer = await ResolveCustomerAsync(tenantId, ct).ConfigureAwait(false);
+        var catalog = await _catalog.GetBySlugAsync(planSlug, ct).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(catalog.StripePriceId))
+        {
+            throw new TammaError(
+                "BILLING.CATALOG.NO_PRICE",
+                $"Plan '{planSlug}' has no Stripe base price id in the catalog — run `seed-billing`.",
+                new Dictionary<string, object?> { ["planSlug"] = planSlug },
+                retryable: false, severity: TammaErrorSeverity.High);
+        }
+
+        var lineItems = new List<Stripe.Checkout.SessionLineItemOptions>
+        {
+            new() { Price = catalog.StripePriceId, Quantity = 1 },
+        };
+        if (seats is > 1 && !string.IsNullOrEmpty(catalog.SeatsPriceId))
+        {
+            lineItems.Add(new Stripe.Checkout.SessionLineItemOptions
+            {
+                Price = catalog.SeatsPriceId,
+                Quantity = seats.Value,
+            });
+        }
+
+        var sessionOptions = new Stripe.Checkout.SessionCreateOptions
+        {
+            Mode = "subscription",
+            Customer = customer.StripeCustomerId,
+            LineItems = lineItems,
+            SuccessUrl = _options.CheckoutSuccessUrl,
+            CancelUrl = _options.CheckoutCancelUrl,
+        };
+        if (trialDays is > 0)
+        {
+            sessionOptions.SubscriptionData = new Stripe.Checkout.SessionSubscriptionDataOptions
+            {
+                TrialPeriodDays = trialDays.Value,
+            };
+        }
+
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        var idempotencyKey = $"sub-checkout-{tenantId:D}-{planSlug}";
+        _logger.LogDebug(
+            "Creating Checkout session for tenant {TenantId} (planSlug={PlanSlug}, seats={Seats}, "
+            + "trialDays={TrialDays}, idempotencyKey set).",
+            tenantId, planSlug, seats, trialDays);
+
+        var session = await stripe.CheckoutSessions
+            .CreateAsync(sessionOptions, Idem(idempotencyKey), ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Checkout session created for tenant {TenantId} (planSlug={PlanSlug}, sessionId={SessionId}).",
+            tenantId, planSlug, session.Id);
+
+        return new CheckoutResult(session.Url, session.Id);
+    }
+
+    /// <inheritdoc />
+    public async Task<SubscriptionProjection> ChangePlanAsync(
+        Guid tenantId, string newPlanSlug, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(newPlanSlug);
+        EnsureSaas();
+
+        var mirror = await ResolveActiveMirrorAsync(tenantId, ct).ConfigureAwait(false);
+        var currentPlan = await GetActivePlanAsync(mirror.PlanSlug, ct).ConfigureAwait(false);
+        var targetPlan = await GetActivePlanAsync(newPlanSlug, ct).ConfigureAwait(false);
+        var targetCatalog = await _catalog.GetBySlugAsync(newPlanSlug, ct).ConfigureAwait(false);
+
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        var isUpgrade = targetPlan.MonthlyPriceUsd >= currentPlan.MonthlyPriceUsd;
+        _logger.LogDebug(
+            "Plan change for tenant {TenantId}: {CurrentSlug} (${CurrentPrice}) → {TargetSlug} "
+            + "(${TargetPrice}) — {Decision}.",
+            tenantId, mirror.PlanSlug, currentPlan.MonthlyPriceUsd, newPlanSlug,
+            targetPlan.MonthlyPriceUsd, isUpgrade ? "upgrade/prorate" : "downgrade/schedule");
+
+        if (isUpgrade)
+        {
+            // Immediate upgrade with proration — swap the base item's price.
+            var sub = await stripe.Subscriptions
+                .GetAsync(mirror.StripeSubscriptionId, null, null, ct).ConfigureAwait(false);
+            var baseItemId = ResolveBaseItemId(sub);
+
+            var updateOptions = new SubscriptionUpdateOptions
+            {
+                ProrationBehavior = "create_prorations",
+                Items = new List<SubscriptionItemOptions>
+                {
+                    new() { Id = baseItemId, Price = targetCatalog.StripePriceId },
+                },
+            };
+            var idempotencyKey =
+                $"sub-change-{tenantId:D}-{newPlanSlug}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+            var updated = await stripe.Subscriptions
+                .UpdateAsync(mirror.StripeSubscriptionId, updateOptions, Idem(idempotencyKey), ct)
+                .ConfigureAwait(false);
+
+            return await _mirror.ApplyAsync(
+                tenantId, updated, SubscriptionMirrorUpdater.TransitionUpgraded, ct)
+                .ConfigureAwait(false);
+        }
+
+        // Downgrade — schedule at period end via a Stripe Subscription Schedule.
+        // The live PlanSlug/Tenant.Plan stay at the current (higher) plan until the
+        // rollover webhook fires (AC3); the mirror records the scheduled target.
+        var scheduleOptions = new SubscriptionScheduleCreateOptions
+        {
+            FromSubscription = mirror.StripeSubscriptionId,
+        };
+        var scheduleKey =
+            $"sub-downgrade-{tenantId:D}-{newPlanSlug}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+        var schedule = await stripe.SubscriptionSchedules
+            .CreateAsync(scheduleOptions, Idem(scheduleKey), ct)
+            .ConfigureAwait(false);
+
+        return await _mirror.RecordScheduledDowngradeAsync(
+            mirror, newPlanSlug, mirror.CurrentPeriodEnd, schedule.Id, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<SubscriptionProjection> CancelAsync(
+        Guid tenantId, bool atPeriodEnd, CancellationToken ct = default)
+    {
+        EnsureSaas();
+        var mirror = await ResolveActiveMirrorAsync(tenantId, ct).ConfigureAwait(false);
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        var idempotencyKey =
+            $"sub-cancel-{tenantId:D}-{atPeriodEnd}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+
+        if (atPeriodEnd)
+        {
+            var updated = await stripe.Subscriptions
+                .UpdateAsync(
+                    mirror.StripeSubscriptionId,
+                    new SubscriptionUpdateOptions { CancelAtPeriodEnd = true },
+                    Idem(idempotencyKey), ct)
+                .ConfigureAwait(false);
+            return await _mirror.ApplyAsync(
+                tenantId, updated, SubscriptionMirrorUpdater.TransitionCanceledAtPeriodEnd, ct)
+                .ConfigureAwait(false);
+        }
+
+        var canceled = await stripe.Subscriptions
+            .CancelAsync(mirror.StripeSubscriptionId, null, Idem(idempotencyKey), ct)
+            .ConfigureAwait(false);
+        return await _mirror.ApplyAsync(
+            tenantId, canceled, SubscriptionMirrorUpdater.TransitionCanceled, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<SubscriptionProjection> ChangeSeatsAsync(
+        Guid tenantId, int seats, CancellationToken ct = default)
+    {
+        EnsureSaas();
+        if (seats < 1)
+        {
+            throw new TammaError(
+                "BILLING.SUBSCRIPTION.INVALID_SEATS",
+                "Seat count must be at least 1.",
+                new Dictionary<string, object?> { ["seats"] = seats },
+                retryable: false, severity: TammaErrorSeverity.Low);
+        }
+
+        var mirror = await ResolveActiveMirrorAsync(tenantId, ct).ConfigureAwait(false);
+
+        // Seat floor is enforced BEFORE any Stripe call (AC6) — a rejected decrease
+        // never mutates Stripe.
+        var activeMembers = (await _memberships.ListAllByTenantAsync(tenantId).ConfigureAwait(false)).Count;
+        if (seats < activeMembers)
+        {
+            _logger.LogWarning(
+                "Seat decrease rejected for tenant {TenantId}: requested {Requested} < active members "
+                + "{ActiveMembers}.", tenantId, seats, activeMembers);
+            throw new TammaError(
+                SeatsBelowActiveMembersCode,
+                $"Cannot set seats to {seats}: the tenant has {activeMembers} active members. "
+                + "Remove members first.",
+                new Dictionary<string, object?>
+                {
+                    ["requested"] = seats,
+                    ["activeMembers"] = activeMembers,
+                },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+
+        var catalog = await _catalog.GetBySlugAsync(mirror.PlanSlug, ct).ConfigureAwait(false);
+        var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        var sub = await stripe.Subscriptions
+            .GetAsync(mirror.StripeSubscriptionId, null, null, ct).ConfigureAwait(false);
+
+        // Update the existing seats item's quantity, or add one if the sub has none.
+        var seatItemId = ResolveItemIdByPrice(sub, catalog.SeatsPriceId);
+        var itemOptions = seatItemId is null
+            ? new SubscriptionItemOptions { Price = catalog.SeatsPriceId, Quantity = seats }
+            : new SubscriptionItemOptions { Id = seatItemId, Quantity = seats };
+
+        var idempotencyKey = $"sub-seats-{tenantId:D}-{seats}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+        var updated = await stripe.Subscriptions
+            .UpdateAsync(
+                mirror.StripeSubscriptionId,
+                new SubscriptionUpdateOptions
+                {
+                    ProrationBehavior = "create_prorations",
+                    Items = new List<SubscriptionItemOptions> { itemOptions },
+                },
+                Idem(idempotencyKey), ct)
+            .ConfigureAwait(false);
+
+        return await _mirror.ApplyAsync(
+            tenantId, updated, SubscriptionMirrorUpdater.TransitionSeatsChanged, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<SubscriptionProjection> GetAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        var mirror = await _repo.GetActiveByTenantAsync(tenantId, ct).ConfigureAwait(false);
+        return mirror is null ? SubscriptionProjection.FreeDefault() : SubscriptionProjection.From(mirror);
+    }
+
+    // ── helpers ──
+
+    private void EnsureSaas()
+    {
+        if (_provider.IsEnabled) return;
+        throw new TammaError(
+            SaasOnlyCode,
+            "Billing is a SaaS-only feature; subscription management is unavailable in single-user mode.",
+            new Dictionary<string, object?>(),
+            retryable: false, severity: TammaErrorSeverity.Low);
+    }
+
+    private async Task<BillingCustomer> ResolveCustomerAsync(Guid tenantId, CancellationToken ct)
+    {
+        var customer = await _db.BillingCustomers
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.TenantId == tenantId, ct)
+            .ConfigureAwait(false);
+        if (customer is null || string.IsNullOrEmpty(customer.StripeCustomerId))
+        {
+            throw new TammaError(
+                NoCustomerCode,
+                $"Tenant {tenantId:D} has no Stripe customer mapping yet — billing is not provisioned.",
+                new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+        return customer;
+    }
+
+    private async Task<BillingSubscription> ResolveActiveMirrorAsync(Guid tenantId, CancellationToken ct)
+    {
+        var mirror = await _repo.GetActiveByTenantAsync(tenantId, ct).ConfigureAwait(false);
+        if (mirror is null || string.IsNullOrEmpty(mirror.StripeSubscriptionId))
+        {
+            throw new TammaError(
+                NoActiveSubscriptionCode,
+                $"Tenant {tenantId:D} has no active Stripe subscription to modify. "
+                + "Start one via checkout first.",
+                new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+        return mirror;
+    }
+
+    private async Task<Tamma.Data.Entities.Plan> GetActivePlanAsync(string slug, CancellationToken ct)
+    {
+        var plan = await _db.Plans
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Slug == slug && p.Status == "active", ct)
+            .ConfigureAwait(false);
+        if (plan is null)
+        {
+            throw new TammaError(
+                "BILLING.SUBSCRIPTION.UNKNOWN_PLAN",
+                $"No active plan for slug '{slug}'.",
+                new Dictionary<string, object?> { ["slug"] = slug },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+        return plan;
+    }
+
+    /// <summary>The base subscription item id (first item, or the non-seats item).</summary>
+    private static string ResolveBaseItemId(Stripe.Subscription sub)
+    {
+        var items = sub.Items?.Data;
+        if (items is null || items.Count == 0)
+        {
+            throw new TammaError(
+                "BILLING.SUBSCRIPTION.NO_ITEMS",
+                "Stripe subscription has no items to update.",
+                new Dictionary<string, object?> { ["subscriptionId"] = sub.Id },
+                retryable: false, severity: TammaErrorSeverity.High);
+        }
+        return items[0].Id;
+    }
+
+    private static string? ResolveItemIdByPrice(Stripe.Subscription sub, string? priceId)
+    {
+        if (string.IsNullOrEmpty(priceId)) return null;
+        return sub.Items?.Data?
+            .FirstOrDefault(i => string.Equals(i.Price?.Id, priceId, StringComparison.Ordinal))?.Id;
+    }
+
+    private static RequestOptions Idem(string key) => new() { IdempotencyKey = key };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/SubscriptionService.cs
@@ -118,7 +118,11 @@ public sealed class SubscriptionService : ISubscriptionService
         }
 
         var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
-        var idempotencyKey = $"sub-checkout-{tenantId:D}-{planSlug}";
+        // Fold the checkout params (seats + trialDays) into the key so two DISTINCT
+        // checkout intents get DISTINCT keys — a same-key replay with different
+        // params 502s at Stripe; a genuine retry of the SAME params still dedups.
+        var idempotencyKey =
+            $"sub-checkout-{tenantId:D}-{planSlug}-s{seats ?? 0}-t{trialDays ?? 0}";
         _logger.LogDebug(
             "Creating Checkout session for tenant {TenantId} (planSlug={PlanSlug}, seats={Seats}, "
             + "trialDays={TrialDays}, idempotencyKey set).",
@@ -170,8 +174,14 @@ public sealed class SubscriptionService : ISubscriptionService
                     new() { Id = baseItemId, Price = targetCatalog.StripePriceId },
                 },
             };
+            // Fold the PRE-CHANGE slug into the key so an A→B→A plan sequence issues
+            // DISTINCT keys (each intent applies), while a genuine retry of the SAME
+            // change reuses the key (dedups). Pre-change slug read from the mirror
+            // (residual mirror-lag edge: a webhook that already moved the mirror
+            // could shift the "from" — acceptable vs. a schema column/migration).
             var idempotencyKey =
-                $"sub-change-{tenantId:D}-{newPlanSlug}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+                $"sub-change-{tenantId:D}-{mirror.PlanSlug}-to-{newPlanSlug}"
+                + $"-{mirror.CurrentPeriodEnd:yyyyMMdd}";
             var updated = await stripe.Subscriptions
                 .UpdateAsync(mirror.StripeSubscriptionId, updateOptions, Idem(idempotencyKey), ct)
                 .ConfigureAwait(false);
@@ -184,18 +194,90 @@ public sealed class SubscriptionService : ISubscriptionService
         // Downgrade — schedule at period end via a Stripe Subscription Schedule.
         // The live PlanSlug/Tenant.Plan stay at the current (higher) plan until the
         // rollover webhook fires (AC3); the mirror records the scheduled target.
-        var scheduleOptions = new SubscriptionScheduleCreateOptions
+        //
+        // A schedule created with ONLY FromSubscription is a single-phase mirror of
+        // the CURRENT sub (end_behavior=release) — at period end it releases back to
+        // the current (higher) plan and keeps charging; the target downgrade never
+        // fires. So we CREATE from the subscription, then UPDATE it into TWO phases:
+        // phase 1 = the current price item(s) through the current period end, phase 2
+        // = the TARGET plan's price (from billing_plan_prices). end_behavior=release
+        // then leaves the sub live on the target plan after the rollover.
+        if (string.IsNullOrEmpty(targetCatalog.StripePriceId))
         {
-            FromSubscription = mirror.StripeSubscriptionId,
-        };
-        var scheduleKey =
-            $"sub-downgrade-{tenantId:D}-{newPlanSlug}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+            throw new TammaError(
+                "BILLING.CATALOG.NO_PRICE",
+                $"Target plan '{newPlanSlug}' has no Stripe base price id in the catalog — "
+                + "run `seed-billing`.",
+                new Dictionary<string, object?> { ["planSlug"] = newPlanSlug },
+                retryable: false, severity: TammaErrorSeverity.High);
+        }
+
+        var fromSlug = mirror.PlanSlug;
+        var period = $"{mirror.CurrentPeriodEnd:yyyyMMdd}";
+        var scheduleKey = $"sub-downgrade-{tenantId:D}-{fromSlug}-to-{newPlanSlug}-{period}";
         var schedule = await stripe.SubscriptionSchedules
-            .CreateAsync(scheduleOptions, Idem(scheduleKey), ct)
+            .CreateAsync(
+                new SubscriptionScheduleCreateOptions { FromSubscription = mirror.StripeSubscriptionId },
+                Idem(scheduleKey), ct)
+            .ConfigureAwait(false);
+
+        var currentPhase = schedule.Phases?.FirstOrDefault();
+        List<SubscriptionSchedulePhaseItemOptions> phaseOneItems;
+        if (currentPhase?.Items is { Count: > 0 } phaseItems)
+        {
+            // Canonical path: carry the current sub's price item(s) as phase 1.
+            phaseOneItems = phaseItems
+                .Select(i => new SubscriptionSchedulePhaseItemOptions
+                {
+                    Price = i.PriceId ?? i.Price?.Id,
+                    Quantity = i.Quantity,
+                })
+                .ToList();
+        }
+        else
+        {
+            // Defensive fallback (a from_subscription schedule always seeds phase[0]
+            // in practice): rebuild phase 1 from the current plan's catalog base price.
+            var currentCatalog = await _catalog.GetBySlugAsync(fromSlug, ct).ConfigureAwait(false);
+            phaseOneItems = new List<SubscriptionSchedulePhaseItemOptions>
+            {
+                new() { Price = currentCatalog.StripePriceId, Quantity = 1 },
+            };
+        }
+
+        var effectiveAt = currentPhase is not null && currentPhase.EndDate != default
+            ? currentPhase.EndDate
+            : mirror.CurrentPeriodEnd;
+
+        var scheduleUpdateOptions = new SubscriptionScheduleUpdateOptions
+        {
+            EndBehavior = "release",
+            Phases = new List<SubscriptionSchedulePhaseOptions>
+            {
+                new()
+                {
+                    Items = phaseOneItems,
+                    StartDate = currentPhase?.StartDate ?? mirror.CurrentPeriodStart,
+                    EndDate = effectiveAt,
+                },
+                new()
+                {
+                    Items = new List<SubscriptionSchedulePhaseItemOptions>
+                    {
+                        new() { Price = targetCatalog.StripePriceId, Quantity = 1 },
+                    },
+                },
+            },
+        };
+        // Distinct key from the create so a create-then-update retry doesn't replay
+        // the create's cached response onto the update call.
+        var updateKey = $"sub-downgrade-update-{tenantId:D}-{fromSlug}-to-{newPlanSlug}-{period}";
+        await stripe.SubscriptionSchedules
+            .UpdateAsync(schedule.Id, scheduleUpdateOptions, Idem(updateKey), ct)
             .ConfigureAwait(false);
 
         return await _mirror.RecordScheduledDowngradeAsync(
-            mirror, newPlanSlug, mirror.CurrentPeriodEnd, schedule.Id, ct).ConfigureAwait(false);
+            mirror, newPlanSlug, effectiveAt, schedule.Id, ct).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -205,8 +287,12 @@ public sealed class SubscriptionService : ISubscriptionService
         EnsureSaas();
         var mirror = await ResolveActiveMirrorAsync(tenantId, ct).ConfigureAwait(false);
         var stripe = await _stripeFactory.CreateAsync(ct).ConfigureAwait(false);
+        // Fold the PRE-CHANGE cancel-at-period-end flag into the key so a
+        // set→undo→set sequence issues DISTINCT keys (each intent applies), while a
+        // genuine retry of the SAME cancel reuses it (dedups).
         var idempotencyKey =
-            $"sub-cancel-{tenantId:D}-{atPeriodEnd}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+            $"sub-cancel-{tenantId:D}-{atPeriodEnd}-from{mirror.CancelAtPeriodEnd}"
+            + $"-{mirror.CurrentPeriodEnd:yyyyMMdd}";
 
         if (atPeriodEnd)
         {
@@ -276,7 +362,13 @@ public sealed class SubscriptionService : ISubscriptionService
             ? new SubscriptionItemOptions { Price = catalog.SeatsPriceId, Quantity = seats }
             : new SubscriptionItemOptions { Id = seatItemId, Quantity = seats };
 
-        var idempotencyKey = $"sub-seats-{tenantId:D}-{seats}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
+        // Fold the PRE-CHANGE seat count into the key so a 5→10→5 sequence issues
+        // DISTINCT keys (each applies at Stripe), while a genuine retry of the SAME
+        // change (same from/to) reuses it (dedups). Pre-change count read from the
+        // mirror (residual mirror-lag edge: a webhook that already moved Seats could
+        // shift the "from" — acceptable vs. a schema column/migration).
+        var idempotencyKey =
+            $"sub-seats-{tenantId:D}-{mirror.Seats}-to-{seats}-{mirror.CurrentPeriodEnd:yyyyMMdd}";
         var updated = await stripe.Subscriptions
             .UpdateAsync(
                 mirror.StripeSubscriptionId,

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -666,6 +666,14 @@ public class ControlPlaneDbContext : DbContext
     public DbSet<BillingWebhookEvent> BillingWebhookEvents => Set<BillingWebhookEvent>();
 
     /// <summary>
+    /// Story 35-4 — the control-plane mirror of a tenant's Stripe subscription.
+    /// At most one non-terminal row per tenant (partial-unique on
+    /// <c>TenantId</c>). Story 35-6 reads <c>PlanSlug</c> + <c>Seats</c> as the
+    /// single quota source. See <see cref="Entities.BillingSubscription"/>.
+    /// </summary>
+    public DbSet<BillingSubscription> BillingSubscriptions => Set<BillingSubscription>();
+
+    /// <summary>
     /// Story 37-1 — platform-scope curated audit trail. Tenant-scope rows live
     /// in the per-tenant schema's <c>audit_records</c>; these are the
     /// platform/lifecycle rows (impersonation, tenant provision/move, etc.).

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/BillingSubscription.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/BillingSubscription.cs
@@ -1,0 +1,80 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 35-4 — the control-plane mirror of a tenant's Stripe subscription. One
+/// non-terminal row per tenant (a partial-unique index over
+/// <see cref="TenantId"/> filtered to non-terminal <see cref="Status"/> values
+/// enforces "at most one live subscription"; historical <c>canceled</c> /
+/// <c>incomplete_expired</c> rows may accumulate). SaaS only — single-user never
+/// writes here (<c>NullBillingProvider</c>).
+///
+/// <para><b>Mirror is the enforcement source of truth; Stripe is the state
+/// source of truth.</b> The mirror exists so Story 35-6 can enforce quota
+/// without a Stripe round-trip. On every lifecycle transition the <i>state</i>
+/// (<see cref="Status"/>/period/<see cref="TrialEnd"/>) is copied from the Stripe
+/// object by <c>SubscriptionMirrorUpdater</c>, never inferred from the API
+/// request, so the mirror can never claim a state Stripe has not confirmed
+/// (AC13).</para>
+///
+/// <para>CP-resident (control plane): billing is a cross-cutting concern keyed by
+/// tenant, and the webhook (Story 35-5) arrives with no tenant context (tenant is
+/// resolved from the Stripe customer id).</para>
+/// </summary>
+public class BillingSubscription
+{
+    /// <summary>Stable id (server default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning tenant — FK to <c>tenants.Id</c> (cascade on tenant purge).</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>
+    /// Stripe subscription id (<c>sub_...</c>). Null until the
+    /// <c>customer.subscription.created</c> webhook (Story 35-5) materializes the
+    /// mirror; unique once assigned (partial index skips the null rows).
+    /// </summary>
+    public string? StripeSubscriptionId { get; set; }
+
+    /// <summary>Current EFFECTIVE plan slug — <c>free</c> | <c>team</c> | <c>enterprise</c>.</summary>
+    public string PlanSlug { get; set; } = "free";
+
+    /// <summary>
+    /// Text-domain status pinned by a CHECK constraint:
+    /// <c>trialing</c> | <c>active</c> | <c>past_due</c> | <c>canceled</c> |
+    /// <c>incomplete</c> | <c>incomplete_expired</c> | <c>unpaid</c>. Copied from
+    /// the Stripe subscription object (AC13).
+    /// </summary>
+    public string Status { get; set; } = "active";
+
+    /// <summary>Current billing-period start (from the Stripe subscription item).</summary>
+    public DateTime CurrentPeriodStart { get; set; }
+
+    /// <summary>Current billing-period end (from the Stripe subscription item).</summary>
+    public DateTime CurrentPeriodEnd { get; set; }
+
+    /// <summary>True when an at-period-end cancellation is scheduled (status stays <c>active</c>).</summary>
+    public bool CancelAtPeriodEnd { get; set; }
+
+    /// <summary>Trial end instant when <see cref="Status"/> is <c>trialing</c>; else null.</summary>
+    public DateTime? TrialEnd { get; set; }
+
+    /// <summary>Purchased seat count (drives the seat-cap enforcement in Story 35-6). Default 1.</summary>
+    public int Seats { get; set; } = 1;
+
+    // ── Pending downgrade (scheduled at period end via a Stripe Subscription Schedule) ──
+
+    /// <summary>Target slug of a pending downgrade; null when none is scheduled.</summary>
+    public string? ScheduledPlanSlug { get; set; }
+
+    /// <summary>When the scheduled downgrade takes effect (= <see cref="CurrentPeriodEnd"/> at schedule time).</summary>
+    public DateTime? ScheduledEffectiveAt { get; set; }
+
+    /// <summary>Stripe Subscription Schedule id (<c>sub_sched_...</c>) backing the pending downgrade.</summary>
+    public string? StripeScheduleId { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>Navigation to the owning tenant.</summary>
+    public Tenant? Tenant { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702193642_AddBillingSubscription.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702193642_AddBillingSubscription.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702193642_AddBillingSubscription")]
+    partial class AddBillingSubscription
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702193642_AddBillingSubscription.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702193642_AddBillingSubscription.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddBillingSubscription : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "billing_subscriptions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    StripeSubscriptionId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    PlanSlug = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "free"),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "active"),
+                    CurrentPeriodStart = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CurrentPeriodEnd = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CancelAtPeriodEnd = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    TrialEnd = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Seats = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    ScheduledPlanSlug = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ScheduledEffectiveAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    StripeScheduleId = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_billing_subscriptions", x => x.Id);
+                    table.CheckConstraint("ck_billing_subscriptions_status", "\"Status\" IN ('trialing','active','past_due','canceled','incomplete','incomplete_expired','unpaid')");
+                    table.ForeignKey(
+                        name: "FK_billing_subscriptions_tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_subscriptions_StripeSubscriptionId",
+                table: "billing_subscriptions",
+                column: "StripeSubscriptionId",
+                unique: true,
+                filter: "\"StripeSubscriptionId\" IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_billing_subscriptions_TenantId_NonTerminal",
+                table: "billing_subscriptions",
+                column: "TenantId",
+                unique: true,
+                filter: "\"Status\" NOT IN ('canceled','incomplete_expired')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "billing_subscriptions");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/BillingSubscriptionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/BillingSubscriptionRepository.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 35-4 — EF-backed <see cref="IBillingSubscriptionRepository"/> over
+/// <see cref="ControlPlaneDbContext"/>. Reads are tenant-scoped; the terminal
+/// statuses (<c>canceled</c>, <c>incomplete_expired</c>) are excluded from the
+/// "active" lookup so a fresh subscription after a prior cancellation resolves
+/// cleanly (mirrors the partial-unique index filter).
+/// </summary>
+public sealed class BillingSubscriptionRepository : IBillingSubscriptionRepository
+{
+    private static readonly string[] TerminalStatuses = { "canceled", "incomplete_expired" };
+
+    private readonly ControlPlaneDbContext _db;
+
+    public BillingSubscriptionRepository(ControlPlaneDbContext db)
+    {
+        ArgumentNullException.ThrowIfNull(db);
+        _db = db;
+    }
+
+    /// <inheritdoc />
+    public async Task<BillingSubscription?> GetActiveByTenantAsync(
+        Guid tenantId, CancellationToken ct = default) =>
+        await _db.BillingSubscriptions
+            .Where(s => s.TenantId == tenantId && !TerminalStatuses.Contains(s.Status))
+            .OrderByDescending(s => s.UpdatedAt)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task<BillingSubscription?> GetByStripeSubscriptionIdAsync(
+        string stripeSubscriptionId, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stripeSubscriptionId);
+        return await _db.BillingSubscriptions
+            .FirstOrDefaultAsync(s => s.StripeSubscriptionId == stripeSubscriptionId, ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(BillingSubscription subscription, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(subscription);
+        await _db.BillingSubscriptions.AddAsync(subscription, ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/BillingSubscriptionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/BillingSubscriptionRepository.cs
@@ -12,7 +12,15 @@ namespace Tamma.Data.Repositories;
 /// </summary>
 public sealed class BillingSubscriptionRepository : IBillingSubscriptionRepository
 {
-    private static readonly string[] TerminalStatuses = { "canceled", "incomplete_expired" };
+    // Declared as IReadOnlyList<string> (NOT string[]) on purpose: under C# 13's
+    // first-class-span overload resolution, `array.Contains(x)` binds to
+    // MemoryExtensions.Contains(ReadOnlySpan<T>, T) via the implicit array→span
+    // conversion. EF Core's LINQ interpreter then tries to use ReadOnlySpan<string>
+    // as a generic argument and throws TypeLoadException (a ref struct can't be a
+    // generic type arg). The interface receiver has no array→span conversion, so the
+    // call binds to Enumerable.Contains, which EF translates cleanly to SQL `IN`.
+    private static readonly IReadOnlyList<string> TerminalStatuses =
+        new[] { "canceled", "incomplete_expired" };
 
     private readonly ControlPlaneDbContext _db;
 

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IBillingSubscriptionRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IBillingSubscriptionRepository.cs
@@ -1,0 +1,25 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 35-4 — tenant-scoped CRUD over the <see cref="BillingSubscription"/>
+/// mirror. Every method is filtered by <c>TenantId</c>; there is no cross-tenant
+/// read path (tenant isolation is structural — AC12).
+/// </summary>
+public interface IBillingSubscriptionRepository
+{
+    /// <summary>
+    /// The single non-terminal subscription for a tenant, or null when the tenant
+    /// has none (free tier) or only terminal (<c>canceled</c>/<c>incomplete_expired</c>)
+    /// rows. Tracked so the caller can mutate + save it.
+    /// </summary>
+    Task<BillingSubscription?> GetActiveByTenantAsync(Guid tenantId, CancellationToken ct = default);
+
+    /// <summary>Resolve the mirror by its Stripe subscription id (webhook path), or null.</summary>
+    Task<BillingSubscription?> GetByStripeSubscriptionIdAsync(
+        string stripeSubscriptionId, CancellationToken ct = default);
+
+    /// <summary>Add a new mirror row (not yet saved).</summary>
+    Task AddAsync(BillingSubscription subscription, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1079,6 +1079,53 @@ internal static class TammaModelConfiguration
                 .HasDatabaseName("IX_billing_webhook_events_TenantId")
                 .HasFilter("\"TenantId\" IS NOT NULL");
         });
+
+        // ── BillingSubscription (Story 35-4 — control-plane subscription mirror) ──
+        modelBuilder.Entity<BillingSubscription>(entity =>
+        {
+            entity.ToTable("billing_subscriptions", t =>
+            {
+                // Text domain for the Stripe-mirrored status.
+                t.HasCheckConstraint(
+                    "ck_billing_subscriptions_status",
+                    "\"Status\" IN ('trialing','active','past_due','canceled',"
+                    + "'incomplete','incomplete_expired','unpaid')");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.StripeSubscriptionId).HasMaxLength(255);
+            entity.Property(e => e.PlanSlug)
+                .IsRequired().HasMaxLength(64).HasDefaultValue("free");
+            entity.Property(e => e.Status)
+                .IsRequired().HasMaxLength(32).HasDefaultValue("active");
+            entity.Property(e => e.CancelAtPeriodEnd).HasDefaultValue(false);
+            entity.Property(e => e.Seats).HasDefaultValue(1);
+            entity.Property(e => e.ScheduledPlanSlug).HasMaxLength(64);
+            entity.Property(e => e.StripeScheduleId).HasMaxLength(255);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // At most ONE non-terminal subscription per tenant (AC1 / AC12). A
+            // tenant may keep many historical terminal rows; only the live one is
+            // constrained. Partial-unique expresses that without a soft-delete col.
+            entity.HasIndex(e => e.TenantId)
+                .HasDatabaseName("UX_billing_subscriptions_TenantId_NonTerminal")
+                .HasFilter("\"Status\" NOT IN ('canceled','incomplete_expired')")
+                .IsUnique();
+
+            // Stripe subscription ids are globally unique once assigned. Partial so
+            // the null-until-acked rows don't collide on NULL.
+            entity.HasIndex(e => e.StripeSubscriptionId)
+                .HasDatabaseName("UX_billing_subscriptions_StripeSubscriptionId")
+                .HasFilter("\"StripeSubscriptionId\" IS NOT NULL")
+                .IsUnique();
+
+            // Tenant purge cascades the subscription mirror.
+            entity.HasOne(e => e.Tenant)
+                .WithMany()
+                .HasForeignKey(e => e.TenantId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
     }
 
     /// <summary>

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddBillingWebhookIngestionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/AddBillingWebhookIngestionTests.cs
@@ -34,6 +34,12 @@ public class AddBillingWebhookIngestionTests
         services.AddSingleton<ITammaModeProvider, TammaModeProvider>();
         services.TryAddSingletonDoubles();
         services.AddPlatformTaskWorker(configuration);
+        // Story 35-4 supersedes 35-5's SubscriptionWebhookHandler with
+        // SubscriptionMirrorWebhookHandler; register just its deps (the shared
+        // mirror updater + subscription repo) so the SaaS handler set resolves.
+        // (In Program.cs these come from AddTammaBilling, called before this.)
+        services.AddScoped<IBillingSubscriptionRepository, BillingSubscriptionRepository>();
+        services.AddScoped<SubscriptionMirrorUpdater>();
         services.AddBillingWebhookIngestion(configuration);
         return services.BuildServiceProvider();
     }
@@ -54,7 +60,9 @@ public class AddBillingWebhookIngestionTests
         s.GetServices<IBillingEventHandler>().Select(h => h.GetType().Name)
             .Should().Contain(new[]
             {
-                "SubscriptionWebhookHandler", "InvoiceWebhookHandler",
+                // Story 35-4 superseded SubscriptionWebhookHandler with the
+                // mirror-writing SubscriptionMirrorWebhookHandler.
+                "SubscriptionMirrorWebhookHandler", "InvoiceWebhookHandler",
                 "PaymentWebhookHandler", "DisputeWebhookHandler",
             });
         s.GetServices<IPlatformTaskHandler>()

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSubscriptionMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingSubscriptionMigrationTests.cs
@@ -1,0 +1,199 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC1) — applies the ControlPlane migration bundle to a clean
+/// Postgres testcontainer and asserts the <c>billing_subscriptions</c> schema
+/// landed: the table, the status CHECK, the partial-unique
+/// "one-non-terminal-per-tenant" index, the partial-unique Stripe-subscription-id
+/// index, and clean down/up reversibility. Raw Npgsql introspection — mirrors
+/// <see cref="BillingMigrationTests"/>.
+/// </summary>
+[TestFixture]
+public class BillingSubscriptionMigrationTests
+{
+    private const string ThisMigration = "20260702193642_AddBillingSubscription";
+    private const string PriorMigration = "20260702172018_BillingWebhookEvents";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("billing_subscription_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private static async Task<string?> ScalarAsync(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        var v = await cmd.ExecuteScalarAsync();
+        return v is null or DBNull ? null : v.ToString();
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Subscriptions_Table_And_Status_Check()
+    {
+        await using var conn = await OpenAsync();
+
+        var table = await ScalarAsync(conn,
+            "SELECT table_name FROM information_schema.tables "
+            + "WHERE table_schema='public' AND table_name='billing_subscriptions';");
+        table.Should().Be("billing_subscriptions");
+
+        var check = await ScalarAsync(conn,
+            "SELECT conname FROM pg_constraint "
+            + "WHERE contype='c' AND conname='ck_billing_subscriptions_status';");
+        check.Should().Be("ck_billing_subscriptions_status");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Partial_Unique_OneNonTerminal_PerTenant_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes "
+            + "WHERE indexname='UX_billing_subscriptions_TenantId_NonTerminal';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("TenantId");
+        def.Should().Contain("canceled", "the index is partial — excludes terminal statuses");
+        def.Should().Contain("incomplete_expired");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Partial_Unique_StripeSubscriptionId_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes "
+            + "WHERE indexname='UX_billing_subscriptions_StripeSubscriptionId';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("StripeSubscriptionId");
+        def.Should().Contain("IS NOT NULL", "the index is partial — only acked subscriptions");
+    }
+
+    [Test]
+    public async Task PartialUnique_Rejects_Second_NonTerminal_But_Allows_Terminal_Plus_Active()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        // First non-terminal row — OK.
+        await InsertSubscriptionAsync(tenantId, "sub_A", "active");
+
+        // Second non-terminal row for the SAME tenant — rejected by the partial index.
+        var act = async () => await InsertSubscriptionAsync(tenantId, "sub_B", "trialing");
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Where(e => e.SqlState == PostgresErrorCodes.UniqueViolation);
+
+        // A terminal row + a fresh non-terminal row coexist fine.
+        await CancelSubscriptionAsync(tenantId, "sub_A");
+        await InsertSubscriptionAsync(tenantId, "sub_C", "active");
+    }
+
+    [Test]
+    public async Task Migration_Down_Drops_Then_Up_Restores()
+    {
+        await using (var down = NewContext())
+        {
+            await down.GetService<IMigrator>().MigrateAsync(PriorMigration);
+        }
+        await using (var conn = await OpenAsync())
+        {
+            var t = await ScalarAsync(conn,
+                "SELECT table_name FROM information_schema.tables "
+                + "WHERE table_schema='public' AND table_name='billing_subscriptions';");
+            t.Should().BeNull();
+        }
+
+        await using (var up = NewContext())
+        {
+            await up.GetService<IMigrator>().MigrateAsync(ThisMigration);
+        }
+        await using (var conn = await OpenAsync())
+        {
+            var t = await ScalarAsync(conn,
+                "SELECT table_name FROM information_schema.tables "
+                + "WHERE table_schema='public' AND table_name='billing_subscriptions';");
+            t.Should().Be("billing_subscriptions");
+        }
+    }
+
+    private async Task<Guid> SeedTenantAsync()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var conn = await OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "INSERT INTO tenants (\"Id\", \"Name\", \"Slug\", \"Plan\", \"CreatedAt\", \"UpdatedAt\") "
+            + "VALUES (@id, @name, @slug, 'free', now(), now());", conn);
+        cmd.Parameters.AddWithValue("id", tenantId);
+        cmd.Parameters.AddWithValue("name", $"t-{tenantId:N}");
+        cmd.Parameters.AddWithValue("slug", $"s{tenantId:N}"[..12]);
+        await cmd.ExecuteNonQueryAsync();
+        return tenantId;
+    }
+
+    private async Task InsertSubscriptionAsync(Guid tenantId, string stripeSubId, string status)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "INSERT INTO billing_subscriptions "
+            + "(\"Id\", \"TenantId\", \"StripeSubscriptionId\", \"PlanSlug\", \"Status\", "
+            + "\"CurrentPeriodStart\", \"CurrentPeriodEnd\", \"CancelAtPeriodEnd\", \"Seats\", "
+            + "\"CreatedAt\", \"UpdatedAt\") "
+            + "VALUES (gen_random_uuid(), @t, @sid, 'team', @st, now(), now(), false, 1, now(), now());",
+            conn);
+        cmd.Parameters.AddWithValue("t", tenantId);
+        cmd.Parameters.AddWithValue("sid", stripeSubId);
+        cmd.Parameters.AddWithValue("st", status);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task CancelSubscriptionAsync(Guid tenantId, string stripeSubId)
+    {
+        await using var conn = await OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "UPDATE billing_subscriptions SET \"Status\"='canceled' "
+            + "WHERE \"TenantId\"=@t AND \"StripeSubscriptionId\"=@sid;", conn);
+        cmd.Parameters.AddWithValue("t", tenantId);
+        cmd.Parameters.AddWithValue("sid", stripeSubId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingSubscriptionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/NullBillingSubscriptionTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC11) — single-user mode: the <see cref="SubscriptionService"/>
+/// resolves the disabled billing provider (<c>IsEnabled = false</c>), so every
+/// mutating call is a hard SaaS-only error and ZERO Stripe calls are made. GET
+/// still returns the free-tier default.
+/// </summary>
+[TestFixture]
+public class NullBillingSubscriptionTests
+{
+    [Test]
+    public async Task SingleUser_Mutations_Throw_SaasOnly_With_Zero_Stripe_Calls()
+    {
+        var h = SubscriptionHarness.Create(
+            nameof(SingleUser_Mutations_Throw_SaasOnly_With_Zero_Stripe_Calls), enabled: false);
+        var tenantId = Guid.NewGuid();
+
+        Func<Task>[] mutations =
+        {
+            () => h.Service.CreateCheckoutSessionAsync(tenantId, "team", null, null),
+            () => h.Service.ChangePlanAsync(tenantId, "team"),
+            () => h.Service.CancelAsync(tenantId, false),
+            () => h.Service.ChangeSeatsAsync(tenantId, 3),
+        };
+
+        foreach (var mutate in mutations)
+        {
+            (await mutate.Should().ThrowAsync<Tamma.Core.TammaError>())
+                .Where(e => e.Code == SubscriptionService.SaasOnlyCode);
+        }
+
+        // Zero Stripe surface touched (AC11).
+        h.Factory.Verify(f => f.CreateAsync(It.IsAny<CancellationToken>()), Times.Never);
+        h.Checkout.VerifyNoOtherCalls();
+        h.Subscriptions.VerifyNoOtherCalls();
+        h.Schedules.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task SingleUser_Get_Returns_Free_Default()
+    {
+        var h = SubscriptionHarness.Create(
+            nameof(SingleUser_Get_Returns_Free_Default), enabled: false);
+
+        var projection = await h.Service.GetAsync(Guid.NewGuid());
+
+        projection.PlanSlug.Should().Be("free");
+        projection.Status.Should().Be("active");
+        projection.Seats.Should().Be(1);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionEndpointsRbacTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionEndpointsRbacTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Authorization;
+using Tamma.Api.Endpoints.Billing;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC2, AC9) — subscription endpoint RBAC. A <c>member</c> caller is
+/// rejected with 403 on every mutation BEFORE the service is touched;
+/// <c>admin</c>/<c>owner</c> pass; GET is allowed for any member.
+/// </summary>
+[TestFixture]
+public class SubscriptionEndpointsRbacTests
+{
+    private static readonly ILoggerFactory Logs = NullLoggerFactory.Instance;
+
+    private static HttpContext Ctx(string? role)
+    {
+        var http = new DefaultHttpContext();
+        if (role is not null)
+            http.Items[RequireTenantMembershipFilter.TenantRoleItemKey] = role;
+        return http;
+    }
+
+    private static int Status(IResult result)
+        => ((IStatusCodeHttpResult)result).StatusCode ?? StatusCodes.Status200OK;
+
+    [TestCase("member")]
+    [TestCase(null)]
+    public async Task Member_Gets_403_On_Every_Mutation_Without_Service_Call(string? role)
+    {
+        var svc = new Mock<ISubscriptionService>(MockBehavior.Strict);
+        var tenantId = Guid.NewGuid();
+
+        var checkout = await SubscriptionEndpoints.Checkout(
+            tenantId, new SubscriptionEndpoints.CheckoutRequest("team", null, null),
+            Ctx(role), svc.Object, Logs, CancellationToken.None);
+        var change = await SubscriptionEndpoints.ChangePlan(
+            tenantId, new SubscriptionEndpoints.ChangePlanRequest("team"),
+            Ctx(role), svc.Object, Logs, CancellationToken.None);
+        var cancel = await SubscriptionEndpoints.Cancel(
+            tenantId, new SubscriptionEndpoints.CancelRequest(true),
+            Ctx(role), svc.Object, Logs, CancellationToken.None);
+        var seats = await SubscriptionEndpoints.ChangeSeats(
+            tenantId, new SubscriptionEndpoints.SeatsRequest(3),
+            Ctx(role), svc.Object, Logs, CancellationToken.None);
+
+        Status(checkout).Should().Be(StatusCodes.Status403Forbidden);
+        Status(change).Should().Be(StatusCodes.Status403Forbidden);
+        Status(cancel).Should().Be(StatusCodes.Status403Forbidden);
+        Status(seats).Should().Be(StatusCodes.Status403Forbidden);
+
+        // Strict mock — never invoked (403 short-circuits before the service).
+        svc.VerifyNoOtherCalls();
+    }
+
+    [TestCase("admin")]
+    [TestCase("owner")]
+    public async Task Admin_And_Owner_Pass_Mutations_To_Service(string role)
+    {
+        var svc = new Mock<ISubscriptionService>();
+        svc.Setup(s => s.CancelAsync(It.IsAny<Guid>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionProjection.FreeDefault());
+        var tenantId = Guid.NewGuid();
+
+        var result = await SubscriptionEndpoints.Cancel(
+            tenantId, new SubscriptionEndpoints.CancelRequest(false),
+            Ctx(role), svc.Object, Logs, CancellationToken.None);
+
+        Status(result).Should().Be(StatusCodes.Status200OK);
+        svc.Verify(s => s.CancelAsync(tenantId, false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Member_Can_Read_Subscription()
+    {
+        var svc = new Mock<ISubscriptionService>();
+        svc.Setup(s => s.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionProjection.FreeDefault());
+        var tenantId = Guid.NewGuid();
+
+        var result = await SubscriptionEndpoints.GetSubscription(
+            tenantId, Ctx("member"), svc.Object, CancellationToken.None);
+
+        Status(result).Should().Be(StatusCodes.Status200OK);
+        svc.Verify(s => s.GetAsync(tenantId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Seats_Floor_Conflict_Maps_To_409()
+    {
+        var svc = new Mock<ISubscriptionService>();
+        svc.Setup(s => s.ChangeSeatsAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Tamma.Core.TammaError(
+                SubscriptionService.SeatsBelowActiveMembersCode, "too few seats"));
+        var tenantId = Guid.NewGuid();
+
+        var result = await SubscriptionEndpoints.ChangeSeats(
+            tenantId, new SubscriptionEndpoints.SeatsRequest(1),
+            Ctx("admin"), svc.Object, Logs, CancellationToken.None);
+
+        Status(result).Should().Be(StatusCodes.Status409Conflict);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorUpdaterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorUpdaterTests.cs
@@ -1,0 +1,184 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC5, AC7, AC8, AC13) — the shared <see cref="SubscriptionMirrorUpdater"/>:
+/// applies a Stripe object onto the mirror + <c>Tenant.Plan</c>/<c>PlanId</c>
+/// lockstep (no drift), takes status/period from the Stripe object (not the
+/// request), and emits exactly one <c>BILLING.SUBSCRIPTION.*</c> event per
+/// transition. A scheduled downgrade never touches the live plan.
+/// </summary>
+[TestFixture]
+public class SubscriptionMirrorUpdaterTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Apply_Created_Materializes_Mirror_And_Lockstep()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_Created_Materializes_Mirror_And_Lockstep));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "free");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End);
+        var projection = await h.Updater.ApplyAsync(
+            tenantId, sub, SubscriptionMirrorUpdater.TransitionCreated);
+
+        projection.PlanSlug.Should().Be("team");
+        projection.Status.Should().Be("active");
+
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.StripeSubscriptionId.Should().Be("sub_1");
+        mirror.PlanSlug.Should().Be("team");
+        mirror.Status.Should().Be("active");
+        mirror.CurrentPeriodStart.Should().Be(Start);
+        mirror.CurrentPeriodEnd.Should().Be(End);
+
+        // No-drift lockstep (AC7).
+        var tenant = await h.Db.Tenants.SingleAsync();
+        tenant.Plan.Should().Be("team");
+        var planId = (Guid?)h.Db.Entry(tenant).Property("PlanId").CurrentValue;
+        var teamPlanId = (await h.Db.Plans.SingleAsync(p => p.Slug == "team")).Id;
+        planId.Should().Be(teamPlanId);
+
+        h.Emitted.Should().ContainSingle(e =>
+            e.Type == BillingEvents.SubscriptionCreatedType && e.TenantId == tenantId);
+    }
+
+    [Test]
+    public async Task Apply_Takes_Status_And_Period_From_Stripe_Not_Mirror()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_Takes_Status_And_Period_From_Stripe_Not_Mirror));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", status: "active");
+
+        // Stripe now reports past_due with a NEW period — AC13: the mirror must
+        // reflect Stripe's confirmed state, never a stale request-side value.
+        var sub = SubscriptionHarness.MakeSub("sub_1", "past_due", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionUpdated);
+
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Status.Should().Be("past_due");
+        mirror.CurrentPeriodEnd.Should().Be(End);
+    }
+
+    [Test]
+    public async Task Apply_Immediate_Cancel_Sets_Free_And_Emits_Canceled()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_Immediate_Cancel_Sets_Free_And_Emits_Canceled));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "canceled", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionCanceled);
+
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Status.Should().Be("canceled");
+        mirror.PlanSlug.Should().Be("free");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("free");
+        h.Emitted.Should().ContainSingle(e =>
+            e.Type == BillingEvents.SubscriptionCanceledType && e.TenantId == tenantId);
+    }
+
+    [Test]
+    public async Task Apply_TrialEnded_Conversion_Emits_TrialEnded_Active()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_TrialEnded_Conversion_Emits_TrialEnded_Active));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", status: "trialing");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionTrialEnded);
+
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Status.Should().Be("active");
+        h.Emitted.Should().ContainSingle(e =>
+            e.Type == BillingEvents.SubscriptionTrialEndedType && e.TenantId == tenantId);
+    }
+
+    [Test]
+    public async Task Apply_TrialEnded_Expiry_Falls_To_Free()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_TrialEnded_Expiry_Falls_To_Free));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", status: "trialing");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "unpaid", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionTrialEnded);
+
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Status.Should().Be("unpaid");
+        mirror.PlanSlug.Should().Be("free");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("free");
+    }
+
+    [Test]
+    public async Task RecordScheduledDowngrade_Leaves_Live_Plan_Unchanged()
+    {
+        var h = SubscriptionHarness.Create(nameof(RecordScheduledDowngrade_Leaves_Live_Plan_Unchanged));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedTenant(tenantId, plan: "team");
+        var mirror = h.SeedMirror(tenantId, "team", "sub_1");
+        var effectiveAt = mirror.CurrentPeriodEnd;
+
+        var projection = await h.Updater.RecordScheduledDowngradeAsync(
+            mirror, "free", effectiveAt, "sub_sched_1");
+
+        projection.ScheduledPlanSlug.Should().Be("free");
+        projection.PlanSlug.Should().Be("team", "the live plan stays until the rollover webhook (AC3)");
+
+        var reloaded = await h.Db.BillingSubscriptions.SingleAsync();
+        reloaded.ScheduledPlanSlug.Should().Be("free");
+        reloaded.ScheduledEffectiveAt.Should().Be(effectiveAt);
+        reloaded.StripeScheduleId.Should().Be("sub_sched_1");
+        reloaded.PlanSlug.Should().Be("team");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("team");
+
+        h.Emitted.Should().ContainSingle(e =>
+            e.Type == BillingEvents.SubscriptionUpdatedType && e.Data.Contains("free"));
+    }
+
+    [Test]
+    public async Task Apply_Emits_One_Event_With_Tenant_Tags()
+    {
+        var h = SubscriptionHarness.Create(nameof(Apply_Emits_One_Event_With_Tenant_Tags));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionUpgraded);
+
+        h.Emitted.Should().HaveCount(1);
+        var evt = h.Emitted[0];
+        evt.Type.Should().Be(BillingEvents.SubscriptionUpdatedType);
+        evt.TenantId.Should().Be(tenantId);
+        evt.Tags.Should().Contain("team").And.Contain("active");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorUpdaterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorUpdaterTests.cs
@@ -96,28 +96,32 @@ public class SubscriptionMirrorUpdaterTests
     }
 
     [Test]
-    public async Task Apply_TrialEnded_Conversion_Emits_TrialEnded_Active()
+    public async Task Apply_TrialWillEnd_Emits_TrialEnding_Not_TrialEnded()
     {
-        var h = SubscriptionHarness.Create(nameof(Apply_TrialEnded_Conversion_Emits_TrialEnded_Active));
+        // trial_will_end fires BEFORE the trial ends → the DCB type must be the
+        // semantically-correct TRIAL_ENDING (matching Story 35-5's name), NOT
+        // TRIAL_ENDED (which would orphan any consumer on the 35-5 string).
+        var h = SubscriptionHarness.Create(nameof(Apply_TrialWillEnd_Emits_TrialEnding_Not_TrialEnded));
         var tenantId = Guid.NewGuid();
         h.SeedPlan("team", 50m);
         h.SeedCatalog("team", "price_team");
         h.SeedTenant(tenantId, plan: "team");
-        h.SeedMirror(tenantId, "team", "sub_1", status: "trialing");
+        // Still trialing when trial_will_end fires (3 days out).
+        h.SeedMirror(tenantId, "team", "sub_1", status: "active");
 
-        var sub = SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End);
-        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionTrialEnded);
+        var sub = SubscriptionHarness.MakeSub("sub_1", "trialing", "price_team", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionTrialWillEnd);
 
-        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
-        mirror.Status.Should().Be("active");
         h.Emitted.Should().ContainSingle(e =>
-            e.Type == BillingEvents.SubscriptionTrialEndedType && e.TenantId == tenantId);
+            e.Type == BillingEvents.SubscriptionTrialEndingType && e.TenantId == tenantId);
+        h.Emitted.Should().NotContain(e => e.Type == "BILLING.SUBSCRIPTION.TRIAL_ENDED");
+        BillingEvents.SubscriptionTrialEndingType.Should().Be("BILLING.SUBSCRIPTION.TRIAL_ENDING");
     }
 
     [Test]
-    public async Task Apply_TrialEnded_Expiry_Falls_To_Free()
+    public async Task Apply_Terminal_Trial_Expiry_Falls_To_Free()
     {
-        var h = SubscriptionHarness.Create(nameof(Apply_TrialEnded_Expiry_Falls_To_Free));
+        var h = SubscriptionHarness.Create(nameof(Apply_Terminal_Trial_Expiry_Falls_To_Free));
         var tenantId = Guid.NewGuid();
         h.SeedPlan("free", 0m);
         h.SeedPlan("team", 50m);
@@ -126,7 +130,7 @@ public class SubscriptionMirrorUpdaterTests
         h.SeedMirror(tenantId, "team", "sub_1", status: "trialing");
 
         var sub = SubscriptionHarness.MakeSub("sub_1", "unpaid", "price_team", Start, End);
-        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionTrialEnded);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionCanceled);
 
         var mirror = await h.Db.BillingSubscriptions.SingleAsync();
         mirror.Status.Should().Be("unpaid");
@@ -180,5 +184,84 @@ public class SubscriptionMirrorUpdaterTests
         evt.Type.Should().Be(BillingEvents.SubscriptionUpdatedType);
         evt.TenantId.Should().Be(tenantId);
         evt.Tags.Should().Contain("team").And.Contain("active");
+    }
+
+    [Test]
+    public async Task Apply_Same_Stripe_State_Twice_Emits_Exactly_One_Event()
+    {
+        // An API-initiated change applies once (emits), then the resulting Stripe
+        // webhook re-applies the SAME state. The second apply must NOT emit a
+        // duplicate DCB event (Epic 36/37 double-count) — emit only on real change.
+        var h = SubscriptionHarness.Create(nameof(Apply_Same_Stripe_State_Twice_Emits_Exactly_One_Event));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", status: "active");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "past_due", "price_team", Start, End);
+
+        // First apply changes the mirror (status active→past_due, new period) → emits.
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionUpdated);
+        h.Emitted.Should().HaveCount(1);
+
+        // Second apply of the IDENTICAL Stripe state is a pure replay → no emit.
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionUpdated);
+        h.Emitted.Should().HaveCount(1, "applying the same Stripe state twice emits exactly one event");
+    }
+
+    [Test]
+    public async Task Apply_Rollover_To_Scheduled_Target_Clears_Pending_Downgrade()
+    {
+        // When the schedule rolls over, Stripe fires customer.subscription.updated
+        // with the TARGET (free) price. ApplyAsync resolves effectiveSlug == free ==
+        // ScheduledPlanSlug and clears the pending-downgrade fields.
+        var h = SubscriptionHarness.Create(nameof(Apply_Rollover_To_Scheduled_Target_Clears_Pending_Downgrade));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("free", "price_free");
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        var mirror = h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+        mirror.ScheduledPlanSlug = "free";
+        mirror.ScheduledEffectiveAt = End;
+        mirror.StripeScheduleId = "sub_sched_1";
+        await h.Db.SaveChangesAsync();
+
+        // Rollover: the sub's base price is now the target (free) price.
+        var sub = SubscriptionHarness.MakeSub("sub_1", "active", "price_free", Start, End);
+        await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionUpdated);
+
+        var reloaded = await h.Db.BillingSubscriptions.SingleAsync();
+        reloaded.PlanSlug.Should().Be("free");
+        reloaded.ScheduledPlanSlug.Should().BeNull("the pending downgrade has rolled over");
+        reloaded.ScheduledEffectiveAt.Should().BeNull();
+        reloaded.StripeScheduleId.Should().BeNull();
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("free");
+    }
+
+    [Test]
+    public async Task Apply_Missing_Target_Plan_Row_Throws_Rather_Than_Drifting()
+    {
+        // Fail LOUD (Finding 5): a cancel→free with no seeded `free` Plan row must
+        // throw, not silently leave Tenant.Plan on the old higher plan.
+        var h = SubscriptionHarness.Create(nameof(Apply_Missing_Target_Plan_Row_Throws_Rather_Than_Drifting));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1");
+        // NB: no "free" plan seeded → the free-fallback lockstep has no target row.
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "canceled", "price_team", Start, End);
+        var act = async () =>
+            await h.Updater.ApplyAsync(tenantId, sub, SubscriptionMirrorUpdater.TransitionCanceled);
+
+        (await act.Should().ThrowAsync<Tamma.Core.TammaError>())
+            .Where(e => e.Code == SubscriptionMirrorUpdater.LockstepPlanMissingCode);
+
+        // Tenant.Plan was NOT silently downgraded/left stale via a committed drift.
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("team");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorWebhookHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionMirrorWebhookHandlerTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (Finding 4) — the registered <see cref="SubscriptionMirrorWebhookHandler"/>
+/// (which supersedes 35-5's audit-only handler) maps the Stripe
+/// <c>customer.subscription.trial_will_end</c> event to the semantically-correct
+/// <c>BILLING.SUBSCRIPTION.TRIAL_ENDING</c> DCB type — that Stripe event fires
+/// BEFORE the trial ends (the sub is still <c>trialing</c>), so it must not be
+/// labelled <c>..._ENDED</c>.
+/// </summary>
+[TestFixture]
+public class SubscriptionMirrorWebhookHandlerTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task TrialWillEnd_Webhook_Emits_TrialEnding()
+    {
+        var h = SubscriptionHarness.Create(nameof(TrialWillEnd_Webhook_Emits_TrialEnding));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", status: "trialing", periodEnd: End);
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "trialing", "price_team", Start, End);
+        var evt = new Stripe.Event
+        {
+            Id = "evt_twe",
+            Type = BillingWebhookEventTypes.SubscriptionTrialWillEnd,
+            Data = new Stripe.EventData { Object = sub },
+        };
+        var ctx = new BillingWebhookContext(
+            evt, tenantId, BillingWebhookEventTypes.SubscriptionTrialWillEnd,
+            "evt_twe", "sub_1", "{}");
+
+        var handler = new SubscriptionMirrorWebhookHandler(h.Updater);
+        var followup = await handler.HandleAsync(ctx, CancellationToken.None);
+
+        followup.Should().BeNull();
+        h.Emitted.Should().Contain(e => e.Type == BillingEvents.SubscriptionTrialEndingType);
+        h.Emitted.Should().NotContain(e => e.Type == "BILLING.SUBSCRIPTION.TRIAL_ENDED");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCancelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCancelTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC4) — <c>CancelAsync</c>: at-period-end keeps status
+/// <c>active</c> + sets <c>CancelAtPeriodEnd</c>; immediate flips to
+/// <c>canceled</c> and recomputes <c>Tenant.Plan</c> to free now.
+/// </summary>
+[TestFixture]
+public class SubscriptionServiceCancelTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Cancel_AtPeriodEnd_Keeps_Active_And_Sets_Flag()
+    {
+        var h = SubscriptionHarness.Create(nameof(Cancel_AtPeriodEnd_Keeps_Active_And_Sets_Flag));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+
+        Stripe.SubscriptionUpdateOptions? captured = null;
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, _, _) => captured = o)
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End, cancelAtPeriodEnd: true));
+
+        var projection = await h.Service.CancelAsync(tenantId, atPeriodEnd: true);
+
+        captured!.CancelAtPeriodEnd.Should().Be(true);
+        projection.Status.Should().Be("active");
+        projection.CancelAtPeriodEnd.Should().BeTrue();
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("team");
+        h.Emitted.Should().Contain(e =>
+            e.Type == Tamma.Api.Services.Billing.BillingEvents.SubscriptionCanceledType);
+    }
+
+    [Test]
+    public async Task Cancel_Immediate_Flips_To_Canceled_And_Free()
+    {
+        var h = SubscriptionHarness.Create(nameof(Cancel_Immediate_Flips_To_Canceled_And_Free));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+
+        h.Subscriptions.Setup(s => s.CancelAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionCancelOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub("sub_1", "canceled", "price_team", Start, End));
+
+        var projection = await h.Service.CancelAsync(tenantId, atPeriodEnd: false);
+
+        projection.Status.Should().Be("canceled");
+        projection.PlanSlug.Should().Be("free");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("free");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceChangeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceChangeTests.cs
@@ -49,7 +49,8 @@ public class SubscriptionServiceChangeTests
         captured.Items.Should().ContainSingle();
         captured.Items[0].Id.Should().Be("si_base");
         captured.Items[0].Price.Should().Be("price_enterprise");
-        capturedRo!.IdempotencyKey.Should().Be($"sub-change-{tenantId:D}-enterprise-{End:yyyyMMdd}");
+        capturedRo!.IdempotencyKey.Should().Be(
+            $"sub-change-{tenantId:D}-team-to-enterprise-{End:yyyyMMdd}");
 
         projection.PlanSlug.Should().Be("enterprise");
         (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("enterprise");
@@ -57,9 +58,10 @@ public class SubscriptionServiceChangeTests
     }
 
     [Test]
-    public async Task Downgrade_Schedules_And_Leaves_Live_Plan_Unchanged()
+    public async Task Downgrade_Schedules_TwoPhase_With_Target_Price_And_Leaves_Live_Plan_Unchanged()
     {
-        var h = SubscriptionHarness.Create(nameof(Downgrade_Schedules_And_Leaves_Live_Plan_Unchanged));
+        var h = SubscriptionHarness.Create(
+            nameof(Downgrade_Schedules_TwoPhase_With_Target_Price_And_Leaves_Live_Plan_Unchanged));
         var tenantId = Guid.NewGuid();
         h.SeedPlan("free", 0m);
         h.SeedPlan("team", 50m);
@@ -68,30 +70,113 @@ public class SubscriptionServiceChangeTests
         h.SeedTenant(tenantId, plan: "team");
         h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
 
-        Stripe.SubscriptionScheduleCreateOptions? captured = null;
-        Stripe.RequestOptions? capturedRo = null;
+        // A from_subscription create returns a single-phase schedule mirroring the
+        // CURRENT (team) sub through the current period end.
+        Stripe.SubscriptionScheduleCreateOptions? createOpts = null;
+        Stripe.RequestOptions? createRo = null;
         h.Schedules.Setup(s => s.CreateAsync(
                 It.IsAny<Stripe.SubscriptionScheduleCreateOptions>(),
                 It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
             .Callback<Stripe.SubscriptionScheduleCreateOptions, Stripe.RequestOptions, CancellationToken>(
-                (o, ro, _) => { captured = o; capturedRo = ro; })
-            .ReturnsAsync(new Stripe.SubscriptionSchedule { Id = "sub_sched_1" });
+                (o, ro, _) => { createOpts = o; createRo = ro; })
+            .ReturnsAsync(SubscriptionHarness.MakeSchedule("sub_sched_1", "price_team", Start, End));
+
+        // The real scheduled downgrade is the UPDATE: two phases, phase 2 carrying
+        // the TARGET (free) price id.
+        Stripe.SubscriptionScheduleUpdateOptions? updateOpts = null;
+        Stripe.RequestOptions? updateRo = null;
+        h.Schedules.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionScheduleUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionScheduleUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, ro, _) => { updateOpts = o; updateRo = ro; })
+            .ReturnsAsync(SubscriptionHarness.MakeSchedule("sub_sched_1", "price_free", Start, End));
 
         var projection = await h.Service.ChangePlanAsync(tenantId, "free");
 
-        captured!.FromSubscription.Should().Be("sub_1");
-        capturedRo!.IdempotencyKey.Should().Be($"sub-downgrade-{tenantId:D}-free-{End:yyyyMMdd}");
+        createOpts!.FromSubscription.Should().Be("sub_1");
+        createRo!.IdempotencyKey.Should().Be($"sub-downgrade-{tenantId:D}-team-to-free-{End:yyyyMMdd}");
 
+        // The schedule UPDATE is what actually applies the downgrade at period end.
+        updateOpts.Should().NotBeNull();
+        updateOpts!.EndBehavior.Should().Be("release");
+        updateOpts.Phases.Should().HaveCount(2);
+        // Phase 1 = the current (team) price through the current period end.
+        updateOpts.Phases[0].Items.Should().ContainSingle();
+        updateOpts.Phases[0].Items[0].Price.Should().Be("price_team");
+        // Phase 2 = the TARGET (free) price — the crux of the fix.
+        updateOpts.Phases[1].Items.Should().ContainSingle();
+        updateOpts.Phases[1].Items[0].Price.Should().Be("price_free");
+        updateRo!.IdempotencyKey.Should().Be(
+            $"sub-downgrade-update-{tenantId:D}-team-to-free-{End:yyyyMMdd}");
+
+        // Live plan / Tenant.Plan stay on team until the rollover webhook (AC3).
         projection.ScheduledPlanSlug.Should().Be("free");
         projection.PlanSlug.Should().Be("team");
         var mirror = await h.Db.BillingSubscriptions.SingleAsync();
         mirror.PlanSlug.Should().Be("team");
         mirror.StripeScheduleId.Should().Be("sub_sched_1");
+        mirror.ScheduledEffectiveAt.Should().Be(End);
         (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("team");
 
-        // No immediate subscription update on a downgrade.
+        // No immediate subscription UPDATE on a downgrade (only the schedule moves).
         h.Subscriptions.Verify(s => s.UpdateAsync(
             It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
             It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Plan_Change_Keys_Distinguish_Source_Slug_But_Dedup_Same_Intent()
+    {
+        // Two DISTINCT upgrade intents to the SAME target (enterprise) from DIFFERENT
+        // sources (team vs team2) must get DISTINCT keys — otherwise Stripe replays
+        // the first and never re-applies the second (drift). A genuine retry of the
+        // SAME source→target dedups. Before the fix the key was keyed only on the
+        // TARGET slug, so team→enterprise and team2→enterprise COLLIDED.
+        var h = SubscriptionHarness.Create(
+            nameof(Plan_Change_Keys_Distinguish_Source_Slug_But_Dedup_Same_Intent));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedPlan("team2", 50m);
+        h.SeedPlan("enterprise", 100m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedCatalog("team2", "price_team2");
+        h.SeedCatalog("enterprise", "price_enterprise");
+        h.SeedTenant(tenantId, plan: "team");
+        var mirror = h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+
+        h.Subscriptions.Setup(s => s.GetAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionGetOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End));
+
+        var keys = new List<string?>();
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, ro, _) => keys.Add(ro.IdempotencyKey))
+            .ReturnsAsync((string _, Stripe.SubscriptionUpdateOptions o, Stripe.RequestOptions _, CancellationToken _) =>
+                SubscriptionHarness.MakeSub("sub_1", "active", o.Items[0].Price, Start, End));
+
+        // team → enterprise
+        await h.Service.ChangePlanAsync(tenantId, "enterprise");
+        // Reset the source to team2, then team2 → enterprise (SAME target, DIFFERENT source).
+        mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.PlanSlug = "team2";
+        await h.Db.SaveChangesAsync();
+        await h.Service.ChangePlanAsync(tenantId, "enterprise");
+        // Reset the source back to team, retry team → enterprise (SAME intent as call 1).
+        mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.PlanSlug = "team";
+        await h.Db.SaveChangesAsync();
+        await h.Service.ChangePlanAsync(tenantId, "enterprise");
+
+        keys.Should().HaveCount(3);
+        keys[0].Should().Be($"sub-change-{tenantId:D}-team-to-enterprise-{End:yyyyMMdd}");
+        keys[1].Should().Be($"sub-change-{tenantId:D}-team2-to-enterprise-{End:yyyyMMdd}");
+        keys[0].Should().NotBe(keys[1],
+            "distinct source→same-target intents must get distinct keys (else Stripe replays)");
+        keys[2].Should().Be(keys[0], "a genuine retry of the SAME source→target dedups");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceChangeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceChangeTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC3, AC7, AC10) — <c>ChangePlanAsync</c>: an upgrade updates the
+/// Stripe subscription with immediate proration and applies the new slug now; a
+/// downgrade creates a Subscription Schedule, records the scheduled fields, and
+/// leaves the live plan / <c>Tenant.Plan</c> at the current (higher) plan.
+/// </summary>
+[TestFixture]
+public class SubscriptionServiceChangeTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Upgrade_Prorates_And_Applies_New_Slug_Now()
+    {
+        var h = SubscriptionHarness.Create(nameof(Upgrade_Prorates_And_Applies_New_Slug_Now));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedPlan("enterprise", 100m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedCatalog("enterprise", "price_enterprise");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+
+        h.Subscriptions.Setup(s => s.GetAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionGetOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub("sub_1", "active", "price_team", Start, End));
+
+        Stripe.SubscriptionUpdateOptions? captured = null;
+        Stripe.RequestOptions? capturedRo = null;
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, ro, _) => { captured = o; capturedRo = ro; })
+            .ReturnsAsync(SubscriptionHarness.MakeSub("sub_1", "active", "price_enterprise", Start, End));
+
+        var projection = await h.Service.ChangePlanAsync(tenantId, "enterprise");
+
+        captured!.ProrationBehavior.Should().Be("create_prorations");
+        captured.Items.Should().ContainSingle();
+        captured.Items[0].Id.Should().Be("si_base");
+        captured.Items[0].Price.Should().Be("price_enterprise");
+        capturedRo!.IdempotencyKey.Should().Be($"sub-change-{tenantId:D}-enterprise-{End:yyyyMMdd}");
+
+        projection.PlanSlug.Should().Be("enterprise");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("enterprise");
+        h.Emitted.Should().Contain(e => e.Type == Tamma.Api.Services.Billing.BillingEvents.SubscriptionUpdatedType);
+    }
+
+    [Test]
+    public async Task Downgrade_Schedules_And_Leaves_Live_Plan_Unchanged()
+    {
+        var h = SubscriptionHarness.Create(nameof(Downgrade_Schedules_And_Leaves_Live_Plan_Unchanged));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("free", 0m);
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("free", "price_free");
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", periodEnd: End);
+
+        Stripe.SubscriptionScheduleCreateOptions? captured = null;
+        Stripe.RequestOptions? capturedRo = null;
+        h.Schedules.Setup(s => s.CreateAsync(
+                It.IsAny<Stripe.SubscriptionScheduleCreateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stripe.SubscriptionScheduleCreateOptions, Stripe.RequestOptions, CancellationToken>(
+                (o, ro, _) => { captured = o; capturedRo = ro; })
+            .ReturnsAsync(new Stripe.SubscriptionSchedule { Id = "sub_sched_1" });
+
+        var projection = await h.Service.ChangePlanAsync(tenantId, "free");
+
+        captured!.FromSubscription.Should().Be("sub_1");
+        capturedRo!.IdempotencyKey.Should().Be($"sub-downgrade-{tenantId:D}-free-{End:yyyyMMdd}");
+
+        projection.ScheduledPlanSlug.Should().Be("free");
+        projection.PlanSlug.Should().Be("team");
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.PlanSlug.Should().Be("team");
+        mirror.StripeScheduleId.Should().Be("sub_sched_1");
+        (await h.Db.Tenants.SingleAsync()).Plan.Should().Be("team");
+
+        // No immediate subscription update on a downgrade.
+        h.Subscriptions.Verify(s => s.UpdateAsync(
+            It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+            It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCheckoutTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCheckoutTests.cs
@@ -46,7 +46,7 @@ public class SubscriptionServiceCheckoutTests
         captured.LineItems[1].Price.Should().Be("price_seats");
         captured.LineItems[1].Quantity.Should().Be(3);
         captured.SubscriptionData!.TrialPeriodDays.Should().Be(14);
-        capturedRo!.IdempotencyKey.Should().Be($"sub-checkout-{tenantId:D}-team");
+        capturedRo!.IdempotencyKey.Should().Be($"sub-checkout-{tenantId:D}-team-s3-t14");
 
         // No local mirror row is created here (AC2).
         (await h.Db.BillingSubscriptions.CountAsync()).Should().Be(0);
@@ -73,6 +73,36 @@ public class SubscriptionServiceCheckoutTests
 
         captured!.LineItems.Should().HaveCount(1);
         captured.SubscriptionData.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Checkout_Keys_Differ_When_Params_Differ_But_Dedup_When_Same()
+    {
+        // Two checkouts for the SAME plan but DIFFERENT params (seats/trialDays) must
+        // get DISTINCT keys — a same-key replay with different params 502s at Stripe.
+        // A genuine retry of the SAME params dedups. Before the fix the key was only
+        // (tenant, planSlug), so different-param checkouts COLLIDED.
+        var h = SubscriptionHarness.Create(nameof(Checkout_Keys_Differ_When_Params_Differ_But_Dedup_When_Same));
+        var tenantId = Guid.NewGuid();
+        h.SeedCustomer(tenantId, "cus_x");
+        h.SeedCatalog("team", "price_team", "price_seats");
+
+        var keys = new List<string?>();
+        h.Checkout.Setup(c => c.CreateAsync(
+                It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stripe.Checkout.SessionCreateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, ro, _) => keys.Add(ro.IdempotencyKey))
+            .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs", Url = "https://checkout/cs" });
+
+        await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: 3, trialDays: 14);
+        await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: 5, trialDays: 14);
+        await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: 3, trialDays: 14);
+
+        keys[0].Should().Be($"sub-checkout-{tenantId:D}-team-s3-t14");
+        keys[1].Should().Be($"sub-checkout-{tenantId:D}-team-s5-t14");
+        keys[0].Should().NotBe(keys[1], "different seats ⇒ different key (else Stripe 502s on param mismatch)");
+        keys[2].Should().Be(keys[0], "identical params dedup");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCheckoutTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceCheckoutTests.cs
@@ -1,0 +1,89 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC2, AC10) — <c>CreateCheckoutSessionAsync</c> builds a
+/// <c>mode=subscription</c> Stripe Checkout Session with the right base price,
+/// optional seats line + trial days, and a deterministic idempotency key. No
+/// local mirror row is created (the 35-5 webhook materializes it).
+/// </summary>
+[TestFixture]
+public class SubscriptionServiceCheckoutTests
+{
+    [Test]
+    public async Task Checkout_Builds_Session_With_Price_Seats_Trial_And_IdempotencyKey()
+    {
+        var h = SubscriptionHarness.Create(nameof(Checkout_Builds_Session_With_Price_Seats_Trial_And_IdempotencyKey));
+        var tenantId = Guid.NewGuid();
+        h.SeedCustomer(tenantId, "cus_abc");
+        h.SeedCatalog("team", "price_team", "price_seats");
+
+        Stripe.Checkout.SessionCreateOptions? captured = null;
+        Stripe.RequestOptions? capturedRo = null;
+        h.Checkout.Setup(c => c.CreateAsync(
+                It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Stripe.Checkout.SessionCreateOptions, Stripe.RequestOptions, CancellationToken>(
+                (o, ro, _) => { captured = o; capturedRo = ro; })
+            .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_1", Url = "https://checkout.stripe/cs_1" });
+
+        var result = await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: 3, trialDays: 14);
+
+        result.CheckoutUrl.Should().Be("https://checkout.stripe/cs_1");
+        result.StripeSessionId.Should().Be("cs_1");
+
+        captured.Should().NotBeNull();
+        captured!.Mode.Should().Be("subscription");
+        captured.Customer.Should().Be("cus_abc");
+        captured.LineItems.Should().HaveCount(2);
+        captured.LineItems[0].Price.Should().Be("price_team");
+        captured.LineItems[0].Quantity.Should().Be(1);
+        captured.LineItems[1].Price.Should().Be("price_seats");
+        captured.LineItems[1].Quantity.Should().Be(3);
+        captured.SubscriptionData!.TrialPeriodDays.Should().Be(14);
+        capturedRo!.IdempotencyKey.Should().Be($"sub-checkout-{tenantId:D}-team");
+
+        // No local mirror row is created here (AC2).
+        (await h.Db.BillingSubscriptions.CountAsync()).Should().Be(0);
+    }
+
+    [Test]
+    public async Task Checkout_Without_Seats_Or_Trial_Has_Single_LineItem()
+    {
+        var h = SubscriptionHarness.Create(nameof(Checkout_Without_Seats_Or_Trial_Has_Single_LineItem));
+        var tenantId = Guid.NewGuid();
+        h.SeedCustomer(tenantId);
+        h.SeedCatalog("team", "price_team", "price_seats");
+
+        Stripe.Checkout.SessionCreateOptions? captured = null;
+        h.Checkout.Setup(c => c.CreateAsync(
+                It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Stripe.Checkout.SessionCreateOptions, Stripe.RequestOptions, CancellationToken>(
+                (o, _, _) => captured = o)
+            .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_2", Url = "https://checkout.stripe/cs_2" });
+
+        await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: null, trialDays: null);
+
+        captured!.LineItems.Should().HaveCount(1);
+        captured.SubscriptionData.Should().BeNull();
+    }
+
+    [Test]
+    public void Checkout_Without_Customer_Mapping_Throws()
+    {
+        var h = SubscriptionHarness.Create(nameof(Checkout_Without_Customer_Mapping_Throws));
+        var tenantId = Guid.NewGuid();
+        h.SeedCatalog("team", "price_team");
+
+        var act = async () => await h.Service.CreateCheckoutSessionAsync(tenantId, "team", null, null);
+        act.Should().ThrowAsync<Tamma.Core.TammaError>()
+            .Where(e => e.Code == Tamma.Api.Services.Billing.SubscriptionService.NoCustomerCode);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceSeatsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceSeatsTests.cs
@@ -101,4 +101,58 @@ public class SubscriptionServiceSeatsTests
         var projection = await h.Service.ChangeSeatsAsync(tenantId, 3);
         projection.Seats.Should().Be(3);
     }
+
+    [Test]
+    public async Task Seat_Keys_Distinguish_From_Count_But_Dedup_Same_Intent()
+    {
+        // Two DISTINCT seat intents to the SAME target (10) from DIFFERENT current
+        // counts (5 vs 8) must get DISTINCT keys — otherwise Stripe replays the
+        // first cached response and never re-applies the second (Stripe drifts from
+        // the mirror). A genuine retry of the SAME from→to dedups. Before the fix
+        // the key was keyed only on the TARGET count, so 5→10 and 8→10 COLLIDED.
+        var h = SubscriptionHarness.Create(nameof(Seat_Keys_Distinguish_From_Count_But_Dedup_Same_Intent));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team", "price_seats");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", seats: 5, periodEnd: End);
+        // No SeedMembers → 0 active members → every decrease is allowed.
+
+        h.Subscriptions.Setup(s => s.GetAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionGetOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End,
+                seatsPriceId: "price_seats", seatsQty: 5));
+
+        var keys = new List<string?>();
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, ro, _) => keys.Add(ro.IdempotencyKey))
+            .ReturnsAsync((string _, Stripe.SubscriptionUpdateOptions o, Stripe.RequestOptions _, CancellationToken _) =>
+                SubscriptionHarness.MakeSub(
+                    "sub_1", "active", "price_team", Start, End,
+                    seatsPriceId: "price_seats", seatsQty: o.Items[0].Quantity ?? 0));
+
+        await h.Service.ChangeSeatsAsync(tenantId, 10); // 5 → 10 (mirror advances to 10)
+        // Reset the current count to 8, then 8 → 10 (SAME target, DIFFERENT source).
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Seats = 8;
+        await h.Db.SaveChangesAsync();
+        await h.Service.ChangeSeatsAsync(tenantId, 10);
+        // Reset the current count back to 5, retry 5 → 10 (SAME intent as call 1).
+        mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Seats = 5;
+        await h.Db.SaveChangesAsync();
+        await h.Service.ChangeSeatsAsync(tenantId, 10);
+
+        keys.Should().HaveCount(3);
+        keys[0].Should().Be($"sub-seats-{tenantId:D}-5-to-10-{End:yyyyMMdd}");
+        keys[1].Should().Be($"sub-seats-{tenantId:D}-8-to-10-{End:yyyyMMdd}");
+        keys[0].Should().NotBe(keys[1],
+            "distinct from→same-target seat intents must get distinct keys (else Stripe replays)");
+        keys[2].Should().Be(keys[0], "a genuine retry of the SAME seat change dedups");
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceSeatsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceSeatsTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC6) — <c>ChangeSeatsAsync</c>: an increase updates the Stripe
+/// seat quantity + the mirror <c>Seats</c>; a decrease below the tenant's active
+/// membership count is rejected with <c>seats_below_active_members</c> BEFORE any
+/// Stripe call.
+/// </summary>
+[TestFixture]
+public class SubscriptionServiceSeatsTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Increase_Updates_Stripe_Quantity_And_Mirror_Seats()
+    {
+        var h = SubscriptionHarness.Create(nameof(Increase_Updates_Stripe_Quantity_And_Mirror_Seats));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team", "price_seats");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", seats: 1, periodEnd: End);
+        h.SeedMembers(tenantId, 1);
+
+        h.Subscriptions.Setup(s => s.GetAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionGetOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End,
+                seatsPriceId: "price_seats", seatsQty: 1));
+
+        Stripe.SubscriptionUpdateOptions? captured = null;
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Stripe.SubscriptionUpdateOptions, Stripe.RequestOptions, CancellationToken>(
+                (_, o, _, _) => captured = o)
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End,
+                seatsPriceId: "price_seats", seatsQty: 5));
+
+        var projection = await h.Service.ChangeSeatsAsync(tenantId, 5);
+
+        captured!.Items.Should().ContainSingle();
+        captured.Items[0].Id.Should().Be("si_seat");
+        captured.Items[0].Quantity.Should().Be(5);
+        projection.Seats.Should().Be(5);
+        (await h.Db.BillingSubscriptions.SingleAsync()).Seats.Should().Be(5);
+    }
+
+    [Test]
+    public async Task Decrease_Below_Active_Members_Rejected_With_No_Stripe_Call()
+    {
+        var h = SubscriptionHarness.Create(nameof(Decrease_Below_Active_Members_Rejected_With_No_Stripe_Call));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team", "price_seats");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", seats: 5, periodEnd: End);
+        h.SeedMembers(tenantId, 3);
+
+        var act = async () => await h.Service.ChangeSeatsAsync(tenantId, 2);
+
+        (await act.Should().ThrowAsync<Tamma.Core.TammaError>())
+            .Where(e => e.Code == Tamma.Api.Services.Billing.SubscriptionService.SeatsBelowActiveMembersCode);
+
+        // Rejected before any Stripe call (AC6).
+        h.Factory.Verify(f => f.CreateAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Seats_Equal_To_Active_Members_Allowed()
+    {
+        var h = SubscriptionHarness.Create(nameof(Seats_Equal_To_Active_Members_Allowed));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team", "price_seats");
+        h.SeedTenant(tenantId, plan: "team");
+        h.SeedMirror(tenantId, "team", "sub_1", seats: 5, periodEnd: End);
+        h.SeedMembers(tenantId, 3);
+
+        h.Subscriptions.Setup(s => s.GetAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionGetOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End,
+                seatsPriceId: "price_seats", seatsQty: 5));
+        h.Subscriptions.Setup(s => s.UpdateAsync(
+                It.IsAny<string>(), It.IsAny<Stripe.SubscriptionUpdateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SubscriptionHarness.MakeSub(
+                "sub_1", "active", "price_team", Start, End,
+                seatsPriceId: "price_seats", seatsQty: 3));
+
+        var projection = await h.Service.ChangeSeatsAsync(tenantId, 3);
+        projection.Seats.Should().Be(3);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceTrialTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceTrialTests.cs
@@ -9,8 +9,9 @@ namespace Tamma.Api.Tests.Billing;
 /// <summary>
 /// Story 35-4 (AC5) — trial handling: a checkout with <c>trialDays</c> passes the
 /// trial period to Stripe; a trialing subscription applied through the shared
-/// updater sets <c>Status=trialing</c> + <c>TrialEnd</c>; conversion/expiry emit
-/// <c>BILLING.SUBSCRIPTION.TRIAL_ENDED</c> (covered in the updater tests).
+/// updater sets <c>Status=trialing</c> + <c>TrialEnd</c>; the pre-end
+/// <c>trial_will_end</c> event emits <c>BILLING.SUBSCRIPTION.TRIAL_ENDING</c>
+/// (covered in the updater tests).
 /// </summary>
 [TestFixture]
 public class SubscriptionServiceTrialTests

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceTrialTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionServiceTrialTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 (AC5) — trial handling: a checkout with <c>trialDays</c> passes the
+/// trial period to Stripe; a trialing subscription applied through the shared
+/// updater sets <c>Status=trialing</c> + <c>TrialEnd</c>; conversion/expiry emit
+/// <c>BILLING.SUBSCRIPTION.TRIAL_ENDED</c> (covered in the updater tests).
+/// </summary>
+[TestFixture]
+public class SubscriptionServiceTrialTests
+{
+    private static readonly DateTime Start = new(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime End = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Trial = new(2026, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public async Task Checkout_With_TrialDays_Sets_TrialPeriod()
+    {
+        var h = SubscriptionHarness.Create(nameof(Checkout_With_TrialDays_Sets_TrialPeriod));
+        var tenantId = Guid.NewGuid();
+        h.SeedCustomer(tenantId);
+        h.SeedCatalog("team", "price_team");
+
+        Stripe.Checkout.SessionCreateOptions? captured = null;
+        h.Checkout.Setup(c => c.CreateAsync(
+                It.IsAny<Stripe.Checkout.SessionCreateOptions>(),
+                It.IsAny<Stripe.RequestOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<Stripe.Checkout.SessionCreateOptions, Stripe.RequestOptions, CancellationToken>(
+                (o, _, _) => captured = o)
+            .ReturnsAsync(new Stripe.Checkout.Session { Id = "cs_trial", Url = "https://checkout/trial" });
+
+        await h.Service.CreateCheckoutSessionAsync(tenantId, "team", seats: null, trialDays: 30);
+
+        captured!.SubscriptionData!.TrialPeriodDays.Should().Be(30);
+    }
+
+    [Test]
+    public async Task Trialing_Subscription_Materializes_With_TrialEnd()
+    {
+        var h = SubscriptionHarness.Create(nameof(Trialing_Subscription_Materializes_With_TrialEnd));
+        var tenantId = Guid.NewGuid();
+        h.SeedPlan("team", 50m);
+        h.SeedCatalog("team", "price_team");
+        h.SeedTenant(tenantId, plan: "free");
+
+        var sub = SubscriptionHarness.MakeSub("sub_1", "trialing", "price_team", Start, End, trialEnd: Trial);
+        var projection = await h.Updater.ApplyAsync(
+            tenantId, sub, SubscriptionMirrorUpdater.TransitionCreated);
+
+        projection.Status.Should().Be("trialing");
+        projection.TrialEnd.Should().Be(Trial);
+        var mirror = await h.Db.BillingSubscriptions.SingleAsync();
+        mirror.Status.Should().Be("trialing");
+        mirror.TrialEnd.Should().Be(Trial);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionTestSupport.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionTestSupport.cs
@@ -219,4 +219,31 @@ internal sealed class SubscriptionHarness
             Items = new Stripe.StripeList<Stripe.SubscriptionItem> { Data = items },
         };
     }
+
+    /// <summary>
+    /// Fabricate a <see cref="Stripe.SubscriptionSchedule"/> as returned by a
+    /// <c>from_subscription</c> create: a single phase[0] mirroring the current sub
+    /// (base price item + current-period boundaries). The service reads this phase
+    /// to build phase 1 of the two-phase downgrade update.
+    /// </summary>
+    public static Stripe.SubscriptionSchedule MakeSchedule(
+        string id, string currentPriceId, DateTime periodStart, DateTime periodEnd,
+        long currentQty = 1)
+        => new()
+        {
+            Id = id,
+            EndBehavior = "release",
+            Phases = new List<Stripe.SubscriptionSchedulePhase>
+            {
+                new()
+                {
+                    StartDate = periodStart,
+                    EndDate = periodEnd,
+                    Items = new List<Stripe.SubscriptionSchedulePhaseItem>
+                    {
+                        new() { Price = new Stripe.Price { Id = currentPriceId }, Quantity = currentQty },
+                    },
+                },
+            },
+        };
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionTestSupport.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/SubscriptionTestSupport.cs
@@ -1,0 +1,222 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Tamma.Api.Services.Billing;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-4 — shared in-memory harness for the subscription lifecycle unit
+/// tests. Wires the real <see cref="SubscriptionMirrorUpdater"/> +
+/// <see cref="BillingSubscriptionRepository"/> over an EF InMemory
+/// <see cref="ControlPlaneDbContext"/>, with Stripe (subscription / schedule /
+/// checkout) mocked at the <see cref="IStripeServices"/> boundary. Emitted DCB
+/// events are captured in <see cref="Emitted"/>.
+/// </summary>
+internal sealed class SubscriptionHarness
+{
+    public ControlPlaneDbContext Db { get; }
+    public Mock<IBillingProvider> Provider { get; }
+    public Mock<IStripeServicesFactory> Factory { get; }
+    public Mock<IStripeServices> Stripe { get; }
+    public Mock<Stripe.SubscriptionService> Subscriptions { get; }
+    public Mock<Stripe.SubscriptionScheduleService> Schedules { get; }
+    public Mock<Stripe.Checkout.SessionService> Checkout { get; }
+    public Mock<IBillingCatalog> Catalog { get; }
+    public Mock<IEventRepository> Events { get; }
+    public Mock<ITenantMembershipRepository> Members { get; }
+    public BillingSubscriptionRepository Repo { get; }
+    public SubscriptionMirrorUpdater Updater { get; }
+    public SubscriptionService Service { get; }
+    public List<DomainEvent> Emitted { get; } = new();
+
+    private SubscriptionHarness(string dbName, bool enabled)
+    {
+        Db = new ControlPlaneDbContext(
+            new DbContextOptionsBuilder<ControlPlaneDbContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options);
+
+        Provider = new Mock<IBillingProvider>();
+        Provider.SetupGet(p => p.IsEnabled).Returns(enabled);
+
+        Subscriptions = new Mock<Stripe.SubscriptionService>();
+        Schedules = new Mock<Stripe.SubscriptionScheduleService>();
+        Checkout = new Mock<Stripe.Checkout.SessionService>();
+
+        Stripe = new Mock<IStripeServices>();
+        Stripe.SetupGet(s => s.Subscriptions).Returns(Subscriptions.Object);
+        Stripe.SetupGet(s => s.SubscriptionSchedules).Returns(Schedules.Object);
+        Stripe.SetupGet(s => s.CheckoutSessions).Returns(Checkout.Object);
+
+        Factory = new Mock<IStripeServicesFactory>();
+        Factory.Setup(f => f.CreateAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Stripe.Object);
+
+        Events = new Mock<IEventRepository>();
+        Events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .Callback<DomainEvent>(Emitted.Add)
+            .ReturnsAsync((DomainEvent d) => d);
+
+        Catalog = new Mock<IBillingCatalog>();
+        Members = new Mock<ITenantMembershipRepository>();
+        Members.Setup(m => m.ListAllByTenantAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new List<TenantMembership>());
+
+        Repo = new BillingSubscriptionRepository(Db);
+        Updater = new SubscriptionMirrorUpdater(
+            Db, Repo, Events.Object, TimeProvider.System,
+            NullLogger<SubscriptionMirrorUpdater>.Instance);
+        Service = new SubscriptionService(
+            Provider.Object, Factory.Object, Catalog.Object, Repo, Updater, Db,
+            Members.Object, Options.Create(new BillingOptions()),
+            NullLogger<SubscriptionService>.Instance);
+    }
+
+    public static SubscriptionHarness Create(string dbName, bool enabled = true)
+        => new(dbName, enabled);
+
+    // ── seeding ──
+
+    public void SeedPlan(string slug, decimal monthlyPriceUsd)
+    {
+        Db.Plans.Add(new Plan
+        {
+            Id = Guid.NewGuid(),
+            Slug = slug,
+            DisplayName = slug,
+            Status = "active",
+            IsActive = true,
+            MonthlyPriceUsd = monthlyPriceUsd,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        Db.SaveChanges();
+    }
+
+    /// <summary>Seed a catalog row (db + <see cref="IBillingCatalog"/> mock) for a slug.</summary>
+    public BillingPlanPrice SeedCatalog(string slug, string basePriceId, string? seatsPriceId = null)
+    {
+        var row = new BillingPlanPrice
+        {
+            Id = Guid.NewGuid(),
+            PlanSlug = slug,
+            StripeProductId = $"prod_{slug}",
+            StripePriceId = basePriceId,
+            SeatsPriceId = seatsPriceId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        Db.BillingPlanPrices.Add(row);
+        Db.SaveChanges();
+        Catalog.Setup(c => c.GetBySlugAsync(slug, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(row);
+        return row;
+    }
+
+    public Tenant SeedTenant(Guid tenantId, string plan = "free")
+    {
+        var tenant = new Tenant
+        {
+            Id = tenantId,
+            Name = $"tenant-{tenantId:N}",
+            Slug = $"t-{tenantId:N}"[..12],
+            Plan = plan,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        Db.Tenants.Add(tenant);
+        Db.SaveChanges();
+        return tenant;
+    }
+
+    public void SeedCustomer(Guid tenantId, string stripeCustomerId = "cus_test")
+    {
+        Db.BillingCustomers.Add(new BillingCustomer
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            StripeCustomerId = stripeCustomerId,
+            BillingMode = "PlatformProvided",
+            DefaultCurrency = "usd",
+            TaxStatus = "none",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        Db.SaveChanges();
+    }
+
+    public BillingSubscription SeedMirror(
+        Guid tenantId, string planSlug, string stripeSubId, string status = "active",
+        int seats = 1, DateTime? periodEnd = null)
+    {
+        var mirror = new BillingSubscription
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenantId,
+            StripeSubscriptionId = stripeSubId,
+            PlanSlug = planSlug,
+            Status = status,
+            Seats = seats,
+            CurrentPeriodStart = DateTime.UtcNow.AddDays(-5),
+            CurrentPeriodEnd = periodEnd ?? DateTime.UtcNow.AddDays(25),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        Db.BillingSubscriptions.Add(mirror);
+        Db.SaveChanges();
+        return mirror;
+    }
+
+    public void SeedMembers(Guid tenantId, int count)
+    {
+        var list = Enumerable.Range(0, count)
+            .Select(_ => new TenantMembership { TenantId = tenantId, UserId = Guid.NewGuid(), Role = "member" })
+            .ToList();
+        Members.Setup(m => m.ListAllByTenantAsync(tenantId)).ReturnsAsync(list);
+    }
+
+    // ── Stripe object fabrication ──
+
+    public static Stripe.Subscription MakeSub(
+        string id, string status, string basePriceId, DateTime periodStart, DateTime periodEnd,
+        DateTime? trialEnd = null, bool cancelAtPeriodEnd = false, string baseItemId = "si_base",
+        string? seatsPriceId = null, long seatsQty = 0, string seatItemId = "si_seat")
+    {
+        var items = new List<Stripe.SubscriptionItem>
+        {
+            new()
+            {
+                Id = baseItemId,
+                Price = new Stripe.Price { Id = basePriceId },
+                Quantity = 1,
+                CurrentPeriodStart = periodStart,
+                CurrentPeriodEnd = periodEnd,
+            },
+        };
+        if (seatsPriceId is not null)
+        {
+            items.Add(new Stripe.SubscriptionItem
+            {
+                Id = seatItemId,
+                Price = new Stripe.Price { Id = seatsPriceId },
+                Quantity = seatsQty,
+                CurrentPeriodStart = periodStart,
+                CurrentPeriodEnd = periodEnd,
+            });
+        }
+
+        return new Stripe.Subscription
+        {
+            Id = id,
+            Status = status,
+            CancelAtPeriodEnd = cancelAtPeriodEnd,
+            TrialEnd = trialEnd,
+            Items = new Stripe.StripeList<Stripe.SubscriptionItem> { Data = items },
+        };
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -125,6 +125,11 @@ public class ControlPlaneDbContextModelTests
             // billing is a cross-cutting platform concern; the webhook arrives
             // with no tenant context (tenant resolved from the Stripe customer).
             "billing_webhook_events",
+            // Story 35-4 — control-plane mirror of a tenant's Stripe subscription.
+            // CP-resident (billing is cross-cutting, keyed by tenant); Story 35-6
+            // reads PlanSlug + Seats as the single quota source. At most one
+            // non-terminal row per tenant (partial-unique).
+            "billing_subscriptions",
             // Story 37-1 — curated audit-record read-model + the per-(projector,
             // tenant) cursor. audit_records is mapped on BOTH contexts (the CP
             // build materializes platform-scope + single-user rows); the cursor
@@ -153,6 +158,7 @@ public class ControlPlaneDbContextModelTests
             + "Story 34-1 adds plan_features + plan_entitlements + plan_prices. "
             + "Story 35-1 adds billing_customers + billing_plan_prices. "
             + "Story 35-5 adds billing_webhook_events. "
+            + "Story 35-4 adds billing_subscriptions. "
             + "Story 37-1 adds audit_records + audit_projector_cursor. "
             + "Story 34-11 adds providers + provider_model_prices. "
             + "Story 34-5 adds margin_policies. "


### PR DESCRIPTION
## What

Story 35-4 (P0). Outbound Stripe subscription lifecycle under `/api/v1/orgs/{tenantId}/billing/subscription`: checkout, upgrade (immediate proration), downgrade (scheduled), cancel (at-period-end / immediate), trial, seats. A `BillingSubscription` mirror (ControlPlaneDbContext, one-non-terminal-per-tenant partial-unique), `BILLING.SUBSCRIPTION.*` DCB events, `Tenant.Plan` + shadow `PlanId` lockstep. Deterministic Stripe idempotency keys. Supersedes 35-5's audit-only subscription webhook handler via the registry's duplicate-claim guard (shared `SubscriptionMirrorUpdater`, so no double-projection). New `AddBillingSubscription` migration (CP three-place gotcha handled).

## Review outcome

Adversarial review verified RBAC, tenant isolation, the seat-floor-before-Stripe guard, the effective-plan fallback posture, and null-safe period extraction (Stripe.net 51.x moved period fields to `SubscriptionItem`) as SOLID. **Five findings fixed** (TDD, 10 red-before/green-after):
- **Critical — downgrade never applied:** `from_subscription` alone yields a single-phase schedule that *releases back to the current plan* (charges forever). Now issues the required second `SubscriptionScheduleUpdate` with a **target-price phase 2** + `EndBehavior=release`; the `customer.subscription.updated` rollover clears the pending downgrade.
- **Important — idempotency-key collisions:** keys were `(op, target, period)` → a `5→10→5` seat / `A→B→A` plan sequence replayed the cached response (drift). Now fold the **pre-change state** into each key (distinct intents → distinct keys; genuine retries still dedup).
- **Lower:** emit-once (skip the DCB event when the applied Stripe state is unchanged — kills the API+webhook double-emit); `trial_will_end`→`TRIAL_ENDING` (was mislabeled `TRIAL_ENDED`, re-unified with 35-5's type, no orphaned consumers); plan-lockstep now **fails loud** (throws) on a missing target plan row instead of leaving a canceled tenant entitled.

Follow-up noted: paid→paid downgrade drops per-seat quantity on rollover (correct for downgrade-to-free; seat-carry-forward is a follow-up).

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Subscription|Billing tests: 146 passed (incl. Postgres migration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)