### PR TITLE
feat(epic-34): Story 34-2 — Plan Catalog Admin API & Custom Enterprise Plans

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/PlanDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Pricing/PlanDtos.cs
@@ -1,0 +1,64 @@
+namespace Tamma.Api.Dtos.Pricing;
+
+/// <summary>
+/// Story 34-2 — request/response DTOs for the plan-catalog admin API and the
+/// public read routes. These are the wire shapes; the endpoint layer maps them
+/// onto the typed <c>PlanDraftSpec</c> the immutable <c>PlanVersionEditor</c>
+/// consumes (Story 34-1 owns the versioning invariants — 34-2 never mutates a
+/// row in place). Responses are the typed <c>PlanSnapshot</c> projection from
+/// Story 34-1 (AC13 — no raw EF entity is ever serialised).
+/// </summary>
+public sealed record CreatePlanRequest(
+    string Slug,
+    string DisplayName,
+    string BillingInterval,
+    IReadOnlyList<PlanFeatureDto>? Features,
+    IReadOnlyList<PlanEntitlementDto>? Entitlements,
+    IReadOnlyList<PlanPriceDto>? Prices);
+
+/// <summary>
+/// Body for <c>PUT /api/admin/pricing/plans/{slug}</c> — versions the existing
+/// active plan. Header fields are optional overrides (null ⇒ copy from the prior
+/// version); child collections are full replacements when non-null (null ⇒ copy
+/// the prior version's children), matching <c>PlanDraftSpec</c> semantics.
+/// </summary>
+public sealed record VersionPlanRequest(
+    string? DisplayName = null,
+    string? BillingInterval = null,
+    IReadOnlyList<PlanFeatureDto>? Features = null,
+    IReadOnlyList<PlanEntitlementDto>? Entitlements = null,
+    IReadOnlyList<PlanPriceDto>? Prices = null);
+
+/// <summary>
+/// Body for <c>POST /api/admin/pricing/plans/custom</c> — mints a bespoke
+/// enterprise plan bound to exactly one tenant. The slug is server-derived
+/// (<c>custom-{tenantId:N}-{n}</c>) so the binding is recoverable without a
+/// dedicated column; <see cref="MakePublic"/> exists only as the fail-loud guard
+/// (AC5): a custom plan must NEVER surface in the public catalog, so a request
+/// that asks for public visibility is rejected 400.
+/// </summary>
+public sealed record CreateCustomPlanRequest(
+    Guid TenantId,
+    string DisplayName,
+    string BillingInterval,
+    IReadOnlyList<PlanFeatureDto>? Features,
+    IReadOnlyList<PlanEntitlementDto>? Entitlements,
+    IReadOnlyList<PlanPriceDto>? Prices,
+    bool? MakePublic = null);
+
+/// <summary>A typed feature flag on the wire (bool capability OR string value).</summary>
+public sealed record PlanFeatureDto(string FeatureKey, bool? BoolValue, string? StringValue);
+
+/// <summary>
+/// A typed quota entitlement on the wire. <c>MetricKey</c> is the snake_case
+/// string validated against the <c>EntitlementMetricKey</c> enum (AC8);
+/// <c>LimitValue == null</c> ⇒ unlimited.
+/// </summary>
+public sealed record PlanEntitlementDto(string MetricKey, long? LimitValue, string Period, string OverageMode);
+
+/// <summary>
+/// A pricing row on the wire. <c>PricingMode</c> is validated against
+/// <c>platform_provided | byok</c> (AC8); <c>MeteredComponentJson</c> is stored
+/// verbatim (defaults to <c>{}</c>).
+/// </summary>
+public sealed record PlanPriceDto(string PricingMode, decimal RecurringUsd, decimal SeatUsd, string? MeteredComponentJson);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPlanCatalogEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPlanCatalogEndpoints.cs
@@ -285,6 +285,7 @@ public static class AdminPlanCatalogEndpoints
         "PLAN.METRIC_KEY.INVALID" or "PLAN.METRIC_KEY.UNKNOWN" or "PLAN.METRIC_KEY.UNMAPPED"
             or "PLAN.PRICING_MODE.INVALID" or "PLAN.BILLING_INTERVAL.INVALID"
             or "PLAN.ENTITLEMENT_PERIOD.INVALID" or "PLAN.OVERAGE_MODE.INVALID"
+            or "PLAN.PRICE.INVALID" or "PLAN.LIMIT.INVALID"
             => Results.UnprocessableEntity(new { error = ex.Code, message = ex.Message, context = ex.Context }),
 
         "PLAN.CUSTOM.PUBLIC_REJECTED" or "PLAN.DISPLAY_NAME.REQUIRED" or "PLAN.CUSTOM.TENANT_REQUIRED"

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPlanCatalogEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPlanCatalogEndpoints.cs
@@ -1,0 +1,310 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 34-2 — the plan-catalog ADMIN write surface under
+/// <c>/api/admin/pricing/plans*</c>. Every route MUST be gated behind the
+/// <c>PlatformOwnerAccess</c> policy at the wiring site (NOT <c>OwnerAccess</c>,
+/// which admits every personal-tenant owner — Finding C1): the price book is
+/// platform-GLOBAL in both single-user and SaaS modes with no per-tenant
+/// override layer, so it is platform-scoped admin work.
+///
+/// <para>All mutation goes through the immutable, versioned
+/// <see cref="IPlanVersionEditor"/> (Story 34-1) — this class never mutates a
+/// plan row in place and never duplicates the supersede/deprecate logic. It maps
+/// the wire DTOs onto <c>PlanDraftSpec</c>, validates the closed-enum fields
+/// (fail-loud, before any write), translates the editor's stable
+/// <c>TammaError</c> codes onto HTTP status codes (422/400/404/409), and returns
+/// the typed <see cref="PlanSnapshot"/> projection (AC13 — never a raw EF
+/// entity). The editor emits the <c>PLAN.CATALOG.UPDATED</c> /
+/// <c>PLAN.CUSTOM.CREATED</c> DCB events.</para>
+/// </summary>
+public static class AdminPlanCatalogEndpoints
+{
+    // ── GET /api/admin/pricing/plans?status=&isCustom=&tenantId= ──
+    public static async Task<IResult> ListForAdmin(
+        string? status,
+        bool? isCustom,
+        Guid? tenantId,
+        IPlanCatalogService catalog,
+        CancellationToken ct)
+    {
+        var plans = await catalog.ListAllForAdminAsync(
+            new PlanListFilter(Status: status, IsCustom: isCustom, TenantId: tenantId), ct);
+        return Results.Ok(new { plans });
+    }
+
+    // ── POST /api/admin/pricing/plans ── (create initial version → 201)
+    public static async Task<IResult> CreatePlan(
+        CreatePlanRequest body,
+        IPlanVersionEditor editor,
+        IPlanCatalogService catalog,
+        ClaimsPrincipal principal,
+        CancellationToken ct)
+    {
+        if (body is null || string.IsNullOrWhiteSpace(body.Slug))
+        {
+            return Results.BadRequest(new { error = "slug_required" });
+        }
+
+        try
+        {
+            var draft = ToDraft(
+                body.DisplayName, body.BillingInterval,
+                body.Features, body.Entitlements, body.Prices);
+
+            var plan = await editor.CreateInitialVersionAsync(
+                body.Slug.Trim(), draft, ActorFrom(principal), ct);
+
+            var snapshot = await catalog.GetByIdAsync(plan.Id, ct);
+            return Results.Json(snapshot, statusCode: StatusCodes.Status201Created);
+        }
+        catch (TammaError ex)
+        {
+            return MapError(ex);
+        }
+        catch (DbUpdateException dbEx) when (IsUniqueViolation(dbEx))
+        {
+            return Results.Conflict(new { error = "PLAN.SLUG_VERSION.CONFLICT", message = "A plan with this (slug, version) already exists." });
+        }
+    }
+
+    // ── PUT /api/admin/pricing/plans/{slug} ── (new version → 200)
+    public static async Task<IResult> VersionPlan(
+        string slug,
+        VersionPlanRequest body,
+        IPlanVersionEditor editor,
+        IPlanCatalogService catalog,
+        ClaimsPrincipal principal,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            return Results.BadRequest(new { error = "slug_required" });
+        }
+
+        body ??= new VersionPlanRequest();
+
+        try
+        {
+            var draft = ToDraft(
+                body.DisplayName, body.BillingInterval,
+                body.Features, body.Entitlements, body.Prices);
+
+            var plan = await editor.VersionPlanAsync(slug.Trim(), draft, ActorFrom(principal), ct);
+
+            var snapshot = await catalog.GetByIdAsync(plan.Id, ct);
+            return Results.Ok(snapshot);
+        }
+        catch (TammaError ex)
+        {
+            return MapError(ex);
+        }
+        catch (DbUpdateException dbEx) when (IsUniqueViolation(dbEx))
+        {
+            return Results.Conflict(new { error = "PLAN.SLUG_VERSION.CONFLICT", message = "A plan with this (slug, version) already exists." });
+        }
+    }
+
+    // ── POST /api/admin/pricing/plans/custom ── (mint bespoke plan → 201)
+    public static async Task<IResult> CreateCustomPlan(
+        CreateCustomPlanRequest body,
+        IPlanVersionEditor editor,
+        IPlanCatalogService catalog,
+        ClaimsPrincipal principal,
+        CancellationToken ct)
+    {
+        if (body is null || body.TenantId == Guid.Empty)
+        {
+            return Results.BadRequest(new { error = "tenantId_required" });
+        }
+
+        // AC5 — a custom plan must NEVER surface in the public catalog. A request
+        // that asks for public visibility is a fail-loud 400 (the IsCustom filter
+        // is the real defence; this 400 is the explicit rejection signal).
+        if (body.MakePublic == true)
+        {
+            return Results.BadRequest(new
+            {
+                error = "PLAN.CUSTOM.PUBLIC_REJECTED",
+                message = "A custom (bespoke enterprise) plan cannot be published to the public catalog.",
+            });
+        }
+
+        try
+        {
+            var draft = ToDraft(
+                body.DisplayName, body.BillingInterval,
+                body.Features, body.Entitlements, body.Prices);
+
+            var plan = await editor.CreateCustomVersionAsync(
+                body.TenantId, draft, ActorFrom(principal), ct);
+
+            var snapshot = await catalog.GetByIdAsync(plan.Id, ct);
+            return Results.Json(snapshot, statusCode: StatusCodes.Status201Created);
+        }
+        catch (TammaError ex)
+        {
+            return MapError(ex);
+        }
+        catch (DbUpdateException dbEx) when (IsUniqueViolation(dbEx))
+        {
+            return Results.Conflict(new { error = "PLAN.SLUG_VERSION.CONFLICT", message = "A plan with this (slug, version) already exists." });
+        }
+    }
+
+    // ── DELETE /api/admin/pricing/plans/{slug}/versions/{version}?force= ──
+    public static async Task<IResult> DeprecateVersion(
+        string slug,
+        int version,
+        bool? force,
+        IPlanVersionEditor editor,
+        ClaimsPrincipal principal,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            return Results.BadRequest(new { error = "slug_required" });
+        }
+
+        try
+        {
+            var result = await editor.DeprecateVersionAsync(
+                slug.Trim(), version, force ?? false, ActorFrom(principal), ct);
+
+            if (!result.Deprecated)
+            {
+                // Blocked by active assignments + no force (AC7).
+                return Results.Conflict(new
+                {
+                    error = "PLAN.DEPRECATE.HAS_ASSIGNMENTS",
+                    message = "Version has active tenant assignments; pass force=true to deprecate anyway.",
+                    affectedTenantCount = result.AffectedTenantCount,
+                });
+            }
+
+            return Results.NoContent();
+        }
+        catch (TammaError ex)
+        {
+            return MapError(ex);
+        }
+    }
+
+    // ── Mapping + validation helpers ──
+
+    /// <summary>
+    /// Map the wire DTO fields onto a <c>PlanDraftSpec</c>. Parses + validates
+    /// each entitlement metric key against the <c>EntitlementMetricKey</c> enum
+    /// (AC8) — an unknown key throws <c>PLAN.METRIC_KEY.UNKNOWN</c> which
+    /// <see cref="MapError"/> translates to 422. Null child collections are
+    /// preserved as null (⇒ "copy prior version" on the version path).
+    /// </summary>
+    private static PlanDraftSpec ToDraft(
+        string? displayName,
+        string? billingInterval,
+        IReadOnlyList<PlanFeatureDto>? features,
+        IReadOnlyList<PlanEntitlementDto>? entitlements,
+        IReadOnlyList<PlanPriceDto>? prices)
+    {
+        var featureDrafts = features?
+            .Select(f => new PlanFeatureDraft(f.FeatureKey, f.BoolValue, f.StringValue))
+            .ToList();
+
+        var entitlementDrafts = entitlements?
+            .Select(e => new PlanEntitlementDraft(
+                ParseMetricKey(e.MetricKey), e.LimitValue, e.Period, e.OverageMode))
+            .ToList();
+
+        var priceDrafts = prices?
+            .Select(p => new PlanPriceDraft(
+                p.PricingMode, p.RecurringUsd, p.SeatUsd,
+                string.IsNullOrWhiteSpace(p.MeteredComponentJson) ? "{}" : p.MeteredComponentJson))
+            .ToList();
+
+        return new PlanDraftSpec(
+            DisplayName: string.IsNullOrWhiteSpace(displayName) ? null : displayName,
+            BillingInterval: string.IsNullOrWhiteSpace(billingInterval) ? null : billingInterval,
+            Features: featureDrafts,
+            Entitlements: entitlementDrafts,
+            Prices: priceDrafts);
+    }
+
+    /// <summary>
+    /// Parse a snake_case metric key string, re-throwing as
+    /// <c>PLAN.METRIC_KEY.INVALID</c> (a stable 422 code) so a malformed catalog
+    /// write names the offending key.
+    /// </summary>
+    private static EntitlementMetricKey ParseMetricKey(string metricKey)
+    {
+        if (string.IsNullOrWhiteSpace(metricKey))
+        {
+            throw new TammaError(
+                "PLAN.METRIC_KEY.INVALID",
+                "Entitlement metric key is required.",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        try
+        {
+            return EntitlementMetricKeyExtensions.Parse(metricKey);
+        }
+        catch (TammaError ex)
+        {
+            // Normalise the 34-1 PLAN.METRIC_KEY.UNKNOWN code to the AC8
+            // PLAN.METRIC_KEY.INVALID contract while preserving the offending key.
+            throw new TammaError(
+                "PLAN.METRIC_KEY.INVALID",
+                ex.Message,
+                new Dictionary<string, object?> { ["metricKey"] = metricKey },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+    }
+
+    private static PlanEditorPrincipal ActorFrom(ClaimsPrincipal? principal)
+    {
+        var userId = principal?.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+            ?? principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        var email = principal?.FindFirst(JwtRegisteredClaimNames.Email)?.Value
+            ?? principal?.FindFirst(ClaimTypes.Email)?.Value
+            ?? principal?.FindFirst("email")?.Value;
+        return new PlanEditorPrincipal(userId, email);
+    }
+
+    private static IResult MapError(TammaError ex) => ex.Code switch
+    {
+        "PLAN.METRIC_KEY.INVALID" or "PLAN.METRIC_KEY.UNKNOWN" or "PLAN.METRIC_KEY.UNMAPPED"
+            or "PLAN.PRICING_MODE.INVALID" or "PLAN.BILLING_INTERVAL.INVALID"
+            or "PLAN.ENTITLEMENT_PERIOD.INVALID" or "PLAN.OVERAGE_MODE.INVALID"
+            => Results.UnprocessableEntity(new { error = ex.Code, message = ex.Message, context = ex.Context }),
+
+        "PLAN.CUSTOM.PUBLIC_REJECTED" or "PLAN.DISPLAY_NAME.REQUIRED" or "PLAN.CUSTOM.TENANT_REQUIRED"
+            => Results.BadRequest(new { error = ex.Code, message = ex.Message }),
+
+        "PLAN.SLUG.EXISTS" or "PLAN.VERSION.IMMUTABLE"
+            => Results.Conflict(new { error = ex.Code, message = ex.Message }),
+
+        "PLAN.VERSION.NOT_FOUND" or "PLAN.VERSION.NO_ACTIVE"
+            => Results.NotFound(new { error = ex.Code, message = ex.Message }),
+
+        _ => Results.Problem(title: ex.Code, detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError),
+    };
+
+    /// <summary>
+    /// Postgres 23505 unique-violation from the <c>UX_plans_Slug_Version</c>
+    /// index (AC12) — surfaced as 409, not a bare 500. Mirrors
+    /// <c>AdminPricingEndpoints.IsUniqueViolation</c>.
+    /// </summary>
+    private static bool IsUniqueViolation(DbUpdateException dbEx)
+        => dbEx.InnerException is Npgsql.PostgresException pgEx
+           && string.Equals(pgEx.SqlState, "23505", StringComparison.Ordinal);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -186,4 +186,40 @@ public static class PricingEndpoints
                 statusCode: StatusCodes.Status401Unauthorized);
         }
     }
+
+    // ── GET /api/pricing/plans ── (Story 34-2 AC1, MemberAccess)
+    //
+    // The PUBLIC catalog: active, non-custom plans only. Deprecated / draft /
+    // custom plans are excluded by construction (IPlanCatalogService filters
+    // Status='active' AND IsCustom=false), so a bespoke enterprise plan can never
+    // leak into the pricing/upgrade UI. Works identically in single-user and
+    // SaaS mode — the list is platform-global with no per-tenant view.
+    public static async Task<IResult> ListPublicPlans(
+        IPlanCatalogService planCatalog,
+        CancellationToken ct)
+    {
+        var plans = await planCatalog.ListActivePublicAsync(ct);
+        return Results.Ok(new { plans });
+    }
+
+    // ── GET /api/pricing/plans/{slug} ── (Story 34-2 AC2, MemberAccess)
+    //
+    // The single active public plan for a slug. A custom plan's slug is never
+    // resolvable here (it is IsCustom=true) → 404. Returns the typed PlanSnapshot
+    // projection (AC13 — never a raw EF entity).
+    public static async Task<IResult> GetPublicPlanBySlug(
+        string slug,
+        IPlanCatalogService planCatalog,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            return Results.NotFound(new { error = "plan_not_found", slug });
+        }
+
+        var snapshot = await planCatalog.GetActivePublicBySlugAsync(slug, ct);
+        return snapshot is null
+            ? Results.NotFound(new { error = "plan_not_found", slug })
+            : Results.Ok(snapshot);
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1734,6 +1734,28 @@ admin.MapPut("/pricing/margins",
         Tamma.Api.Endpoints.Admin.AdminPricingEndpoints.VersionMargin)
     .RequireAuthorization("PlatformOwnerAccess");
 
+// Story 34-2 — plan-catalog admin write surface under /api/admin/pricing/plans*.
+// PlatformOwnerAccess (Finding C1): the price book is platform-GLOBAL in both
+// modes (no per-tenant override layer), so it is platform-scoped admin work — a
+// tenant_owner/admin/member gets 403. All mutation flows through the immutable,
+// versioned PlanVersionEditor (Story 34-1) and emits PLAN.CATALOG.UPDATED /
+// PLAN.CUSTOM.CREATED DCB events. (The 34-1 read routes stay at /api/admin/plans.)
+admin.MapGet("/pricing/plans",
+        Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.ListForAdmin)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPost("/pricing/plans",
+        Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.CreatePlan)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPut("/pricing/plans/{slug}",
+        Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.VersionPlan)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPost("/pricing/plans/custom",
+        Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.CreateCustomPlan)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapDelete("/pricing/plans/{slug}/versions/{version:int}",
+        Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.DeprecateVersion)
+    .RequireAuthorization("PlatformOwnerAccess");
+
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
 // Epic-28 shadow columns on tenants (Status, PlanId, KekVersion,
 // FailureReason, DeleteRequestedAt); action endpoints re-drive the Story
@@ -1919,6 +1941,12 @@ pricing.MapGet("/estimate", Tamma.Api.Endpoints.PricingEndpoints.GetEstimate);
 // unprivileged (any authenticated member); tenant is taken from ITenantContext
 // (SaaS) / the sole user (single-user), never from a request param.
 pricing.MapGet("/entitlements", Tamma.Api.Endpoints.PricingEndpoints.GetEntitlements);
+// Story 34-2 (AC1/AC2) — the PUBLIC plan catalog powering the pricing/upgrade UI.
+// Active, non-custom plans only (deprecated/draft/custom excluded by the
+// IPlanCatalogService filter). MemberAccess: any authenticated tenant member can
+// read; the admin write surface stays platform-owner-only (/api/admin/pricing/plans*).
+pricing.MapGet("/plans", Tamma.Api.Endpoints.PricingEndpoints.ListPublicPlans);
+pricing.MapGet("/plans/{slug}", Tamma.Api.Endpoints.PricingEndpoints.GetPublicPlanBySlug);
 
 var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");
 orgs.MapPost("/", OrgEndpoints.CreateOrg);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/CustomPlanSlug.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/CustomPlanSlug.cs
@@ -1,0 +1,31 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-2 — the server-derived slug convention for a custom (bespoke
+/// enterprise) plan: <c>custom-{tenantId:N}-{seq}</c>. Encoding the full tenant
+/// id (32 hex) into the slug makes the plan→tenant binding recoverable and
+/// queryable WITHOUT a dedicated <c>CustomTenantId</c> column (kept additive-
+/// migration-free per the catalog serialisation rule); the <c>{seq}</c> suffix
+/// lets a tenant hold more than one bespoke plan. Total length ≤ 46 chars, well
+/// under the <c>plans.Slug</c> 64-char limit.
+///
+/// <para>The public catalog excludes custom plans by construction
+/// (<c>IsCustom == false</c> filter), so the slug is never resolvable through
+/// <c>/api/pricing/plans*</c> regardless of its shape.</para>
+/// </summary>
+public static class CustomPlanSlug
+{
+    /// <summary>Prefix that every custom plan for <paramref name="tenantId"/> shares.</summary>
+    public static string PrefixFor(Guid tenantId) => $"custom-{tenantId:N}-";
+
+    /// <summary>Mint a fresh, unique-by-construction custom slug for a tenant.</summary>
+    public static string New(Guid tenantId) =>
+        PrefixFor(tenantId) + Guid.NewGuid().ToString("N")[..6];
+
+    /// <summary>
+    /// True when <paramref name="slug"/> is a custom plan slug bound to
+    /// <paramref name="tenantId"/>.
+    /// </summary>
+    public static bool IsBoundTo(string slug, Guid tenantId) =>
+        slug is not null && slug.StartsWith(PrefixFor(tenantId), StringComparison.Ordinal);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanCatalogService.cs
@@ -31,9 +31,47 @@ public interface IPlanCatalogService
     Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default);
 
     /// <summary>
+    /// Story 34-2 (AC1) — the public catalog: every <c>active</c>, non-custom
+    /// (<c>IsCustom == false</c>) version, ordered by slug. This is what the
+    /// pricing / upgrade UI renders — deprecated, draft, and custom plans are
+    /// excluded by construction so a bespoke enterprise plan can never leak into
+    /// the public list.
+    /// </summary>
+    Task<IReadOnlyList<PlanSnapshot>> ListActivePublicAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 (AC2) — the single <c>active</c>, non-custom version for a slug,
+    /// or <c>null</c>. A custom plan's slug is never resolvable through this route
+    /// (it is <c>IsCustom == true</c>), so the public read returns 404 for it.
+    /// </summary>
+    Task<PlanSnapshot?> GetActivePublicBySlugAsync(string slug, CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 — the admin catalog list. Unlike <see cref="ListActiveAsync"/>
+    /// this surfaces every status (active / deprecated / draft) and includes
+    /// custom plans, filtered by the supplied <paramref name="filter"/>
+    /// (status / isCustom / bound tenantId). Ordered by slug then version
+    /// descending.
+    /// </summary>
+    Task<IReadOnlyList<PlanSnapshot>> ListAllForAdminAsync(
+        PlanListFilter filter, CancellationToken ct = default);
+
+    /// <summary>
     /// The full version chain for a slug — the active version plus all
     /// deprecated versions, ordered by <c>Version</c> descending. Empty when
     /// the slug is unknown.
     /// </summary>
     Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default);
 }
+
+/// <summary>
+/// Story 34-2 — server-side filter for the admin catalog list
+/// (<see cref="IPlanCatalogService.ListAllForAdminAsync"/>). All fields are
+/// optional (null ⇒ no filter on that dimension). <see cref="TenantId"/> filters
+/// custom plans to those bound to that tenant (matched on the server-derived
+/// <c>custom-{tenantId:N}-*</c> slug — see <see cref="CustomPlanSlug"/>).
+/// </summary>
+public sealed record PlanListFilter(
+    string? Status = null,
+    bool? IsCustom = null,
+    Guid? TenantId = null);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanVersionEditor.cs
@@ -34,4 +34,68 @@ public interface IPlanVersionEditor
         PlanDraftSpec draft,
         PlanEditorPrincipal principal,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 — create the FIRST (v1, active) version of a brand-new plan
+    /// <paramref name="slug"/>. Throws <c>PLAN.SLUG.EXISTS</c> if any version of
+    /// the slug already exists (the caller must version via
+    /// <see cref="VersionPlanAsync"/> instead). Emits
+    /// <c>PLAN.CATALOG.UPDATED</c> (action=created).
+    /// </summary>
+    Task<Plan> CreateInitialVersionAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 — version an existing plan: a thin admin-surface wrapper over
+    /// <see cref="CreateNewVersionAsync"/> (reusing ALL of the supersede/deprecate
+    /// versioning logic and its <c>PLAN.VERSION.CREATED</c>/<c>PLAN.DEPRECATED</c>
+    /// events) that additionally emits the admin-surface
+    /// <c>PLAN.CATALOG.UPDATED</c> (action=versioned) event.
+    /// </summary>
+    Task<Plan> VersionPlanAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 — mint a bespoke enterprise plan (v1, active,
+    /// <c>IsCustom = true</c>) bound to <paramref name="tenantId"/>. The slug is
+    /// server-derived (<see cref="CustomPlanSlug"/>); the plan is excluded from
+    /// the public catalog by construction. Emits <c>PLAN.CUSTOM.CREATED</c> with
+    /// the bound tenant id in tags + data.
+    /// </summary>
+    Task<Plan> CreateCustomVersionAsync(
+        Guid tenantId,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Story 34-2 — deprecate a specific plan version. Counts tenants whose
+    /// assignment pins that version; when the count is &gt; 0 and
+    /// <paramref name="force"/> is false NO write happens and the result reports
+    /// <c>Deprecated = false</c> (the endpoint returns 409). With
+    /// <paramref name="force"/> (or zero affected tenants) the version flips to
+    /// <c>deprecated</c> — existing tenants stay pinned to it (immutability rule)
+    /// — and <c>PLAN.CATALOG.UPDATED</c> (action=deprecated) is emitted. Throws
+    /// <c>PLAN.VERSION.NOT_FOUND</c> for an unknown (slug, version).
+    /// </summary>
+    Task<PlanDeprecationResult> DeprecateVersionAsync(
+        string slug,
+        int version,
+        bool force,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default);
 }
+
+/// <summary>
+/// Story 34-2 — outcome of <see cref="IPlanVersionEditor.DeprecateVersionAsync"/>.
+/// <see cref="Deprecated"/> is false ONLY on the blocked path (active
+/// assignments + no force); <see cref="AffectedTenantCount"/> is the number of
+/// tenants pinned to the version either way.
+/// </summary>
+public sealed record PlanDeprecationResult(bool Deprecated, int AffectedTenantCount);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogEventTypes.cs
@@ -14,4 +14,19 @@ public static class PlanCatalogEventTypes
 
     /// <summary>A prior plan version was flipped to <c>deprecated</c>.</summary>
     public const string Deprecated = "PLAN.DEPRECATED";
+
+    /// <summary>
+    /// Story 34-2 — admin-surface catalog mutation (create / version /
+    /// deprecate). Carries an <c>action</c> tag (<c>created|versioned|deprecated</c>)
+    /// so a single event type covers the whole admin write surface; the
+    /// lower-level <see cref="VersionCreated"/> / <see cref="Deprecated"/>
+    /// lifecycle events (34-1) are still emitted by the version path.
+    /// </summary>
+    public const string CatalogUpdated = "PLAN.CATALOG.UPDATED";
+
+    /// <summary>
+    /// Story 34-2 — a bespoke enterprise plan was minted and bound to a single
+    /// tenant. Carries the bound <c>tenantId</c> in both tags and data.
+    /// </summary>
+    public const string CustomCreated = "PLAN.CUSTOM.CREATED";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanCatalogService.cs
@@ -74,6 +74,64 @@ public sealed class PlanCatalogService : IPlanCatalogService
         return plans.Select(ToSnapshot).ToList();
     }
 
+    public async Task<IReadOnlyList<PlanSnapshot>> ListActivePublicAsync(CancellationToken ct = default)
+    {
+        var plans = await BaseQuery()
+            .Where(p => p.Status == "active" && !p.IsCustom)
+            .OrderBy(p => p.Slug)
+            .ToListAsync(ct);
+
+        _logger.LogDebug("ListActivePublicAsync returned {Count} public plan(s)", plans.Count);
+        return plans.Select(ToSnapshot).ToList();
+    }
+
+    public async Task<PlanSnapshot?> GetActivePublicBySlugAsync(string slug, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+
+        var plan = await BaseQuery()
+            .FirstOrDefaultAsync(p => p.Slug == slug && p.Status == "active" && !p.IsCustom, ct);
+
+        return plan is null ? null : ToSnapshot(plan);
+    }
+
+    public async Task<IReadOnlyList<PlanSnapshot>> ListAllForAdminAsync(
+        PlanListFilter filter, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        var query = BaseQuery();
+
+        if (!string.IsNullOrWhiteSpace(filter.Status))
+        {
+            query = query.Where(p => p.Status == filter.Status);
+        }
+
+        if (filter.IsCustom is bool isCustom)
+        {
+            query = query.Where(p => p.IsCustom == isCustom);
+        }
+
+        if (filter.TenantId is Guid tenantId)
+        {
+            // Custom plans encode their bound tenant in the slug
+            // (custom-{tenantId:N}-*), so filter on that prefix. Only custom
+            // plans carry the binding.
+            var prefix = CustomPlanSlug.PrefixFor(tenantId);
+            query = query.Where(p => p.IsCustom && p.Slug.StartsWith(prefix));
+        }
+
+        var plans = await query
+            .OrderBy(p => p.Slug)
+            .ThenByDescending(p => p.Version)
+            .ToListAsync(ct);
+
+        _logger.LogDebug(
+            "ListAllForAdminAsync(status={Status}, isCustom={IsCustom}, tenantId={TenantId}) returned {Count}",
+            filter.Status, filter.IsCustom, filter.TenantId, plans.Count);
+        return plans.Select(ToSnapshot).ToList();
+    }
+
     public async Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(slug);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
@@ -268,6 +268,358 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
         return newPlan;
     }
 
+    /// <inheritdoc />
+    public async Task<Plan> CreateInitialVersionAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        ValidateDraft(draft);
+        RequireDisplayName(draft);
+
+        // A brand-new plan may not collide with ANY existing version of the slug
+        // — the caller must version an existing slug via VersionPlanAsync.
+        var exists = await _db.Plans.AsNoTracking().AnyAsync(p => p.Slug == slug, ct);
+        if (exists)
+        {
+            throw new TammaError(
+                "PLAN.SLUG.EXISTS",
+                $"Plan slug '{slug}' already exists — create a new version via PUT instead.",
+                new Dictionary<string, object?> { ["slug"] = slug },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        var plan = await InsertNewV1PlanAsync(slug, draft, isCustom: false, ct);
+
+        _logger.LogInformation(
+            "Plan created (initial version): {Slug} v1 ({PlanId}) by {ActorUserId}",
+            slug, plan.Id, principal.UserId);
+
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.CatalogUpdated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["action"] = "created",
+                    ["slug"] = slug,
+                    ["version"] = "1",
+                    ["planId"] = plan.Id.ToString("D"),
+                }),
+            ct);
+
+        return plan;
+    }
+
+    /// <inheritdoc />
+    public async Task<Plan> VersionPlanAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        ValidateDraft(draft);
+
+        // Reuse ALL of the supersede/deprecate versioning logic (and its
+        // PLAN.VERSION.CREATED / PLAN.DEPRECATED events) — do NOT duplicate it.
+        var newPlan = await CreateNewVersionAsync(slug, draft, principal, ct);
+
+        // Add the admin-surface catalog event on top (AC9).
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.CatalogUpdated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["action"] = "versioned",
+                    ["slug"] = slug,
+                    ["version"] = newPlan.Version.ToString(),
+                    ["planId"] = newPlan.Id.ToString("D"),
+                    ["supersedesPlanId"] = newPlan.SupersedesPlanId?.ToString("D"),
+                }),
+            ct);
+
+        return newPlan;
+    }
+
+    /// <inheritdoc />
+    public async Task<Plan> CreateCustomVersionAsync(
+        Guid tenantId,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(draft);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        if (tenantId == Guid.Empty)
+        {
+            throw new TammaError(
+                "PLAN.CUSTOM.TENANT_REQUIRED",
+                "A custom plan must be bound to a non-empty tenant id.",
+                new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        ValidateDraft(draft);
+        RequireDisplayName(draft);
+
+        var slug = CustomPlanSlug.New(tenantId);
+        var plan = await InsertNewV1PlanAsync(slug, draft, isCustom: true, ct);
+
+        _logger.LogInformation(
+            "Custom plan minted: {Slug} v1 ({PlanId}) bound to tenant {TenantId} by {ActorUserId}",
+            slug, plan.Id, tenantId, principal.UserId);
+
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.CustomCreated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["slug"] = slug,
+                    ["version"] = "1",
+                    ["planId"] = plan.Id.ToString("D"),
+                    ["tenantId"] = tenantId.ToString("D"),
+                }),
+            ct);
+
+        return plan;
+    }
+
+    /// <inheritdoc />
+    public async Task<PlanDeprecationResult> DeprecateVersionAsync(
+        string slug,
+        int version,
+        bool force,
+        PlanEditorPrincipal principal,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(slug);
+        ArgumentNullException.ThrowIfNull(principal);
+
+        var plan = await _db.Plans
+            .FirstOrDefaultAsync(p => p.Slug == slug && p.Version == version, ct);
+
+        if (plan is null)
+        {
+            throw new TammaError(
+                "PLAN.VERSION.NOT_FOUND",
+                $"Plan '{slug}' v{version} does not exist.",
+                new Dictionary<string, object?> { ["slug"] = slug, ["version"] = version },
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        // Count tenants whose assignment PINS this exact version (the version-
+        // pinned PlanId shadow column — Story 34-1/28). TODO(34-4): once tracked
+        // assignment lands, switch this to the assignment table.
+        var affected = await _db.Tenants
+            .IgnoreQueryFilters()
+            .Where(t => t.DeletedAt == null && EF.Property<Guid?>(t, "PlanId") == plan.Id)
+            .CountAsync(ct);
+
+        _logger.LogDebug(
+            "Deprecate {Slug} v{Version}: status={Status}, affectedTenants={Affected}, force={Force}",
+            slug, version, plan.Status, affected, force);
+
+        // Already deprecated — idempotent success (no write, immutability holds).
+        if (plan.Status == "deprecated")
+        {
+            return new PlanDeprecationResult(Deprecated: true, AffectedTenantCount: affected);
+        }
+
+        // Blocked: active assignments and no force. Re-pricing existing tenants is
+        // never a silent side effect of catalog deprecation (immutability rule).
+        if (affected > 0 && !force)
+        {
+            _logger.LogWarning(
+                "Deprecate blocked: {Slug} v{Version} has {Affected} assigned tenant(s); pass force=true to override",
+                slug, version, affected);
+            return new PlanDeprecationResult(Deprecated: false, AffectedTenantCount: affected);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+        plan.Status = "deprecated";
+        plan.UpdatedAt = now;
+        await _db.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Plan deprecated: {Slug} v{Version} ({PlanId}); {Affected} tenant(s) remain pinned; by {ActorUserId}",
+            slug, version, plan.Id, affected, principal.UserId);
+
+        await _publisher.AppendAndPublishAsync(
+            BuildPlanEvent(
+                PlanCatalogEventTypes.CatalogUpdated,
+                principal,
+                new Dictionary<string, string?>
+                {
+                    ["action"] = "deprecated",
+                    ["slug"] = slug,
+                    ["version"] = version.ToString(),
+                    ["planId"] = plan.Id.ToString("D"),
+                    ["affectedTenantCount"] = affected.ToString(),
+                    ["force"] = force ? "true" : "false",
+                }),
+            ct);
+
+        return new PlanDeprecationResult(Deprecated: true, AffectedTenantCount: affected);
+    }
+
+    /// <summary>
+    /// Build + insert a fresh v1 <c>active</c> plan (with children) from
+    /// <paramref name="draft"/>. Shared by the initial-create and custom-mint
+    /// paths. The immutability interceptor permits a freshly-Added active plan
+    /// and its children.
+    /// </summary>
+    private async Task<Plan> InsertNewV1PlanAsync(
+        string slug, PlanDraftSpec draft, bool isCustom, CancellationToken ct)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        var newPlanId = Guid.NewGuid();
+
+        var plan = new Plan
+        {
+            Id = newPlanId,
+            Slug = slug,
+            DisplayName = draft.DisplayName!,
+            Version = 1,
+            Status = "active",
+            IsCustom = isCustom,
+            BillingInterval = draft.BillingInterval ?? "monthly",
+            SupersedesPlanId = null,
+            MonthlyPriceUsd = draft.MonthlyPriceUsd ?? 0m,
+            Quotas = "{}",
+            IsActive = true,
+            PlacementPolicy = draft.PlacementPolicy ?? "shared",
+            CreatedAt = now,
+            UpdatedAt = now,
+            Features = (draft.Features ?? [])
+                .Select(f => new PlanFeature
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    FeatureKey = f.FeatureKey,
+                    BoolValue = f.BoolValue,
+                    StringValue = f.StringValue,
+                }).ToList(),
+            Entitlements = (draft.Entitlements ?? [])
+                .Select(e => new PlanEntitlement
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    MetricKey = e.MetricKey,
+                    LimitValue = e.LimitValue,
+                    Period = e.Period,
+                    OverageMode = e.OverageMode,
+                }).ToList(),
+            Prices = (draft.Prices ?? [])
+                .Select(p => new PlanPrice
+                {
+                    Id = Guid.NewGuid(),
+                    PlanId = newPlanId,
+                    PricingMode = p.PricingMode,
+                    RecurringUsd = p.RecurringUsd,
+                    SeatUsd = p.SeatUsd,
+                    MeteredComponent = p.MeteredComponent,
+                }).ToList(),
+        };
+
+        _db.Plans.Add(plan);
+        await _db.SaveChangesAsync(ct);
+        return plan;
+    }
+
+    private static readonly string[] s_validPricingModes = { "platform_provided", "byok" };
+    private static readonly string[] s_validBillingIntervals = { "monthly", "annual" };
+    private static readonly string[] s_validPeriods = { "monthly", "total" };
+    private static readonly string[] s_validOverageModes = { "block", "allow", "meter" };
+
+    private static void RequireDisplayName(PlanDraftSpec draft)
+    {
+        if (string.IsNullOrWhiteSpace(draft.DisplayName))
+        {
+            throw new TammaError(
+                "PLAN.DISPLAY_NAME.REQUIRED",
+                "A new plan requires a non-empty display name.",
+                retryable: false,
+                severity: TammaErrorSeverity.Medium);
+        }
+    }
+
+    /// <summary>
+    /// Story 34-2 (AC8) — validate the closed-enum string fields BEFORE any write
+    /// and fail loud with a stable code the endpoint maps to 422/400. The metric
+    /// key is already a typed <c>EntitlementMetricKey</c> on the draft (the DTO
+    /// mapping parsed + validated it), so it is not re-checked here.
+    /// </summary>
+    private static void ValidateDraft(PlanDraftSpec draft)
+    {
+        if (draft.BillingInterval is not null
+            && !s_validBillingIntervals.Contains(draft.BillingInterval))
+        {
+            throw new TammaError(
+                "PLAN.BILLING_INTERVAL.INVALID",
+                $"Invalid billing interval '{draft.BillingInterval}' (expected: monthly | annual).",
+                new Dictionary<string, object?> { ["billingInterval"] = draft.BillingInterval },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        if (draft.Prices is not null)
+        {
+            foreach (var p in draft.Prices)
+            {
+                if (!s_validPricingModes.Contains(p.PricingMode))
+                {
+                    throw new TammaError(
+                        "PLAN.PRICING_MODE.INVALID",
+                        $"Invalid pricing mode '{p.PricingMode}' (expected: platform_provided | byok).",
+                        new Dictionary<string, object?> { ["pricingMode"] = p.PricingMode },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
+            }
+        }
+
+        if (draft.Entitlements is not null)
+        {
+            foreach (var e in draft.Entitlements)
+            {
+                if (!s_validPeriods.Contains(e.Period))
+                {
+                    throw new TammaError(
+                        "PLAN.ENTITLEMENT_PERIOD.INVALID",
+                        $"Invalid entitlement period '{e.Period}' (expected: monthly | total) for metric '{e.MetricKey}'.",
+                        new Dictionary<string, object?> { ["period"] = e.Period, ["metricKey"] = e.MetricKey.ToString() },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
+
+                if (!s_validOverageModes.Contains(e.OverageMode))
+                {
+                    throw new TammaError(
+                        "PLAN.OVERAGE_MODE.INVALID",
+                        $"Invalid overage mode '{e.OverageMode}' (expected: block | allow | meter) for metric '{e.MetricKey}'.",
+                        new Dictionary<string, object?> { ["overageMode"] = e.OverageMode, ["metricKey"] = e.MetricKey.ToString() },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
+            }
+        }
+    }
+
     private PlatformEvent BuildPlanEvent(
         string type,
         PlanEditorPrincipal principal,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanVersionEditor.cs
@@ -107,6 +107,31 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
         PlanEditorPrincipal principal,
         CancellationToken ct = default)
     {
+        var (newPlan, events) = await CreateNewVersionCoreAsync(slug, draft, principal, ct);
+
+        // Post-commit audit emit is BEST-EFFORT (Finding 2): a publisher outage
+        // must NOT fail a change that already committed — that would 500 the
+        // write and invite a retry that mints a SECOND superseding version.
+        await PublishBestEffortAsync("plan.version.create", events, ct);
+        return newPlan;
+    }
+
+    /// <summary>
+    /// State-transition core of the version supersede: fetch the prior active
+    /// version, insert the new active version and flip the prior to deprecated in
+    /// ONE transaction, then RETURN (without emitting) the new plan plus the
+    /// primary <c>PLAN.VERSION.CREATED</c> / <c>PLAN.DEPRECATED</c> events. The
+    /// caller emits them best-effort AFTER commit — <see cref="VersionPlanAsync"/>
+    /// batches these together with its <c>PLAN.CATALOG.UPDATED</c> event in a
+    /// single best-effort block so a publisher outage never leaves a partial
+    /// audit trail.
+    /// </summary>
+    private async Task<(Plan Plan, List<PlatformEvent> Events)> CreateNewVersionCoreAsync(
+        string slug,
+        PlanDraftSpec draft,
+        PlanEditorPrincipal principal,
+        CancellationToken ct)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(slug);
         ArgumentNullException.ThrowIfNull(draft);
         ArgumentNullException.ThrowIfNull(principal);
@@ -238,8 +263,10 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
             "Plan version created: {Slug} v{Version} ({PlanId}); v{PriorVersion} deprecated",
             slug, newVersion, newPlanId, prior.Version);
 
-        // Events only AFTER the real state transition committed.
-        await _publisher.AppendAndPublishAsync(
+        // Build (but DO NOT emit) the primary lifecycle events — the caller
+        // emits them best-effort AFTER this committed state transition.
+        var events = new List<PlatformEvent>
+        {
             BuildPlanEvent(
                 PlanCatalogEventTypes.VersionCreated,
                 principal,
@@ -250,9 +277,6 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
                     ["planId"] = newPlanId.ToString("D"),
                     ["supersedesPlanId"] = prior.Id.ToString("D"),
                 }),
-            ct);
-
-        await _publisher.AppendAndPublishAsync(
             BuildPlanEvent(
                 PlanCatalogEventTypes.Deprecated,
                 principal,
@@ -263,9 +287,9 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
                     ["planId"] = prior.Id.ToString("D"),
                     ["supersededByPlanId"] = newPlanId.ToString("D"),
                 }),
-            ct);
+        };
 
-        return newPlan;
+        return (newPlan, events);
     }
 
     /// <inheritdoc />
@@ -301,17 +325,22 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
             "Plan created (initial version): {Slug} v1 ({PlanId}) by {ActorUserId}",
             slug, plan.Id, principal.UserId);
 
-        await _publisher.AppendAndPublishAsync(
-            BuildPlanEvent(
-                PlanCatalogEventTypes.CatalogUpdated,
-                principal,
-                new Dictionary<string, string?>
-                {
-                    ["action"] = "created",
-                    ["slug"] = slug,
-                    ["version"] = "1",
-                    ["planId"] = plan.Id.ToString("D"),
-                }),
+        // Best-effort audit emit AFTER the plan committed (Finding 2).
+        await PublishBestEffortAsync(
+            "plan.create",
+            new[]
+            {
+                BuildPlanEvent(
+                    PlanCatalogEventTypes.CatalogUpdated,
+                    principal,
+                    new Dictionary<string, string?>
+                    {
+                        ["action"] = "created",
+                        ["slug"] = slug,
+                        ["version"] = "1",
+                        ["planId"] = plan.Id.ToString("D"),
+                    }),
+            },
             ct);
 
         return plan;
@@ -330,25 +359,28 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
 
         ValidateDraft(draft);
 
-        // Reuse ALL of the supersede/deprecate versioning logic (and its
+        // Reuse ALL of the supersede/deprecate state-transition logic (and its
         // PLAN.VERSION.CREATED / PLAN.DEPRECATED events) — do NOT duplicate it.
-        var newPlan = await CreateNewVersionAsync(slug, draft, principal, ct);
+        var (newPlan, events) = await CreateNewVersionCoreAsync(slug, draft, principal, ct);
 
-        // Add the admin-surface catalog event on top (AC9).
-        await _publisher.AppendAndPublishAsync(
-            BuildPlanEvent(
-                PlanCatalogEventTypes.CatalogUpdated,
-                principal,
-                new Dictionary<string, string?>
-                {
-                    ["action"] = "versioned",
-                    ["slug"] = slug,
-                    ["version"] = newPlan.Version.ToString(),
-                    ["planId"] = newPlan.Id.ToString("D"),
-                    ["supersedesPlanId"] = newPlan.SupersedesPlanId?.ToString("D"),
-                }),
-            ct);
+        // Add the admin-surface catalog event on top (AC9), then emit the primary
+        // lifecycle events AND this catalog event TOGETHER in one best-effort
+        // block (Finding 2) so a publisher outage never leaves a partial audit
+        // trail — and never 500s a committed version (which would invite a retry
+        // that mints a second superseding version).
+        events.Add(BuildPlanEvent(
+            PlanCatalogEventTypes.CatalogUpdated,
+            principal,
+            new Dictionary<string, string?>
+            {
+                ["action"] = "versioned",
+                ["slug"] = slug,
+                ["version"] = newPlan.Version.ToString(),
+                ["planId"] = newPlan.Id.ToString("D"),
+                ["supersedesPlanId"] = newPlan.SupersedesPlanId?.ToString("D"),
+            }));
 
+        await PublishBestEffortAsync("plan.version", events, ct);
         return newPlan;
     }
 
@@ -382,17 +414,22 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
             "Custom plan minted: {Slug} v1 ({PlanId}) bound to tenant {TenantId} by {ActorUserId}",
             slug, plan.Id, tenantId, principal.UserId);
 
-        await _publisher.AppendAndPublishAsync(
-            BuildPlanEvent(
-                PlanCatalogEventTypes.CustomCreated,
-                principal,
-                new Dictionary<string, string?>
-                {
-                    ["slug"] = slug,
-                    ["version"] = "1",
-                    ["planId"] = plan.Id.ToString("D"),
-                    ["tenantId"] = tenantId.ToString("D"),
-                }),
+        // Best-effort audit emit AFTER the custom plan committed (Finding 2).
+        await PublishBestEffortAsync(
+            "plan.custom.create",
+            new[]
+            {
+                BuildPlanEvent(
+                    PlanCatalogEventTypes.CustomCreated,
+                    principal,
+                    new Dictionary<string, string?>
+                    {
+                        ["slug"] = slug,
+                        ["version"] = "1",
+                        ["planId"] = plan.Id.ToString("D"),
+                        ["tenantId"] = tenantId.ToString("D"),
+                    }),
+            },
             ct);
 
         return plan;
@@ -459,19 +496,24 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
             "Plan deprecated: {Slug} v{Version} ({PlanId}); {Affected} tenant(s) remain pinned; by {ActorUserId}",
             slug, version, plan.Id, affected, principal.UserId);
 
-        await _publisher.AppendAndPublishAsync(
-            BuildPlanEvent(
-                PlanCatalogEventTypes.CatalogUpdated,
-                principal,
-                new Dictionary<string, string?>
-                {
-                    ["action"] = "deprecated",
-                    ["slug"] = slug,
-                    ["version"] = version.ToString(),
-                    ["planId"] = plan.Id.ToString("D"),
-                    ["affectedTenantCount"] = affected.ToString(),
-                    ["force"] = force ? "true" : "false",
-                }),
+        // Best-effort audit emit AFTER the deprecation committed (Finding 2).
+        await PublishBestEffortAsync(
+            "plan.deprecate",
+            new[]
+            {
+                BuildPlanEvent(
+                    PlanCatalogEventTypes.CatalogUpdated,
+                    principal,
+                    new Dictionary<string, string?>
+                    {
+                        ["action"] = "deprecated",
+                        ["slug"] = slug,
+                        ["version"] = version.ToString(),
+                        ["planId"] = plan.Id.ToString("D"),
+                        ["affectedTenantCount"] = affected.ToString(),
+                        ["force"] = force ? "true" : "false",
+                    }),
+            },
             ct);
 
         return new PlanDeprecationResult(Deprecated: true, AffectedTenantCount: affected);
@@ -577,6 +619,24 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
                 severity: TammaErrorSeverity.High);
         }
 
+        // Non-negative money guard (Finding 1): a negative price would credit
+        // money downstream (Epic 35 billing / markup engine reads PlanPrice).
+        // ValidateDraft is the single write-path choke point, so guarding here
+        // covers create / version / custom-mint alike.
+        if (draft.MonthlyPriceUsd is < 0m)
+        {
+            throw new TammaError(
+                "PLAN.PRICE.INVALID",
+                $"Monthly price must be >= 0 (got {draft.MonthlyPriceUsd}).",
+                new Dictionary<string, object?>
+                {
+                    ["field"] = "monthlyPriceUsd",
+                    ["value"] = draft.MonthlyPriceUsd,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
         if (draft.Prices is not null)
         {
             foreach (var p in draft.Prices)
@@ -590,6 +650,36 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
                         retryable: false,
                         severity: TammaErrorSeverity.High);
                 }
+
+                if (p.RecurringUsd < 0m)
+                {
+                    throw new TammaError(
+                        "PLAN.PRICE.INVALID",
+                        $"Recurring price must be >= 0 (got {p.RecurringUsd}) for pricing mode '{p.PricingMode}'.",
+                        new Dictionary<string, object?>
+                        {
+                            ["field"] = "recurringUsd",
+                            ["value"] = p.RecurringUsd,
+                            ["pricingMode"] = p.PricingMode,
+                        },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
+
+                if (p.SeatUsd < 0m)
+                {
+                    throw new TammaError(
+                        "PLAN.PRICE.INVALID",
+                        $"Seat price must be >= 0 (got {p.SeatUsd}) for pricing mode '{p.PricingMode}'.",
+                        new Dictionary<string, object?>
+                        {
+                            ["field"] = "seatUsd",
+                            ["value"] = p.SeatUsd,
+                            ["pricingMode"] = p.PricingMode,
+                        },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
             }
         }
 
@@ -597,6 +687,23 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
         {
             foreach (var e in draft.Entitlements)
             {
+                // A null limit means UNLIMITED (valid); only a NEGATIVE limit is
+                // invalid (Finding 1).
+                if (e.LimitValue is < 0)
+                {
+                    throw new TammaError(
+                        "PLAN.LIMIT.INVALID",
+                        $"Entitlement limit must be >= 0 or null (unlimited); got {e.LimitValue} for metric '{e.MetricKey}'.",
+                        new Dictionary<string, object?>
+                        {
+                            ["field"] = "limitValue",
+                            ["value"] = e.LimitValue,
+                            ["metricKey"] = e.MetricKey.ToString(),
+                        },
+                        retryable: false,
+                        severity: TammaErrorSeverity.High);
+                }
+
                 if (!s_validPeriods.Contains(e.Period))
                 {
                     throw new TammaError(
@@ -616,6 +723,37 @@ public sealed class PlanVersionEditor : IPlanVersionEditor
                         retryable: false,
                         severity: TammaErrorSeverity.High);
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emit post-commit audit events BEST-EFFORT (Finding 2). Every write path
+    /// calls this only AFTER its state transition has committed, so a transient
+    /// event-store / publisher outage must never fail the operation: a 500 on a
+    /// committed catalog change would invite an operator retry that mints a
+    /// SECOND superseding version. Each event is attempted independently and a
+    /// failure is logged (ERROR) but swallowed, so one bad emit cannot leave the
+    /// remaining audit breadcrumbs unwritten either.
+    /// </summary>
+    private async Task PublishBestEffortAsync(
+        string operation,
+        IReadOnlyList<PlatformEvent> events,
+        CancellationToken ct)
+    {
+        foreach (var evt in events)
+        {
+            try
+            {
+                await _publisher.AppendAndPublishAsync(evt, ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Plan catalog change committed but audit event emit failed (best-effort): {Operation} {EventType}. " +
+                    "The state transition is durable; this audit event was NOT recorded.",
+                    operation, evt.Type);
             }
         }
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -173,6 +173,11 @@ public class PlatformOwnerAccessPolicyTests
         // rows). Same Finding-C1 gate: a tenant-owner who is not a platform admin
         // must NOT view or version them (AC14).
         "/api/admin/pricing/margins",
+        // Story 34-2 — the plan-catalog admin write surface is platform-global
+        // (no per-tenant override layer). Same Finding-C1 gate: a tenant-owner
+        // who is not a platform admin must NOT list/create/version/deprecate
+        // plans or mint custom plans (AC10).
+        "/api/admin/pricing/plans",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPlanCatalogEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPlanCatalogEndpointsTests.cs
@@ -1,0 +1,368 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-2 — <see cref="AdminPlanCatalogEndpoints"/> against a real Postgres
+/// testcontainer. Covers create/version/deprecate/custom-mint over the immutable
+/// <see cref="PlanVersionEditor"/>, input validation → 422/400, the
+/// deprecate-with-assignments 409 + force path, the custom-public rejection,
+/// and the PLAN.CATALOG.UPDATED / PLAN.CUSTOM.CREATED DCB emits. (The
+/// PlatformOwnerAccess 403 gate is pinned by <c>PlatformOwnerAccessPolicyTests</c>,
+/// which lists /api/admin/pricing/plans.)
+/// </summary>
+[TestFixture]
+public class AdminPlanCatalogEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("admin_plan_catalog_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE tenants CASCADE;");
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static ClaimsPrincipal Actor(string userId = "user-34-2", string email = "owner@tamma.dev") =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId),
+            new Claim(JwtRegisteredClaimNames.Email, email),
+            new Claim("platformRole", "platform_admin"),
+        }, "test"));
+
+    private static void AssertStatus(IResult result, int expected)
+    {
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(expected);
+    }
+
+    // Instantiate the handler dependencies over ONE context (mirrors the scoped
+    // wiring: editor writes + catalog reads share the request-scoped context).
+    private async Task<IResult> CreatePlan(CreatePlanRequest body, RecordingPlatformEventPublisher pub)
+    {
+        await using var db = NewContext();
+        return await AdminPlanCatalogEndpoints.CreatePlan(
+            body, Editor(db, pub), Catalog(db), Actor(), default);
+    }
+
+    private async Task<IResult> VersionPlan(string slug, VersionPlanRequest body, RecordingPlatformEventPublisher pub)
+    {
+        await using var db = NewContext();
+        return await AdminPlanCatalogEndpoints.VersionPlan(
+            slug, body, Editor(db, pub), Catalog(db), Actor(), default);
+    }
+
+    private async Task<IResult> CreateCustomPlan(CreateCustomPlanRequest body, RecordingPlatformEventPublisher pub)
+    {
+        await using var db = NewContext();
+        return await AdminPlanCatalogEndpoints.CreateCustomPlan(
+            body, Editor(db, pub), Catalog(db), Actor(), default);
+    }
+
+    private async Task<IResult> DeprecateVersion(string slug, int version, bool? force, RecordingPlatformEventPublisher pub)
+    {
+        await using var db = NewContext();
+        return await AdminPlanCatalogEndpoints.DeprecateVersion(
+            slug, version, force, Editor(db, pub), Actor(), default);
+    }
+
+    private static PlanVersionEditor Editor(ControlPlaneDbContext db, RecordingPlatformEventPublisher pub) =>
+        new(db, pub, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+    private static PlanCatalogService Catalog(ControlPlaneDbContext db) =>
+        new(db, NullLogger<PlanCatalogService>.Instance);
+
+    private static CreatePlanRequest ValidCreate(string slug) => new(
+        slug, $"{slug} plan", "monthly",
+        Features: new[] { new PlanFeatureDto("byok_allowed", true, null) },
+        Entitlements: new[] { new PlanEntitlementDto("seats", 5, "total", "block") },
+        Prices: new[] { new PlanPriceDto("platform_provided", 49m, 15m, null) });
+
+    private async Task<Guid> ActivePlanIdAsync(string slug, int version)
+    {
+        await using var db = NewContext();
+        return (await db.Plans.AsNoTracking()
+            .SingleAsync(p => p.Slug == slug && p.Version == version)).Id;
+    }
+
+    private async Task PinTenantToAsync(Guid planId, string slug)
+    {
+        await using var db = NewContext();
+        var t = new Tenant
+        {
+            Id = Guid.NewGuid(),
+            Name = slug,
+            Slug = slug,
+            Type = "personal",
+            // Legacy slug column is CHECK-constrained to the seeded slugs; the
+            // version pin under test is the PlanId shadow column set below.
+            Plan = "free",
+            Settings = "{}",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            ProvisioningState = "none",
+        };
+        db.Tenants.Add(t);
+        db.Entry(t).Property("PlanId").CurrentValue = planId;
+        await db.SaveChangesAsync();
+    }
+
+    // ── AC3 — create initial version ──
+    [Test]
+    public async Task CreatePlan_Writes_V1_Active_And_Emits_CatalogUpdated_Created()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        var result = await CreatePlan(ValidCreate("startup"), pub);
+        AssertStatus(result, StatusCodes.Status201Created);
+
+        await using var db = NewContext();
+        var row = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == "startup");
+        row.Version.Should().Be(1);
+        row.Status.Should().Be("active");
+        row.IsCustom.Should().BeFalse();
+
+        var evt = pub.Events.Should().ContainSingle(e => e.Type == PlanCatalogEventTypes.CatalogUpdated).Subject;
+        evt.Tags.Should().Contain("\"action\":\"created\"");
+        evt.Tags.Should().Contain("\"actorUserId\":\"user-34-2\"");
+    }
+
+    // ── AC3 / AC12 — creating over an existing slug is a 409 ──
+    [Test]
+    public async Task CreatePlan_ExistingSlug_Returns409()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        await CreatePlan(ValidCreate("team"), pub);
+
+        var again = await CreatePlan(ValidCreate("team"), pub);
+        AssertStatus(again, StatusCodes.Status409Conflict);
+    }
+
+    // ── AC8 — invalid metric key → 422 ──
+    [Test]
+    public async Task CreatePlan_InvalidMetricKey_Returns422()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        var body = new CreatePlanRequest(
+            "badmetric", "Bad", "monthly", null,
+            Entitlements: new[] { new PlanEntitlementDto("not_a_metric", 1, "total", "block") },
+            Prices: null);
+        var result = await CreatePlan(body, pub);
+        AssertStatus(result, StatusCodes.Status422UnprocessableEntity);
+    }
+
+    // ── AC8 — invalid pricing mode → 422 ──
+    [Test]
+    public async Task CreatePlan_InvalidPricingMode_Returns422()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        var body = new CreatePlanRequest(
+            "badmode", "Bad", "monthly", null, null,
+            Prices: new[] { new PlanPriceDto("free_lunch", 0m, 0m, null) });
+        var result = await CreatePlan(body, pub);
+        AssertStatus(result, StatusCodes.Status422UnprocessableEntity);
+    }
+
+    // ── AC3 — version an existing plan (prior → deprecated), emits catalog + lifecycle events ──
+    [Test]
+    public async Task VersionPlan_Supersedes_Prior_And_Emits_CatalogUpdated_Versioned()
+    {
+        await using (var seed = NewContext()) await PlansSeeder.SeedAsync(seed);
+
+        var pub = new RecordingPlatformEventPublisher();
+        var result = await VersionPlan("team", new VersionPlanRequest(DisplayName: "Team v2"), pub);
+        AssertStatus(result, StatusCodes.Status200OK);
+
+        await using var db = NewContext();
+        var active = await db.Plans.CountAsync(p => p.Slug == "team" && p.Status == "active");
+        active.Should().Be(1, "exactly one active version per slug");
+        var v2 = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == "team" && p.Version == 2);
+        v2.Status.Should().Be("active");
+
+        // The 34-1 lifecycle events AND the 34-2 admin-surface catalog event.
+        pub.Events.Should().Contain(e => e.Type == PlanCatalogEventTypes.VersionCreated);
+        pub.Events.Should().Contain(e => e.Type == PlanCatalogEventTypes.Deprecated);
+        var catalog = pub.Events.Should().ContainSingle(e => e.Type == PlanCatalogEventTypes.CatalogUpdated).Subject;
+        catalog.Tags.Should().Contain("\"action\":\"versioned\"");
+    }
+
+    // ── AC4 — mint a custom plan bound to a tenant ──
+    [Test]
+    public async Task CreateCustomPlan_Mints_IsCustom_Bound_To_Tenant_And_Emits_CustomCreated()
+    {
+        var tenantId = Guid.NewGuid();
+        var pub = new RecordingPlatformEventPublisher();
+        var body = new CreateCustomPlanRequest(
+            tenantId, "Acme Enterprise", "annual",
+            Features: new[] { new PlanFeatureDto("support_tier", null, "priority") },
+            Entitlements: new[] { new PlanEntitlementDto("llm_tokens", null, "monthly", "meter") },
+            Prices: new[] { new PlanPriceDto("platform_provided", 5000m, 0m, null) });
+
+        var result = await CreateCustomPlan(body, pub);
+        AssertStatus(result, StatusCodes.Status201Created);
+
+        await using var db = NewContext();
+        var row = await db.Plans.AsNoTracking().SingleAsync(p => p.IsCustom);
+        row.IsCustom.Should().BeTrue();
+        row.Slug.Should().StartWith(CustomPlanSlug.PrefixFor(tenantId));
+        CustomPlanSlug.IsBoundTo(row.Slug, tenantId).Should().BeTrue();
+
+        var evt = pub.Events.Should().ContainSingle(e => e.Type == PlanCatalogEventTypes.CustomCreated).Subject;
+        evt.Tags.Should().Contain($"\"tenantId\":\"{tenantId:D}\"");
+    }
+
+    // ── AC5 — a custom plan asking for public visibility is rejected 400 ──
+    [Test]
+    public async Task CreateCustomPlan_MakePublic_Returns400()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        var body = new CreateCustomPlanRequest(
+            Guid.NewGuid(), "Sneaky", "monthly", null, null, null, MakePublic: true);
+        var result = await CreateCustomPlan(body, pub);
+        AssertStatus(result, StatusCodes.Status400BadRequest);
+
+        await using var db = NewContext();
+        (await db.Plans.CountAsync()).Should().Be(0, "the rejected custom plan is never written");
+    }
+
+    // ── AC11 — custom round-trip: admin list includes it, public list excludes it ──
+    [Test]
+    public async Task CustomPlan_RoundTrip_AdminLists_PublicExcludes()
+    {
+        var tenantId = Guid.NewGuid();
+        var pub = new RecordingPlatformEventPublisher();
+        await CreateCustomPlan(new CreateCustomPlanRequest(
+            tenantId, "Bespoke", "monthly", null,
+            Entitlements: new[] { new PlanEntitlementDto("seats", 100, "total", "allow") },
+            Prices: new[] { new PlanPriceDto("byok", 0m, 0m, null) }), pub);
+
+        await using var db = NewContext();
+        var catalog = Catalog(db);
+
+        var admin = await catalog.ListAllForAdminAsync(new PlanListFilter(IsCustom: true));
+        admin.Should().ContainSingle(p => p.IsCustom);
+
+        var pub2 = await catalog.ListActivePublicAsync();
+        pub2.Should().NotContain(p => p.IsCustom);
+
+        var byTenant = await catalog.ListAllForAdminAsync(new PlanListFilter(TenantId: tenantId));
+        byTenant.Should().ContainSingle(p => p.IsCustom);
+    }
+
+    // ── AC7 — deprecate with zero assignments → 204 ──
+    [Test]
+    public async Task DeprecateVersion_NoAssignments_Returns204_And_Flips_Status()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        await CreatePlan(ValidCreate("solo"), pub);
+
+        var result = await DeprecateVersion("solo", 1, force: false, pub);
+        AssertStatus(result, StatusCodes.Status204NoContent);
+
+        await using var db = NewContext();
+        var row = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == "solo" && p.Version == 1);
+        row.Status.Should().Be("deprecated");
+        pub.Events.Should().Contain(e =>
+            e.Type == PlanCatalogEventTypes.CatalogUpdated && e.Tags.Contains("\"action\":\"deprecated\""));
+    }
+
+    // ── AC7 — deprecate blocked by assignments → 409; force=true deprecates ──
+    [Test]
+    public async Task DeprecateVersion_WithAssignments_Returns409_Then_Force_Deprecates()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        await CreatePlan(ValidCreate("pinned"), pub);
+        var planId = await ActivePlanIdAsync("pinned", 1);
+        await PinTenantToAsync(planId, "pinned-tenant");
+
+        // Blocked — active assignment, no force.
+        var blocked = await DeprecateVersion("pinned", 1, force: false, pub);
+        AssertStatus(blocked, StatusCodes.Status409Conflict);
+        await using (var db = NewContext())
+        {
+            var row = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == "pinned" && p.Version == 1);
+            row.Status.Should().Be("active", "blocked deprecate performs no write");
+        }
+
+        // Force — deprecates; the tenant stays pinned to the deprecated version.
+        var forced = await DeprecateVersion("pinned", 1, force: true, pub);
+        AssertStatus(forced, StatusCodes.Status204NoContent);
+        await using (var db = NewContext())
+        {
+            var row = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == "pinned" && p.Version == 1);
+            row.Status.Should().Be("deprecated");
+            var stillPinned = await db.Tenants.IgnoreQueryFilters()
+                .CountAsync(t => EF.Property<Guid?>(t, "PlanId") == planId);
+            stillPinned.Should().Be(1, "immutability rule: existing tenants stay on the deprecated version");
+        }
+    }
+
+    // ── AC7 — deprecate an unknown (slug, version) → 404 ──
+    [Test]
+    public async Task DeprecateVersion_Unknown_Returns404()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        var result = await DeprecateVersion("ghost", 1, force: false, pub);
+        AssertStatus(result, StatusCodes.Status404NotFound);
+    }
+
+    // ── Admin list filters by status + isCustom ──
+    [Test]
+    public async Task ListForAdmin_Filters_Status_And_IsCustom()
+    {
+        var pub = new RecordingPlatformEventPublisher();
+        await CreatePlan(ValidCreate("alpha"), pub);
+        await CreateCustomPlan(new CreateCustomPlanRequest(
+            Guid.NewGuid(), "Beta", "monthly", null, null,
+            Prices: new[] { new PlanPriceDto("byok", 0m, 0m, null) }), pub);
+
+        await using var db = NewContext();
+        var catalog = Catalog(db);
+
+        (await catalog.ListAllForAdminAsync(new PlanListFilter(Status: "active"))).Should().HaveCount(2);
+        (await catalog.ListAllForAdminAsync(new PlanListFilter(IsCustom: false))).Should().ContainSingle(p => p.Slug == "alpha");
+        (await catalog.ListAllForAdminAsync(new PlanListFilter(IsCustom: true))).Should().ContainSingle(p => p.IsCustom);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanVersionEditorTests.cs
@@ -201,6 +201,152 @@ public class PlanVersionEditorTests
         publisher.Events.Should().BeEmpty("no event on a failed (no-op) operation");
     }
 
+    // ── Finding 1 — non-negative guard on plan prices / entitlement limits.
+    // ValidateDraft is the single choke point (create/version/custom); a
+    // negative price would credit money downstream (Epic 35 billing/markup). ──
+
+    [Test]
+    public async Task CreateInitialVersion_NegativeRecurringPrice_Rejected_And_NotWritten()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(
+            DisplayName: "Bad Recurring",
+            Prices: new[] { new PlanPriceDraft("platform_provided", -5000m, 15m, "{}") });
+
+        var act = async () => await editor.CreateInitialVersionAsync(
+            "guard-neg-recurring", draft, new PlanEditorPrincipal("u", null));
+
+        await act.Should().ThrowAsync<TammaError>().Where(e => e.Code == "PLAN.PRICE.INVALID");
+        (await ctx.Plans.AnyAsync(p => p.Slug == "guard-neg-recurring")).Should().BeFalse();
+        publisher.Events.Should().BeEmpty("no event on a rejected (unwritten) plan");
+    }
+
+    [Test]
+    public async Task CreateInitialVersion_NegativeSeatPrice_Rejected_And_NotWritten()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(
+            DisplayName: "Bad Seat",
+            Prices: new[] { new PlanPriceDraft("platform_provided", 49m, -15m, "{}") });
+
+        var act = async () => await editor.CreateInitialVersionAsync(
+            "guard-neg-seat", draft, new PlanEditorPrincipal("u", null));
+
+        await act.Should().ThrowAsync<TammaError>().Where(e => e.Code == "PLAN.PRICE.INVALID");
+        (await ctx.Plans.AnyAsync(p => p.Slug == "guard-neg-seat")).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateInitialVersion_NegativeMonthlyPrice_Rejected()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(DisplayName: "Bad Monthly", MonthlyPriceUsd: -1m);
+
+        var act = async () => await editor.CreateInitialVersionAsync(
+            "guard-neg-monthly", draft, new PlanEditorPrincipal("u", null));
+
+        await act.Should().ThrowAsync<TammaError>().Where(e => e.Code == "PLAN.PRICE.INVALID");
+        (await ctx.Plans.AnyAsync(p => p.Slug == "guard-neg-monthly")).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateInitialVersion_NegativeLimit_Rejected_And_NotWritten()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(
+            DisplayName: "Bad Limit",
+            Entitlements: new[] { new PlanEntitlementDraft(EntitlementMetricKey.Seats, -1, "total", "block") });
+
+        var act = async () => await editor.CreateInitialVersionAsync(
+            "guard-neg-limit", draft, new PlanEditorPrincipal("u", null));
+
+        await act.Should().ThrowAsync<TammaError>().Where(e => e.Code == "PLAN.LIMIT.INVALID");
+        (await ctx.Plans.AnyAsync(p => p.Slug == "guard-neg-limit")).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateInitialVersion_NullLimit_Unlimited_Is_Accepted()
+    {
+        var publisher = new RecordingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(
+            DisplayName: "Unlimited",
+            Entitlements: new[] { new PlanEntitlementDraft(EntitlementMetricKey.LlmTokens, null, "monthly", "meter") },
+            Prices: new[] { new PlanPriceDraft("platform_provided", 0m, 0m, "{}") });
+
+        var plan = await editor.CreateInitialVersionAsync(
+            "guard-unlimited", draft, new PlanEditorPrincipal("u", null));
+        plan.Version.Should().Be(1);
+
+        await using var verify = NewContext();
+        (await verify.Plans.AnyAsync(p => p.Slug == "guard-unlimited" && p.Status == "active"))
+            .Should().BeTrue("null limit means unlimited and is a valid plan");
+    }
+
+    // ── Finding 2 — POST-COMMIT audit emit is best-effort: a publisher outage
+    // must NOT fail a catalog change that already committed. ──
+
+    [Test]
+    public async Task CreateNewVersion_PublisherFailure_Does_Not_Fail_The_Committed_Change()
+    {
+        var publisher = new ThrowingPlatformEventPublisher();
+        Guid v1Id;
+
+        await using (var ctx = NewContext())
+        {
+            v1Id = (await ctx.Plans.FirstAsync(p => p.Slug == "team" && p.Status == "active")).Id;
+            var editor = new PlanVersionEditor(
+                ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+            // Must NOT throw even though every publish attempt fails.
+            var v2 = await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(DisplayName: "Team v2"), new PlanEditorPrincipal("u", null));
+            v2.Version.Should().Be(2);
+        }
+
+        publisher.Attempts.Should().BeGreaterThan(0, "the emit was attempted (best-effort)");
+
+        await using var verify = NewContext();
+        (await verify.Plans.FirstAsync(p => p.Id == v1Id)).Status.Should().Be("deprecated");
+        (await verify.Plans.CountAsync(p => p.Slug == "team" && p.Status == "active")).Should().Be(1);
+        (await verify.Plans.SingleAsync(p => p.Slug == "team" && p.Version == 2)).Status
+            .Should().Be("active", "the version was committed despite the publisher outage");
+    }
+
+    [Test]
+    public async Task CreateInitialVersion_PublisherFailure_Still_Persists_The_Plan()
+    {
+        var publisher = new ThrowingPlatformEventPublisher();
+        await using var ctx = NewContext();
+        var editor = new PlanVersionEditor(ctx, publisher, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+        var draft = new PlanDraftSpec(
+            DisplayName: "Resilient",
+            Prices: new[] { new PlanPriceDraft("platform_provided", 10m, 0m, "{}") });
+
+        var plan = await editor.CreateInitialVersionAsync(
+            "emit-fail-ok", draft, new PlanEditorPrincipal("u", null));
+        plan.Version.Should().Be(1);
+
+        await using var verify = NewContext();
+        (await verify.Plans.AnyAsync(p => p.Slug == "emit-fail-ok" && p.Status == "active"))
+            .Should().BeTrue("the plan committed despite the publisher outage");
+    }
+
     private static Dictionary<string, string?> ParseTags(string json) =>
         JsonSerializer.Deserialize<Dictionary<string, string?>>(json)!;
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingEstimateEndpointTests.cs
@@ -224,6 +224,12 @@ public class PricingEstimateEndpointTests
             Task.FromResult<PlanSnapshot?>(null);
         public Task<IReadOnlyList<PlanSnapshot>> ListActiveAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
+        public Task<IReadOnlyList<PlanSnapshot>> ListActivePublicAsync(CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
+        public Task<PlanSnapshot?> GetActivePublicBySlugAsync(string slug, CancellationToken ct = default) =>
+            Task.FromResult<PlanSnapshot?>(null);
+        public Task<IReadOnlyList<PlanSnapshot>> ListAllForAdminAsync(PlanListFilter filter, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
         public Task<IReadOnlyList<PlanSnapshot>> GetVersionsBySlugAsync(string slug, CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<PlanSnapshot>>(Array.Empty<PlanSnapshot>());
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PublicPricingPlansEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PublicPricingPlansEndpointsTests.cs
@@ -1,0 +1,192 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-2 (AC1/AC2/AC14) — the PUBLIC plan-catalog read routes
+/// (<see cref="PricingEndpoints.ListPublicPlans"/> /
+/// <see cref="PricingEndpoints.GetPublicPlanBySlug"/>). Proves the public list
+/// surfaces active, non-custom plans and excludes deprecated / draft / custom
+/// plans, and that a custom plan's slug is never resolvable through the public
+/// route (tenant-isolation by construction).
+/// </summary>
+[TestFixture]
+public class PublicPricingPlansEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("public_pricing_plans_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private PlanCatalogService Catalog(ControlPlaneDbContext db) =>
+        new(db, NullLogger<PlanCatalogService>.Instance);
+
+    private static IReadOnlyList<PlanSnapshot> PlansFrom(IResult result)
+    {
+        var value = ((IValueHttpResult)result).Value!;
+        var plans = value.GetType().GetProperty("plans")!.GetValue(value)!;
+        return ((IEnumerable<PlanSnapshot>)plans).ToList();
+    }
+
+    // ── AC1 — public list returns the seeded active public plans ──
+    [Test]
+    public async Task ListPublicPlans_Returns_Active_Public_Only()
+    {
+        await using var db = NewContext();
+        var result = await PricingEndpoints.ListPublicPlans(Catalog(db), default);
+
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status200OK);
+        var plans = PlansFrom(result);
+        plans.Select(p => p.Slug).Should().BeEquivalentTo(new[] { "free", "team", "enterprise" });
+        plans.Should().OnlyContain(p => p.Status == "active" && !p.IsCustom);
+    }
+
+    // ── AC1 — deprecated versions are excluded ──
+    [Test]
+    public async Task ListPublicPlans_Excludes_Deprecated()
+    {
+        // Version "team" so v1 flips to deprecated.
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                ctx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(DisplayName: "Team v2"),
+                new PlanEditorPrincipal("u", "e@x.io"));
+        }
+
+        await using var db = NewContext();
+        var plans = PlansFrom(await PricingEndpoints.ListPublicPlans(Catalog(db), default));
+        plans.Where(p => p.Slug == "team").Should().ContainSingle()
+            .Which.Version.Should().Be(2, "only the active (v2) team plan is public; the deprecated v1 is excluded");
+    }
+
+    // ── AC1 — draft plans are excluded ──
+    [Test]
+    public async Task ListPublicPlans_Excludes_Draft()
+    {
+        await using (var ctx = NewContext())
+        {
+            ctx.Plans.Add(new Plan
+            {
+                Id = Guid.NewGuid(),
+                Slug = "preview",
+                DisplayName = "Preview",
+                Version = 1,
+                Status = "draft",
+                IsCustom = false,
+                BillingInterval = "monthly",
+                Quotas = "{}",
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var db = NewContext();
+        var plans = PlansFrom(await PricingEndpoints.ListPublicPlans(Catalog(db), default));
+        plans.Should().NotContain(p => p.Slug == "preview");
+    }
+
+    // ── AC5 — custom plans never appear in the public list ──
+    [Test]
+    public async Task ListPublicPlans_Excludes_Custom()
+    {
+        var tenantId = Guid.NewGuid();
+        string customSlug;
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                ctx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            var plan = await editor.CreateCustomVersionAsync(
+                tenantId, new PlanDraftSpec(DisplayName: "Bespoke"),
+                new PlanEditorPrincipal("u", "e@x.io"));
+            customSlug = plan.Slug;
+        }
+
+        await using var db = NewContext();
+        var plans = PlansFrom(await PricingEndpoints.ListPublicPlans(Catalog(db), default));
+        plans.Should().NotContain(p => p.IsCustom);
+        plans.Should().NotContain(p => p.Slug == customSlug);
+    }
+
+    // ── AC2 — get by slug returns the active public plan; unknown → 404 ──
+    [Test]
+    public async Task GetPublicPlanBySlug_Returns_Active_Or_404()
+    {
+        await using var db = NewContext();
+        var ok = await PricingEndpoints.GetPublicPlanBySlug("team", Catalog(db), default);
+        ((IStatusCodeHttpResult)ok).StatusCode.Should().Be(StatusCodes.Status200OK);
+
+        var missing = await PricingEndpoints.GetPublicPlanBySlug("nope", Catalog(db), default);
+        ((IStatusCodeHttpResult)missing).StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    // ── AC2/AC14 — a custom plan's slug is never resolvable publicly ──
+    [Test]
+    public async Task GetPublicPlanBySlug_Custom_Returns404()
+    {
+        string customSlug;
+        await using (var ctx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                ctx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            var plan = await editor.CreateCustomVersionAsync(
+                Guid.NewGuid(), new PlanDraftSpec(DisplayName: "Bespoke"),
+                new PlanEditorPrincipal("u", "e@x.io"));
+            customSlug = plan.Slug;
+        }
+
+        await using var db = NewContext();
+        var result = await PricingEndpoints.GetPublicPlanBySlug(customSlug, Catalog(db), default);
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TestDoubles/ThrowingPlatformEventPublisher.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TestDoubles/ThrowingPlatformEventPublisher.cs
@@ -1,0 +1,26 @@
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.TestDoubles;
+
+/// <summary>
+/// Test double for <see cref="IPlatformEventPublisher"/> that ALWAYS throws on
+/// <see cref="AppendAndPublishAsync"/>, simulating a transient event-store /
+/// publisher outage. Used to prove that a POST-COMMIT audit emit is best-effort:
+/// a publisher failure must NOT fail a catalog change that has already committed
+/// (which would otherwise 500 the write and invite a retry that mints a second
+/// superseding version).
+/// </summary>
+internal sealed class ThrowingPlatformEventPublisher : IPlatformEventPublisher
+{
+    /// <summary>Number of publish attempts observed (each throws).</summary>
+    public int Attempts { get; private set; }
+
+    public Task<PlatformEvent?> AppendAndPublishAsync(
+        PlatformEvent evt, CancellationToken ct = default)
+    {
+        Attempts++;
+        throw new InvalidOperationException(
+            "Simulated platform-event publisher outage (AppendAndPublishAsync).");
+    }
+}


### PR DESCRIPTION
## What

Story 34-2 (P0). Admin CRUD/versioning over the 34-1 plan catalog + custom enterprise plans. Admin writes under `/api/admin/pricing/plans*` (**PlatformOwnerAccess**): create, version (PUT), custom-mint, deprecate (409 + `affectedTenantCount` unless `?force=true`). Public reads `/api/pricing/plans*` (MemberAccess, active + non-custom only). Reuses the existing `PlanVersionEditor` (single write path — no duplicated versioning) + `IPlanCatalogService`. **No migration.**

- Custom plans bound to a tenant via deterministic slug `custom-{tenantId:N}-{seq}` + `PLAN.CUSTOM.CREATED` event; excluded from the public catalog (custom slug → 404); custom-as-public → 400.
- `PLAN.CATALOG.UPDATED` / `PLAN.CUSTOM.CREATED` events carry actor + slug + version + tenantId.

> **Deferral (tracked):** the spec wanted a `plans.CustomTenantId` column + CHECK; deferred to a later migration wave (my no-migration constraint while 35-4's migration was in flight). Nothing reads a column today; the slug+event encode the binding.

## Review outcome

Focused review verified RBAC (all writes `PlatformOwnerAccess`), custom-plan cross-tenant isolation, the deprecate guard (version-pinned affected count; force can't strand tenants), and enum validation as SOLID. Two findings fixed:
- **Money integrity:** the write path validated enum fields but not amounts — a negative `recurringUsd`/`seatUsd`/`limitValue` could persist a plan that credits money. Added non-negative guards (422 `PLAN.PRICE.INVALID`/`PLAN.LIMIT.INVALID`; `null` limit = unlimited stays valid).
- **Idempotent retry:** post-commit event emit was fatal-on-failure → a publisher hiccup 500'd a committed change, and a retry double-versioned. Emits are now best-effort (logged, non-fatal).

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Pricing tests: 332 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)