### PR TITLE
feat(epic-37): Story 37-10 — Sensitive-Action Audit Emission Coverage

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
@@ -735,10 +735,18 @@ public class ApiKeyAuthHandler(
                 ["ip"] = ip,
             };
 
+            // Hot path: this runs inside request authentication. A stalled CP
+            // DB/bus must NOT block the auth request until the DB command timeout.
+            // Bound the emit with a short timeout linked to the request-abort
+            // token so a slow audit sink can't hang authentication (the throttle
+            // caps frequency, but the once-per-bucket request still shouldn't stall).
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(Context.RequestAborted);
+            cts.CancelAfter(TimeSpan.FromSeconds(2));
             await emitter.EmitAsync(
                 Tamma.Api.Services.Audit.SensitiveAction.ForPlatform(
                     Tamma.Core.Audit.SensitiveActionCatalog.ApiKeyUsed,
-                    tenantId, actorUserId: null, tags, data));
+                    tenantId, actorUserId: null, tags, data),
+                cts.Token);
         }
         catch (Exception ex)
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
@@ -713,7 +713,7 @@ public class ApiKeyAuthHandler(
 
             // Safe display prefix: the banner + a few chars only, short enough that
             // the credential redactor's secret-prefix regex (which needs 6+ trailing
-            // chars after tamma_sk_/sk_live_/...) does NOT scrub it away. Never the key.
+            // chars after a known key banner) does NOT scrub it away. Never the key.
             var safePrefix = apiKey.KeyPrefix.Length > 12
                 ? apiKey.KeyPrefix[..12]
                 : apiKey.KeyPrefix;

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/ApiKeyAuthHandler.cs
@@ -674,7 +674,79 @@ public class ApiKeyAuthHandler(
             LogSanitizer.Clean(Request.Method),
             LogSanitizer.Clean(Request.Path.Value));
 
+        // Story 37-10 (AC8) — AUTH.APIKEY.USED, throttled to one heartbeat per
+        // key per time bucket so the hot per-request auth path does not flood the
+        // audit trail. Prefix only, never the key. Best-effort + never-throws.
+        await EmitApiKeyUsedHeartbeatAsync(apiKey, effectiveTenantId, scope);
+
         return AuthenticateResult.Success(ticket);
+    }
+
+    /// <summary>
+    /// Story 37-10 — emit the throttled <c>AUTH.APIKEY.USED</c> heartbeat. The
+    /// throttle (<see cref="Tamma.Api.Services.Audit.IApiKeyAuditHeartbeat"/>) and
+    /// the emitter are resolved from the request scope; a missing registration
+    /// simply skips the emission. Platform-edge event carrying the tenant when the
+    /// key is tenant-scoped. Never throws (audit is best-effort).
+    /// </summary>
+    private async Task EmitApiKeyUsedHeartbeatAsync(
+        ApiKey apiKey, Guid? tenantId, IServiceScope scope)
+    {
+        try
+        {
+            var heartbeat = scope.ServiceProvider
+                .GetService<Tamma.Api.Services.Audit.IApiKeyAuditHeartbeat>();
+            var emitter = scope.ServiceProvider
+                .GetService<Tamma.Api.Services.Audit.ISensitiveActionEmitter>();
+            if (heartbeat is null || emitter is null) return;
+
+            // Throttle: one event per key per bucket (heartbeat, not per-request).
+            if (!heartbeat.ShouldEmit(apiKey.Id))
+            {
+                Logger.LogDebug(
+                    "AUTH.APIKEY.USED suppressed by throttle keyId={KeyId}", apiKey.Id);
+                return;
+            }
+
+            var ip = Context.Connection.RemoteIpAddress?.ToString();
+            if (!string.IsNullOrEmpty(ip) && ip.Length > 64) ip = ip[..64];
+
+            // Safe display prefix: the banner + a few chars only, short enough that
+            // the credential redactor's secret-prefix regex (which needs 6+ trailing
+            // chars after tamma_sk_/sk_live_/...) does NOT scrub it away. Never the key.
+            var safePrefix = apiKey.KeyPrefix.Length > 12
+                ? apiKey.KeyPrefix[..12]
+                : apiKey.KeyPrefix;
+
+            var tags = new Dictionary<string, string?>
+            {
+                ["apiKeyId"] = apiKey.Id.ToString("D"),
+                ["apiKeyPrefix"] = safePrefix,
+                ["scope"] = apiKey.Scope,
+                ["source"] = "api-key",
+            };
+            if (!string.IsNullOrEmpty(ip)) tags["ip"] = ip;
+
+            var data = new Dictionary<string, object?>
+            {
+                ["apiKeyId"] = apiKey.Id.ToString("D"),
+                ["apiKeyPrefix"] = safePrefix,
+                ["scope"] = apiKey.Scope,
+                ["ip"] = ip,
+            };
+
+            await emitter.EmitAsync(
+                Tamma.Api.Services.Audit.SensitiveAction.ForPlatform(
+                    Tamma.Core.Audit.SensitiveActionCatalog.ApiKeyUsed,
+                    tenantId, actorUserId: null, tags, data));
+        }
+        catch (Exception ex)
+        {
+            // Best-effort — an audit emit failure must never fail authentication.
+            Logger.LogWarning(ex,
+                "AUTH.APIKEY.USED emission failed keyId={KeyId}; auth is unaffected.",
+                apiKey.Id);
+        }
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
@@ -1056,6 +1056,13 @@ public static class AuthEndpoints
         if (emitter is null) return;
         var (ip, ua) = ResolveRequestFingerprint(httpContext);
 
+        // The submitted email is attacker-controlled and unbounded (no validation
+        // filter). Clamp to the RFC 5321 max (254) before it enters the audit
+        // tags/data so a padded value can't overflow the ActorEmailSnapshot
+        // varchar(320) column downstream. The projector also caps defensively,
+        // but capping at the source keeps the emitted event tidy too.
+        if (email.Length > 254) email = email[..254];
+
         var tags = new Dictionary<string, string?>
         {
             ["reason"] = reason,

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AuthEndpoints.cs
@@ -7,9 +7,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Auth;
 using Tamma.Api.Dtos.Auth;
+using Tamma.Api.Services.Audit;
 using Tamma.Api.Services.Auth;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.RateLimit;
+using Tamma.Core.Audit;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -563,9 +565,17 @@ public static class AuthEndpoints
         if (string.IsNullOrWhiteSpace(req.Email) || string.IsNullOrWhiteSpace(req.Password))
             return Results.BadRequest(new { error = "Email and password are required" });
 
+        // Story 37-10 — best-effort resolve the sensitive-action emitter off the
+        // request scope (mirrors the Refresh handler's IPlatformEventPublisher
+        // pattern) so the many tests that call Login/Refresh directly with
+        // positional args keep compiling; a missing registration simply skips the
+        // audit emission (never-throws / best-effort).
+        var auditEmitter = TryResolveEmitter(httpContext);
+
         if (lockout.IsLocked(req.Email))
         {
             var remaining = lockout.GetRemainingLockoutSeconds(req.Email);
+            await EmitLoginFailureAsync(auditEmitter, req.Email, "locked_out", httpContext);
             return Results.Json(new { error = $"Account locked. Try again in {remaining} seconds" }, statusCode: 429);
         }
 
@@ -577,21 +587,29 @@ public static class AuthEndpoints
         {
             passwordService.VerifyPassword(req.Password, passwordService.DummyHash);
             lockout.RecordFailedAttempt(req.Email);
+            await EmitLoginFailureAsync(auditEmitter, req.Email, "bad_credentials", httpContext);
             return Results.Unauthorized();
         }
 
         if (!passwordService.VerifyPassword(req.Password, user.PasswordHash))
         {
             lockout.RecordFailedAttempt(req.Email);
+            await EmitLoginFailureAsync(auditEmitter, req.Email, "bad_credentials", httpContext);
             return Results.Unauthorized();
         }
 
         if (!user.IsActive)
+        {
+            await EmitLoginFailureAsync(auditEmitter, req.Email, "account_deactivated", httpContext);
             return Results.Json(new { error = "Account deactivated" }, statusCode: 403);
+        }
 
         // Email verification gate. Audit finding 006 / Story 18-2 AC 2.
         if (!user.EmailVerified)
+        {
+            await EmitLoginFailureAsync(auditEmitter, req.Email, "unverified_email", httpContext);
             return Results.Json(new { error = "Please verify your email" }, statusCode: 403);
+        }
 
         lockout.ResetAttempts(req.Email);
 
@@ -650,6 +668,12 @@ public static class AuthEndpoints
             BuildSessionCookie(config, 900));
 
         await userRepo.UpdateLastActiveAsync(user.Id);
+
+        // Story 37-10 — AUTH.LOGIN.SUCCESS. Platform-edge event carrying the
+        // resolved active tenant (null => control-plane), so the 37-1 projector
+        // routes the curated row to that tenant's schema in SaaS.
+        await EmitLoginSuccessAsync(
+            auditEmitter, user, tenantId == Guid.Empty ? null : tenantId, httpContext);
 
         return Results.Ok(new LoginResponse(
             accessToken,
@@ -854,6 +878,13 @@ public static class AuthEndpoints
         httpContext.Response.Cookies.Append("tamma_session", accessToken,
             BuildSessionCookie(config, 900));
 
+        // Story 37-10 — AUTH.TOKEN.REFRESHED (distinct from the reuse-detection
+        // event, which is untouched above). Platform-edge event carrying the
+        // resolved tenant when present. Best-effort emitter off the request scope.
+        await EmitTokenRefreshedAsync(
+            TryResolveEmitter(httpContext),
+            user.Id, tenantId == Guid.Empty ? null : tenantId, user.Email, httpContext);
+
         return Results.Ok(new RefreshResponse(accessToken, newRefresh, 900));
     }
 
@@ -983,6 +1014,131 @@ public static class AuthEndpoints
             // Audit failures must not break the user's logout flow. The
             // structured logger picks these up via Serilog request logging.
         }
+    }
+
+    // ─── Story 37-10 — curated auth sensitive-action emission ──────────────
+
+    /// <summary>Best-effort resolve the sensitive-action emitter off the request
+    /// scope. Swallows resolution failures (e.g. a test double whose fallback is a
+    /// root provider that can't resolve the scoped emitter) — audit emission is a
+    /// side effect that must never break auth.</summary>
+    private static ISensitiveActionEmitter? TryResolveEmitter(HttpContext httpContext)
+    {
+        try { return httpContext.RequestServices?.GetService<ISensitiveActionEmitter>(); }
+        catch { return null; }
+    }
+
+    /// <summary>Resolve the request fingerprint (ip + user-agent) with the same
+    /// TrustedProxyResolver logic as <see cref="BuildAuthAuditEvent"/>. Falls back
+    /// to the socket peer when the resolver isn't registered (test contexts).</summary>
+    private static (string? Ip, string? UserAgent) ResolveRequestFingerprint(HttpContext httpContext)
+    {
+        TrustedProxyResolver? resolver;
+        try { resolver = httpContext.RequestServices?.GetService<TrustedProxyResolver>(); }
+        catch { resolver = null; }
+        var ip = resolver is not null
+            ? resolver.ResolveActorIp(httpContext)
+            : httpContext.Connection.RemoteIpAddress?.ToString();
+        if (!string.IsNullOrEmpty(ip) && ip.Length > 64) ip = ip[..64];
+
+        var ua = httpContext.Request.Headers.UserAgent.ToString();
+        if (ua.Length > 256) ua = ua[..256];
+
+        return (ip, string.IsNullOrEmpty(ua) ? null : ua);
+    }
+
+    /// <summary>Emit <c>AUTH.LOGIN.FAILURE</c> (platform-edge; no trusted tenant
+    /// yet). Redaction-safe — the submitted email + machine-readable reason only,
+    /// NEVER the password. No-op when the emitter isn't registered.</summary>
+    private static async Task EmitLoginFailureAsync(
+        ISensitiveActionEmitter? emitter, string email, string reason, HttpContext httpContext)
+    {
+        if (emitter is null) return;
+        var (ip, ua) = ResolveRequestFingerprint(httpContext);
+
+        var tags = new Dictionary<string, string?>
+        {
+            ["reason"] = reason,
+            ["actorEmail"] = email,
+            ["source"] = "auth",
+        };
+        if (!string.IsNullOrEmpty(ip)) tags["ip"] = ip;
+        if (!string.IsNullOrEmpty(ua)) tags["userAgent"] = ua;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["reason"] = reason,
+            ["actorEmail"] = email,
+            ["ip"] = ip,
+            ["userAgent"] = ua,
+        };
+
+        await emitter.EmitAsync(
+            SensitiveAction.ForPlatform(
+                SensitiveActionCatalog.LoginFailure, tenantId: null, actorUserId: null, tags, data),
+            httpContext.RequestAborted);
+    }
+
+    /// <summary>Emit <c>AUTH.LOGIN.SUCCESS</c>. Platform-edge event carrying the
+    /// resolved active tenant (null => control-plane). No password material.</summary>
+    private static async Task EmitLoginSuccessAsync(
+        ISensitiveActionEmitter? emitter, User user, Guid? tenantId, HttpContext httpContext)
+    {
+        if (emitter is null) return;
+        var (ip, ua) = ResolveRequestFingerprint(httpContext);
+
+        var tags = new Dictionary<string, string?>
+        {
+            ["actorUserId"] = user.Id.ToString("D"),
+            ["actorEmail"] = user.Email,
+            ["source"] = "auth",
+        };
+        if (!string.IsNullOrEmpty(ip)) tags["ip"] = ip;
+        if (!string.IsNullOrEmpty(ua)) tags["userAgent"] = ua;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["userId"] = user.Id.ToString("D"),
+            ["actorEmail"] = user.Email,
+            ["ip"] = ip,
+            ["userAgent"] = ua,
+        };
+
+        await emitter.EmitAsync(
+            SensitiveAction.ForPlatform(
+                SensitiveActionCatalog.LoginSuccess, tenantId, user.Id, tags, data),
+            httpContext.RequestAborted);
+    }
+
+    /// <summary>Emit <c>AUTH.TOKEN.REFRESHED</c> on a successful refresh-token
+    /// rotation. Platform-edge event carrying the resolved tenant when present.</summary>
+    private static async Task EmitTokenRefreshedAsync(
+        ISensitiveActionEmitter? emitter, Guid userId, Guid? tenantId,
+        string? email, HttpContext httpContext)
+    {
+        if (emitter is null) return;
+        var (ip, ua) = ResolveRequestFingerprint(httpContext);
+
+        var tags = new Dictionary<string, string?>
+        {
+            ["actorUserId"] = userId.ToString("D"),
+            ["source"] = "auth",
+        };
+        if (!string.IsNullOrEmpty(email)) tags["actorEmail"] = email;
+        if (!string.IsNullOrEmpty(ip)) tags["ip"] = ip;
+        if (!string.IsNullOrEmpty(ua)) tags["userAgent"] = ua;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["userId"] = userId.ToString("D"),
+            ["ip"] = ip,
+            ["userAgent"] = ua,
+        };
+
+        await emitter.EmitAsync(
+            SensitiveAction.ForPlatform(
+                SensitiveActionCatalog.TokenRefreshed, tenantId, userId, tags, data),
+            httpContext.RequestAborted);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderCredentialEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/ProviderCredentialEndpoints.cs
@@ -1,13 +1,16 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.Security;
 using Tamma.Api.Auth;
+using Tamma.Api.Services.Audit;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Api.Services.Providers;
 using Tamma.Api.Services.Secrets;
 using Tamma.Api.Services.Secrets.Query;
 using Tamma.Api.Services.Secrets.Reveal;
+using Tamma.Core.Audit;
 using Tamma.Data;
 
 namespace Tamma.Api.Endpoints;
@@ -117,6 +120,13 @@ public static class ProviderCredentialEndpoints
 
             resolver.Invalidate(tid, norm!);
 
+            // Story 37-10 — curated BYOK audit event (the SECRET.WRITE cabinet
+            // event stays the secret source of truth; this is derived alongside it,
+            // NOT a second write). Metadata only — the key never travels here.
+            await EmitByokChangeAsync(
+                http, tid, principal.GetUserId(), norm!, "set",
+                result.Metadata.ActiveVersionNumber).ConfigureAwait(false);
+
             return Results.Created(
                 $"/api/v1/agents/providers/{norm}/credential",
                 new SetProviderCredentialResponse(
@@ -182,6 +192,11 @@ public static class ProviderCredentialEndpoints
 
             resolver.Invalidate(tid, norm!);
 
+            // Story 37-10 — curated BYOK rotate audit event (see RegisterCredential).
+            await EmitByokChangeAsync(
+                http, tid, principal.GetUserId(), norm!, "rotated",
+                result.Metadata.ActiveVersionNumber).ConfigureAwait(false);
+
             return Results.Ok(new SetProviderCredentialResponse(
                 norm!, result.Metadata.ActiveVersionNumber,
                 result.RevealToken, result.ExpiresAt));
@@ -227,6 +242,7 @@ public static class ProviderCredentialEndpoints
             });
         }
 
+        var retiredVersion = meta.ActiveVersionNumber;
         try
         {
             await query.RetireVersionAsync(
@@ -246,10 +262,58 @@ public static class ProviderCredentialEndpoints
         }
 
         resolver.Invalidate(tid, norm!);
+
+        // Story 37-10 — curated BYOK remove audit event (see RegisterCredential).
+        await EmitByokChangeAsync(
+            http, tid, principal.GetUserId(), norm!, "removed",
+            retiredVersion).ConfigureAwait(false);
+
         return Results.NoContent();
     }
 
     // ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Story 37-10 — emit the curated <c>PROVIDER_KEY.CHANGED.SUCCESS</c> BYOK
+    /// audit event (tenant-scoped) after a successful cabinet write. Metadata
+    /// only (provider, operation, mode, version) — the emitter additionally
+    /// scrubs any secret-shaped value defensively. The emitter is resolved
+    /// best-effort off the request scope (keeps the handler signature stable for
+    /// the direct-call tests); a missing registration simply skips the emission.
+    /// Never throws.
+    /// </summary>
+    private static async Task EmitByokChangeAsync(
+        HttpContext http,
+        Guid tenantId,
+        Guid? actorUserId,
+        string provider,
+        string operation,
+        int? version)
+    {
+        ISensitiveActionEmitter? emitter;
+        try { emitter = http.RequestServices?.GetService<ISensitiveActionEmitter>(); }
+        catch { emitter = null; }
+        if (emitter is null) return;
+
+        var tags = new Dictionary<string, string?>
+        {
+            ["provider"] = provider,
+            ["operation"] = operation,
+            ["mode"] = "byok",
+        };
+        var data = new Dictionary<string, object?>
+        {
+            ["provider"] = provider,
+            ["operation"] = operation,
+            ["mode"] = "byok",
+        };
+        if (version is int v) data["version"] = v;
+
+        await emitter.EmitAsync(
+            SensitiveAction.ForTenant(
+                SensitiveActionCatalog.ProviderKeyChanged, tenantId, actorUserId, tags, data),
+            http.RequestAborted).ConfigureAwait(false);
+    }
 
     private static async Task<Guid?> FindSecretIdAsync(
         ISecretQueryService query, Guid tenantId, string provider, CancellationToken ct)

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditEmissionServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditEmissionServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Audit;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 37-10 — DI registration for the curated sensitive-action EMISSION seam
+/// (distinct from Story 37-1's <c>AddTammaAuditProjection</c>, which registers
+/// the read-side projector). Single entry-point so Program.cs wires it with one
+/// call.
+/// </summary>
+public static class AuditEmissionServiceCollectionExtensions
+{
+    /// <summary>
+    /// Register <see cref="ISensitiveActionEmitter"/> (scoped — depends on the
+    /// scoped <c>IEventRepository</c>) and the <see cref="IApiKeyAuditHeartbeat"/>
+    /// throttle (singleton — the per-key/time-bucket state must survive across
+    /// requests). Idempotent.
+    /// </summary>
+    public static IServiceCollection AddTammaSensitiveActionEmitter(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddScoped<ISensitiveActionEmitter, SensitiveActionEmitter>();
+        services.TryAddSingleton<IApiKeyAuditHeartbeat, ApiKeyAuditHeartbeat>();
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1015,6 +1015,15 @@ builder.Services.AddTammaAlertRuleEngine();
 // background loop is opt-in (AuditProjectorOptions.RunOnStartup defaults false).
 builder.Services.AddTammaAuditProjection();
 
+// Story 37-10 — curated sensitive-action EMISSION seam (write side): the single
+// ISensitiveActionEmitter every sensitive-action call site (auth login/refresh,
+// API-key auth, BYOK provider-key changes, ...) appends through, plus the
+// per-key AUTH.APIKEY.USED heartbeat throttle. Routes tenant actions to
+// domain_events and platform-edge actions to platform_events so the 37-1
+// projector materialises them into audit_records in the correct scope. Never
+// throws to the caller (a failed audit emit must not break the action).
+builder.Services.AddTammaSensitiveActionEmitter();
+
 // Story 37-3 — audit query/search/filter read seam over the curated
 // audit_records read-model (Story 37-1). Scoped (depends on the scoped
 // ControlPlaneDbContext); reads the tenant schema via ITenantDbContextFactory

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/ApiKeyAuditHeartbeat.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/ApiKeyAuditHeartbeat.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-10 (AC8) — throttle for <c>AUTH.APIKEY.USED</c>. API-key auth runs
+/// on the hot per-request path; emitting an audit event every request would
+/// flood the trail. This returns <c>true</c> at most once per
+/// <c>(apiKeyId, coarse time bucket)</c> so a busy key produces a heartbeat, not
+/// a flood.
+/// </summary>
+public interface IApiKeyAuditHeartbeat
+{
+    /// <summary>True the first time an API key is seen in the current time
+    /// bucket; false for every subsequent request by the same key in that
+    /// bucket. Thread-safe.</summary>
+    bool ShouldEmit(Guid apiKeyId);
+}
+
+/// <summary>
+/// In-process heartbeat: one <c>AUTH.APIKEY.USED</c> per key per
+/// <see cref="Window"/>. Keyed by <c>apiKeyId</c> (bounded by the number of
+/// distinct keys), driven off an injected <see cref="TimeProvider"/> so tests
+/// can advance time deterministically.
+/// </summary>
+public sealed class ApiKeyAuditHeartbeat : IApiKeyAuditHeartbeat
+{
+    /// <summary>Heartbeat window. One audit event per key per window.</summary>
+    public static readonly TimeSpan Window = TimeSpan.FromMinutes(5);
+
+    private readonly TimeProvider _time;
+    private readonly ConcurrentDictionary<Guid, long> _lastBucket = new();
+
+    public ApiKeyAuditHeartbeat(TimeProvider time)
+    {
+        ArgumentNullException.ThrowIfNull(time);
+        _time = time;
+    }
+
+    /// <inheritdoc />
+    public bool ShouldEmit(Guid apiKeyId)
+    {
+        var bucket = _time.GetUtcNow().UtcDateTime.Ticks / Window.Ticks;
+        while (true)
+        {
+            if (_lastBucket.TryGetValue(apiKeyId, out var existing))
+            {
+                // Already emitted for this (or a later) bucket → suppress.
+                if (existing >= bucket) return false;
+                if (_lastBucket.TryUpdate(apiKeyId, bucket, existing)) return true;
+            }
+            else if (_lastBucket.TryAdd(apiKeyId, bucket))
+            {
+                return true;
+            }
+            // Lost a race — retry with a fresh read.
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/ISensitiveActionEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/ISensitiveActionEmitter.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-10 — the single seam every sensitive-action call site emits through
+/// so the curated DCB event has one shape and the scope-routing decision lives
+/// in one tested place.
+///
+/// <para><b>Never throws to the caller.</b> An audit-sink outage must NOT roll
+/// back the action that already happened (a failed login-audit must not turn a
+/// successful login into a 500) — this mirrors <c>ISecretAccessAuditor</c>. The
+/// implementation logs and swallows; the action is authoritative, the audit
+/// emission is a best-effort side effect.</para>
+///
+/// <para><b>Catalog-validated.</b> A <see cref="SensitiveAction.Type"/> that is
+/// not a <c>SensitiveActionCatalog</c> code is logged (WARN) and dropped so a
+/// typo cannot silently create an un-cataloged event the projector would never
+/// materialise.</para>
+/// </summary>
+public interface ISensitiveActionEmitter
+{
+    /// <summary>
+    /// Append a curated sensitive-action event. Routes to the tenant
+    /// <c>domain_events</c> stream (<c>IEventRepository</c>) for
+    /// <see cref="SensitiveActionScope.Tenant"/>, or to <c>platform_events</c>
+    /// (<c>IPlatformEventPublisher</c>) for <see cref="SensitiveActionScope.Platform"/>.
+    /// Never throws.
+    /// </summary>
+    Task EmitAsync(SensitiveAction action, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveAction.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveAction.cs
@@ -1,0 +1,81 @@
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-10 — which DCB stream a curated sensitive-action event is appended
+/// to. The <see cref="ISensitiveActionEmitter"/> makes exactly one routing
+/// decision, in one tested place, keyed off this value (never duplicated at the
+/// 12 call sites).
+/// </summary>
+public enum SensitiveActionScope
+{
+    /// <summary>Tenant-scoped action (BYOK, plan, persona/config, tenant agent
+    /// action, tenant export). Appends to the tenant's <c>domain_events</c>
+    /// stream via <c>IEventRepository</c> with <c>TenantId</c> set. The Story
+    /// 37-1 projector materialises it into that tenant's <c>audit_records</c>.</summary>
+    Tenant,
+
+    /// <summary>Control-plane / platform-edge action (login success/failure,
+    /// token refresh, API-key auth, impersonation, system-scope config). Appends
+    /// to <c>platform_events</c> via <c>IPlatformEventPublisher</c>. A platform
+    /// event MAY still carry a <c>TenantId</c> — the projector then routes the
+    /// curated row to that tenant's schema (SaaS); a null <c>TenantId</c> keeps
+    /// it in the control plane, never exposed to a tenant.</summary>
+    Platform,
+}
+
+/// <summary>
+/// Story 37-10 — one curated sensitive-action event to append to the DCB store
+/// so the Story 37-1 <c>AuditProjector</c> can materialise it into
+/// <c>audit_records</c>. <see cref="Type"/> MUST be a code in
+/// <c>SensitiveActionCatalog</c>; the emitter validates and drops (never throws)
+/// an un-cataloged type so a typo cannot silently create an un-cataloged event.
+///
+/// <para><b>Redaction-safe payload only.</b> <see cref="Tags"/> / <see cref="Data"/>
+/// carry metadata (provider, mode, version, ip, reason, ...), never key material,
+/// plaintext secrets, card data, or a full API key. The emitter additionally runs
+/// a defensive strip (belt-and-suspenders on top of the projector's redaction).</para>
+/// </summary>
+/// <param name="Type">Canonical DCB event-type string — a <c>SensitiveActionCatalog</c> code.</param>
+/// <param name="Scope">Tenant <c>domain_events</c> vs platform <c>platform_events</c>.</param>
+/// <param name="TenantId">Tenant owner. Required for <see cref="SensitiveActionScope.Tenant"/>;
+/// optional for <see cref="SensitiveActionScope.Platform"/> (null = control-plane only).</param>
+/// <param name="ActorUserId">The acting user id, when known.</param>
+/// <param name="Tags">Filterable tags (projector reads <c>actorUserId</c>/<c>userId</c>,
+/// <c>ip</c>, <c>userAgent</c>, <c>tenantId</c>, plus site-specific keys).</param>
+/// <param name="Data">Redaction-safe event payload (metadata only).</param>
+public sealed record SensitiveAction(
+    string Type,
+    SensitiveActionScope Scope,
+    Guid? TenantId,
+    Guid? ActorUserId,
+    IReadOnlyDictionary<string, string?> Tags,
+    IReadOnlyDictionary<string, object?> Data)
+{
+    private static readonly IReadOnlyDictionary<string, string?> EmptyTags =
+        new Dictionary<string, string?>(0);
+    private static readonly IReadOnlyDictionary<string, object?> EmptyData =
+        new Dictionary<string, object?>(0);
+
+    /// <summary>Build a tenant-scoped action (routes to <c>domain_events</c>).</summary>
+    public static SensitiveAction ForTenant(
+        string type,
+        Guid tenantId,
+        Guid? actorUserId,
+        IReadOnlyDictionary<string, string?>? tags = null,
+        IReadOnlyDictionary<string, object?>? data = null) =>
+        new(type, SensitiveActionScope.Tenant, tenantId, actorUserId,
+            tags ?? EmptyTags, data ?? EmptyData);
+
+    /// <summary>Build a platform-edge action (routes to <c>platform_events</c>).
+    /// <paramref name="tenantId"/> is optional — set it when the action is about a
+    /// tenant (so the curated row lands in that tenant's schema in SaaS), null for
+    /// a purely control-plane action.</summary>
+    public static SensitiveAction ForPlatform(
+        string type,
+        Guid? tenantId,
+        Guid? actorUserId,
+        IReadOnlyDictionary<string, string?>? tags = null,
+        IReadOnlyDictionary<string, object?>? data = null) =>
+        new(type, SensitiveActionScope.Platform, tenantId, actorUserId,
+            tags ?? EmptyTags, data ?? EmptyData);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveActionEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SensitiveActionEmitter.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Tamma.Core.Audit;
+using Tamma.Core.Redaction;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-10 — the single curated sensitive-action emitter. Validates the
+/// event type against <see cref="SensitiveActionCatalog"/>, defensively strips
+/// secret-shaped values, and routes to the correct DCB stream:
+/// <list type="bullet">
+///   <item><see cref="SensitiveActionScope.Tenant"/> → the tenant's
+///     <c>domain_events</c> via <see cref="IEventRepository"/>.</item>
+///   <item><see cref="SensitiveActionScope.Platform"/> → <c>platform_events</c>
+///     via <see cref="IPlatformEventPublisher"/> (TenantId optional).</item>
+/// </list>
+/// Never throws to the caller (mirrors <c>ISecretAccessAuditor</c>).
+/// </summary>
+public sealed class SensitiveActionEmitter : ISensitiveActionEmitter
+{
+    // Repo convention (matches OrgEndpoints.EmitTenantEvent / BuildLifecycleEvent).
+    private const string MetadataJson = """{"workflowVersion":"1.0.0","eventSource":"system"}""";
+
+    /// <summary>Tag/data keys whose VALUE is presumed secret and is scrubbed to a
+    /// placeholder regardless of shape (belt-and-suspenders — callers should never
+    /// pass these, but a caller bug must not leak a secret into the audit trail).</summary>
+    private static readonly HashSet<string> DeniedKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "key", "apikey", "token", "password", "passwd", "pwd", "secret",
+        "connectionstring", "card", "cardnumber", "plaintext", "initialplaintext",
+        "authorization",
+    };
+
+    private readonly IEventRepository _events;
+    private readonly IPlatformEventPublisher _platform;
+    private readonly TimeProvider _time;
+    private readonly ILogger<SensitiveActionEmitter> _logger;
+
+    public SensitiveActionEmitter(
+        IEventRepository events,
+        IPlatformEventPublisher platform,
+        TimeProvider time,
+        ILogger<SensitiveActionEmitter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(events);
+        ArgumentNullException.ThrowIfNull(platform);
+        ArgumentNullException.ThrowIfNull(time);
+        ArgumentNullException.ThrowIfNull(logger);
+        _events = events;
+        _platform = platform;
+        _time = time;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task EmitAsync(SensitiveAction action, CancellationToken ct = default)
+    {
+        if (action is null)
+        {
+            _logger.LogWarning("SensitiveActionEmitter received a null action; dropped.");
+            return;
+        }
+
+        // Typo guard (AC — validation): an un-cataloged Type is logged + dropped,
+        // never thrown, and never emitted (the projector would skip it anyway, but
+        // dropping here keeps the raw stream free of un-cataloged "audit" events).
+        if (!SensitiveActionCatalog.IsSensitive(action.Type))
+        {
+            _logger.LogWarning(
+                "SensitiveActionEmitter dropped an event: type '{Type}' is not in the "
+                + "SensitiveActionCatalog (typo guard).", action.Type);
+            return;
+        }
+
+        try
+        {
+            var tags = BuildTags(action);
+            var data = Redact(action.Data);
+
+            if (action.Scope == SensitiveActionScope.Tenant)
+            {
+                if (action.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+                {
+                    _logger.LogWarning(
+                        "SensitiveActionEmitter dropped a tenant-scoped '{Type}' event: no TenantId.",
+                        action.Type);
+                    return;
+                }
+
+                await _events.AppendAsync(new DomainEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = action.Type,
+                    TenantId = tenantId,
+                    Tags = JsonSerializer.Serialize(tags),
+                    Metadata = MetadataJson,
+                    Data = JsonSerializer.Serialize(data),
+                    CreatedAt = _time.GetUtcNow().UtcDateTime,
+                }).ConfigureAwait(false);
+            }
+            else
+            {
+                await _platform.AppendAndPublishAsync(new PlatformEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = action.Type,
+                    // A platform event MAY carry a tenant id — the projector then
+                    // materialises the curated row into that tenant's schema (SaaS).
+                    TenantId = action.TenantId,
+                    UserId = action.ActorUserId,
+                    Tags = JsonSerializer.Serialize(tags),
+                    Metadata = MetadataJson,
+                    Data = JsonSerializer.Serialize(data),
+                    CreatedAt = _time.GetUtcNow().UtcDateTime,
+                }, ct).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation(
+                "Sensitive-action emitted type={Type} scope={Scope} tenantId={TenantId} actor={Actor}",
+                action.Type, action.Scope,
+                action.TenantId?.ToString("D") ?? "(platform)",
+                action.ActorUserId?.ToString("D") ?? "(none)");
+        }
+        catch (Exception ex)
+        {
+            // Never-throws contract: an audit-sink outage must NOT roll back the
+            // action that already happened. Log loudly and swallow.
+            _logger.LogError(ex,
+                "SensitiveActionEmitter sink write failed for type={Type} scope={Scope}; "
+                + "the action is NOT rolled back (audit emission is best-effort).",
+                action.Type, action.Scope);
+        }
+    }
+
+    /// <summary>
+    /// Assemble the tag map: caller tags (redacted) plus the actor/tenant keys the
+    /// Story 37-1 projector resolves (<c>actorUserId</c>, <c>tenantId</c>). Caller
+    /// tags win when present so a site can override (e.g. a login-failure has no
+    /// trusted actor).
+    /// </summary>
+    private static Dictionary<string, string?> BuildTags(SensitiveAction action)
+    {
+        var tags = new Dictionary<string, string?>(StringComparer.Ordinal);
+
+        if (action.ActorUserId is Guid actor && actor != Guid.Empty)
+            tags["actorUserId"] = actor.ToString("D");
+        if (action.TenantId is Guid tenant && tenant != Guid.Empty)
+            tags["tenantId"] = tenant.ToString("D");
+
+        foreach (var (key, value) in action.Tags)
+        {
+            if (string.IsNullOrEmpty(key)) continue;
+            tags[key] = DeniedKeys.Contains(key)
+                ? CredentialRedactor.Placeholder
+                : Scrub(value);
+        }
+
+        return tags;
+    }
+
+    /// <summary>Redact the data payload: denylisted keys → placeholder; string
+    /// values → credential-scrubbed; other values passed through.</summary>
+    private static Dictionary<string, object?> Redact(IReadOnlyDictionary<string, object?> data)
+    {
+        var clean = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var (key, value) in data)
+        {
+            if (string.IsNullOrEmpty(key)) continue;
+            if (DeniedKeys.Contains(key))
+            {
+                clean[key] = CredentialRedactor.Placeholder;
+                continue;
+            }
+            clean[key] = value is string s ? Scrub(s) : value;
+        }
+        return clean;
+    }
+
+    /// <summary>Run the shared credential redactor over a string value. Null stays
+    /// null; a secret-shaped value (e.g. <c>tamma_sk_…</c>) becomes
+    /// <c>[REDACTED]</c>; an ordinary value is returned unchanged.</summary>
+    private static string? Scrub(string? value) =>
+        string.IsNullOrEmpty(value) ? value : CredentialRedactor.Clean(value);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
@@ -69,7 +69,12 @@ public static class SensitiveActionCatalog
     public const string PromptDeleted = "PROMPT.DELETED.SUCCESS";
     public const string PromptReset = "PROMPT.RESET.SUCCESS";
 
-    // ── BYOK (forward-looking — provider-key / provider-chain edits) ──
+    // ── BYOK (provider-key wired in 37-10; provider-chain forward-looking) ──
+    /// <summary>A tenant BYOK provider key was set / rotated / removed — wired by
+    /// Story 37-10 (<c>ProviderCredentialEndpoints</c>). The concrete operation
+    /// (set|rotated|removed) travels in the event's <c>operation</c> tag/data;
+    /// the underlying <c>SECRET.*</c> cabinet write stays the secret source of
+    /// truth (this is the curated, catalog-facing BYOK event, not a second write).</summary>
     public const string ProviderKeyChanged = "PROVIDER_KEY.CHANGED.SUCCESS";
     public const string ProviderChainChanged = "PROVIDER_CHAIN.CHANGED.SUCCESS";
 
@@ -85,16 +90,26 @@ public static class SensitiveActionCatalog
     public const string DataExported = "DATA.EXPORTED.SUCCESS";
     public const string DsarRequested = "GDPR.DSAR.REQUESTED";
 
-    // ── AUTH (maps existing AuthEndpoints emitters; login/reset forward-looking) ──
+    // ── AUTH (maps existing AuthEndpoints emitters; login/refresh/api-key wired in 37-10) ──
     public const string LogoutAll = "USER.LOGOUT_ALL.SUCCESS";
     public const string OrgSwitched = "USER.ORG_SWITCHED.SUCCESS";
     public const string RefreshReuseDetected = "AUTH.REFRESH_REUSE_DETECTED";
 
-    /// <summary>Forward-looking: an interactive login succeeded.</summary>
+    /// <summary>An interactive login succeeded — wired by Story 37-10
+    /// (<c>AuthEndpoints.Login</c>) as a platform-edge auth event.</summary>
     public const string LoginSuccess = "AUTH.LOGIN.SUCCESS";
 
-    /// <summary>Forward-looking: an interactive login failed (brute-force signal).</summary>
+    /// <summary>An interactive login failed (brute-force signal). Wired by Story
+    /// 37-10 (<c>AuthEndpoints.Login</c>) carrying a machine-readable reason.</summary>
     public const string LoginFailure = "AUTH.LOGIN.FAILURE";
+
+    /// <summary>A refresh-token rotation succeeded — wired by Story 37-10
+    /// (<c>AuthEndpoints.Refresh</c>). Distinct from the reuse-detection event.</summary>
+    public const string TokenRefreshed = "AUTH.TOKEN.REFRESHED";
+
+    /// <summary>An API key authenticated a request — wired by Story 37-10
+    /// (<c>ApiKeyAuthHandler</c>), throttled to a heartbeat (never per-request).</summary>
+    public const string ApiKeyUsed = "AUTH.APIKEY.USED";
 
     /// <summary>Forward-looking: a password-reset completed.</summary>
     public const string PasswordReset = "AUTH.PASSWORD_RESET.SUCCESS";
@@ -179,7 +194,7 @@ public static class SensitiveActionCatalog
         Add(PromptReset, AuditCategory.Persona, AuditSeverity.Notice, "CC8.1", "prompt", true);
 
         // ── BYOK — CC6.1 (provider credential / chain configuration) ──
-        Add(ProviderKeyChanged, AuditCategory.Byok, AuditSeverity.Warning, "CC6.1", "provider", false);
+        Add(ProviderKeyChanged, AuditCategory.Byok, AuditSeverity.Warning, "CC6.1", "provider", true);
         Add(ProviderChainChanged, AuditCategory.Byok, AuditSeverity.Notice, "CC6.1", "provider", false);
 
         // ── BILLING — A1.1 (commitments affecting availability/spend) ──
@@ -196,8 +211,11 @@ public static class SensitiveActionCatalog
         Add(LogoutAll, AuditCategory.Auth, AuditSeverity.Notice, "CC6.1", "user", true);
         Add(OrgSwitched, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", true);
         Add(RefreshReuseDetected, AuditCategory.Auth, AuditSeverity.Critical, "CC6.1", "user", true);
-        Add(LoginSuccess, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", false);
-        Add(LoginFailure, AuditCategory.Auth, AuditSeverity.Notice, "CC6.1", "user", false);
+        // Story 37-10 wired the emitters for these — flip MapsExistingEmitter true.
+        Add(LoginSuccess, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", true);
+        Add(LoginFailure, AuditCategory.Auth, AuditSeverity.Notice, "CC6.1", "user", true);
+        Add(TokenRefreshed, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "user", true);
+        Add(ApiKeyUsed, AuditCategory.Auth, AuditSeverity.Info, "CC6.1", "api_key", true);
         Add(PasswordReset, AuditCategory.Auth, AuditSeverity.Warning, "CC6.1", "user", false);
 
         // ── TENANT lifecycle — A1.2 (provisioning/de-provisioning) ──

--- a/apps/tamma-elsa/src/Tamma.Core/Redaction/CredentialRedactor.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Redaction/CredentialRedactor.cs
@@ -44,11 +44,13 @@ public static class CredentialRedactor
         @"(?<q>[""']?)(?<value>[^""'\s,;)\]}]+)\k<q>",
         RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
 
-    // Tamma API key / session prefix tokens — ship with a recognisable
-    // prefix so we can redact them even when the surrounding key name
-    // doesn't match the credential heuristic.
+    // Tamma + provider API-key prefix tokens — these ship with a recognisable
+    // prefix so we can redact them even when the surrounding key name doesn't
+    // match the credential heuristic. Covers Tamma/Stripe (tamma_sk_ / sk_live_ /
+    // sk_test_), Anthropic (sk-ant-), OpenAI project keys (sk-proj-), GitHub
+    // (ghp_ / github_pat_), Slack (xoxb- / xoxp-) and AWS access keys (AKIA).
     private static readonly Regex TammaSecretPrefix = new(
-        @"\b(?:tamma_sk_|sk_live_|sk_test_|ghp_|github_pat_|xoxb-|xoxp-|AKIA)[A-Za-z0-9_\-]{6,}",
+        @"\b(?:tamma_sk_|sk_live_|sk_test_|sk-ant-|sk-proj-|ghp_|github_pat_|xoxb-|xoxp-|AKIA)[A-Za-z0-9_\-]{6,}",
         RegexOptions.Compiled, TimeSpan.FromMilliseconds(200));
 
     // Basic-auth userinfo inside URL: scheme://user:pass@host

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditProjector.cs
@@ -44,6 +44,23 @@ public sealed class AuditProjector : IAuditProjector
     /// for the descriptor-missing quarantine path only.</summary>
     public const string UnclassifiedCategory = "unclassified";
 
+    // Physical varchar column lengths of audit_records (see
+    // TammaModelConfiguration.ConfigureAuditEntities + migration AddAuditRecords).
+    // Every resolved string field is clamped to its column length BEFORE the row
+    // is built so no over-length — possibly attacker-controlled — value can throw
+    // Npgsql 22001 (string_data_right_truncation) on INSERT and break the curated
+    // trail for that event. Belt-and-suspenders: this protects EVERY current and
+    // future emitter, not just any one call site.
+    private const int MaxActionCodeLength = 128;
+    private const int MaxCategoryLength = 32;
+    private const int MaxSeverityLength = 16;
+    private const int MaxActorEmailLength = 320;
+    private const int MaxTargetTypeLength = 64;
+    private const int MaxTargetIdLength = 255;
+    private const int MaxOutcomeLength = 16;
+    private const int MaxIpAddressLength = 64;
+    private const int MaxUserAgentLength = 512;
+
     /// <inheritdoc />
     public AuditRecord? TryBuildRecord(
         RawAuditEvent rawEvent, AuditOwnershipMode mode, Guid? singleUserOwnerId)
@@ -83,6 +100,7 @@ public sealed class AuditProjector : IAuditProjector
             PrevRecordHash = null,
         };
 
+        ClampToColumnLimits(record);
         AssignOwnership(record, rawEvent, mode, singleUserOwnerId);
         return record;
     }
@@ -146,9 +164,40 @@ public sealed class AuditProjector : IAuditProjector
             PrevRecordHash = null,
         };
 
+        ClampToColumnLimits(record);
         AssignOwnership(record, rawEvent, mode, singleUserOwnerId);
         return record;
     }
+
+    /// <summary>
+    /// Defensively cap every varchar-bounded field to its physical column length
+    /// so an over-length resolved value (e.g. an attacker-padded login email in
+    /// <c>ActorEmailSnapshot</c>) can NEVER overflow the column and throw Npgsql
+    /// 22001 (string_data_right_truncation) on INSERT. Left unbounded, that
+    /// overflow breaks the audit trail for the event — the failed insert leaves a
+    /// tracked poison entity that re-throws on the next SaveChanges (the cursor
+    /// write), stalling the projector tick — so an attacker could suppress the
+    /// audit of their own failed logins by padding the email. Capping here makes
+    /// the insert always fit. The redacted <c>PayloadJson</c> is already
+    /// length-bounded by <see cref="CredentialRedactor.MaxLength"/>; the outcome
+    /// is a closed enum but is capped too for uniformity. Guid / long / timestamp
+    /// columns cannot overflow and are left untouched.
+    /// </summary>
+    private static void ClampToColumnLimits(AuditRecord record)
+    {
+        record.ActionCode = Truncate(record.ActionCode, MaxActionCodeLength)!;
+        record.Category = Truncate(record.Category, MaxCategoryLength)!;
+        record.Severity = Truncate(record.Severity, MaxSeverityLength)!;
+        record.ActorEmailSnapshot = Truncate(record.ActorEmailSnapshot, MaxActorEmailLength);
+        record.TargetType = Truncate(record.TargetType, MaxTargetTypeLength);
+        record.TargetId = Truncate(record.TargetId, MaxTargetIdLength);
+        record.Outcome = Truncate(record.Outcome, MaxOutcomeLength)!;
+        record.IpAddress = Truncate(record.IpAddress, MaxIpAddressLength);
+        record.UserAgent = Truncate(record.UserAgent, MaxUserAgentLength);
+    }
+
+    private static string? Truncate(string? value, int maxLength) =>
+        value is not null && value.Length > maxLength ? value[..maxLength] : value;
 
     // Quarantine field extraction must never itself throw — wrap the resolvers.
     private static string? SafeResolveString(

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/ApiKeyAuditHeartbeatTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/ApiKeyAuditHeartbeatTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Tests.Alerts;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-10 (AC8) — the <c>AUTH.APIKEY.USED</c> throttle: one heartbeat per
+/// key per time bucket so the hot per-request auth path does not flood the trail.
+/// </summary>
+[TestFixture]
+public class ApiKeyAuditHeartbeatTests
+{
+    [Test]
+    public void First_Call_Emits_Subsequent_In_Same_Bucket_Suppressed()
+    {
+        var time = new TestTimeProvider(DateTimeOffset.UtcNow);
+        var heartbeat = new ApiKeyAuditHeartbeat(time);
+        var keyId = Guid.NewGuid();
+
+        heartbeat.ShouldEmit(keyId).Should().BeTrue("the first request in a bucket emits");
+        heartbeat.ShouldEmit(keyId).Should().BeFalse("subsequent requests in the same bucket are suppressed");
+        heartbeat.ShouldEmit(keyId).Should().BeFalse();
+    }
+
+    [Test]
+    public void Hundred_Requests_In_One_Bucket_Emit_Exactly_Once()
+    {
+        var time = new TestTimeProvider(DateTimeOffset.UtcNow);
+        var heartbeat = new ApiKeyAuditHeartbeat(time);
+        var keyId = Guid.NewGuid();
+
+        var emitted = 0;
+        for (var i = 0; i < 100; i++)
+            if (heartbeat.ShouldEmit(keyId)) emitted++;
+
+        emitted.Should().Be(1, "100 auths in one bucket produce one heartbeat, not 100");
+    }
+
+    [Test]
+    public void After_Window_Elapses_Emits_Again()
+    {
+        var time = new TestTimeProvider(DateTimeOffset.UtcNow);
+        var heartbeat = new ApiKeyAuditHeartbeat(time);
+        var keyId = Guid.NewGuid();
+
+        heartbeat.ShouldEmit(keyId).Should().BeTrue();
+        heartbeat.ShouldEmit(keyId).Should().BeFalse();
+
+        // Advance past the window into the next bucket.
+        time.Advance(ApiKeyAuditHeartbeat.Window + TimeSpan.FromSeconds(1));
+
+        heartbeat.ShouldEmit(keyId).Should().BeTrue("a new bucket emits a fresh heartbeat");
+    }
+
+    [Test]
+    public void Distinct_Keys_Are_Throttled_Independently()
+    {
+        var time = new TestTimeProvider(DateTimeOffset.UtcNow);
+        var heartbeat = new ApiKeyAuditHeartbeat(time);
+
+        heartbeat.ShouldEmit(Guid.NewGuid()).Should().BeTrue();
+        heartbeat.ShouldEmit(Guid.NewGuid()).Should().BeTrue("a different key has its own bucket");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorIntegrationTests.cs
@@ -459,6 +459,38 @@ public class AuditProjectorIntegrationTests
         failing.ThrowCount.Should().Be(1);
     }
 
+    // ════════════════════ Finding 1 (37-10 review) — over-length actor email ════════════════════
+    //
+    // Security (audit evasion): the submitted login email is attacker-controlled
+    // and unbounded. Padded past varchar(320), it overflows ActorEmailSnapshot on
+    // INSERT (Npgsql 22001); ProjectOneAsync swallows the exception, returns
+    // false, and the cursor STILL advances — the failed-login audit row is
+    // silently DROPPED, letting an attacker suppress the audit of their own brute
+    // force. The projector must defensively truncate the field so the row STILL
+    // persists. This test DROPS the row against the pre-fix code (inserted == 0)
+    // and persists it (truncated) after.
+    [Test]
+    public async Task OverLength_LoginFailure_Email_Still_Persists_Truncated_Row()
+    {
+        var longEmail = new string('a', 400) + "@attacker.example.com";
+        await SeedPlatformEvent("AUTH.LOGIN.FAILURE", tenantId: null,
+            data: new { actorEmail = longEmail, reason = "bad_credentials" });
+
+        await using var sp = BuildServices(TammaMode.SaaS);
+        var inserted = await Svc(sp).ProcessOnceAsync(default);
+
+        inserted.Should().Be(1,
+            "the failed-login audit row must be persisted, not dropped by a varchar(320) 22001 overflow");
+        (await CountCp()).Should().Be(1);
+
+        await using var cp = NewCp();
+        var row = await cp.AuditRecords.SingleAsync();
+        row.ActionCode.Should().Be("AUTH.LOGIN.FAILURE");
+        row.ActorEmailSnapshot!.Length.Should().Be(320,
+            "ActorEmailSnapshot is capped to its varchar(320) column length");
+        row.ActorEmailSnapshot.Should().Be(longEmail[..320]);
+    }
+
     // ── snapshot/raw helpers ──
 
     private async Task<List<string>> SnapshotTenant(Guid tenantId, string schema)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditProjectorTests.cs
@@ -266,4 +266,62 @@ public class AuditProjectorTests
         rec.Outcome.Should().Be("failure");
         rec.PayloadJson.Should().Be(AuditProjector.QuarantinePayload);
     }
+
+    // ── Finding 1 (Story 37-10 review, security — audit evasion) ──
+    //
+    // Resolved string fields are attacker-influenced (e.g. the submitted login
+    // email travels under actorEmail). If an over-length value reaches the row
+    // it overflows its varchar column on INSERT (Npgsql 22001) and the audit row
+    // is SILENTLY DROPPED while the cursor still advances — an attacker padding
+    // their email suppresses the audit of their own brute force. The projector
+    // MUST defensively cap every varchar-bounded field to its column length so no
+    // over-length value can ever throw 22001.
+
+    [Test]
+    public void OverLength_ActorEmail_Is_Truncated_To_Column_Limit()
+    {
+        // 421-char attacker-controlled email → would overflow varchar(320).
+        var longEmail = new string('a', 400) + "@attacker.example.com";
+        var raw = Raw("AUTH.LOGIN.FAILURE", tenantId: null,
+            data: new { actorEmail = longEmail, reason = "bad_credentials" });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.ActorEmailSnapshot!.Length.Should().Be(320,
+            "ActorEmailSnapshot must be capped to its varchar(320) column length");
+        rec.ActorEmailSnapshot.Should().Be(longEmail[..320]);
+    }
+
+    [Test]
+    public void OverLength_Context_Fields_Are_Truncated_To_Column_Limits()
+    {
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid(),
+            tags: new
+            {
+                targetType = new string('t', 200), // varchar(64)
+                targetId = new string('i', 400),   // varchar(255)
+                ip = new string('9', 200),         // varchar(64)
+                userAgent = new string('u', 1000), // varchar(512)
+            });
+
+        var rec = _projector.TryBuildRecord(raw, AuditOwnershipMode.SaaS, null)!;
+
+        rec.TargetType!.Length.Should().Be(64);
+        rec.TargetId!.Length.Should().Be(255);
+        rec.IpAddress!.Length.Should().Be(64);
+        rec.UserAgent!.Length.Should().Be(512);
+    }
+
+    [Test]
+    public void OverLength_Fields_Are_Also_Truncated_On_The_Quarantine_Path()
+    {
+        var longEmail = new string('z', 500) + "@attacker.example.com";
+        var raw = Raw("SECRET.REVEAL", tenantId: Guid.NewGuid(),
+            data: new { actorEmail = longEmail });
+
+        var rec = _projector.BuildQuarantineRecord(raw, AuditOwnershipMode.SaaS, null);
+
+        rec.ActorEmailSnapshot!.Length.Should().Be(320,
+            "the quarantine builder must also cap fields so the placeholder row cannot 22001");
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionEmissionCoverageTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionEmissionCoverageTests.cs
@@ -1,0 +1,360 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-10 (AC15) — end-to-end coverage: drive the REAL
+/// <see cref="SensitiveActionEmitter"/> for each sensitive-action site, then run
+/// the Story 37-1 <see cref="AuditProjectorBackgroundService"/> and assert the
+/// curated <c>audit_records</c> row lands with the right catalog code, category,
+/// and scope. Proves the emitter's OUTPUT (tags/data/scope) projects correctly —
+/// the missing link between "the action happened" and "the audit trail has it".
+/// </summary>
+[TestFixture]
+public class SensitiveActionEmissionCoverageTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+    private Guid _tenantA;
+    private Guid _tenantB;
+    private string _schemaA = null!;
+    private string _schemaB = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_emission_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using (var cp = NewCp())
+            await cp.Database.MigrateAsync();
+
+        _tenantA = Guid.NewGuid();
+        _tenantB = Guid.NewGuid();
+        _schemaA = TenantNaming.SchemaName(_tenantA);
+        _schemaB = TenantNaming.SchemaName(_tenantB);
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(_schemaB));
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task ResetTables()
+    {
+        await using var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        await Exec(conn, "TRUNCATE audit_records, audit_projector_cursor, platform_events, users RESTART IDENTITY CASCADE;");
+        foreach (var schema in new[] { _schemaA, _schemaB })
+        {
+            await Exec(conn, $"TRUNCATE \"{schema}\".audit_records RESTART IDENTITY;");
+            await Exec(conn, $"TRUNCATE \"{schema}\".domain_events RESTART IDENTITY;");
+        }
+        await SeedTenant(_tenantA, _schemaA);
+        await SeedTenant(_tenantB, _schemaB);
+    }
+
+    // ════════════════════ BYOK (tenant scope) ════════════════════
+
+    [Test]
+    public async Task Byok_ProviderKeyChanged_Emits_And_Projects_Tenant_Scoped()
+    {
+        var actor = Guid.NewGuid();
+        await Emitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, _tenantA, actor,
+            new Dictionary<string, string?> { ["provider"] = "anthropic", ["operation"] = "set", ["mode"] = "byok" },
+            new Dictionary<string, object?> { ["provider"] = "anthropic", ["operation"] = "set", ["version"] = 1 }));
+
+        await RunProjector();
+
+        var row = await SingleTenantRow(_tenantA, _schemaA);
+        row.ActionCode.Should().Be(SensitiveActionCatalog.ProviderKeyChanged);
+        row.Category.Should().Be("byok");
+        row.TenantId.Should().Be(_tenantA);
+        row.ActorUserId.Should().Be(actor);
+
+        (await CountTenant(_tenantB, _schemaB)).Should().Be(0, "tenant-B never sees tenant-A's BYOK event");
+        (await CountCp()).Should().Be(0, "a tenant-scoped BYOK event does not land in the control plane");
+    }
+
+    [Test]
+    public async Task Byok_KeySet_With_Real_Looking_Secret_Persists_Zero_Key_Bytes()
+    {
+        const string plaintext = "tamma_sk_LIVEDEADBEEF0123456789";
+        await Emitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, _tenantA, Guid.NewGuid(),
+            new Dictionary<string, string?> { ["provider"] = "anthropic" },
+            // A buggy caller shoves the raw key into data — the emitter + projector
+            // must ensure zero key bytes reach the stored audit record.
+            new Dictionary<string, object?> { ["provider"] = "anthropic", ["apiKey"] = plaintext }));
+
+        await RunProjector();
+
+        var row = await SingleTenantRow(_tenantA, _schemaA);
+        row.PayloadJson.Should().NotContain(plaintext, "no key material may ever land in the audit record");
+        row.PayloadJson.Should().Contain("anthropic", "the redaction-safe metadata is preserved");
+    }
+
+    // ════════════════════ AUTH (platform edge) ════════════════════
+
+    [Test]
+    public async Task Login_Success_Platform_With_Tenant_Projects_Into_Tenant_Schema()
+    {
+        var actor = Guid.NewGuid();
+        await Emitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.LoginSuccess, _tenantA, actor,
+            new Dictionary<string, string?>
+            {
+                ["actorEmail"] = "user@example.com",
+                ["ip"] = "203.0.113.10",
+                ["userAgent"] = "Mozilla/5.0",
+            }));
+
+        await RunProjector();
+
+        var row = await SingleTenantRow(_tenantA, _schemaA);
+        row.ActionCode.Should().Be(SensitiveActionCatalog.LoginSuccess);
+        row.Category.Should().Be("auth");
+        row.Outcome.Should().Be("success");
+        row.ActorUserId.Should().Be(actor);
+        row.ActorEmailSnapshot.Should().Be("user@example.com");
+        row.IpAddress.Should().Be("203.0.113.10");
+    }
+
+    [Test]
+    public async Task Login_Failure_Platform_Null_Tenant_Projects_To_ControlPlane_With_Reason()
+    {
+        await Emitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.LoginFailure, tenantId: null, actorUserId: null,
+            new Dictionary<string, string?>
+            {
+                ["reason"] = "bad_credentials",
+                ["actorEmail"] = "attacker@example.com",
+                ["ip"] = "198.51.100.7",
+            },
+            new Dictionary<string, object?> { ["reason"] = "bad_credentials" }));
+
+        await RunProjector();
+
+        (await CountCp()).Should().Be(1, "a login failure has no trusted tenant → control plane");
+        (await CountTenant(_tenantA, _schemaA)).Should().Be(0);
+
+        await using var cp = NewCp();
+        var row = await cp.AuditRecords.SingleAsync();
+        row.ActionCode.Should().Be(SensitiveActionCatalog.LoginFailure);
+        row.Category.Should().Be("auth");
+        row.Outcome.Should().Be("failure");
+        row.TenantId.Should().BeNull();
+        row.ActorEmailSnapshot.Should().Be("attacker@example.com");
+        row.PayloadJson.Should().Contain("bad_credentials");
+    }
+
+    [Test]
+    public async Task TokenRefreshed_And_ApiKeyUsed_Project_Auth_Category()
+    {
+        await Emitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.TokenRefreshed, _tenantA, Guid.NewGuid(),
+            new Dictionary<string, string?> { ["ip"] = "203.0.113.20" }));
+        await Emitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.ApiKeyUsed, _tenantA, actorUserId: null,
+            new Dictionary<string, string?> { ["apiKeyPrefix"] = "tamma_sk_t_", ["scope"] = "tenant" }));
+
+        await RunProjector();
+
+        await using var t = NewTenant(_tenantA, _schemaA);
+        var rows = await t.AuditRecords.OrderBy(r => r.ActionCode).ToListAsync();
+        rows.Select(r => r.ActionCode).Should().BeEquivalentTo(new[]
+        {
+            SensitiveActionCatalog.ApiKeyUsed, SensitiveActionCatalog.TokenRefreshed,
+        });
+        rows.Should().OnlyContain(r => r.Category == "auth");
+    }
+
+    // ════════════════════ Catalog coverage enumeration ════════════════════
+
+    [Test]
+    public void Every_Site_Code_This_Story_Wires_Is_Catalogued()
+    {
+        // AC1/AC15 — each site's emitted code must be in the 37-1 catalog so the
+        // projector materialises it. A drift here means an emission that never
+        // reaches audit_records.
+        foreach (var code in new[]
+        {
+            SensitiveActionCatalog.LoginSuccess,
+            SensitiveActionCatalog.LoginFailure,
+            SensitiveActionCatalog.TokenRefreshed,
+            SensitiveActionCatalog.ApiKeyUsed,
+            SensitiveActionCatalog.ProviderKeyChanged,
+            SensitiveActionCatalog.PlanUpdated,
+            SensitiveActionCatalog.RefreshReuseDetected,
+            SensitiveActionCatalog.SecretWrite,
+            SensitiveActionCatalog.ImpersonationStarted,
+            SensitiveActionCatalog.TenantMemberRoleChanged,
+        })
+        {
+            SensitiveActionCatalog.IsSensitive(code).Should()
+                .BeTrue($"the site code '{code}' must be catalogued so it projects");
+        }
+    }
+
+    // ── infra ────────────────────────────────────────────────────────────
+
+    private SensitiveActionEmitter Emitter() =>
+        new(new ContainerEventRepository(_cs),
+            new ContainerPlatformPublisher(_cs),
+            TimeProvider.System,
+            NullLogger<SensitiveActionEmitter>.Instance);
+
+    private async Task RunProjector()
+    {
+        var services = new ServiceCollection();
+        services.AddDbContext<ControlPlaneDbContext>(o => o.UseNpgsql(_cs));
+        services.AddSingleton<ITammaModeProvider>(new FixedModeProvider(TammaMode.SaaS));
+        services.AddSingleton<ITenantDbContextFactory>(new SearchPathTenantFactory(_cs));
+        services.AddSingleton<IAuditProjector, AuditProjector>();
+        services.AddSingleton<IAuditRecordRepository, AuditRecordRepository>();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton<AuditProjectionMetrics>();
+        services.AddSingleton(new AuditProjectorOptions { RunOnStartup = false });
+        await using var sp = services.BuildServiceProvider();
+        var svc = new AuditProjectorBackgroundService(
+            sp, sp.GetRequiredService<AuditProjectorOptions>(),
+            sp.GetRequiredService<TimeProvider>(),
+            sp.GetRequiredService<AuditProjectionMetrics>(),
+            NullLogger<AuditProjectorBackgroundService>.Instance);
+        await svc.ProcessOnceAsync(default);
+    }
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_cs) { SearchPath = schema }.ConnectionString;
+
+    private ControlPlaneDbContext NewCp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private TenantDbContext NewTenant(Guid tenantId, string schema) =>
+        new(new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options, tenantId);
+
+    private async Task<AuditRecord> SingleTenantRow(Guid tenantId, string schema)
+    {
+        await using var t = NewTenant(tenantId, schema);
+        return await t.AuditRecords.SingleAsync();
+    }
+
+    private async Task<int> CountTenant(Guid tenantId, string schema)
+    {
+        await using var t = NewTenant(tenantId, schema);
+        return await t.AuditRecords.CountAsync();
+    }
+
+    private async Task<int> CountCp()
+    {
+        await using var cp = NewCp();
+        return await cp.AuditRecords.CountAsync();
+    }
+
+    private async Task SeedTenant(Guid id, string schema)
+    {
+        await using var cp = NewCp();
+        if (await cp.Tenants.AnyAsync(t => t.Id == id)) return;
+        cp.Tenants.Add(new Tenant
+        {
+            Id = id,
+            Name = schema,
+            Slug = schema,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        });
+        await cp.SaveChangesAsync();
+    }
+
+    private static async Task Exec(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private sealed class FixedModeProvider(TammaMode mode) : ITammaModeProvider
+    {
+        public TammaMode Mode { get; } = mode;
+    }
+
+    private sealed class SearchPathTenantFactory(string baseCs) : ITenantDbContextFactory
+    {
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            var schema = TenantNaming.SchemaName(tenantId);
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options, tenantId);
+            return ValueTask.FromResult(ctx);
+        }
+    }
+
+    /// <summary>Minimal IEventRepository that writes the emitted DomainEvent into
+    /// the tenant's schema (where the projector reads it). Only AppendAsync is
+    /// exercised.</summary>
+    private sealed class ContainerEventRepository(string baseCs) : IEventRepository
+    {
+        public async Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            var schema = TenantNaming.SchemaName(evt.TenantId!.Value);
+            var cs = new NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            await using var ctx = new TenantDbContext(
+                new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(cs).Options, evt.TenantId.Value);
+            if (evt.Id == Guid.Empty) evt.Id = Guid.NewGuid();
+            ctx.DomainEvents.Add(evt);
+            await ctx.SaveChangesAsync();
+            return evt;
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+
+    /// <summary>Minimal IPlatformEventPublisher that writes the emitted
+    /// PlatformEvent into the control plane (where the projector reads it).</summary>
+    private sealed class ContainerPlatformPublisher(string baseCs) : IPlatformEventPublisher
+    {
+        public async Task<PlatformEvent?> AppendAndPublishAsync(PlatformEvent evt, CancellationToken ct = default)
+        {
+            await using var cp = new ControlPlaneDbContext(
+                new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(baseCs).Options);
+            if (evt.Id == Guid.Empty) evt.Id = Guid.NewGuid();
+            cp.PlatformEvents.Add(evt);
+            await cp.SaveChangesAsync(ct);
+            return evt;
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionEmitterTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/SensitiveActionEmitterTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-10 (S1) — unit tests for <see cref="SensitiveActionEmitter"/>: the
+/// single seam that validates the catalog, routes tenant vs platform, redacts
+/// defensively, and never throws to the caller.
+/// </summary>
+[TestFixture]
+public class SensitiveActionEmitterTests
+{
+    private Mock<IEventRepository> _events = null!;
+    private Mock<IPlatformEventPublisher> _platform = null!;
+    private DomainEvent? _appendedDomain;
+    private PlatformEvent? _appendedPlatform;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _appendedDomain = null;
+        _appendedPlatform = null;
+
+        _events = new Mock<IEventRepository>();
+        _events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .Callback<DomainEvent>(d => _appendedDomain = d)
+            .ReturnsAsync((DomainEvent d) => d);
+
+        _platform = new Mock<IPlatformEventPublisher>();
+        _platform.Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<PlatformEvent, CancellationToken>((p, _) => _appendedPlatform = p)
+            .ReturnsAsync((PlatformEvent p, CancellationToken _) => p);
+    }
+
+    private SensitiveActionEmitter NewEmitter() =>
+        new(_events.Object, _platform.Object, TimeProvider.System,
+            NullLogger<SensitiveActionEmitter>.Instance);
+
+    // ── Scope routing ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Tenant_Scope_Appends_To_EventRepository_Not_Platform()
+    {
+        var tenantId = Guid.NewGuid();
+        var actor = Guid.NewGuid();
+
+        await NewEmitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, tenantId, actor,
+            new Dictionary<string, string?> { ["provider"] = "anthropic" },
+            new Dictionary<string, object?> { ["operation"] = "set" }));
+
+        _events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Once);
+        _platform.Verify(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        _appendedDomain.Should().NotBeNull();
+        _appendedDomain!.Type.Should().Be(SensitiveActionCatalog.ProviderKeyChanged);
+        _appendedDomain.TenantId.Should().Be(tenantId);
+        _appendedDomain.Metadata.Should().Contain("\"workflowVersion\":\"1.0.0\"");
+        _appendedDomain.Metadata.Should().Contain("\"eventSource\":\"system\"");
+
+        var tags = JsonSerializer.Deserialize<Dictionary<string, string?>>(_appendedDomain.Tags)!;
+        tags["actorUserId"].Should().Be(actor.ToString("D"));
+        tags["tenantId"].Should().Be(tenantId.ToString("D"));
+        tags["provider"].Should().Be("anthropic");
+    }
+
+    [Test]
+    public async Task Platform_Scope_Publishes_To_Platform_Not_EventRepository()
+    {
+        var tenantId = Guid.NewGuid();
+
+        await NewEmitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.LoginSuccess, tenantId, Guid.NewGuid(),
+            new Dictionary<string, string?> { ["ip"] = "203.0.113.5" }));
+
+        _platform.Verify(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        _events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+
+        _appendedPlatform.Should().NotBeNull();
+        _appendedPlatform!.Type.Should().Be(SensitiveActionCatalog.LoginSuccess);
+        _appendedPlatform.TenantId.Should().Be(tenantId, "a platform event may still carry a tenant id");
+    }
+
+    [Test]
+    public async Task Platform_Scope_With_Null_Tenant_Publishes_Platform_Only()
+    {
+        await NewEmitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.LoginFailure, tenantId: null, actorUserId: null,
+            new Dictionary<string, string?> { ["reason"] = "bad_credentials" }));
+
+        _appendedPlatform.Should().NotBeNull();
+        _appendedPlatform!.TenantId.Should().BeNull();
+    }
+
+    // ── Catalog typo-guard ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task Uncatalogued_Type_Is_Dropped_Neither_Sink_Called()
+    {
+        await NewEmitter().EmitAsync(SensitiveAction.ForTenant(
+            "NOT.A.CATALOG.CODE", Guid.NewGuid(), Guid.NewGuid()));
+
+        _events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+        _platform.Verify(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Tenant_Scope_Without_TenantId_Is_Dropped()
+    {
+        await NewEmitter().EmitAsync(new SensitiveAction(
+            SensitiveActionCatalog.ProviderKeyChanged, SensitiveActionScope.Tenant,
+            TenantId: null, ActorUserId: Guid.NewGuid(),
+            new Dictionary<string, string?>(), new Dictionary<string, object?>()));
+
+        _events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    // ── Never-throws contract ──────────────────────────────────────────────
+
+    [Test]
+    public async Task Sink_Failure_Is_Swallowed_Not_Rethrown()
+    {
+        _events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ThrowsAsync(new InvalidOperationException("db down"));
+
+        var act = async () => await NewEmitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, Guid.NewGuid(), Guid.NewGuid()));
+
+        await act.Should().NotThrowAsync("a failed audit emit must never break the action");
+    }
+
+    [Test]
+    public async Task Platform_Sink_Failure_Is_Swallowed()
+    {
+        _platform.Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("bus down"));
+
+        var act = async () => await NewEmitter().EmitAsync(SensitiveAction.ForPlatform(
+            SensitiveActionCatalog.LoginSuccess, null, Guid.NewGuid()));
+
+        await act.Should().NotThrowAsync();
+    }
+
+    // ── Redaction (belt-and-suspenders) ────────────────────────────────────
+
+    [Test]
+    public async Task Secret_Shaped_Value_Is_Scrubbed_From_Data()
+    {
+        const string plaintext = "tamma_sk_LIVEDEADBEEF0123456789";
+
+        await NewEmitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, Guid.NewGuid(), Guid.NewGuid(),
+            data: new Dictionary<string, object?>
+            {
+                ["provider"] = "anthropic",
+                ["note"] = $"raw={plaintext}",
+            }));
+
+        _appendedDomain!.Data.Should().NotContain(plaintext);
+        _appendedDomain.Data.Should().Contain("[REDACTED]");
+    }
+
+    [Test]
+    public async Task Denylisted_Key_Is_Replaced_With_Placeholder()
+    {
+        await NewEmitter().EmitAsync(SensitiveAction.ForTenant(
+            SensitiveActionCatalog.ProviderKeyChanged, Guid.NewGuid(), Guid.NewGuid(),
+            data: new Dictionary<string, object?>
+            {
+                ["provider"] = "anthropic",
+                ["apiKey"] = "should-never-appear",
+            }));
+
+        _appendedDomain!.Data.Should().NotContain("should-never-appear");
+        _appendedDomain.Data.Should().Contain("[REDACTED]");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Redaction/CredentialRedactorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Redaction/CredentialRedactorTests.cs
@@ -165,4 +165,30 @@ public class CredentialRedactorTests
         output.Should().Contain("HttpRequestException");
         output.Should().Contain("canceled");
     }
+
+    // ── Finding 3 (Story 37-10 review) — provider-key prefix backstop ──
+    // The backstop must match its "belt-and-suspenders" doc: common provider-key
+    // shapes (Anthropic sk-ant-, OpenAI project sk-proj-) must be redacted even
+    // when the surrounding key name doesn't match the credential heuristic.
+
+    [Test]
+    public void Clean_AnthropicKeyPrefix_Redacts()
+    {
+        // Synthetic value (clearly fake) with the real sk-ant- banner shape.
+        const string fakeKey = "sk-ant-api03-FAKE0123456789abcdefFAKE";
+        var input = $"anthropic call failed using {fakeKey} at boundary";
+        var output = CredentialRedactor.Clean(input);
+        output.Should().NotContain(fakeKey);
+        output.Should().Contain("[REDACTED]");
+    }
+
+    [Test]
+    public void Clean_OpenAiProjectKeyPrefix_Redacts()
+    {
+        const string fakeKey = "sk-proj-FAKE0123456789abcdefFAKE";
+        var input = $"openai auth error token={fakeKey} rejected";
+        var output = CredentialRedactor.Clean(input);
+        output.Should().NotContain(fakeKey);
+        output.Should().Contain("[REDACTED]");
+    }
 }


### PR DESCRIPTION
## What

Story 37-10 (P0). Wires sensitive-action audit emission into the 37-1 catalog/projector so the audit taxonomy has real data: BYOK key set/rotate/remove, login success/failure (+ coarse reason), token refresh, and API-key auth (throttled one-per-key-per-5-min). A single `ISensitiveActionEmitter` routes Tenant-scope events → `domain_events` and Platform-scope → `platform_events`. Credential-redaction end-to-end tested (a real `tamma_sk_` persists zero key bytes). **No migration.**

Reasonable deferrals (reported): AC3 BYOK-mode-toggle / AC5 subscription events (no distinct site yet — now largely covered by 35-4/35-5), AC9–11 agentId-tag/persona/export refinements (underlying events already project).

## Review outcome

Focused security review verified **no credential leakage** into stored records, correct scope routing, non-fatal emission, no login-enumeration oracle, and catalog-code correctness. One Important finding fixed:
- **Audit evasion via `varchar(320)` overflow:** the attacker-controlled login email was written uncapped; a 321–1024-char email overflowed `ActorEmailSnapshot(320)`, throwing Npgsql `22001` in the projector — which (verified) leaves the poison entity un-detached and **stalls the projector**, breaking the audit trail an attacker could trigger to hide their own brute-force. Fixed belt-and-suspenders: `AuditProjector` now **clamps every varchar field to its column length** (protects all current/future emitters), and the login email is capped to ≤254 at source. Fail-before/pass-after test added.
- Lower: API-key heartbeat emit now bounded by a 2s linked-token timeout (can't hang auth); `CredentialRedactor` backstop extended with `sk-ant-`/`sk-proj-` prefixes.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Tests: Audit|Auth 564 passed + redactor 18 + projector over-length 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)