### PR TITLE
ci: bump .NET Tests job timeout 15 → 25 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,10 @@ jobs:
   dotnet-tests:
     name: .NET Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The C# suite (4000+ tests, Postgres testcontainers) grew to ~13-15 min as
+    # Epics 32/34/35/36/37 landed and began flaking on the old 15-min cap. 25 min
+    # gives headroom for continued growth without masking a real hang.
+    timeout-minutes: 25
     permissions:
       contents: read
     defaults:


### PR DESCRIPTION
The C# test suite (4000+ tests + Postgres testcontainers) grew to ~13–15 min as the Epic 32/34/35/36/37 stories landed, and started flaking on the 15-min cap (jobs cancelled at 15m0s with all tests passing — e.g. PR #426). Bumps `.NET Tests` `timeout-minutes` 15 → 25 for headroom; still tight enough to surface a real hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)