### PR TITLE
feat(epic-34): Story 34-4 — Per-Tenant Plan Assignment & Lifecycle

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Admin/AdminTenantDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Admin/AdminTenantDtos.cs
@@ -111,6 +111,43 @@ public record AdminTenantActionGate(
 public record UpdateTenantPlanRequest(Guid PlanId);
 
 /// <summary>
+/// Story 34-4 — request body for the idempotent
+/// <c>PUT /api/admin/tenants/{id}/plan</c>. <see cref="PlanId"/> is a specific
+/// versioned plan row; <see cref="Reason"/> is an audit note; <see cref="Force"/>
+/// permits assigning a <c>deprecated</c> version (a <c>draft</c> is always
+/// rejected).
+/// </summary>
+public record PutTenantPlanRequest(Guid PlanId, string? Reason = null, bool Force = false);
+
+/// <summary>
+/// Story 34-4 — request body for
+/// <c>POST /api/admin/tenants/{id}/plan/cancel</c>. <see cref="Immediate"/> drops
+/// the tenant to <c>free</c> now instead of at the current billing-interval
+/// boundary.
+/// </summary>
+public record CancelTenantPlanRequest(string? Reason = null, bool Immediate = false);
+
+/// <summary>
+/// Story 34-4 — 200 body for the assign / subscribe / cancel plan operations.
+/// <see cref="Warnings"/> lists over-limit downgrade flags (never blocking).
+/// <see cref="ScheduledEffectiveAt"/> is set only for a period-end cancel.
+/// </summary>
+public record PlanAssignmentResponse(
+    Guid TenantId,
+    Guid PlanId,
+    int PlanVersion,
+    string Status,
+    string Direction,
+    IReadOnlyList<PlanAssignmentWarningItem> Warnings,
+    DateTime? ScheduledEffectiveAt);
+
+/// <summary>Story 34-4 — one over-limit downgrade warning on a plan change.</summary>
+public record PlanAssignmentWarningItem(
+    string MetricKey,
+    long? CurrentUsage,
+    long? NewLimit);
+
+/// <summary>
 /// Minimal response the action POST handlers return (retry / delete /
 /// force-delete / change-plan). <see cref="Status"/> is the new Status
 /// value after the action applies; <see cref="Message"/> is a

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminTenantsEndpoints.cs
@@ -719,12 +719,19 @@ public static class AdminTenantsEndpoints
 
     // ── PATCH /api/admin/tenants/{id}/plan ──
 
+    /// <summary>
+    /// Story 34-4 — refactored to DELEGATE to
+    /// <see cref="IPlanAssignmentService.AssignAsync"/> (replacing the inline
+    /// shadow-column flip + ad-hoc <c>PLAN.UPDATED</c> emit). The tenant-status
+    /// gate stays here (a plan change is only legal in a stable state); the
+    /// service pins the version, keeps the lockstep tenant columns, and emits the
+    /// superseding <c>TENANT.PLAN.CHANGED</c> event.
+    /// </summary>
     public static async Task<IResult> UpdateTenantPlan(
         Guid tenantId,
         UpdateTenantPlanRequest req,
         ControlPlaneDbContext db,
-        IPlatformEventPublisher publisher,
-        [FromServices] TimeProvider timeProvider,
+        IPlanAssignmentService assignments,
         ClaimsPrincipal principal,
         CancellationToken ct = default)
     {
@@ -741,39 +748,174 @@ public static class AdminTenantsEndpoints
         if (!IsPlanChangeAllowed(current))
             return IllegalTransition(current, "change-plan");
 
-        var plan = await db.Plans.AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Id == req.PlanId, ct);
-        if (plan is null)
-            return Results.BadRequest(new { error = "plan_not_found" });
-        if (!plan.IsActive)
-            return Results.BadRequest(new { error = "plan_inactive" });
+        var actor = ActorTriple(principal);
+        try
+        {
+            var result = await assignments.AssignAsync(
+                tenantId, req.PlanId,
+                new AssignPlanOptions(
+                    ActorUserId: actor.UserId,
+                    Reason: "admin plan change (PATCH)",
+                    Source: "admin",
+                    ActorEmail: actor.Email,
+                    ActorPlatformRole: actor.Role),
+                ct);
 
-        var oldPlanId = (Guid?)db.Entry(tenant).Property("PlanId").CurrentValue;
-        db.Entry(tenant).Property("PlanId").CurrentValue = plan.Id;
-        // Keep the legacy string column in lockstep so dashboards that still
-        // read it render the same plan.
-        tenant.Plan = plan.Slug;
-        tenant.UpdatedAt = timeProvider.GetUtcNow().UtcDateTime;
-        await db.SaveChangesAsync(ct);
-
-        await publisher.AppendAndPublishAsync(
-            BuildAdminEvent(
-                "PLAN.UPDATED",
+            return Results.Ok(new AdminTenantActionResponse(
                 tenantId,
-                principal,
-                new Dictionary<string, object?>
-                {
-                    ["oldPlanId"] = oldPlanId?.ToString("D"),
-                    ["newPlanId"] = plan.Id.ToString("D"),
-                    ["newPlanSlug"] = plan.Slug,
-                }),
-            ct);
-
-        return Results.Ok(new AdminTenantActionResponse(
-            tenantId,
-            current ?? StatusActive,
-            $"Plan changed to {plan.DisplayName}."));
+                current ?? StatusActive,
+                $"Plan changed to {result.Assignment.PlanId:D} v{result.Assignment.PlanVersion}."));
+        }
+        catch (TammaError ex)
+        {
+            return MapPlanAssignmentError(ex);
+        }
     }
+
+    // ── PUT /api/admin/tenants/{id}/plan (idempotent assign) ──
+
+    /// <summary>
+    /// Story 34-4 — idempotent version-pinned assign with an optional reason +
+    /// force (deprecated). Returns the full <see cref="PlanAssignmentResponse"/>
+    /// (planVersion, direction, warnings). PlatformOwnerAccess.
+    /// </summary>
+    public static async Task<IResult> PutTenantPlan(
+        Guid tenantId,
+        PutTenantPlanRequest req,
+        ControlPlaneDbContext db,
+        IPlanAssignmentService assignments,
+        ClaimsPrincipal principal,
+        CancellationToken ct = default)
+    {
+        if (req.PlanId == Guid.Empty)
+            return Results.BadRequest(new { error = "plan_id_required" });
+
+        var tenant = await db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId && t.DeletedAt == null, ct);
+        if (tenant is null)
+            return Results.NotFound(new { error = "tenant_not_found" });
+
+        var current = (string?)db.Entry(tenant).Property("Status").CurrentValue;
+        if (!IsPlanChangeAllowed(current))
+            return IllegalTransition(current, "change-plan");
+
+        var actor = ActorTriple(principal);
+        try
+        {
+            var result = await assignments.AssignAsync(
+                tenantId, req.PlanId,
+                new AssignPlanOptions(
+                    ActorUserId: actor.UserId,
+                    Reason: req.Reason,
+                    Force: req.Force,
+                    Source: "admin",
+                    ActorEmail: actor.Email,
+                    ActorPlatformRole: actor.Role),
+                ct);
+
+            return Results.Ok(ToPlanAssignmentResponse(tenantId, result));
+        }
+        catch (TammaError ex)
+        {
+            return MapPlanAssignmentError(ex);
+        }
+    }
+
+    // ── POST /api/admin/tenants/{id}/plan/cancel ──
+
+    /// <summary>
+    /// Story 34-4 — schedule a cancel → <c>free</c> at the period boundary (or
+    /// immediately). Returns 200 with the scheduled assignment + effectiveAt.
+    /// PlatformOwnerAccess.
+    /// </summary>
+    public static async Task<IResult> CancelTenantPlan(
+        Guid tenantId,
+        CancelTenantPlanRequest? req,
+        ControlPlaneDbContext db,
+        IPlanAssignmentService assignments,
+        ClaimsPrincipal principal,
+        CancellationToken ct = default)
+    {
+        var tenant = await db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId && t.DeletedAt == null, ct);
+        if (tenant is null)
+            return Results.NotFound(new { error = "tenant_not_found" });
+
+        var current = (string?)db.Entry(tenant).Property("Status").CurrentValue;
+        if (!IsPlanChangeAllowed(current))
+            return IllegalTransition(current, "change-plan");
+
+        var actor = ActorTriple(principal);
+        try
+        {
+            var result = await assignments.CancelAsync(
+                tenantId,
+                new CancelPlanOptions(
+                    ActorUserId: actor.UserId,
+                    Reason: req?.Reason,
+                    Immediate: req?.Immediate ?? false,
+                    ActorEmail: actor.Email,
+                    ActorPlatformRole: actor.Role),
+                ct);
+
+            return Results.Ok(ToPlanAssignmentResponse(tenantId, result));
+        }
+        catch (TammaError ex)
+        {
+            return MapPlanAssignmentError(ex);
+        }
+    }
+
+    /// <summary>
+    /// Story 34-4 — the full actor breadcrumb (user id + email + platform role)
+    /// for the assignment audit event, extracted the same way
+    /// <see cref="BuildAdminEvent"/> does.
+    /// </summary>
+    internal static (Guid? UserId, string? Email, string? Role) ActorTriple(ClaimsPrincipal? principal)
+    {
+        var actor = ExtractActor(principal);
+        var userId = Guid.TryParse(actor.UserId, out var id) ? id : (Guid?)null;
+        return (userId, actor.Email, actor.PlatformRole);
+    }
+
+    /// <summary>Story 34-4 — project a service result onto the wire DTO.</summary>
+    internal static PlanAssignmentResponse ToPlanAssignmentResponse(
+        Guid tenantId, PlanAssignmentResult result) =>
+        new(
+            tenantId,
+            result.Assignment.PlanId,
+            result.Assignment.PlanVersion,
+            result.Assignment.Status,
+            result.Direction.ToString().ToLowerInvariant(),
+            result.Warnings
+                .Select(w => new PlanAssignmentWarningItem(
+                    w.MetricKey.ToString(), w.CurrentUsage, w.NewLimit))
+                .ToList(),
+            result.ScheduledEffectiveAt);
+
+    /// <summary>Story 34-4 — map a typed assignment <see cref="TammaError"/> to an HTTP status.</summary>
+    internal static IResult MapPlanAssignmentError(TammaError ex) => ex.Code switch
+    {
+        "PLAN.ASSIGN.PLAN_NOT_FOUND" => Results.BadRequest(new { error = "plan_not_found" }),
+        "PLAN.ASSIGN.TENANT_NOT_FOUND" => Results.NotFound(new { error = "tenant_not_found" }),
+        "PLAN.CANCEL.NO_ACTIVE_ASSIGNMENT" => Results.Json(
+            new { error = "no_active_assignment" }, statusCode: StatusCodes.Status409Conflict),
+        "PLAN.ASSIGN.PLAN_DRAFT" => Results.UnprocessableEntity(new { error = "plan_draft" }),
+        "PLAN.ASSIGN.PLAN_DEPRECATED" => Results.UnprocessableEntity(
+            new { error = "plan_deprecated_no_force" }),
+        "PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND" => Results.UnprocessableEntity(
+            new { error = "custom_plan_misbound" }),
+        "PLAN.ASSIGN.CONCURRENT" => Results.Json(
+            new { error = "concurrent_assign" }, statusCode: StatusCodes.Status409Conflict),
+        "PLAN.CANCEL.NO_FREE_PLAN" => Results.Problem(
+            title: ex.Code, detail: ex.Message,
+            statusCode: StatusCodes.Status500InternalServerError),
+        _ => Results.Problem(
+            title: ex.Code, detail: ex.Message,
+            statusCode: StatusCodes.Status500InternalServerError),
+    };
 
     // ── POST /api/admin/tenants/{id}/move ──
 

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -222,4 +222,74 @@ public static class PricingEndpoints
             ? Results.NotFound(new { error = "plan_not_found", slug })
             : Results.Ok(snapshot);
     }
+
+    // ── POST /api/pricing/subscribe ── (Story 34-4 AC11, SettingsManage)
+    //
+    // Tenant self-service: a tenant_owner picks a PUBLIC (active, non-custom)
+    // plan for their OWN tenant. The tenant is resolved STRICTLY from
+    // ITenantContext (SaaS) / the sole user's instance (single-user) — a request
+    // body NEVER selects the tenant, so a caller can never subscribe/affect
+    // another tenant (tenant isolation, AC12/AC14). A member-role caller is
+    // rejected 403 by the SettingsManage policy on the route; subscribing to a
+    // custom / draft / deprecated / unknown plan returns 422.
+    public static async Task<IResult> Subscribe(
+        SubscribeRequest? req,
+        ClaimsPrincipal user,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider,
+        IPlanCatalogService planCatalog,
+        IPlanAssignmentService assignments,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.PricingEndpoints");
+
+        if (req is null || string.IsNullOrWhiteSpace(req.PlanSlug))
+        {
+            return Results.BadRequest(new { error = "plan_slug_required" });
+        }
+
+        // Tenant strictly from context — never from the body.
+        if (tenantContext.TenantId is not Guid tenantId)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        // Only a PUBLIC (active, non-custom) plan is subscribable here. A custom
+        // plan's slug is never resolvable through this route (IsCustom filter),
+        // and draft/deprecated are excluded by construction.
+        var snapshot = await planCatalog.GetActivePublicBySlugAsync(req.PlanSlug, ct);
+        if (snapshot is null)
+        {
+            return Results.UnprocessableEntity(new { error = "plan_not_public" });
+        }
+
+        var actor = Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.ActorTriple(user);
+        try
+        {
+            var result = await assignments.AssignAsync(
+                tenantId, snapshot.PlanId,
+                new AssignPlanOptions(
+                    ActorUserId: actor.UserId,
+                    Reason: "tenant self-service subscribe",
+                    Source: "self-service",
+                    ActorEmail: actor.Email,
+                    ActorPlatformRole: actor.Role),
+                ct);
+
+            logger.LogInformation(
+                "Tenant {TenantId} subscribed to plan {Slug} v{Version} (mode={Mode})",
+                tenantId, snapshot.Slug, snapshot.Version, modeProvider.Mode);
+
+            return Results.Ok(
+                Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.ToPlanAssignmentResponse(tenantId, result));
+        }
+        catch (TammaError ex)
+        {
+            return Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.MapPlanAssignmentError(ex);
+        }
+    }
 }
+
+/// <summary>Story 34-4 — request body for <c>POST /api/pricing/subscribe</c>.</summary>
+public sealed record SubscribeRequest(string PlanSlug);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.PlatformTasks;
 using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Provisioning;
 
 namespace Tamma.Api.Extensions;
 
@@ -67,11 +69,15 @@ public static class PricingServiceCollectionExtensions
     ///     hosted service subscribing the in-process event bus.</description></item>
     /// </list>
     ///
-    /// <para><b>34-4 interim:</b> the default
-    /// <see cref="IActivePlanAssignmentSource"/> reads the tenant's Epic-28
-    /// <c>PlanId</c> shadow column. Swap in a 34-4
-    /// <c>IPlanAssignmentService</c> adapter under this same seam once that
-    /// story lands — no resolver change required.</para>
+    /// <para><b>34-4 wired:</b> the <see cref="IActivePlanAssignmentSource"/> now
+    /// reads the tenant's active <c>TenantPlanAssignment</c> row via
+    /// <see cref="PlanAssignmentActivePlanSource"/> (which delegates to
+    /// <see cref="IPlanAssignmentService"/>, registered by
+    /// <see cref="AddPlanAssignment"/>). This is the one-line swap Story 34-6
+    /// anticipated — it replaces the interim
+    /// <see cref="TenantShadowColumnPlanAssignmentSource"/> behind the same seam
+    /// with no entitlement-resolver change, and now supplies the pinned
+    /// <c>PlanVersion</c> directly.</para>
     /// </summary>
     public static IServiceCollection AddEntitlementResolution(this IServiceCollection services)
     {
@@ -83,11 +89,45 @@ public static class PricingServiceCollectionExtensions
         services.TryAddSingleton<IEntitlementSnapshotCache>(sp =>
             new EntitlementSnapshotCache(sp.GetRequiredService<TimeProvider>()));
 
-        services.TryAddScoped<IActivePlanAssignmentSource, TenantShadowColumnPlanAssignmentSource>();
+        // Story 34-4 — read the pinned (PlanId, PlanVersion) from the real
+        // assignment table. Ensure IPlanAssignmentService is registered
+        // (AddPlanAssignment); called independently from Program.cs.
+        services.TryAddScoped<IActivePlanAssignmentSource, PlanAssignmentActivePlanSource>();
         services.TryAddScoped<IEntitlementUsageReader, ControlPlaneEntitlementUsageReader>();
         services.TryAddScoped<IEntitlementService, EntitlementService>();
 
         services.AddHostedService<EntitlementCacheInvalidationListener>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Story 34-4 — the version-pinned plan-assignment service + its usage seam
+    /// and the platform-queue boundary-activation handler.
+    ///
+    /// <list type="bullet">
+    ///   <item><description><see cref="IPlanAssignmentService"/> — scoped
+    ///     (depends on the scoped <c>ControlPlaneDbContext</c> + catalog).</description></item>
+    ///   <item><description><see cref="ITenantUsageReader"/> —
+    ///     <see cref="NullTenantUsageReader"/> default (Epic 35 supplies the real
+    ///     metering reader behind this same seam; keeps Billing out of the
+    ///     assignment path).</description></item>
+    ///   <item><description><see cref="ActivateScheduledPlanTaskHandler"/> —
+    ///     platform-task handler promoting a due scheduled assignment at its
+    ///     boundary (requires <c>AddPlatformTaskWorker</c>).</description></item>
+    /// </list>
+    /// </summary>
+    public static IServiceCollection AddPlanAssignment(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        services.TryAddScoped<ITenantUsageReader, NullTenantUsageReader>();
+        services.TryAddScoped<IPlanAssignmentService, PlanAssignmentService>();
+
+        // Boundary-activation platform-task handler (period-end cancel → free).
+        services.AddPlatformTaskHandler<ActivateScheduledPlanTaskHandler>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1041,6 +1041,13 @@ builder.Services.AddUsagePricingEngine();
 // cache-invalidation listener. Read-only; fails loud on no assignment.
 builder.Services.AddEntitlementResolution();
 
+// Story 34-4 — the version-pinned plan-assignment service (source of truth for
+// "what plan version is this tenant on"), its ITenantUsageReader seam (null
+// default; Epic 35 supplies the real reader), and the platform-queue
+// boundary-activation handler. AddEntitlementResolution's
+// IActivePlanAssignmentSource now reads the assignment table via this service.
+builder.Services.AddPlanAssignment();
+
 // Wave C.4 §4 — per-process health monitor for TammaApiClient.
 // Singleton so the rolling 5-min failure window is shared across every
 // call site. Fires PLATFORM.API.UNHEALTHY via IAlertEventEmitter when
@@ -1793,6 +1800,16 @@ admin.MapPost("/tenants/{tenantId:guid}/cleanup",
 admin.MapPatch("/tenants/{tenantId:guid}/plan",
         Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.UpdateTenantPlan)
     .RequireAuthorization("PlatformOwnerAccess");
+// Story 34-4 — idempotent version-pinned assign (body { planId, reason?, force? })
+// + period-end / immediate cancel → free. Both delegate to
+// IPlanAssignmentService, emit TENANT.PLAN.CHANGED / .CANCELLED, and keep the
+// lockstep tenant plan columns aligned. PlatformOwnerAccess.
+admin.MapPut("/tenants/{tenantId:guid}/plan",
+        Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.PutTenantPlan)
+    .RequireAuthorization("PlatformOwnerAccess");
+admin.MapPost("/tenants/{tenantId:guid}/plan/cancel",
+        Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.CancelTenantPlan)
+    .RequireAuthorization("PlatformOwnerAccess");
 
 // Unified-tenancy Phase 4 — move a tenant's schema to another pool row.
 // POST validates cheaply + enqueues a `tenant.move` platform task and
@@ -1947,6 +1964,13 @@ pricing.MapGet("/entitlements", Tamma.Api.Endpoints.PricingEndpoints.GetEntitlem
 // read; the admin write surface stays platform-owner-only (/api/admin/pricing/plans*).
 pricing.MapGet("/plans", Tamma.Api.Endpoints.PricingEndpoints.ListPublicPlans);
 pricing.MapGet("/plans/{slug}", Tamma.Api.Endpoints.PricingEndpoints.GetPublicPlanBySlug);
+// Story 34-4 (AC11) — tenant self-service subscribe to a PUBLIC plan. Tenant is
+// resolved strictly from ITenantContext (never the body) so a caller can only
+// affect their OWN tenant. Gated by SettingsManage (tenant_owner) on top of the
+// group's MemberAccess — a member-role caller gets 403; custom/draft/deprecated
+// or unknown plans return 422.
+pricing.MapPost("/subscribe", Tamma.Api.Endpoints.PricingEndpoints.Subscribe)
+    .RequireAuthorization("SettingsManage");
 
 var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");
 orgs.MapPost("/", OrgEndpoints.CreateOrg);
@@ -2734,6 +2758,7 @@ using (var scope = app.Services.CreateScope())
                     junior_developers, kek_rotations,
                     mentorship_events, mentorship_sessions,
                     password_reset_tokens,
+                    tenant_plan_assignments,
                     plan_features, plan_entitlements, plan_prices, plans,
                     margin_policies,
                     provider_model_prices, providers,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanAssignmentService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IPlanAssignmentService.cs
@@ -1,0 +1,65 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — the REAL, audited plan-assignment surface. A
+/// <c>TenantPlanAssignment</c> row is the source of truth for "what plan version
+/// is this tenant on right now"; this service is the ONLY writer of the
+/// lockstep <c>Tenant.PlanId</c> / <c>Tenant.Plan</c> cache columns.
+///
+/// <para>Every write pins the plan <c>Version</c> (never "latest"), keeps
+/// exactly one <c>active</c> row per tenant (partial unique index +
+/// transactional swap), classifies the change direction, flags (never blocks)
+/// over-limit downgrades, and emits a <c>TENANT.PLAN.CHANGED</c> /
+/// <c>TENANT.PLAN.CANCELLED</c> DCB event carrying the proration boundary Epic
+/// 35 Billing consumes. The <c>TENANT.PLAN.CHANGED</c> emit is what evicts Story
+/// 34-6's cached entitlement snapshot for the tenant.</para>
+/// </summary>
+public interface IPlanAssignmentService
+{
+    /// <summary>
+    /// Pin the tenant to a plan version. Guards: rejects a <c>draft</c> plan
+    /// always and a <c>deprecated</c> plan unless <see cref="AssignPlanOptions.Force"/>;
+    /// rejects a custom (<c>IsCustom</c>) plan not bound to this tenant. Flips the
+    /// prior active row to <c>cancelled</c> and inserts a new <c>active</c> row in
+    /// one transaction, then updates the lockstep tenant columns. Idempotent — a
+    /// re-assign of the same <c>(PlanId, PlanVersion)</c> is a <c>lateral</c> no-op
+    /// (returns the existing row, emits no event).
+    /// </summary>
+    /// <exception cref="Tamma.Core.TammaError">
+    /// <c>PLAN.ASSIGN.PLAN_NOT_FOUND</c> / <c>PLAN.ASSIGN.PLAN_DRAFT</c> /
+    /// <c>PLAN.ASSIGN.PLAN_DEPRECATED</c> / <c>PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND</c>
+    /// / <c>PLAN.ASSIGN.TENANT_NOT_FOUND</c> / <c>PLAN.ASSIGN.CONCURRENT</c>.
+    /// </exception>
+    Task<PlanAssignmentResult> AssignAsync(
+        Guid tenantId, Guid planId, AssignPlanOptions opts, CancellationToken ct = default);
+
+    /// <summary>
+    /// Schedule a cancel → <c>plan_free</c>. Does NOT drop the tenant immediately:
+    /// stamps <c>EffectiveTo</c> on the current active row at the period boundary
+    /// (or now, if <see cref="CancelPlanOptions.Immediate"/>), inserts a
+    /// <c>scheduled</c> <c>plan_free</c> row at that boundary, enqueues the
+    /// boundary-activation task, and emits <c>TENANT.PLAN.CANCELLED</c>. Already
+    /// on <c>plan_free</c> ⇒ no-op.
+    /// </summary>
+    Task<PlanAssignmentResult> CancelAsync(
+        Guid tenantId, CancelPlanOptions opts, CancellationToken ct = default);
+
+    /// <summary>
+    /// Promote a due <c>scheduled</c> assignment to <c>active</c> (called by the
+    /// platform-queue boundary task). Flips the expiring <c>active</c> row to
+    /// <c>cancelled</c>, the scheduled row to <c>active</c>, updates the tenant
+    /// columns, and emits <c>TENANT.PLAN.CHANGED</c> with
+    /// <c>source=scheduled-activation</c>. Idempotent by <paramref name="assignmentId"/>
+    /// — a re-run whose target is already active is a no-op.
+    /// </summary>
+    Task<PlanAssignmentResult?> ActivateScheduledAsync(
+        Guid tenantId, Guid assignmentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// The tenant's current effective <c>(PlanId, PlanVersion)</c> assignment, or
+    /// <c>null</c> when the tenant has no active assignment. Read-only.
+    /// </summary>
+    Task<TenantPlanAssignment?> GetActiveAsync(Guid tenantId, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantUsageReader.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantUsageReader.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — usage seam consumed ONLY to FLAG (never block) over-limit
+/// downgrades. On a plan change, <see cref="PlanAssignmentService"/> asks this
+/// reader for the tenant's current usage of each metric the new plan limits; a
+/// current value above the new limit becomes an <see cref="EntitlementWarning"/>
+/// on the result and sets the <c>entitlementWarnings=true</c> tag on
+/// <c>TENANT.PLAN.CHANGED</c>.
+///
+/// <para><b>Scope boundary (34-4 non-goal):</b> this story ships the interface +
+/// a null default (<see cref="NullTenantUsageReader"/>) that returns "unknown"
+/// for every metric, so no metering/Billing dependency leaks into the
+/// assignment transaction. Epic 35 / Epic 20 supply the real reader behind this
+/// same seam. A <c>null</c> return degrades to "no warning" — the assignment
+/// still succeeds.</para>
+/// </summary>
+public interface ITenantUsageReader
+{
+    /// <summary>
+    /// The tenant's current usage of <paramref name="metric"/>, or <c>null</c>
+    /// when this reader cannot answer it (degrades to no warning). Read-only.
+    /// </summary>
+    Task<long?> GetCurrentUsageAsync(
+        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Story 34-4 — the shipped default: answers "unknown" (<c>null</c>) for every
+/// metric so a downgrade never produces a warning until Epic 35 wires the real
+/// metering reader behind the same seam. Deliberately dependency-free and
+/// deterministic (no DB, no metering) — keeping usage/Billing out of the
+/// assignment path (the whole point of the seam).
+/// </summary>
+public sealed class NullTenantUsageReader : ITenantUsageReader
+{
+    private readonly ILogger<NullTenantUsageReader> _logger;
+
+    public NullTenantUsageReader(ILogger<NullTenantUsageReader> logger)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<long?> GetCurrentUsageAsync(
+        Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default)
+    {
+        _logger.LogDebug(
+            "NullTenantUsageReader: no usage signal for tenant {TenantId} metric {Metric} "
+            + "(downgrade warnings degrade to none until Epic 35 supplies the reader)",
+            tenantId, metric);
+        return Task.FromResult<long?>(null);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentActivePlanSource.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentActivePlanSource.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — the REAL <see cref="IActivePlanAssignmentSource"/>: reads the
+/// tenant's active <c>TenantPlanAssignment</c> row (via
+/// <see cref="IPlanAssignmentService.GetActiveAsync"/>) and returns its pinned
+/// <c>(PlanId, PlanVersion)</c>. This is the one-line DI swap Story 34-6
+/// anticipated — it replaces the interim
+/// <see cref="TenantShadowColumnPlanAssignmentSource"/> (which read the raw
+/// Epic-28 <c>PlanId</c> shadow column) behind the same seam, with no change to
+/// the entitlement resolver. Because the assignment row carries the pinned
+/// version directly, this source supplies <c>PlanVersion</c> (the shadow-column
+/// source left it <c>null</c>).
+/// </summary>
+public sealed class PlanAssignmentActivePlanSource : IActivePlanAssignmentSource
+{
+    private readonly IPlanAssignmentService _assignments;
+    private readonly ILogger<PlanAssignmentActivePlanSource> _logger;
+
+    public PlanAssignmentActivePlanSource(
+        IPlanAssignmentService assignments,
+        ILogger<PlanAssignmentActivePlanSource> logger)
+    {
+        _assignments = assignments ?? throw new ArgumentNullException(nameof(assignments));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ActivePlanAssignment?> GetActiveAsync(
+        Guid tenantId, CancellationToken ct = default)
+    {
+        var active = await _assignments.GetActiveAsync(tenantId, ct).ConfigureAwait(false);
+        if (active is null)
+        {
+            _logger.LogDebug(
+                "No active plan assignment for tenant {TenantId} (tenant_plan_assignments)",
+                tenantId);
+            return null;
+        }
+
+        return new ActivePlanAssignment(active.PlanId, active.PlanVersion);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentEventTypes.cs
@@ -1,0 +1,27 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — DCB event type names emitted by <see cref="PlanAssignmentService"/>
+/// to the control-plane <c>platform_events</c> store. Pattern
+/// <c>AGGREGATE.ACTION.STATUS</c>. Both live under the <c>TENANT.PLAN.</c>
+/// prefix that Story 34-6's <c>EntitlementCacheInvalidationListener</c>
+/// subscribes for per-tenant snapshot eviction, so every assignment change
+/// evicts exactly that tenant's cached entitlements.
+///
+/// <para>The legacy <c>PLAN.UPDATED</c> tag (the ad-hoc emit the pre-34-4
+/// <c>UpdateTenantPlan</c> path used) is superseded by
+/// <see cref="TenantPlanChanged"/>; a <c>supersedesLegacy = PLAN.UPDATED</c> tag
+/// is carried for one release so the admin dashboard timeline does not blank
+/// out mid-migration.</para>
+/// </summary>
+public static class PlanAssignmentEventTypes
+{
+    /// <summary>Emitted on assign + scheduled-activation (upgrade/downgrade/lateral).</summary>
+    public const string TenantPlanChanged = "TENANT.PLAN.CHANGED";
+
+    /// <summary>Emitted when a cancellation is scheduled (drop → plan_free at boundary).</summary>
+    public const string TenantPlanCancelled = "TENANT.PLAN.CANCELLED";
+
+    /// <summary>Superseded legacy tag kept for one-release dashboard back-compat.</summary>
+    public const string LegacyPlanUpdated = "PLAN.UPDATED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentModels.cs
@@ -1,0 +1,67 @@
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — options for <see cref="IPlanAssignmentService.AssignAsync"/>.
+/// </summary>
+/// <param name="ActorUserId">The actor making the change; <c>null</c> = system/scheduler.</param>
+/// <param name="Reason">Free-text audit note (admin note / self-service).</param>
+/// <param name="Force">
+/// Allow assigning a <c>deprecated</c> plan version (a <c>draft</c> is ALWAYS
+/// rejected regardless). Default <c>false</c>.
+/// </param>
+/// <param name="Source">
+/// Where the assignment originated — one of <c>admin</c> | <c>self-service</c> |
+/// <c>scheduled-activation</c>. Stamped as the <c>source</c> event tag.
+/// </param>
+/// <param name="ActorEmail">Actor email for the audit breadcrumb (like <c>BuildAdminEvent</c>).</param>
+/// <param name="ActorPlatformRole">Actor platform role for the audit breadcrumb.</param>
+public sealed record AssignPlanOptions(
+    Guid? ActorUserId = null,
+    string? Reason = null,
+    bool Force = false,
+    string Source = "admin",
+    string? ActorEmail = null,
+    string? ActorPlatformRole = null);
+
+/// <summary>
+/// Story 34-4 — options for <see cref="IPlanAssignmentService.CancelAsync"/>.
+/// </summary>
+/// <param name="ActorUserId">The actor scheduling the cancel; <c>null</c> = system.</param>
+/// <param name="Reason">Free-text audit note.</param>
+/// <param name="Immediate">
+/// When <c>true</c> the tenant drops to <c>plan_free</c> NOW instead of at the
+/// current billing-interval boundary. Default <c>false</c> (period-end).
+/// </param>
+public sealed record CancelPlanOptions(
+    Guid? ActorUserId = null,
+    string? Reason = null,
+    bool Immediate = false,
+    string? ActorEmail = null,
+    string? ActorPlatformRole = null);
+
+/// <summary>
+/// Story 34-4 — result of an assign / cancel / activate operation. Carries the
+/// resulting assignment row, the classified change direction, any over-limit
+/// downgrade <see cref="Warnings"/> (flagged, never blocking), and — for a
+/// scheduled cancel — the boundary instant the drop takes effect.
+/// </summary>
+public sealed record PlanAssignmentResult(
+    TenantPlanAssignment Assignment,
+    PlanChangeDirection Direction,
+    IReadOnlyList<EntitlementWarning> Warnings,
+    DateTime? ScheduledEffectiveAt);
+
+/// <summary>
+/// Story 34-4 — a single over-limit downgrade warning: the tenant's current
+/// usage of <paramref name="MetricKey"/> exceeds the NEW plan's limit. Purely
+/// informational — this story flags, it never blocks (enforcement is a sibling
+/// epic). <c>CurrentUsage</c> / <c>NewLimit</c> are <c>null</c> when unknown
+/// (usage reader can't answer / unlimited).
+/// </summary>
+public sealed record EntitlementWarning(
+    EntitlementMetricKey MetricKey,
+    long? CurrentUsage,
+    long? NewLimit);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs
@@ -1,0 +1,654 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Provisioning;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-4 — the version-pinned, audited plan-assignment service. See
+/// <see cref="IPlanAssignmentService"/>. Writes are transactional (one active
+/// row per tenant), pin the plan <c>Version</c>, keep the lockstep
+/// <c>Tenant.PlanId</c>/<c>Tenant.Plan</c> cache columns aligned, and emit a
+/// <c>TENANT.PLAN.CHANGED</c>/<c>.CANCELLED</c> platform event (which is what
+/// evicts Story 34-6's cached entitlement snapshot for the tenant).
+/// </summary>
+public sealed class PlanAssignmentService : IPlanAssignmentService
+{
+    private const string FreePlanSlug = "free";
+    private const string PlatformProvidedPricingMode = "platform_provided";
+
+    // The legacy Tenant.Plan string column is constrained by the pre-existing
+    // ck_tenants_plan CHECK (Plan IN ('free','team','enterprise')). It is only a
+    // best-effort cache for old dashboards — the source of truth is the
+    // assignment row + the Tenant.PlanId shadow FK (which accepts ANY plan,
+    // incl. custom/deprecated). So the legacy slug is written ONLY for a
+    // canonical slug; a custom/non-canonical plan updates PlanId + the assignment
+    // row and leaves the (stale-but-valid) legacy string untouched.
+    private static readonly IReadOnlySet<string> CanonicalPlanSlugs =
+        new HashSet<string>(StringComparer.Ordinal) { "free", "team", "enterprise" };
+
+    private static bool IsCanonicalPlanSlug(string slug) => CanonicalPlanSlugs.Contains(slug);
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IPlanCatalogService _catalog;
+    private readonly ITenantUsageReader _usageReader;
+    private readonly IPlatformEventPublisher _publisher;
+    private readonly IPlatformQueuedTaskRepository _platformTasks;
+    private readonly ITammaModeProvider _mode;
+    private readonly TimeProvider _time;
+    private readonly ILogger<PlanAssignmentService> _logger;
+
+    public PlanAssignmentService(
+        ControlPlaneDbContext db,
+        IPlanCatalogService catalog,
+        ITenantUsageReader usageReader,
+        IPlatformEventPublisher publisher,
+        IPlatformQueuedTaskRepository platformTasks,
+        ITammaModeProvider mode,
+        TimeProvider time,
+        ILogger<PlanAssignmentService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        _usageReader = usageReader ?? throw new ArgumentNullException(nameof(usageReader));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _platformTasks = platformTasks ?? throw new ArgumentNullException(nameof(platformTasks));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<TenantPlanAssignment?> GetActiveAsync(
+        Guid tenantId, CancellationToken ct = default)
+    {
+        // Scalar comparison against the Active constant — no collection is
+        // referenced in the predicate (C#13 EF span-overload trap avoided).
+        return await _db.TenantPlanAssignments
+            .Where(a => a.TenantId == tenantId && a.Status == PlanAssignmentStatus.Active)
+            .OrderByDescending(a => a.EffectiveFrom)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<PlanAssignmentResult> AssignAsync(
+        Guid tenantId, Guid planId, AssignPlanOptions opts, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(opts);
+
+        var snapshot = await _catalog.GetByIdAsync(planId, ct).ConfigureAwait(false);
+        if (snapshot is null)
+        {
+            throw new TammaError(
+                "PLAN.ASSIGN.PLAN_NOT_FOUND",
+                $"Plan '{planId:D}' does not exist — cannot assign.",
+                new Dictionary<string, object?> { ["planId"] = planId.ToString("D") },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+
+        GuardAssignable(tenantId, snapshot, opts.Force);
+
+        var tenant = await LoadTenantAsync(tenantId, ct).ConfigureAwait(false);
+
+        var current = await GetActiveAsync(tenantId, ct).ConfigureAwait(false);
+
+        // Idempotent PUT — re-assigning the exact same (PlanId, PlanVersion) is a
+        // lateral no-op: no swap, no event.
+        if (current is not null
+            && current.PlanId == planId
+            && current.PlanVersion == snapshot.Version)
+        {
+            _logger.LogDebug(
+                "Plan assign no-op: tenant {TenantId} already on plan {PlanId} v{Version}",
+                tenantId, planId, snapshot.Version);
+            return new PlanAssignmentResult(
+                current, PlanChangeDirection.Lateral,
+                Array.Empty<EntitlementWarning>(), null);
+        }
+
+        var direction = await ClassifyDirectionAsync(current, snapshot, ct).ConfigureAwait(false);
+        var warnings = await ComputeDowngradeWarningsAsync(tenantId, direction, snapshot, ct)
+            .ConfigureAwait(false);
+
+        var now = _time.GetUtcNow().UtcDateTime;
+        var newRow = await SwapActiveAsync(
+            tenant, tenantId, current, snapshot, now, opts.ActorUserId, opts.Reason, ct)
+            .ConfigureAwait(false);
+
+        await EmitPlanChangedAsync(
+            tenantId, current, snapshot, direction, warnings,
+            opts.ActorUserId, opts.ActorEmail, opts.ActorPlatformRole, opts.Source,
+            prorationBoundaryAt: now, billingIntervalAnchor: newRow.EffectiveFrom, ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Plan assigned: tenant {TenantId} {OldPlan}→{NewPlan} v{Version} direction={Direction} source={Source} warnings={Warnings}",
+            tenantId, current?.PlanId, planId, snapshot.Version, direction, opts.Source, warnings.Count);
+
+        return new PlanAssignmentResult(newRow, direction, warnings, null);
+    }
+
+    public async Task<PlanAssignmentResult> CancelAsync(
+        Guid tenantId, CancelPlanOptions opts, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(opts);
+
+        var free = await _catalog.GetActiveBySlugAsync(FreePlanSlug, ct).ConfigureAwait(false);
+        if (free is null)
+        {
+            throw new TammaError(
+                "PLAN.CANCEL.NO_FREE_PLAN",
+                "No active 'free' plan version exists to cancel down to — the catalog is misconfigured.",
+                retryable: false, severity: TammaErrorSeverity.High);
+        }
+
+        var tenant = await LoadTenantAsync(tenantId, ct).ConfigureAwait(false);
+        var current = await GetActiveAsync(tenantId, ct).ConfigureAwait(false);
+        if (current is null)
+        {
+            throw new TammaError(
+                "PLAN.CANCEL.NO_ACTIVE_ASSIGNMENT",
+                $"Tenant '{tenantId:D}' has no active plan assignment to cancel.",
+                new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+
+        // Already on free → nothing to cancel (idempotent no-op).
+        if (current.PlanId == free.PlanId)
+        {
+            _logger.LogDebug("Cancel no-op: tenant {TenantId} already on free plan", tenantId);
+            return new PlanAssignmentResult(
+                current, PlanChangeDirection.Lateral, Array.Empty<EntitlementWarning>(), null);
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        if (opts.Immediate)
+        {
+            // Drop to free NOW — a transactional swap identical to an assign.
+            var newRow = await SwapActiveAsync(
+                tenant, tenantId, current, free, now, opts.ActorUserId, opts.Reason, ct)
+                .ConfigureAwait(false);
+
+            await EmitCancelledAsync(
+                tenantId, current.PlanId, effectiveAt: now, immediate: true,
+                opts.ActorUserId, opts.ActorEmail, opts.ActorPlatformRole, ct)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Plan cancel (immediate): tenant {TenantId} {OldPlan}→free at {At}",
+                tenantId, current.PlanId, now);
+
+            return new PlanAssignmentResult(
+                newRow, PlanChangeDirection.Downgrade, Array.Empty<EntitlementWarning>(), now);
+        }
+
+        // Period-end cancel — stamp the boundary on the current active row (it
+        // stays active until activation) and queue a scheduled free row.
+        var boundary = await ComputePeriodEndAsync(current, now, ct).ConfigureAwait(false);
+
+        TenantPlanAssignment scheduled;
+        await using (var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false))
+        {
+            current.EffectiveTo = boundary;
+            current.UpdatedAt = now;
+
+            scheduled = new TenantPlanAssignment
+            {
+                TenantId = tenantId,
+                PlanId = free.PlanId,
+                PlanVersion = free.Version,
+                Status = PlanAssignmentStatus.Scheduled,
+                EffectiveFrom = boundary,
+                AssignedByUserId = opts.ActorUserId,
+                Reason = opts.Reason ?? "cancel: scheduled downgrade to free at period end",
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            _db.TenantPlanAssignments.Add(scheduled);
+
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            await tx.CommitAsync(ct).ConfigureAwait(false);
+        }
+
+        // Enqueue the boundary-activation task AFTER commit (the platform-queue
+        // repository runs on its own context/connection). VisibleAt defers the
+        // reservation until the boundary; the handler is idempotent by
+        // AssignmentId, so a duplicate enqueue is harmless.
+        await EnqueueActivationAsync(tenantId, scheduled.Id, boundary, ct).ConfigureAwait(false);
+
+        await EmitCancelledAsync(
+            tenantId, current.PlanId, effectiveAt: boundary, immediate: false,
+            opts.ActorUserId, opts.ActorEmail, opts.ActorPlatformRole, ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Plan cancel scheduled: tenant {TenantId} {OldPlan}→free effectiveAt={At}",
+            tenantId, current.PlanId, boundary);
+
+        return new PlanAssignmentResult(
+            scheduled, PlanChangeDirection.Downgrade, Array.Empty<EntitlementWarning>(), boundary);
+    }
+
+    public async Task<PlanAssignmentResult?> ActivateScheduledAsync(
+        Guid tenantId, Guid assignmentId, CancellationToken ct = default)
+    {
+        var scheduled = await _db.TenantPlanAssignments
+            .FirstOrDefaultAsync(a => a.Id == assignmentId && a.TenantId == tenantId, ct)
+            .ConfigureAwait(false);
+        if (scheduled is null)
+        {
+            _logger.LogDebug(
+                "Activate no-op: scheduled assignment {AssignmentId} for tenant {TenantId} not found",
+                assignmentId, tenantId);
+            return null;
+        }
+
+        // Idempotent — already promoted (or superseded). A re-run is a no-op.
+        if (scheduled.Status == PlanAssignmentStatus.Active)
+        {
+            return new PlanAssignmentResult(
+                scheduled, PlanChangeDirection.Lateral, Array.Empty<EntitlementWarning>(), null);
+        }
+        if (scheduled.Status != PlanAssignmentStatus.Scheduled)
+        {
+            _logger.LogDebug(
+                "Activate no-op: assignment {AssignmentId} is '{Status}', not scheduled",
+                assignmentId, scheduled.Status);
+            return null;
+        }
+
+        var snapshot = await _catalog.GetByIdAsync(scheduled.PlanId, ct).ConfigureAwait(false);
+        var tenant = await LoadTenantAsync(tenantId, ct).ConfigureAwait(false);
+        var current = await GetActiveAsync(tenantId, ct).ConfigureAwait(false);
+        var direction = await ClassifyDirectionAsync(current, snapshot, ct).ConfigureAwait(false);
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        await using (var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false))
+        {
+            if (current is not null && current.Id != scheduled.Id)
+            {
+                current.Status = PlanAssignmentStatus.Cancelled;
+                current.EffectiveTo ??= now;
+                current.UpdatedAt = now;
+                // Flip the expiring active row FIRST so the partial unique index
+                // never sees two active rows for the tenant.
+                await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            }
+
+            scheduled.Status = PlanAssignmentStatus.Active;
+            scheduled.EffectiveTo = null;
+            scheduled.UpdatedAt = now;
+
+            _db.Entry(tenant).Property("PlanId").CurrentValue = scheduled.PlanId;
+            if (snapshot is not null && IsCanonicalPlanSlug(snapshot.Slug))
+                tenant.Plan = snapshot.Slug;
+            tenant.UpdatedAt = now;
+
+            try
+            {
+                await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            }
+            catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+            {
+                await tx.RollbackAsync(ct).ConfigureAwait(false);
+                throw ConcurrentAssignError(tenantId, ex);
+            }
+
+            await tx.CommitAsync(ct).ConfigureAwait(false);
+        }
+
+        await EmitPlanChangedAsync(
+            tenantId, current, snapshot, direction, Array.Empty<EntitlementWarning>(),
+            actorUserId: scheduled.AssignedByUserId, actorEmail: null, actorPlatformRole: null,
+            source: "scheduled-activation",
+            prorationBoundaryAt: now, billingIntervalAnchor: scheduled.EffectiveFrom, ct)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Scheduled plan activated: tenant {TenantId} assignment {AssignmentId} plan {PlanId} v{Version}",
+            tenantId, assignmentId, scheduled.PlanId, scheduled.PlanVersion);
+
+        return new PlanAssignmentResult(
+            scheduled, direction, Array.Empty<EntitlementWarning>(), null);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────
+
+    /// <summary>Guards: draft (always), deprecated (unless force), custom binding.</summary>
+    private static void GuardAssignable(Guid tenantId, PlanSnapshot snapshot, bool force)
+    {
+        if (string.Equals(snapshot.Status, "draft", StringComparison.Ordinal))
+        {
+            throw new TammaError(
+                "PLAN.ASSIGN.PLAN_DRAFT",
+                $"Plan '{snapshot.Slug}' v{snapshot.Version} is a draft and cannot be assigned.",
+                DiagContext(tenantId, snapshot),
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+
+        if (string.Equals(snapshot.Status, "deprecated", StringComparison.Ordinal) && !force)
+        {
+            throw new TammaError(
+                "PLAN.ASSIGN.PLAN_DEPRECATED",
+                $"Plan '{snapshot.Slug}' v{snapshot.Version} is deprecated — assign requires force=true.",
+                DiagContext(tenantId, snapshot),
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+
+        if (snapshot.IsCustom && !CustomPlanSlug.IsBoundTo(snapshot.Slug, tenantId))
+        {
+            throw new TammaError(
+                "PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND",
+                $"Custom plan '{snapshot.Slug}' is bound to another tenant and cannot be assigned to '{tenantId:D}'.",
+                DiagContext(tenantId, snapshot),
+                retryable: false, severity: TammaErrorSeverity.High);
+        }
+    }
+
+    private static Dictionary<string, object?> DiagContext(Guid tenantId, PlanSnapshot snapshot) =>
+        new()
+        {
+            ["tenantId"] = tenantId.ToString("D"),
+            ["planId"] = snapshot.PlanId.ToString("D"),
+            ["slug"] = snapshot.Slug,
+            ["version"] = snapshot.Version,
+            ["status"] = snapshot.Status,
+        };
+
+    private async Task<Tenant> LoadTenantAsync(Guid tenantId, CancellationToken ct)
+    {
+        var tenant = await _db.Tenants
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(t => t.Id == tenantId && t.DeletedAt == null, ct)
+            .ConfigureAwait(false);
+        if (tenant is null)
+        {
+            throw new TammaError(
+                "PLAN.ASSIGN.TENANT_NOT_FOUND",
+                $"Tenant '{tenantId:D}' does not exist.",
+                new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+                retryable: false, severity: TammaErrorSeverity.Medium);
+        }
+        return tenant;
+    }
+
+    /// <summary>
+    /// Transactional swap: flip the prior active row → cancelled (stamp
+    /// EffectiveTo), insert the new active row, and update the lockstep tenant
+    /// columns. The flip is committed in its own SaveChanges FIRST so the partial
+    /// unique index never observes two active rows.
+    /// </summary>
+    private async Task<TenantPlanAssignment> SwapActiveAsync(
+        Tenant tenant, Guid tenantId, TenantPlanAssignment? current, PlanSnapshot snapshot,
+        DateTime now, Guid? actorUserId, string? reason, CancellationToken ct)
+    {
+        await using var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+
+        if (current is not null)
+        {
+            current.Status = PlanAssignmentStatus.Cancelled;
+            current.EffectiveTo = now;
+            current.UpdatedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        var newRow = new TenantPlanAssignment
+        {
+            TenantId = tenantId,
+            PlanId = snapshot.PlanId,
+            PlanVersion = snapshot.Version,
+            Status = PlanAssignmentStatus.Active,
+            EffectiveFrom = now,
+            AssignedByUserId = actorUserId,
+            Reason = reason,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+        _db.TenantPlanAssignments.Add(newRow);
+
+        _db.Entry(tenant).Property("PlanId").CurrentValue = snapshot.PlanId;
+        if (IsCanonicalPlanSlug(snapshot.Slug)) tenant.Plan = snapshot.Slug;
+        tenant.UpdatedAt = now;
+
+        try
+        {
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            await tx.RollbackAsync(ct).ConfigureAwait(false);
+            throw ConcurrentAssignError(tenantId, ex);
+        }
+
+        await tx.CommitAsync(ct).ConfigureAwait(false);
+        return newRow;
+    }
+
+    private async Task<PlanChangeDirection> ClassifyDirectionAsync(
+        TenantPlanAssignment? current, PlanSnapshot? newSnapshot, CancellationToken ct)
+    {
+        if (newSnapshot is null) return PlanChangeDirection.Lateral;
+
+        var newPrice = RecurringUsdOf(newSnapshot);
+
+        if (current is null)
+        {
+            // First-ever assignment: a paid plan is an upgrade, free is lateral.
+            return newPrice > 0m ? PlanChangeDirection.Upgrade : PlanChangeDirection.Lateral;
+        }
+
+        var oldSnapshot = await _catalog.GetByIdAsync(current.PlanId, ct).ConfigureAwait(false);
+        var oldPrice = oldSnapshot is null ? 0m : RecurringUsdOf(oldSnapshot);
+
+        if (newPrice > oldPrice) return PlanChangeDirection.Upgrade;
+        if (newPrice < oldPrice) return PlanChangeDirection.Downgrade;
+        return PlanChangeDirection.Lateral;
+    }
+
+    private static decimal RecurringUsdOf(PlanSnapshot snapshot)
+    {
+        var price = snapshot.Prices.FirstOrDefault(
+            p => p.PricingMode == PlatformProvidedPricingMode)
+            ?? snapshot.Prices.FirstOrDefault();
+        return price?.RecurringUsd ?? 0m;
+    }
+
+    /// <summary>Flag (never block) over-limit downgrades via the usage seam.</summary>
+    private async Task<IReadOnlyList<EntitlementWarning>> ComputeDowngradeWarningsAsync(
+        Guid tenantId, PlanChangeDirection direction, PlanSnapshot snapshot, CancellationToken ct)
+    {
+        if (direction != PlanChangeDirection.Downgrade)
+        {
+            return Array.Empty<EntitlementWarning>();
+        }
+
+        var warnings = new List<EntitlementWarning>();
+        foreach (var ent in snapshot.Entitlements)
+        {
+            if (ent.LimitValue is not long limit) continue; // null ⇒ unlimited
+
+            long? currentUsage;
+            try
+            {
+                currentUsage = await _usageReader
+                    .GetCurrentUsageAsync(tenantId, ent.MetricKey, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // Usage unavailable ⇒ degrade to no warning for this metric.
+                _logger.LogWarning(ex,
+                    "Downgrade usage read failed for tenant {TenantId} metric {Metric}; no warning",
+                    tenantId, ent.MetricKey);
+                continue;
+            }
+
+            if (currentUsage is long usage && usage > limit)
+            {
+                _logger.LogWarning(
+                    "Downgrade over-limit: tenant {TenantId} metric {Metric} usage={Usage} newLimit={Limit}",
+                    tenantId, ent.MetricKey, usage, limit);
+                warnings.Add(new EntitlementWarning(ent.MetricKey, usage, limit));
+            }
+        }
+
+        return warnings;
+    }
+
+    /// <summary>
+    /// The period-end boundary for a scheduled cancel. Default = the current
+    /// plan's billing interval from now (monthly ⇒ +1 month, annual ⇒ +1 year).
+    /// A real subscription anchor arrives with Epic 35 Billing behind this seam.
+    /// </summary>
+    private async Task<DateTime> ComputePeriodEndAsync(
+        TenantPlanAssignment current, DateTime now, CancellationToken ct)
+    {
+        var snapshot = await _catalog.GetByIdAsync(current.PlanId, ct).ConfigureAwait(false);
+        var interval = snapshot?.BillingInterval ?? "monthly";
+        return string.Equals(interval, "annual", StringComparison.OrdinalIgnoreCase)
+            ? now.AddYears(1)
+            : now.AddMonths(1);
+    }
+
+    private async Task EnqueueActivationAsync(
+        Guid tenantId, Guid assignmentId, DateTime visibleAt, CancellationToken ct)
+    {
+        try
+        {
+            await _platformTasks.EnqueueAsync(new PlatformQueuedTask
+            {
+                Type = ActivateScheduledPlanTaskPayload.TaskType,
+                TenantId = tenantId,
+                Payload = JsonSerializer.Serialize(new ActivateScheduledPlanTaskPayload
+                {
+                    TenantId = tenantId,
+                    AssignmentId = assignmentId,
+                }),
+                VisibleAt = visibleAt,
+            }, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The scheduled row is already durable; a failed enqueue is logged
+            // loud (an operator/reconciliation can re-drive it) but must not
+            // roll back the committed cancel.
+            _logger.LogError(ex,
+                "Failed to enqueue activate-scheduled-plan task for tenant {TenantId} assignment {AssignmentId}",
+                tenantId, assignmentId);
+        }
+    }
+
+    private async Task EmitPlanChangedAsync(
+        Guid tenantId, TenantPlanAssignment? old, PlanSnapshot? newSnapshot,
+        PlanChangeDirection direction, IReadOnlyList<EntitlementWarning> warnings,
+        Guid? actorUserId, string? actorEmail, string? actorPlatformRole, string source,
+        DateTime prorationBoundaryAt, DateTime billingIntervalAnchor, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = tenantId.ToString("D"),
+            ["oldPlanId"] = old?.PlanId.ToString("D"),
+            ["oldPlanVersion"] = old?.PlanVersion.ToString(),
+            ["newPlanId"] = newSnapshot?.PlanId.ToString("D"),
+            ["newPlanVersion"] = newSnapshot?.Version.ToString(),
+            ["direction"] = direction.ToString().ToLowerInvariant(),
+            ["mode"] = ModeTag(),
+            ["actorUserId"] = actorUserId?.ToString("D"),
+            ["actorEmail"] = actorEmail,
+            ["actorPlatformRole"] = actorPlatformRole,
+            ["source"] = source,
+            ["entitlementWarnings"] = warnings.Count > 0 ? "true" : "false",
+            // One-release back-compat: the dashboard timeline still keys the
+            // superseded PLAN.UPDATED event.
+            ["supersedesLegacy"] = PlanAssignmentEventTypes.LegacyPlanUpdated,
+        };
+
+        var data = new Dictionary<string, object?>
+        {
+            ["prorationBoundaryAt"] = prorationBoundaryAt.ToString("O"),
+            ["billingIntervalAnchor"] = billingIntervalAnchor.ToString("O"),
+            ["direction"] = direction.ToString().ToLowerInvariant(),
+            ["source"] = source,
+            // Defence-in-depth: actor breadcrumb also in the immutable data record.
+            ["actorUserId"] = actorUserId?.ToString("D"),
+            ["actorEmail"] = actorEmail,
+            ["actorPlatformRole"] = actorPlatformRole,
+            ["warnings"] = warnings
+                .Select(w => new
+                {
+                    metricKey = w.MetricKey.ToString(),
+                    currentUsage = w.CurrentUsage,
+                    newLimit = w.NewLimit,
+                })
+                .ToArray(),
+        };
+
+        await _publisher.AppendAndPublishAsync(new PlatformEvent
+        {
+            Type = PlanAssignmentEventTypes.TenantPlanChanged,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        }, ct).ConfigureAwait(false);
+    }
+
+    private async Task EmitCancelledAsync(
+        Guid tenantId, Guid currentPlanId, DateTime effectiveAt, bool immediate,
+        Guid? actorUserId, string? actorEmail, string? actorPlatformRole, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = tenantId.ToString("D"),
+            ["currentPlanId"] = currentPlanId.ToString("D"),
+            ["effectiveAt"] = effectiveAt.ToString("O"),
+            ["mode"] = ModeTag(),
+            ["actorUserId"] = actorUserId?.ToString("D"),
+            ["actorEmail"] = actorEmail,
+            ["actorPlatformRole"] = actorPlatformRole,
+            ["immediate"] = immediate ? "true" : "false",
+        };
+
+        var data = new Dictionary<string, object?>
+        {
+            ["currentPlanId"] = currentPlanId.ToString("D"),
+            ["effectiveAt"] = effectiveAt.ToString("O"),
+            ["immediate"] = immediate,
+            ["actorUserId"] = actorUserId?.ToString("D"),
+            ["actorEmail"] = actorEmail,
+            ["actorPlatformRole"] = actorPlatformRole,
+        };
+
+        await _publisher.AppendAndPublishAsync(new PlatformEvent
+        {
+            Type = PlanAssignmentEventTypes.TenantPlanCancelled,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        }, ct).ConfigureAwait(false);
+    }
+
+    private string ModeTag() =>
+        _mode.Mode == TammaMode.SingleUser ? "single-user" : "saas";
+
+    private static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is Npgsql.PostgresException pg
+        && string.Equals(pg.SqlState, "23505", StringComparison.Ordinal);
+
+    private static TammaError ConcurrentAssignError(Guid tenantId, Exception inner) =>
+        new(
+            "PLAN.ASSIGN.CONCURRENT",
+            $"A concurrent assignment won the race for tenant '{tenantId:D}' — retry.",
+            new Dictionary<string, object?> { ["tenantId"] = tenantId.ToString("D") },
+            retryable: true, severity: TammaErrorSeverity.Low);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PlanAssignmentService.cs
@@ -100,11 +100,24 @@ public sealed class PlanAssignmentService : IPlanAssignmentService
         var current = await GetActiveAsync(tenantId, ct).ConfigureAwait(false);
 
         // Idempotent PUT — re-assigning the exact same (PlanId, PlanVersion) is a
-        // lateral no-op: no swap, no event.
+        // lateral no-op: no swap, no event. It must STILL reconcile away any
+        // pending `scheduled` downgrade (a prior period-end cancel): re-affirming
+        // the current plan means the tenant no longer intends to be downgraded at
+        // the boundary. Without this a "keep my plan" PUT would silently drop the
+        // tenant to free when the scheduled row later activates.
         if (current is not null
             && current.PlanId == planId
             && current.PlanVersion == snapshot.Version)
         {
+            var voided = await VoidPendingScheduledAsync(
+                    tenantId, _time.GetUtcNow().UtcDateTime, saveInOwnTransaction: true, ct)
+                .ConfigureAwait(false);
+            if (voided > 0)
+            {
+                _logger.LogInformation(
+                    "Plan re-affirm voided {Count} pending scheduled downgrade(s) for tenant {TenantId} (plan {PlanId} v{Version})",
+                    voided, tenantId, planId, snapshot.Version);
+            }
             _logger.LogDebug(
                 "Plan assign no-op: tenant {TenantId} already on plan {PlanId} v{Version}",
                 tenantId, planId, snapshot.Version);
@@ -268,9 +281,37 @@ public sealed class PlanAssignmentService : IPlanAssignmentService
         var snapshot = await _catalog.GetByIdAsync(scheduled.PlanId, ct).ConfigureAwait(false);
         var tenant = await LoadTenantAsync(tenantId, ct).ConfigureAwait(false);
         var current = await GetActiveAsync(tenantId, ct).ConfigureAwait(false);
-        var direction = await ClassifyDirectionAsync(current, snapshot, ct).ConfigureAwait(false);
 
         var now = _time.GetUtcNow().UtcDateTime;
+
+        // Reconciliation guard (defence-in-depth alongside the void-on-reassign in
+        // SwapActiveAsync): only promote this scheduled downgrade if the CURRENT
+        // active row is still the one that scheduled it — i.e. its EffectiveTo
+        // boundary equals this scheduled row's EffectiveFrom. A later re-assign
+        // replaces that active row with one whose EffectiveTo is null (or a
+        // different boundary), so the downgrade is no longer intended: void the
+        // stale scheduled row and no-op rather than reverting the tenant. When
+        // there is NO active row we still promote (never leave the tenant with no
+        // active plan).
+        if (current is not null
+            && current.Id != scheduled.Id
+            && current.EffectiveTo != scheduled.EffectiveFrom)
+        {
+            scheduled.Status = PlanAssignmentStatus.Cancelled;
+            // Leave EffectiveTo null (see VoidPendingScheduledAsync): a scheduled
+            // row voided here never activated, and `now` may precede its future
+            // EffectiveFrom (ck_tpa_effective_window).
+            scheduled.UpdatedAt = now;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Scheduled activation superseded: tenant {TenantId} assignment {AssignmentId} voided "
+                + "— a newer active plan {CurrentPlanId} replaced the scheduled downgrade to {ScheduledPlanId}",
+                tenantId, assignmentId, current.PlanId, scheduled.PlanId);
+            return null;
+        }
+
+        var direction = await ClassifyDirectionAsync(current, snapshot, ct).ConfigureAwait(false);
 
         await using (var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false))
         {
@@ -393,6 +434,17 @@ public sealed class PlanAssignmentService : IPlanAssignmentService
     {
         await using var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
 
+        // Reconcile away any pending `scheduled` downgrade for the tenant BEFORE
+        // inserting the new active row — in the SAME transaction. A new active
+        // assignment (or an immediate cancel) supersedes a prior period-end
+        // cancel's scheduled row; leaving it live would let ActivateScheduledAsync
+        // later cancel this new active row and silently revert the tenant. These
+        // rows are `scheduled` (not `active`), so voiding them never trips the
+        // one-active-per-tenant partial unique index. Persisted by the SaveChanges
+        // below (or the current-flip SaveChanges when there is a prior active row).
+        await VoidPendingScheduledAsync(tenantId, now, saveInOwnTransaction: false, ct)
+            .ConfigureAwait(false);
+
         if (current is not null)
         {
             current.Status = PlanAssignmentStatus.Cancelled;
@@ -431,6 +483,46 @@ public sealed class PlanAssignmentService : IPlanAssignmentService
 
         await tx.CommitAsync(ct).ConfigureAwait(false);
         return newRow;
+    }
+
+    /// <summary>
+    /// Void (→ <c>cancelled</c>) every pending <c>scheduled</c> assignment for the
+    /// tenant. A new/re-affirmed active plan supersedes a prior period-end cancel's
+    /// scheduled downgrade; leaving it live lets <see cref="ActivateScheduledAsync"/>
+    /// later revert the tenant to <c>free</c>. Returns the count voided. By default
+    /// it does NOT open a transaction/SaveChanges — the caller
+    /// (<see cref="SwapActiveAsync"/>) persists it inside its own transaction so the
+    /// void and the swap are atomic. When <paramref name="saveInOwnTransaction"/> is
+    /// set (the idempotent re-affirm path, which has no surrounding transaction) it
+    /// commits its own transaction, and only when there is something to void.
+    /// </summary>
+    private async Task<int> VoidPendingScheduledAsync(
+        Guid tenantId, DateTime now, bool saveInOwnTransaction, CancellationToken ct)
+    {
+        var pending = await _db.TenantPlanAssignments
+            .Where(a => a.TenantId == tenantId && a.Status == PlanAssignmentStatus.Scheduled)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        if (pending.Count == 0) return 0;
+
+        foreach (var row in pending)
+        {
+            row.Status = PlanAssignmentStatus.Cancelled;
+            // Leave EffectiveTo null: a scheduled row voided before its boundary
+            // never had an active window. Stamping `now` here would violate
+            // ck_tpa_effective_window (EffectiveTo >= EffectiveFrom) because the
+            // row's EffectiveFrom is the future boundary.
+            row.UpdatedAt = now;
+        }
+
+        if (saveInOwnTransaction)
+        {
+            await using var tx = await _db.Database.BeginTransactionAsync(ct).ConfigureAwait(false);
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+            await tx.CommitAsync(ct).ConfigureAwait(false);
+        }
+
+        return pending.Count;
     }
 
     private async Task<PlanChangeDirection> ClassifyDirectionAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/ActivateScheduledPlanTaskHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/ActivateScheduledPlanTaskHandler.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Provisioning;
+
+/// <summary>
+/// Story 34-4 — platform-queue handler that promotes a due <c>scheduled</c>
+/// plan assignment to <c>active</c> at its boundary, by calling
+/// <see cref="IPlanAssignmentService.ActivateScheduledAsync"/>. Enqueued by the
+/// period-end cancel path with <c>VisibleAt</c> = the boundary, so the queue
+/// only reserves it once the window opens. Idempotent by <c>AssignmentId</c>: a
+/// re-run whose target is already active is a no-op.
+///
+/// <para>Failure semantics mirror <see cref="MoveTenantTaskHandler"/>: a
+/// malformed payload is terminal (dead-letter, no retry budget burn); a
+/// concurrent-assignment race (<c>PLAN.ASSIGN.CONCURRENT</c>, retryable) and any
+/// other exception bubble as a retryable failure so the worker re-enqueues;
+/// worker-shutdown cancellation rethrows without marking failure.</para>
+/// </summary>
+public sealed class ActivateScheduledPlanTaskHandler : IPlatformTaskHandler
+{
+    private readonly IPlanAssignmentService _assignments;
+    private readonly ILogger<ActivateScheduledPlanTaskHandler> _logger;
+
+    public ActivateScheduledPlanTaskHandler(
+        IPlanAssignmentService assignments,
+        ILogger<ActivateScheduledPlanTaskHandler> logger)
+    {
+        _assignments = assignments ?? throw new ArgumentNullException(nameof(assignments));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public string TaskType => ActivateScheduledPlanTaskPayload.TaskType;
+
+    public async Task HandleAsync(PlatformQueuedTask task, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        ActivateScheduledPlanTaskPayload? payload;
+        try
+        {
+            payload = string.IsNullOrEmpty(task.Payload)
+                ? null
+                : JsonSerializer.Deserialize<ActivateScheduledPlanTaskPayload>(task.Payload);
+        }
+        catch (JsonException ex)
+        {
+            throw new PlatformTaskTerminalException(
+                $"activate-scheduled-plan task {task.Id} has malformed JSON payload: {ex.Message}", ex);
+        }
+
+        if (payload is null || payload.TenantId == Guid.Empty || payload.AssignmentId == Guid.Empty)
+        {
+            throw new PlatformTaskTerminalException(
+                $"activate-scheduled-plan task {task.Id} payload missing TenantId/AssignmentId.");
+        }
+
+        _logger.LogInformation(
+            "plan.activate_scheduled.task_started taskId={TaskId} tenantId={TenantId} assignmentId={AssignmentId}",
+            task.Id, payload.TenantId, payload.AssignmentId);
+
+        try
+        {
+            var result = await _assignments
+                .ActivateScheduledAsync(payload.TenantId, payload.AssignmentId, ct)
+                .ConfigureAwait(false);
+
+            if (result is null)
+            {
+                _logger.LogInformation(
+                    "plan.activate_scheduled.noop taskId={TaskId} assignmentId={AssignmentId} (not found / not scheduled)",
+                    task.Id, payload.AssignmentId);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // Worker shutdown — leave the row for the reaper; activation is
+            // idempotent so the re-run is safe.
+            throw;
+        }
+        catch (TammaError ex) when (ex.Code == "PLAN.ASSIGN.CONCURRENT")
+        {
+            // A concurrent assignment won the race — retryable; let the worker
+            // re-enqueue (the scheduled row is either already promoted or will be
+            // re-evaluated).
+            _logger.LogWarning(ex,
+                "plan.activate_scheduled.concurrent taskId={TaskId} assignmentId={AssignmentId}",
+                task.Id, payload.AssignmentId);
+            throw;
+        }
+
+        _logger.LogInformation(
+            "plan.activate_scheduled.task_finished taskId={TaskId} assignmentId={AssignmentId}",
+            task.Id, payload.AssignmentId);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/ActivateScheduledPlanTaskPayload.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/ActivateScheduledPlanTaskPayload.cs
@@ -1,0 +1,26 @@
+namespace Tamma.Api.Services.Provisioning;
+
+/// <summary>
+/// Story 34-4 — payload for the platform-queue boundary-activation task that
+/// promotes a <c>scheduled</c> <c>TenantPlanAssignment</c> to <c>active</c> once
+/// its <c>EffectiveFrom</c> boundary is reached. Enqueued by
+/// <c>PlanAssignmentService.CancelAsync</c> (period-end path) with the row's
+/// <c>EffectiveFrom</c> as the task's <c>VisibleAt</c>, so the queue itself
+/// defers the reservation until the boundary. Mirrors
+/// <see cref="MoveTenantTaskPayload"/>: a placement/lifecycle change rides the
+/// platform queue.
+/// </summary>
+public sealed class ActivateScheduledPlanTaskPayload
+{
+    /// <summary>
+    /// Stable task-type identifier the <c>ActivateScheduledPlanTaskHandler</c>
+    /// matches on. Dot-separated lower-snake-case, matching the queue convention.
+    /// </summary>
+    public const string TaskType = "plan.activate_scheduled";
+
+    /// <summary>Tenant whose scheduled assignment is being promoted.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>The <c>scheduled</c> assignment row to promote (idempotency key).</summary>
+    public Guid AssignmentId { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/CranlProvisioningWorkflow.cs
@@ -632,12 +632,11 @@ public sealed class CranlProvisioningWorkflow
     /// </summary>
     private async Task<bool> IsDedicatedPlacementPlanAsync(Tenant tenant, CancellationToken ct)
     {
-        // Same lookup placement/move use: pin Status=='active' so a multi-
-        // version slug (Story 34-1) resolves the live PlacementPolicy, not a
-        // deprecated row picked in undefined order.
-        var plan = await _db.Plans
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct);
+        // Same lookup placement/move use (Story 34-4): resolve the version-pinned
+        // Tenant.PlanId FK so a custom-plan tenant resolves its REAL
+        // PlacementPolicy; a NULL-PlanId legacy tenant falls back to the active
+        // version of its slug.
+        var plan = await TenantPlacementService.ResolveTenantPlanAsync(_db, tenant, asNoTracking: true, ct);
         if (plan is null)
         {
             await TransitionAsync(tenant,
@@ -749,9 +748,10 @@ public sealed class CranlProvisioningWorkflow
     private async Task<TenantDatabase?> FindMoveBackTargetAsync(
         Tenant tenant, Guid excludeDatabaseId, CancellationToken ct)
     {
-        var plan = await _db.Plans
-            .AsNoTracking()
-            .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct);
+        // Story 34-4: resolve the version-pinned Tenant.PlanId FK (custom-plan
+        // tenants resolve their REAL tier), falling back to the active version of
+        // the legacy slug only for a NULL-PlanId legacy tenant.
+        var plan = await TenantPlacementService.ResolveTenantPlanAsync(_db, tenant, asNoTracking: true, ct);
         if (plan is null)
         {
             return null;

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantMoveService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantMoveService.cs
@@ -460,15 +460,15 @@ public sealed class TenantMoveService : ITenantMoveService
 
         // Tier eligibility/capacity — the SAME predicate placement uses
         // (TenantPlacementService.EligibleFor), evaluated in-memory on the
-        // loaded target row. Story 34-1: pin Status == "active" so a multi-
-        // version slug resolves the live PlacementPolicy, not a deprecated
-        // row picked in undefined order. UX_plans_OneActivePerSlug keeps it
-        // deterministic.
-        var plan = await db.Plans
-                .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct)
+        // loaded target row. Story 34-4: resolve the version-pinned Tenant.PlanId
+        // FK (so a custom-plan tenant with a stale legacy slug moves to a row
+        // eligible for its REAL tier), falling back to the active version of the
+        // legacy slug only for a NULL-PlanId legacy tenant.
+        var plan = await TenantPlacementService.ResolveTenantPlanAsync(db, tenant, asNoTracking: false, ct)
             ?? throw new InvalidOperationException(
-                $"No active plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — move "
-                + "requires plans.PlacementPolicy; seed or repair the plans table.");
+                $"No plans row resolved for tenant '{tenantId}' (PlanId shadow FK or legacy slug "
+                + $"'{tenant.Plan}') — move requires plans.PlacementPolicy; seed or repair the "
+                + "plans table.");
         if (!TenantPlacementService.EligibleFor(plan.Slug, plan.PlacementPolicy)
                 .Compile()(target))
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantPlacementService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/TenantPlacementService.cs
@@ -54,18 +54,19 @@ public sealed class TenantPlacementService : ITenantPlacementService
             return new TenantPlacement(existingDatabaseId.Value, existingSchema);
         }
 
-        // Plan lookup is tenant→system→error: a tenant whose plan slug has
-        // no plans row is a configuration fault — never default silently.
-        // Story 34-1 made a slug a multi-version chain (active + deprecated
-        // rows), so the lookup MUST pin Status == "active" — otherwise it can
-        // return a deprecated row with a stale PlacementPolicy in undefined
-        // order. The partial unique index UX_plans_OneActivePerSlug guarantees
-        // exactly one active row per slug.
-        var plan = await db.Plans
-                .FirstOrDefaultAsync(p => p.Slug == tenant.Plan && p.Status == "active", ct)
+        // Plan lookup is tenant→system→error: a tenant that resolves to no plans
+        // row is a configuration fault — never default silently. Story 34-4:
+        // resolve the version-pinned Tenant.PlanId FK (so a CUSTOM-plan tenant,
+        // whose legacy Tenant.Plan slug is stale/non-canonical, gets the right
+        // PlacementPolicy); only a legacy tenant with a NULL PlanId falls back to
+        // the active version of its slug. (Story 34-1 made a slug a multi-version
+        // chain, so the slug fallback pins Status == "active" — the partial unique
+        // index UX_plans_OneActivePerSlug guarantees exactly one.)
+        var plan = await ResolveTenantPlanAsync(db, tenant, asNoTracking: false, ct)
             ?? throw new InvalidOperationException(
-                $"No active plans row for slug '{tenant.Plan}' (tenant '{tenantId}') — placement "
-                + "requires plans.PlacementPolicy; seed or repair the plans table.");
+                $"No plans row resolved for tenant '{tenantId}' (PlanId shadow FK or legacy slug "
+                + $"'{tenant.Plan}') — placement requires plans.PlacementPolicy; seed or repair "
+                + "the plans table.");
 
         var slug = plan.Slug;
         var policy = plan.PlacementPolicy;
@@ -147,5 +148,37 @@ public sealed class TenantPlacementService : ITenantPlacementService
             && d.PlacementClass == policy
             && Enumerable.Contains(d.TierEligibility, tier)
             && (d.TenantCapacity == null || d.TenantCount < d.TenantCapacity);
+    }
+
+    /// <summary>
+    /// Resolve the tenant's effective <see cref="Plan"/> row for placement/move
+    /// decisions (Story 34-4). When the version-pinned <c>Tenant.PlanId</c> shadow
+    /// FK is set, resolve THAT exact plan version by id — with NO
+    /// <c>Status == "active"</c> filter, because the pin may legitimately point at
+    /// a <b>custom</b> plan (never <c>active</c> under a canonical slug) or an
+    /// intentionally-retained <c>deprecated</c> version. Only when <c>PlanId</c> is
+    /// NULL (legacy, pre-34-4 tenants) does it fall back to the active version of
+    /// the legacy <c>Tenant.Plan</c> slug. This is what lets placement, move, and
+    /// Cranl resolve the correct <c>PlacementPolicy</c>/tier for a custom-plan
+    /// tenant whose stale legacy slug is not canonical.
+    ///
+    /// <para><paramref name="asNoTracking"/> mirrors the caller's prior query
+    /// behaviour: placement/move track the plan; the Cranl read path does not.
+    /// Reading the shadow <c>PlanId</c> requires <paramref name="tenant"/> to be
+    /// tracked by <paramref name="db"/> (all three callers already track it).</para>
+    /// </summary>
+    public static async Task<Plan?> ResolveTenantPlanAsync(
+        ControlPlaneDbContext db, Tenant tenant, bool asNoTracking, CancellationToken ct)
+    {
+        var pinnedPlanId = db.Entry(tenant).Property<Guid?>("PlanId").CurrentValue;
+        IQueryable<Plan> plans = asNoTracking ? db.Plans.AsNoTracking() : db.Plans;
+
+        if (pinnedPlanId is Guid planId)
+        {
+            return await plans.FirstOrDefaultAsync(p => p.Id == planId, ct);
+        }
+
+        return await plans.FirstOrDefaultAsync(
+            p => p.Slug == tenant.Plan && p.Status == "active", ct);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/PlanAssignmentStatus.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/PlanAssignmentStatus.cs
@@ -1,0 +1,30 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-4 — lifecycle status of a <c>TenantPlanAssignment</c> row. Persisted
+/// as the lower-case string (never a numeric ordinal — the DB CHECK constraint
+/// pins the exact strings), matching the string-backed style of the 34-1 plan
+/// catalog (<c>Plan.Status</c>).
+///
+/// <list type="bullet">
+///   <item><description><c>active</c> — the tenant's CURRENT plan version. A
+///     partial unique index guarantees at most one active row per tenant.</description></item>
+///   <item><description><c>scheduled</c> — a future assignment that a boundary
+///     activation task promotes to <c>active</c> once its <c>EffectiveFrom</c>
+///     is reached (e.g. the <c>plan_free</c> row a cancellation queues at the
+///     period boundary).</description></item>
+///   <item><description><c>cancelled</c> — a superseded assignment. Its
+///     <c>EffectiveTo</c> is stamped at the instant it stopped being active
+///     (the proration boundary Billing reads).</description></item>
+/// </list>
+/// </summary>
+public static class PlanAssignmentStatus
+{
+    public const string Active = "active";
+    public const string Scheduled = "scheduled";
+    public const string Cancelled = "cancelled";
+
+    /// <summary>The closed set — used by validation and the model CHECK constraint.</summary>
+    public static readonly System.Collections.Generic.IReadOnlyList<string> All =
+        new[] { Active, Scheduled, Cancelled };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/PlanChangeDirection.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/PlanChangeDirection.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-4 — the direction of a plan change, classified from the recurring
+/// price of the new plan version vs the prior one. Emitted as a tag on
+/// <c>TENANT.PLAN.CHANGED</c> (lower-cased) so Billing / analytics can tell an
+/// upgrade from a downgrade without re-deriving it. A re-assignment to the same
+/// <c>(PlanId, PlanVersion)</c> — or an equal-priced move — is
+/// <see cref="Lateral"/>.
+/// </summary>
+public enum PlanChangeDirection
+{
+    /// <summary>New plan costs more than the prior (or the first-ever paid assignment).</summary>
+    Upgrade,
+
+    /// <summary>New plan costs less than the prior.</summary>
+    Downgrade,
+
+    /// <summary>Same price (incl. the idempotent same-version re-assign no-op).</summary>
+    Lateral,
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -499,6 +499,15 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<PlanPrice> PlanPrices => Set<PlanPrice>();
 
+    /// <summary>
+    /// Story 34-4 — audited, version-pinned per-tenant plan assignments. The
+    /// SOURCE OF TRUTH for "what plan version is this tenant on right now"
+    /// (replaces the loose <c>Tenant.Plan</c> string + the Epic-28 <c>PlanId</c>
+    /// shadow column, which are kept in lockstep as a cache). CP-resident. At
+    /// most one <c>active</c> row per tenant (partial unique index).
+    /// </summary>
+    public DbSet<TenantPlanAssignment> TenantPlanAssignments => Set<TenantPlanAssignment>();
+
     public DbSet<PlatformEvent> PlatformEvents => Set<PlatformEvent>();
     public DbSet<PlatformQueuedTask> PlatformQueuedTasks => Set<PlatformQueuedTask>();
     public DbSet<PlatformEmailOutboxMessage> PlatformEmailOutbox => Set<PlatformEmailOutboxMessage>();
@@ -820,6 +829,12 @@ public class ControlPlaneDbContext : DbContext
         // CP-resident, platform-global, immutable-versioned shape as the 34-11
         // cost rows above.
         ConfigureMarginPolicies(modelBuilder);
+
+        // Story 34-4 — per-tenant, version-pinned plan assignments. CP-resident
+        // (keyed by tenant, alongside the plans catalog). Partial unique index
+        // enforces at most one active assignment per tenant; FKs to tenants
+        // (Cascade) + plans (Restrict).
+        TammaModelConfiguration.ConfigureTenantPlanAssignments(modelBuilder);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/Tenant.cs
@@ -8,6 +8,15 @@ public class Tenant
     public string Type { get; set; } = "personal";
     public Guid? OwnerId { get; set; }
     public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Legacy plan slug. Story 34-4 — <b>DERIVED</b> from the tenant's active
+    /// <see cref="TenantPlanAssignment"/> (the source of truth), kept in lockstep
+    /// by <c>PlanAssignmentService</c> only so dashboards that still read this
+    /// column (and the Epic-28 <c>PlanId</c> shadow column) render the right plan
+    /// without a rewrite. New reads should call
+    /// <c>IPlanAssignmentService.GetActiveAsync</c>, never this field.
+    /// </summary>
     public string Plan { get; set; } = "free";
     public string Settings { get; set; } = "{}";
     public DateTime CreatedAt { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/TenantPlanAssignment.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/TenantPlanAssignment.cs
@@ -1,0 +1,57 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 34-4 — audited, version-pinned record of which plan a tenant is on.
+/// Replaces the loose <see cref="Tenant.Plan"/> string + the Epic-28
+/// <c>Tenant.PlanId</c> shadow column as the SOURCE OF TRUTH for "what plan is
+/// this tenant on right now (and which version)". At most one row per tenant has
+/// <c>Status = 'active'</c> (a partial unique index enforces it).
+///
+/// <para><see cref="PlanVersion"/> is a DENORMALIZED, pinned copy of
+/// <c>Plan.Version</c> (34-1) — never a join to the current plan row — so a
+/// later plan deprecation (34-1/34-2 flips the active version and mints N+1)
+/// can NEVER retro-price an existing tenant. Reading a tenant's effective plan
+/// resolves the pinned <c>(PlanId, PlanVersion)</c> snapshot, never "latest".</para>
+///
+/// <para>CP-resident (lives on <c>ControlPlaneDbContext</c>): plan assignment is
+/// a control-plane concern keyed by tenant, alongside the <c>plans</c> catalog
+/// and the tenant registry.</para>
+/// </summary>
+public class TenantPlanAssignment
+{
+    /// <summary>UUIDv7 (DB default <c>gen_random_uuid()</c>).</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>FK → <c>tenants.Id</c>. Cascade-deleted with the tenant.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>FK → <c>plans.Id</c> — a specific VERSIONED plan row (34-1). Restrict-deleted.</summary>
+    public Guid PlanId { get; set; }
+
+    /// <summary>Pinned copy of <c>Plan.Version</c> at assignment time (never re-read).</summary>
+    public int PlanVersion { get; set; }
+
+    /// <summary>
+    /// <c>active</c> | <c>scheduled</c> | <c>cancelled</c>
+    /// (<see cref="Tamma.Core.Enums.PlanAssignmentStatus"/>).
+    /// </summary>
+    public string Status { get; set; } = "active";
+
+    /// <summary>UTC instant this assignment became (or is scheduled to become) effective.</summary>
+    public DateTime EffectiveFrom { get; set; }
+
+    /// <summary>
+    /// UTC instant this assignment stopped being active (the proration boundary),
+    /// or <c>null</c> while it is still <c>active</c>/<c>scheduled</c>.
+    /// </summary>
+    public DateTime? EffectiveTo { get; set; }
+
+    /// <summary>The actor who made the change; <c>null</c> = system / scheduler.</summary>
+    public Guid? AssignedByUserId { get; set; }
+
+    /// <summary>Free-text reason (admin note / self-service / backfill), nullable.</summary>
+    public string? Reason { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702215607_AddTenantPlanAssignment")]
+    partial class AddTenantPlanAssignment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.cs
@@ -64,32 +64,65 @@ namespace Tamma.Data.Migrations.ControlPlane
                 unique: true,
                 filter: "\"Status\" = 'active'");
 
-            // Story 34-4 AC3 — back-fill exactly one `active` assignment per
-            // existing (non-deleted) tenant, pinning the plan's CURRENT Version
-            // at migration time. Resolution: the Epic-28 shadow `PlanId` column
-            // (p) → else the plan whose Slug matches the legacy `Plan` string (s)
-            // → else the active `free` plan (f). PlanVersion is read from the
-            // SAME chosen plan row so it stays consistent with PlanId.
+            // Story 34-4 AC3 — back-fill exactly one `active` assignment for EVERY
+            // existing (non-deleted) tenant, pinning the plan's CURRENT Version at
+            // migration time. Resolution chain (PlanId + Version stay paired):
+            //   1. the version-pinned Epic-28 shadow `PlanId` FK (p), else
+            //   2. the plan whose Slug matches the legacy `Plan` string (s), else
+            //   3. the active `free` plan as a GUARANTEED terminal fallback.
+            // The prior version silently OMITTED any tenant that resolved to NULL
+            // (via `AND COALESCE(...) IS NOT NULL`), which — if the active `free`
+            // plan were ever absent — left a non-deleted tenant with NO assignment
+            // and made Story 34-6 throw NO_ASSIGNMENT/404 for it post-deploy. This
+            // version drops that filter and instead FAILS LOUD (RAISE) when a
+            // tenant would be left assignment-less because `free` is missing, so the
+            // fault is caught at deploy time, never silently after.
             migrationBuilder.Sql(@"
-                INSERT INTO tenant_plan_assignments
-                    (""Id"", ""TenantId"", ""PlanId"", ""PlanVersion"", ""Status"",
-                     ""EffectiveFrom"", ""AssignedByUserId"", ""Reason"", ""CreatedAt"", ""UpdatedAt"")
-                SELECT gen_random_uuid(),
-                       t.""Id"",
-                       COALESCE(t.""PlanId"", s.""Id"", f.""Id""),
-                       COALESCE(p.""Version"", s.""Version"", f.""Version"", 1),
-                       'active',
-                       t.""CreatedAt"",
-                       NULL,
-                       'backfill: 34-4 migration',
-                       now(),
-                       now()
-                FROM tenants t
-                LEFT JOIN plans p ON p.""Id"" = t.""PlanId""
-                LEFT JOIN plans s ON s.""Slug"" = t.""Plan"" AND s.""Status"" = 'active'
-                LEFT JOIN plans f ON f.""Slug"" = 'free' AND f.""Status"" = 'active'
-                WHERE t.""DeletedAt"" IS NULL
-                  AND COALESCE(t.""PlanId"", s.""Id"", f.""Id"") IS NOT NULL;");
+                DO $$
+                DECLARE
+                    free_id uuid;
+                    free_version int;
+                    orphan_count int;
+                BEGIN
+                    SELECT f.""Id"", f.""Version"" INTO free_id, free_version
+                    FROM plans f
+                    WHERE f.""Slug"" = 'free' AND f.""Status"" = 'active'
+                    LIMIT 1;
+
+                    -- Any non-deleted tenant that resolves to NO plan through the
+                    -- chain (pinned PlanId → active slug match → active free) means
+                    -- the terminal `free` fallback is unavailable. Fail loud rather
+                    -- than leaving that tenant assignment-less.
+                    SELECT count(*) INTO orphan_count
+                    FROM tenants t
+                    LEFT JOIN plans s ON s.""Slug"" = t.""Plan"" AND s.""Status"" = 'active'
+                    WHERE t.""DeletedAt"" IS NULL
+                      AND COALESCE(t.""PlanId"", s.""Id"", free_id) IS NULL;
+
+                    IF orphan_count > 0 THEN
+                        RAISE EXCEPTION
+                            'AddTenantPlanAssignment back-fill: % non-deleted tenant(s) resolve to no plan and the active ''free'' plan is absent — seed the ''free'' plan before migrating so every tenant gets a terminal fallback assignment.',
+                            orphan_count;
+                    END IF;
+
+                    INSERT INTO tenant_plan_assignments
+                        (""Id"", ""TenantId"", ""PlanId"", ""PlanVersion"", ""Status"",
+                         ""EffectiveFrom"", ""AssignedByUserId"", ""Reason"", ""CreatedAt"", ""UpdatedAt"")
+                    SELECT gen_random_uuid(),
+                           t.""Id"",
+                           COALESCE(t.""PlanId"", s.""Id"", free_id),
+                           COALESCE(p.""Version"", s.""Version"", free_version, 1),
+                           'active',
+                           t.""CreatedAt"",
+                           NULL,
+                           'backfill: 34-4 migration',
+                           now(),
+                           now()
+                    FROM tenants t
+                    LEFT JOIN plans p ON p.""Id"" = t.""PlanId""
+                    LEFT JOIN plans s ON s.""Slug"" = t.""Plan"" AND s.""Status"" = 'active'
+                    WHERE t.""DeletedAt"" IS NULL;
+                END $$;");
         }
 
         /// <inheritdoc />

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702215607_AddTenantPlanAssignment.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddTenantPlanAssignment : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenant_plan_assignments",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlanId = table.Column<Guid>(type: "uuid", nullable: false),
+                    PlanVersion = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    EffectiveFrom = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    EffectiveTo = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    AssignedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Reason = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenant_plan_assignments", x => x.Id);
+                    table.CheckConstraint("ck_tpa_effective_window", "\"EffectiveTo\" IS NULL OR \"EffectiveTo\" >= \"EffectiveFrom\"");
+                    table.CheckConstraint("ck_tpa_status", "\"Status\" IN ('active','scheduled','cancelled')");
+                    table.CheckConstraint("ck_tpa_version_positive", "\"PlanVersion\" >= 1");
+                    table.ForeignKey(
+                        name: "FK_tenant_plan_assignments_plans_PlanId",
+                        column: x => x.PlanId,
+                        principalTable: "plans",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_tenant_plan_assignments_tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenant_plan_assignments_PlanId",
+                table: "tenant_plan_assignments",
+                column: "PlanId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_tenant_plan_assignments_TenantId_Status",
+                table: "tenant_plan_assignments",
+                columns: new[] { "TenantId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_tpa_one_active_per_tenant",
+                table: "tenant_plan_assignments",
+                column: "TenantId",
+                unique: true,
+                filter: "\"Status\" = 'active'");
+
+            // Story 34-4 AC3 — back-fill exactly one `active` assignment per
+            // existing (non-deleted) tenant, pinning the plan's CURRENT Version
+            // at migration time. Resolution: the Epic-28 shadow `PlanId` column
+            // (p) → else the plan whose Slug matches the legacy `Plan` string (s)
+            // → else the active `free` plan (f). PlanVersion is read from the
+            // SAME chosen plan row so it stays consistent with PlanId.
+            migrationBuilder.Sql(@"
+                INSERT INTO tenant_plan_assignments
+                    (""Id"", ""TenantId"", ""PlanId"", ""PlanVersion"", ""Status"",
+                     ""EffectiveFrom"", ""AssignedByUserId"", ""Reason"", ""CreatedAt"", ""UpdatedAt"")
+                SELECT gen_random_uuid(),
+                       t.""Id"",
+                       COALESCE(t.""PlanId"", s.""Id"", f.""Id""),
+                       COALESCE(p.""Version"", s.""Version"", f.""Version"", 1),
+                       'active',
+                       t.""CreatedAt"",
+                       NULL,
+                       'backfill: 34-4 migration',
+                       now(),
+                       now()
+                FROM tenants t
+                LEFT JOIN plans p ON p.""Id"" = t.""PlanId""
+                LEFT JOIN plans s ON s.""Slug"" = t.""Plan"" AND s.""Status"" = 'active'
+                LEFT JOIN plans f ON f.""Slug"" = 'free' AND f.""Status"" = 'active'
+                WHERE t.""DeletedAt"" IS NULL
+                  AND COALESCE(t.""PlanId"", s.""Id"", f.""Id"") IS NOT NULL;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenant_plan_assignments");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -968,6 +968,62 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 34-4 — <c>tenant_plan_assignments</c> table. Version-pinned,
+    /// audited plan assignments; CP-resident. Three CHECKs pin the closed
+    /// <c>Status</c> set, the effective-window ordering, and a positive pinned
+    /// version. The partial unique index
+    /// <c>ux_tpa_one_active_per_tenant</c> on <c>(TenantId) WHERE Status='active'</c>
+    /// guarantees at most one active assignment per tenant (mirrors
+    /// <c>UX_plans_OneActivePerSlug</c>). A <c>(TenantId, Status)</c> index backs
+    /// the "current assignment" lookup; a <c>PlanId</c> index backs the FK.
+    /// FKs: TenantId → tenants (Cascade); PlanId → plans (Restrict).
+    /// </summary>
+    public static void ConfigureTenantPlanAssignments(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TenantPlanAssignment>(entity =>
+        {
+            entity.ToTable("tenant_plan_assignments", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_tpa_status",
+                    "\"Status\" IN ('active','scheduled','cancelled')");
+                t.HasCheckConstraint(
+                    "ck_tpa_effective_window",
+                    "\"EffectiveTo\" IS NULL OR \"EffectiveTo\" >= \"EffectiveFrom\"");
+                t.HasCheckConstraint(
+                    "ck_tpa_version_positive",
+                    "\"PlanVersion\" >= 1");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Status).IsRequired().HasMaxLength(16);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // AC2 — at most one active assignment per tenant.
+            entity.HasIndex(e => e.TenantId)
+                .IsUnique()
+                .HasFilter("\"Status\" = 'active'")
+                .HasDatabaseName("ux_tpa_one_active_per_tenant");
+
+            // "current assignment" lookup + FK support index.
+            entity.HasIndex(e => new { e.TenantId, e.Status })
+                .HasDatabaseName("IX_tenant_plan_assignments_TenantId_Status");
+            entity.HasIndex(e => e.PlanId)
+                .HasDatabaseName("IX_tenant_plan_assignments_PlanId");
+
+            entity.HasOne<Tenant>()
+                .WithMany()
+                .HasForeignKey(e => e.TenantId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne<Plan>()
+                .WithMany()
+                .HasForeignKey(e => e.PlanId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+    }
+
+    /// <summary>
     /// Story 35-1 — billing foundation entities. The tenant→Stripe customer
     /// mapping (<c>billing_customers</c>, unique <c>TenantId</c>) and the
     /// slug→Stripe-ids catalog (<c>billing_plan_prices</c>, unique

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsAuditAndNoteTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsAuditAndNoteTests.cs
@@ -156,16 +156,41 @@ public class AdminTenantsAuditAndNoteTests
     {
         var tenantId = await SeedTenantAsync(status: "active");
 
+        // Story 34-4 — the endpoint delegates to IPlanAssignmentService, which
+        // emits TENANT.PLAN.CHANGED (superseding PLAN.UPDATED) with the same
+        // actor breadcrumb BuildAdminEvent captured.
         await AdminTenantsEndpoints.UpdateTenantPlan(
             tenantId,
             new UpdateTenantPlanRequest(PlansSeeder.TeamPlanId),
             _db,
-            _publisher,
-            _timeProvider,
+            BuildAssignments(),
             Operator());
 
-        _publisher.Events.Should().ContainSingle(e => e.Type == "PLAN.UPDATED");
+        _publisher.Events.Should().ContainSingle(e => e.Type == "TENANT.PLAN.CHANGED");
         AssertActorTagsAndData(_publisher.Events[0]);
+    }
+
+    private Tamma.Api.Services.Pricing.IPlanAssignmentService BuildAssignments()
+    {
+        var catalog = new Tamma.Api.Services.Pricing.PlanCatalogService(
+            _db, Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.PlanCatalogService>.Instance);
+        var usage = new Tamma.Api.Services.Pricing.NullTenantUsageReader(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.NullTenantUsageReader>.Instance);
+        return new Tamma.Api.Services.Pricing.PlanAssignmentService(
+            _db, catalog, usage, _publisher,
+            new RecordingPlatformQueuedTaskRepository(),
+            new FakeModeProvider(Tamma.Api.Services.PromptStore.TammaMode.SaaS),
+            _timeProvider,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.PlanAssignmentService>.Instance);
+    }
+
+    private sealed class FakeModeProvider : Tamma.Api.Services.PromptStore.ITammaModeProvider
+    {
+        public FakeModeProvider(Tamma.Api.Services.PromptStore.TammaMode mode) => Mode = mode;
+        public Tamma.Api.Services.PromptStore.TammaMode Mode { get; }
     }
 
     private static void AssertActorTagsAndData(PlatformEvent evt)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Admin/AdminTenantsTests.cs
@@ -759,6 +759,31 @@ public class AdminTenantsTests
 
     // ── Plan change ──
 
+    // Story 34-4 — UpdateTenantPlan now delegates to IPlanAssignmentService.
+    // Build a real service over the InMemory context (PlansSeeder ran in SetUp).
+    private Tamma.Api.Services.Pricing.IPlanAssignmentService BuildAssignments()
+    {
+        var catalog = new Tamma.Api.Services.Pricing.PlanCatalogService(
+            _db, Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.PlanCatalogService>.Instance);
+        var usage = new Tamma.Api.Services.Pricing.NullTenantUsageReader(
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.NullTenantUsageReader>.Instance);
+        return new Tamma.Api.Services.Pricing.PlanAssignmentService(
+            _db, catalog, usage, _publisher,
+            new RecordingPlatformQueuedTaskRepository(),
+            new FakeModeProvider(Tamma.Api.Services.PromptStore.TammaMode.SaaS),
+            _timeProvider,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<
+                Tamma.Api.Services.Pricing.PlanAssignmentService>.Instance);
+    }
+
+    private sealed class FakeModeProvider : Tamma.Api.Services.PromptStore.ITammaModeProvider
+    {
+        public FakeModeProvider(Tamma.Api.Services.PromptStore.TammaMode mode) => Mode = mode;
+        public Tamma.Api.Services.PromptStore.TammaMode Mode { get; }
+    }
+
     [Test]
     public async Task UpdateTenantPlan_SetsPlanIdAndLegacySlug_AndEmitsEvent()
     {
@@ -768,8 +793,8 @@ public class AdminTenantsTests
             tenantId,
             new UpdateTenantPlanRequest(PlansSeeder.TeamPlanId),
             _db,
-            _publisher,
-            _timeProvider, AdminPrincipal());
+            BuildAssignments(),
+            AdminPrincipal());
 
         result.Should().BeOfType<Ok<AdminTenantActionResponse>>();
         var reloaded = await _db.Tenants.IgnoreQueryFilters()
@@ -777,7 +802,8 @@ public class AdminTenantsTests
         ((Guid?)_db.Entry(reloaded).Property("PlanId").CurrentValue)
             .Should().Be(PlansSeeder.TeamPlanId);
         reloaded.Plan.Should().Be("team", "legacy plan string stays in lockstep with PlanId FK");
-        _publisher.Events.Should().ContainSingle(e => e.Type == "PLAN.UPDATED");
+        // Story 34-4 — PLAN.UPDATED is superseded by TENANT.PLAN.CHANGED.
+        _publisher.Events.Should().ContainSingle(e => e.Type == "TENANT.PLAN.CHANGED");
     }
 
     [Test]
@@ -789,8 +815,8 @@ public class AdminTenantsTests
             tenantId,
             new UpdateTenantPlanRequest(Guid.NewGuid()),
             _db,
-            _publisher,
-            _timeProvider, AdminPrincipal());
+            BuildAssignments(),
+            AdminPrincipal());
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
     }
@@ -804,8 +830,8 @@ public class AdminTenantsTests
             tenantId,
             new UpdateTenantPlanRequest(Guid.Empty),
             _db,
-            _publisher,
-            _timeProvider, AdminPrincipal());
+            BuildAssignments(),
+            AdminPrincipal());
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
     }
@@ -819,8 +845,8 @@ public class AdminTenantsTests
             tenantId,
             new UpdateTenantPlanRequest(PlansSeeder.TeamPlanId),
             _db,
-            _publisher,
-            _timeProvider, AdminPrincipal());
+            BuildAssignments(),
+            AdminPrincipal());
 
         StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -147,6 +147,11 @@ public class ControlPlaneDbContextModelTests
             // scope, versioned). Platform-owned (PlatformOwnerAccess); CP-resident
             // because margin is a platform-global pricing concern, not per-tenant.
             "margin_policies",
+            // Story 34-4 — per-tenant, version-pinned plan assignments (source of
+            // truth for "what plan version is this tenant on right now"). CP-resident
+            // (keyed by tenant, alongside the plans catalog). One active row per
+            // tenant (partial unique index).
+            "tenant_plan_assignments",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
@@ -162,6 +167,7 @@ public class ControlPlaneDbContextModelTests
             + "Story 37-1 adds audit_records + audit_projector_cursor. "
             + "Story 34-11 adds providers + provider_model_prices. "
             + "Story 34-5 adds margin_policies. "
+            + "Story 34-4 adds tenant_plan_assignments. "
             + "Story 38-3 adds slack_outbox.");
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentEndpointsTests.cs
@@ -1,0 +1,315 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Admin;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-4 (AC10-12) — handler-direct tests for the admin PUT/cancel plan
+/// routes and the tenant self-service <c>POST /api/pricing/subscribe</c> against
+/// a Postgres testcontainer. Covers the happy paths, the draft/deprecated/custom
+/// 422s, unknown-tenant 404, and tenant isolation (subscribe resolves the tenant
+/// strictly from <see cref="ITenantContext"/>, never a body). The member→403 gate
+/// is enforced by the <c>SettingsManage</c> route policy (wired in Program.cs).
+/// </summary>
+[TestFixture]
+public class PlanAssignmentEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tpa_endpoint_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_plan_assignments, plan_prices, plan_entitlements, plan_features, plans, tenants CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private sealed class FakeTenantContext : ITenantContext
+    {
+        public Guid? TenantId { get; private set; }
+        public FakeTenantContext(Guid? id) => TenantId = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class FakeModeProvider : ITammaModeProvider
+    {
+        public FakeModeProvider(TammaMode mode) => Mode = mode;
+        public TammaMode Mode { get; }
+    }
+
+    private IPlanCatalogService Catalog(ControlPlaneDbContext ctx) =>
+        new PlanCatalogService(ctx, NullLogger<PlanCatalogService>.Instance);
+
+    private IPlanAssignmentService Assignments(ControlPlaneDbContext ctx) =>
+        new PlanAssignmentService(
+            ctx, Catalog(ctx),
+            new NullTenantUsageReader(NullLogger<NullTenantUsageReader>.Instance),
+            new RecordingPlatformEventPublisher(),
+            new RecordingPlatformQueuedTaskRepository(),
+            new FakeModeProvider(TammaMode.SaaS),
+            TimeProvider.System,
+            NullLogger<PlanAssignmentService>.Instance);
+
+    private static ClaimsPrincipal Principal() =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new Claim("email", "admin@x.io"),
+        }, "test"));
+
+    private static int StatusCodeOf(IResult result)
+    {
+        if (result is IStatusCodeHttpResult s && s.StatusCode.HasValue) return s.StatusCode.Value;
+        throw new InvalidOperationException($"{result.GetType().FullName} exposes no status code.");
+    }
+
+    private async Task<Guid> SeedTenantAsync()
+    {
+        await using var ctx = NewContext();
+        var id = Guid.NewGuid();
+        var tenant = new Tenant
+        {
+            Id = id,
+            Name = "Acme",
+            Slug = "acme-" + id.ToString("N")[..6],
+            Type = "team",
+            Plan = "free",
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Tenants.Add(tenant);
+        ctx.Entry(tenant).Property("Status").CurrentValue = "active";
+        ctx.Entry(tenant).Property("PlanId").CurrentValue = PlansSeeder.FreePlanId;
+        ctx.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3, 4 };
+        await ctx.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task<Guid> InsertPlanAsync(string slug, string status, bool isCustom)
+    {
+        await using var ctx = NewContext();
+        var plan = new Plan
+        {
+            Id = Guid.NewGuid(),
+            Slug = slug,
+            DisplayName = slug,
+            Version = 1,
+            Status = status,
+            IsCustom = isCustom,
+            BillingInterval = "monthly",
+            Quotas = "{}",
+            IsActive = status == "active",
+            PlacementPolicy = "shared",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Plans.Add(plan);
+        await ctx.SaveChangesAsync();
+        return plan.Id;
+    }
+
+    // ── Admin PUT ──
+
+    [Test]
+    public async Task PutTenantPlan_Assigns_And_Returns_Version_And_Direction()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using var ctx = NewContext();
+
+        var result = await AdminTenantsEndpoints.PutTenantPlan(
+            tenantId, new PutTenantPlanRequest(PlansSeeder.TeamPlanId, Reason: "upgrade"),
+            ctx, Assignments(ctx), Principal());
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>>();
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>)result).Value!;
+        body.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+        body.PlanVersion.Should().Be(1);
+        body.Status.Should().Be("active");
+        body.Direction.Should().Be("upgrade");
+    }
+
+    [Test]
+    public async Task PutTenantPlan_UnknownTenant_Returns404()
+    {
+        await using var ctx = NewContext();
+        var result = await AdminTenantsEndpoints.PutTenantPlan(
+            Guid.NewGuid(), new PutTenantPlanRequest(PlansSeeder.TeamPlanId),
+            ctx, Assignments(ctx), Principal());
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task PutTenantPlan_DraftPlan_Returns422()
+    {
+        var tenantId = await SeedTenantAsync();
+        var draftId = await InsertPlanAsync("beta", "draft", isCustom: false);
+        await using var ctx = NewContext();
+
+        var result = await AdminTenantsEndpoints.PutTenantPlan(
+            tenantId, new PutTenantPlanRequest(draftId), ctx, Assignments(ctx), Principal());
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Test]
+    public async Task PutTenantPlan_CustomMisbound_Returns422()
+    {
+        var tenantId = await SeedTenantAsync();
+        var customId = await InsertPlanAsync(CustomPlanSlug.New(Guid.NewGuid()), "active", isCustom: true);
+        await using var ctx = NewContext();
+
+        var result = await AdminTenantsEndpoints.PutTenantPlan(
+            tenantId, new PutTenantPlanRequest(customId), ctx, Assignments(ctx), Principal());
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    // ── Admin cancel ──
+
+    [Test]
+    public async Task CancelTenantPlan_Schedules_Free_And_Returns200()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using (var ctx = NewContext())
+        {
+            await AdminTenantsEndpoints.PutTenantPlan(
+                tenantId, new PutTenantPlanRequest(PlansSeeder.TeamPlanId),
+                ctx, Assignments(ctx), Principal());
+        }
+
+        await using var ctx2 = NewContext();
+        var result = await AdminTenantsEndpoints.CancelTenantPlan(
+            tenantId, new CancelTenantPlanRequest(), ctx2, Assignments(ctx2), Principal());
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>>();
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>)result).Value!;
+        body.Status.Should().Be("scheduled");
+        body.PlanId.Should().Be(PlansSeeder.FreePlanId);
+        body.ScheduledEffectiveAt.Should().NotBeNull();
+    }
+
+    // ── Tenant self-service subscribe ──
+
+    [Test]
+    public async Task Subscribe_PublicPlan_Returns200_ForCallerTenant()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using var ctx = NewContext();
+
+        var result = await PricingEndpoints.Subscribe(
+            new SubscribeRequest("team"),
+            Principal(),
+            new FakeTenantContext(tenantId),
+            new FakeModeProvider(TammaMode.SaaS),
+            Catalog(ctx), Assignments(ctx),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>>();
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>)result).Value!;
+        body.TenantId.Should().Be(tenantId);
+        body.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+    }
+
+    [Test]
+    public async Task Subscribe_NoActiveTenant_Returns404()
+    {
+        await using var ctx = NewContext();
+        var result = await PricingEndpoints.Subscribe(
+            new SubscribeRequest("team"),
+            Principal(),
+            new FakeTenantContext(null),
+            new FakeModeProvider(TammaMode.SaaS),
+            Catalog(ctx), Assignments(ctx),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task Subscribe_CustomPlanSlug_Returns422_NotPublic()
+    {
+        var tenantId = await SeedTenantAsync();
+        var customSlug = CustomPlanSlug.New(tenantId);
+        await InsertPlanAsync(customSlug, "active", isCustom: true);
+        await using var ctx = NewContext();
+
+        var result = await PricingEndpoints.Subscribe(
+            new SubscribeRequest(customSlug),
+            Principal(),
+            new FakeTenantContext(tenantId),
+            new FakeModeProvider(TammaMode.SaaS),
+            Catalog(ctx), Assignments(ctx),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Test]
+    public async Task Subscribe_Resolves_Tenant_From_Context_Not_Body_Isolation()
+    {
+        // Two tenants; the caller's context is tenant A. Subscribe assigns to A
+        // only — there is no body field that could select tenant B.
+        var tenantA = await SeedTenantAsync();
+        var tenantB = await SeedTenantAsync();
+        await using var ctx = NewContext();
+
+        var result = await PricingEndpoints.Subscribe(
+            new SubscribeRequest("team"),
+            Principal(),
+            new FakeTenantContext(tenantA),
+            new FakeModeProvider(TammaMode.SaaS),
+            Catalog(ctx), Assignments(ctx),
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Ok<PlanAssignmentResponse>)result).Value!;
+        body.TenantId.Should().Be(tenantA);
+
+        // Tenant B is untouched — no active team assignment.
+        await using var verify = NewContext();
+        (await verify.TenantPlanAssignments.AnyAsync(a => a.TenantId == tenantB))
+            .Should().BeFalse("subscribe must not affect another tenant");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentMigrationTests.cs
@@ -1,0 +1,313 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-4 (AC1, AC2) — applies the ControlPlane migration bundle to a clean
+/// Postgres testcontainer and asserts the <c>tenant_plan_assignments</c> schema
+/// landed: the table, the three CHECK constraints, the partial unique
+/// "one active per tenant" index (and that it rejects a second active insert),
+/// and the supporting indexes. Raw Npgsql introspection — mirrors the existing
+/// migration suites.
+/// </summary>
+[TestFixture]
+public class PlanAssignmentMigrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tpa_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private async Task<HashSet<string>> QueryStringsAsync(NpgsqlConnection conn, string sql)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            if (!reader.IsDBNull(0)) result.Add(reader.GetString(0));
+        }
+        return result;
+    }
+
+    private async Task<string?> ScalarAsync(NpgsqlConnection conn, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        var v = await cmd.ExecuteScalarAsync();
+        return v is null or DBNull ? null : v.ToString();
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Assignments_Table()
+    {
+        await using var conn = await OpenAsync();
+        var tables = await QueryStringsAsync(conn,
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+
+        tables.Should().Contain("tenant_plan_assignments");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Check_Constraints()
+    {
+        await using var conn = await OpenAsync();
+        var checks = await QueryStringsAsync(conn,
+            "SELECT conname FROM pg_constraint WHERE contype='c';");
+
+        checks.Should().Contain("ck_tpa_status");
+        checks.Should().Contain("ck_tpa_effective_window");
+        checks.Should().Contain("ck_tpa_version_positive");
+    }
+
+    [Test]
+    public async Task Migration_Creates_The_Partial_OneActivePerTenant_Index()
+    {
+        await using var conn = await OpenAsync();
+        var def = await ScalarAsync(conn,
+            "SELECT indexdef FROM pg_indexes WHERE indexname='ux_tpa_one_active_per_tenant';");
+
+        def.Should().NotBeNull();
+        def!.Should().Contain("UNIQUE");
+        def.Should().Contain("active", "the index is filtered WHERE Status = 'active'");
+    }
+
+    [Test]
+    public async Task PartialUniqueIndex_Rejects_A_Second_Active_Row_For_The_Same_Tenant()
+    {
+        var tenantId = await SeedTenantWithPlansAsync();
+
+        await using var conn = await OpenAsync();
+
+        // First active insert — succeeds.
+        await ExecAsync(conn, tenantId, PlansSeeder.TeamPlanId, "active");
+
+        // Second active insert for the same tenant — must violate the partial
+        // unique index (23505).
+        var act = () => ExecAsync(conn, tenantId, PlansSeeder.FreePlanId, "active");
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().Be("23505");
+    }
+
+    [Test]
+    public async Task CheckConstraints_Reject_Bad_Status_And_Window_And_Version()
+    {
+        var tenantId = await SeedTenantWithPlansAsync();
+        await using var conn = await OpenAsync();
+
+        // Bad status.
+        var badStatus = () => ExecAsync(conn, tenantId, PlansSeeder.TeamPlanId, "bogus");
+        (await badStatus.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().Be("23514");
+
+        // EffectiveTo < EffectiveFrom.
+        var badWindow = () => ExecAsync(
+            conn, tenantId, PlansSeeder.TeamPlanId, "cancelled",
+            effectiveFrom: DateTime.UtcNow, effectiveTo: DateTime.UtcNow.AddDays(-1));
+        (await badWindow.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().Be("23514");
+
+        // Version < 1.
+        var badVersion = () => ExecAsync(
+            conn, tenantId, PlansSeeder.TeamPlanId, "cancelled", planVersion: 0);
+        (await badVersion.Should().ThrowAsync<PostgresException>())
+            .Which.SqlState.Should().Be("23514");
+    }
+
+    private static async Task ExecAsync(
+        NpgsqlConnection conn, Guid tenantId, Guid planId, string status,
+        int planVersion = 1, DateTime? effectiveFrom = null, DateTime? effectiveTo = null)
+    {
+        await using var cmd = new NpgsqlCommand(
+            @"INSERT INTO tenant_plan_assignments
+                (""Id"",""TenantId"",""PlanId"",""PlanVersion"",""Status"",
+                 ""EffectiveFrom"",""EffectiveTo"",""CreatedAt"",""UpdatedAt"")
+              VALUES (gen_random_uuid(), @t, @p, @v, @s, @from, @to, now(), now());", conn);
+        cmd.Parameters.AddWithValue("t", tenantId);
+        cmd.Parameters.AddWithValue("p", planId);
+        cmd.Parameters.AddWithValue("v", planVersion);
+        cmd.Parameters.AddWithValue("s", status);
+        cmd.Parameters.AddWithValue("from", effectiveFrom ?? DateTime.UtcNow);
+        cmd.Parameters.AddWithValue("to", (object?)effectiveTo ?? DBNull.Value);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    private async Task<Guid> SeedTenantWithPlansAsync()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_plan_assignments, plan_prices, plan_entitlements, plan_features, plans, tenants CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+
+        var tenantId = Guid.NewGuid();
+        var tenant = new Tenant
+        {
+            Id = tenantId,
+            Name = "Acme",
+            Slug = "acme-" + tenantId.ToString("N")[..6],
+            Type = "team",
+            Plan = "free",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Tenants.Add(tenant);
+        ctx.Entry(tenant).Property("Status").CurrentValue = "active";
+        ctx.Entry(tenant).Property("PlanId").CurrentValue = PlansSeeder.FreePlanId;
+        ctx.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3, 4 };
+        await ctx.SaveChangesAsync();
+        return tenantId;
+    }
+}
+
+/// <summary>
+/// Story 34-4 (AC3) — the migration back-fill produces exactly one <c>active</c>
+/// assignment per existing tenant, pinning the plan's current <c>Version</c>. A
+/// dedicated container migrates to the PREVIOUS migration, seeds plans + tenants,
+/// then applies <c>AddTenantPlanAssignment</c> so the raw-SQL back-fill runs.
+/// </summary>
+[TestFixture]
+public class PlanAssignmentBackfillMigrationTests
+{
+    private const string PreviousMigration = "20260702193642_AddBillingSubscription";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tpa_backfill_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        // 1. Migrate to the migration BEFORE AddTenantPlanAssignment.
+        await using (var ctx = NewContext())
+        {
+            var migrator = ctx.GetInfrastructure().GetRequiredService<IMigrator>();
+            await migrator.MigrateAsync(PreviousMigration);
+        }
+
+        // 2. Seed plans + two tenants (one team via PlanId, one free via slug).
+        await using (var ctx = NewContext())
+        {
+            await PlansSeeder.SeedAsync(ctx);
+
+            AddTenant(ctx, TeamTenantId, "team-tenant", planId: PlansSeeder.TeamPlanId, planSlug: "team");
+            AddTenant(ctx, FreeTenantId, "free-tenant", planId: null, planSlug: "free");
+            await ctx.SaveChangesAsync();
+        }
+
+        // 3. Apply AddTenantPlanAssignment — its back-fill runs.
+        await using (var ctx = NewContext())
+        {
+            await ctx.Database.MigrateAsync();
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private static readonly Guid TeamTenantId = Guid.NewGuid();
+    private static readonly Guid FreeTenantId = Guid.NewGuid();
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static void AddTenant(
+        ControlPlaneDbContext ctx, Guid id, string name, Guid? planId, string planSlug)
+    {
+        var tenant = new Tenant
+        {
+            Id = id,
+            Name = name,
+            Slug = name + "-" + id.ToString("N")[..6],
+            Type = "team",
+            Plan = planSlug,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Tenants.Add(tenant);
+        ctx.Entry(tenant).Property("Status").CurrentValue = "active";
+        ctx.Entry(tenant).Property("PlanId").CurrentValue = planId;
+        ctx.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3, 4 };
+    }
+
+    [Test]
+    public async Task Backfill_Creates_Exactly_One_Active_Assignment_Per_Tenant()
+    {
+        await using var ctx = NewContext();
+
+        var all = await ctx.TenantPlanAssignments.AsNoTracking().ToListAsync();
+        all.Should().HaveCount(2, "one active assignment per existing tenant");
+        all.Should().OnlyContain(a => a.Status == "active");
+    }
+
+    [Test]
+    public async Task Backfill_Pins_The_PlanId_From_Shadow_Column()
+    {
+        await using var ctx = NewContext();
+
+        var team = await ctx.TenantPlanAssignments.AsNoTracking()
+            .SingleAsync(a => a.TenantId == TeamTenantId);
+        team.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+        team.PlanVersion.Should().Be(1, "the current active team version is pinned");
+    }
+
+    [Test]
+    public async Task Backfill_Falls_Back_To_Free_Slug_When_Shadow_PlanId_Null()
+    {
+        await using var ctx = NewContext();
+
+        var free = await ctx.TenantPlanAssignments.AsNoTracking()
+            .SingleAsync(a => a.TenantId == FreeTenantId);
+        free.PlanId.Should().Be(PlansSeeder.FreePlanId,
+            "a NULL shadow PlanId back-fills via the Plan slug ('free')");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentMigrationTests.cs
@@ -231,13 +231,25 @@ public class PlanAssignmentBackfillMigrationTests
             await migrator.MigrateAsync(PreviousMigration);
         }
 
-        // 2. Seed plans + two tenants (one team via PlanId, one free via slug).
+        // 2. Seed plans + three tenants: one team via PlanId, one free via slug,
+        //    and one ORPHAN whose PlanId is NULL and whose (canonical) legacy slug
+        //    resolves to no ACTIVE plan (Finding 3). The orphan's slug is
+        //    'enterprise' (canonical → passes ck_tenants_plan) but the active
+        //    enterprise plan is deprecated below, so the slug lookup misses — the
+        //    tenant must STILL back-fill to the terminal `free` fallback, never
+        //    silently vanish.
         await using (var ctx = NewContext())
         {
             await PlansSeeder.SeedAsync(ctx);
 
+            // Deprecate the active 'enterprise' version so slug 'enterprise' has no
+            // active row (bypasses EF plan-immutability enforcement via raw SQL).
+            await ctx.Database.ExecuteSqlRawAsync(
+                "UPDATE plans SET \"Status\" = 'deprecated' WHERE \"Slug\" = 'enterprise';");
+
             AddTenant(ctx, TeamTenantId, "team-tenant", planId: PlansSeeder.TeamPlanId, planSlug: "team");
             AddTenant(ctx, FreeTenantId, "free-tenant", planId: null, planSlug: "free");
+            AddTenant(ctx, OrphanSlugTenantId, "orphan-tenant", planId: null, planSlug: "enterprise");
             await ctx.SaveChangesAsync();
         }
 
@@ -256,6 +268,7 @@ public class PlanAssignmentBackfillMigrationTests
 
     private static readonly Guid TeamTenantId = Guid.NewGuid();
     private static readonly Guid FreeTenantId = Guid.NewGuid();
+    private static readonly Guid OrphanSlugTenantId = Guid.NewGuid();
 
     private ControlPlaneDbContext NewContext() =>
         new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
@@ -285,8 +298,23 @@ public class PlanAssignmentBackfillMigrationTests
         await using var ctx = NewContext();
 
         var all = await ctx.TenantPlanAssignments.AsNoTracking().ToListAsync();
-        all.Should().HaveCount(2, "one active assignment per existing tenant");
+        all.Should().HaveCount(3, "one active assignment per existing (non-deleted) tenant");
         all.Should().OnlyContain(a => a.Status == "active");
+    }
+
+    [Test]
+    public async Task Backfill_OrphanSlug_Tenant_Falls_Back_To_Free()
+    {
+        // Finding 3 — a non-deleted tenant with a NULL shadow PlanId AND a legacy
+        // slug that resolves to no active plan must STILL receive a `free` active
+        // assignment (the guaranteed terminal fallback), never be silently skipped.
+        await using var ctx = NewContext();
+
+        var orphan = await ctx.TenantPlanAssignments.AsNoTracking()
+            .SingleAsync(a => a.TenantId == OrphanSlugTenantId);
+        orphan.PlanId.Should().Be(PlansSeeder.FreePlanId,
+            "an unresolvable legacy slug + NULL PlanId back-fills to the active 'free' plan");
+        orphan.Status.Should().Be("active");
     }
 
     [Test]
@@ -309,5 +337,121 @@ public class PlanAssignmentBackfillMigrationTests
             .SingleAsync(a => a.TenantId == FreeTenantId);
         free.PlanId.Should().Be(PlansSeeder.FreePlanId,
             "a NULL shadow PlanId back-fills via the Plan slug ('free')");
+    }
+}
+
+/// <summary>
+/// Story 34-4 (Finding 3) — when the active <c>free</c> plan is ABSENT and a
+/// non-deleted tenant would resolve to no plan (NULL <c>PlanId</c> + a legacy slug
+/// with no active version), the back-fill must FAIL LOUD (RAISE) rather than
+/// silently skip the tenant and leave it assignment-less (→ Story 34-6
+/// <c>NO_ASSIGNMENT</c>/404 post-deploy). fail-before: the prior
+/// <c>AND COALESCE(...) IS NOT NULL</c> filter let the migration succeed while
+/// omitting the tenant; pass-after: the migration throws.
+/// </summary>
+[TestFixture]
+public class PlanAssignmentBackfillFreeAbsentMigrationTests
+{
+    private const string PreviousMigration = "20260702193642_AddBillingSubscription";
+
+    private static readonly Guid OrphanTenantId = Guid.NewGuid();
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tpa_backfill_free_absent_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        // 1. Migrate to the migration BEFORE AddTenantPlanAssignment.
+        await using (var ctx = NewContext())
+        {
+            var migrator = ctx.GetInfrastructure().GetRequiredService<IMigrator>();
+            await migrator.MigrateAsync(PreviousMigration);
+        }
+
+        // 2. Seed plans, then deprecate EVERY plan version (raw SQL, bypassing EF's
+        //    plan-immutability guard) so there is no active `free` terminal
+        //    fallback (nor any other active plan). Add an orphan tenant (NULL
+        //    PlanId + a canonical slug 'free' that no longer resolves to an active
+        //    plan) that therefore resolves to no plan at all.
+        await using (var ctx = NewContext())
+        {
+            await PlansSeeder.SeedAsync(ctx);
+            await ctx.Database.ExecuteSqlRawAsync(
+                "UPDATE plans SET \"Status\" = 'deprecated';");
+
+            var tenant = new Tenant
+            {
+                Id = OrphanTenantId,
+                Name = "orphan-tenant",
+                Slug = "orphan-" + OrphanTenantId.ToString("N")[..6],
+                Type = "team",
+                Plan = "free", // canonical (passes ck_tenants_plan); no active row now
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+                UpdatedAt = DateTime.UtcNow,
+            };
+            ctx.Tenants.Add(tenant);
+            ctx.Entry(tenant).Property("Status").CurrentValue = "active";
+            ctx.Entry(tenant).Property("PlanId").CurrentValue = (Guid?)null;
+            ctx.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3, 4 };
+            await ctx.SaveChangesAsync();
+        }
+        // NOTE: AddTenantPlanAssignment is intentionally NOT applied here — the
+        // test applies it and asserts it throws.
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    [Test]
+    public async Task Backfill_FailsLoud_When_Free_Absent_And_Tenant_Would_Be_Orphaned()
+    {
+        var act = async () =>
+        {
+            await using var ctx = NewContext();
+            await ctx.Database.MigrateAsync();
+        };
+
+        var ex = (await act.Should().ThrowAsync<Exception>(
+            "the back-fill must fail loud, not silently leave a tenant assignment-less")).Which;
+
+        Flatten(ex).Should().Contain("free",
+            "the RAISE message must name the missing 'free' terminal fallback");
+
+        // And the migration aborted transactionally: the assignments table it
+        // would have created never landed (PostgreSQL DDL is transactional).
+        await using var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+            + "WHERE table_schema='public' AND table_name='tenant_plan_assignments');", conn);
+        var tableExists = (bool)(await cmd.ExecuteScalarAsync())!;
+        tableExists.Should().BeFalse(
+            "the failed migration rolled back — the assignments table was never created");
+    }
+
+    private static string Flatten(Exception ex)
+    {
+        var messages = new List<string>();
+        for (Exception? e = ex; e is not null; e = e.InnerException)
+        {
+            messages.Add(e.Message);
+        }
+        return string.Join(" | ", messages);
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs
@@ -1,0 +1,468 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Seeders;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-4 — <see cref="PlanAssignmentService"/> against a real Postgres
+/// testcontainer (so the transactional swap, the partial unique index, and the
+/// FK behave like production). Covers version pinning surviving deprecation, the
+/// one-active invariant, draft/deprecated/custom guards, direction
+/// classification, downgrade warning surfacing, cancel scheduling + boundary
+/// activation, and DCB event emission.
+/// </summary>
+[TestFixture]
+public class PlanAssignmentServiceTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("tpa_service_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE tenant_plan_assignments, plan_prices, plan_entitlements, plan_features, plans, tenants CASCADE;");
+        await PlansSeeder.SeedAsync(ctx);
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private sealed class StubUsageReader : ITenantUsageReader
+    {
+        private readonly long? _value;
+        public StubUsageReader(long? value) => _value = value;
+        public Task<long?> GetCurrentUsageAsync(Guid tenantId, EntitlementMetricKey metric, CancellationToken ct = default)
+            => Task.FromResult(_value);
+    }
+
+    private sealed class FakeModeProvider : ITammaModeProvider
+    {
+        public FakeModeProvider(TammaMode mode) => Mode = mode;
+        public TammaMode Mode { get; }
+    }
+
+    private (PlanAssignmentService svc, RecordingPlatformEventPublisher events,
+        RecordingPlatformQueuedTaskRepository queue, PricingTestClock clock)
+        Build(ControlPlaneDbContext ctx, ITenantUsageReader? usage = null,
+              TammaMode mode = TammaMode.SaaS)
+    {
+        var events = new RecordingPlatformEventPublisher();
+        var queue = new RecordingPlatformQueuedTaskRepository();
+        var clock = new PricingTestClock();
+        var svc = new PlanAssignmentService(
+            ctx,
+            new PlanCatalogService(ctx, NullLogger<PlanCatalogService>.Instance),
+            usage ?? new NullTenantUsageReader(NullLogger<NullTenantUsageReader>.Instance),
+            events, queue, new FakeModeProvider(mode), clock,
+            NullLogger<PlanAssignmentService>.Instance);
+        return (svc, events, queue, clock);
+    }
+
+    private async Task<Guid> SeedTenantAsync(Guid? planId = null, string plan = "free")
+    {
+        await using var ctx = NewContext();
+        var id = Guid.NewGuid();
+        var tenant = new Tenant
+        {
+            Id = id,
+            Name = "Acme",
+            Slug = "acme-" + id.ToString("N")[..6],
+            Type = "team",
+            Plan = plan,
+            CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Tenants.Add(tenant);
+        ctx.Entry(tenant).Property("Status").CurrentValue = "active";
+        ctx.Entry(tenant).Property("PlanId").CurrentValue = planId;
+        ctx.Entry(tenant).Property("EncryptedConnectionString").CurrentValue = new byte[] { 1, 2, 3, 4 };
+        await ctx.SaveChangesAsync();
+        return id;
+    }
+
+    private async Task<Guid?> ShadowPlanIdAsync(Guid tenantId)
+    {
+        await using var ctx = NewContext();
+        return await ctx.Tenants.IgnoreQueryFilters()
+            .Where(t => t.Id == tenantId)
+            .Select(t => EF.Property<Guid?>(t, "PlanId"))
+            .FirstAsync();
+    }
+
+    [Test]
+    public async Task Assign_Pins_Version_And_Sets_Lockstep_Columns_And_Emits()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        await using var ctx = NewContext();
+        var (svc, events, _, _) = Build(ctx);
+
+        var result = await svc.AssignAsync(
+            tenantId, PlansSeeder.TeamPlanId,
+            new AssignPlanOptions(Reason: "test", Source: "admin"));
+
+        result.Assignment.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+        result.Assignment.PlanVersion.Should().Be(1);
+        result.Assignment.Status.Should().Be("active");
+
+        (await ShadowPlanIdAsync(tenantId)).Should().Be(PlansSeeder.TeamPlanId);
+        (await NewContext().Tenants.IgnoreQueryFilters().FirstAsync(t => t.Id == tenantId))
+            .Plan.Should().Be("team");
+
+        events.Events.Should().ContainSingle(e => e.Type == PlanAssignmentEventTypes.TenantPlanChanged);
+        var tags = events.Events.Single().Tags;
+        tags.Should().Contain("\"newPlanVersion\":\"1\"");
+        tags.Should().Contain("\"source\":\"admin\"");
+    }
+
+    [Test]
+    public async Task Assign_Pin_Survives_Plan_Deprecation()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        // Assign team v1.
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        // Deprecate team (mints v2, flips v1 → deprecated).
+        await using (var editCtx = NewContext())
+        {
+            var editor = new PlanVersionEditor(
+                editCtx, new RecordingPlatformEventPublisher(),
+                TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+            await editor.CreateNewVersionAsync(
+                "team", new PlanDraftSpec(DisplayName: "Team v2"),
+                new PlanEditorPrincipal("u", "u@x.io"));
+        }
+
+        // The pinned assignment still reports v1 — no silent re-price.
+        await using var verify = NewContext();
+        var (svc2, _, _, _) = Build(verify);
+        var active = await svc2.GetActiveAsync(tenantId);
+        active!.PlanVersion.Should().Be(1, "the pinned version survives deprecation");
+        active.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+    }
+
+    [Test]
+    public async Task Assign_Twice_Flips_Prior_To_Cancelled_And_Keeps_One_Active()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.EnterprisePlanId, new AssignPlanOptions());
+        }
+
+        await using var verify = NewContext();
+        var rows = await verify.TenantPlanAssignments.AsNoTracking()
+            .Where(a => a.TenantId == tenantId).ToListAsync();
+
+        rows.Count(a => a.Status == "active").Should().Be(1, "exactly one active row");
+        rows.Single(a => a.Status == "active").PlanId.Should().Be(PlansSeeder.EnterprisePlanId);
+        var cancelled = rows.Single(a => a.Status == "cancelled");
+        cancelled.PlanId.Should().Be(PlansSeeder.TeamPlanId);
+        cancelled.EffectiveTo.Should().NotBeNull("the prior active row's EffectiveTo is stamped");
+    }
+
+    [Test]
+    public async Task Assign_Same_Version_Is_Lateral_Noop_No_Event()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        await using var ctx2 = NewContext();
+        var (svc2, events2, _, _) = Build(ctx2);
+        var result = await svc2.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+
+        result.Direction.Should().Be(PlanChangeDirection.Lateral);
+        events2.Events.Should().BeEmpty("an idempotent re-assign emits no event");
+        (await ctx2.TenantPlanAssignments.CountAsync(a => a.TenantId == tenantId && a.Status == "active"))
+            .Should().Be(1);
+    }
+
+    [Test]
+    public async Task Assign_Draft_Plan_Is_Rejected()
+    {
+        var tenantId = await SeedTenantAsync();
+        var draftId = await InsertPlanAsync(slug: "beta", status: "draft", isCustom: false);
+
+        await using var ctx = NewContext();
+        var (svc, _, _, _) = Build(ctx);
+
+        var act = () => svc.AssignAsync(tenantId, draftId, new AssignPlanOptions());
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("PLAN.ASSIGN.PLAN_DRAFT");
+    }
+
+    [Test]
+    public async Task Assign_Deprecated_Plan_Rejected_Unless_Force()
+    {
+        var tenantId = await SeedTenantAsync();
+        var depId = await InsertPlanAsync(slug: "legacy", status: "deprecated", isCustom: false);
+
+        await using var ctx = NewContext();
+        var (svc, _, _, _) = Build(ctx);
+
+        var act = () => svc.AssignAsync(tenantId, depId, new AssignPlanOptions());
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("PLAN.ASSIGN.PLAN_DEPRECATED");
+
+        // With Force it succeeds.
+        var forced = await svc.AssignAsync(tenantId, depId, new AssignPlanOptions(Force: true));
+        forced.Assignment.PlanId.Should().Be(depId);
+    }
+
+    [Test]
+    public async Task Assign_Custom_Plan_Misbound_Is_Rejected()
+    {
+        var tenantA = await SeedTenantAsync();
+        var tenantB = Guid.NewGuid();
+        var customSlug = CustomPlanSlug.New(tenantB);
+        var customId = await InsertPlanAsync(slug: customSlug, status: "active", isCustom: true);
+
+        await using var ctx = NewContext();
+        var (svc, _, _, _) = Build(ctx);
+
+        var act = () => svc.AssignAsync(tenantA, customId, new AssignPlanOptions());
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("PLAN.ASSIGN.CUSTOM_PLAN_MISBOUND");
+    }
+
+    [Test]
+    public async Task Assign_Custom_Plan_To_Bound_Tenant_Succeeds()
+    {
+        var tenantA = await SeedTenantAsync();
+        var customSlug = CustomPlanSlug.New(tenantA);
+        var customId = await InsertPlanAsync(slug: customSlug, status: "active", isCustom: true);
+
+        await using var ctx = NewContext();
+        var (svc, _, _, _) = Build(ctx);
+
+        var result = await svc.AssignAsync(tenantA, customId, new AssignPlanOptions());
+        result.Assignment.PlanId.Should().Be(customId);
+    }
+
+    [Test]
+    public async Task Direction_Is_Upgrade_Then_Downgrade()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            var up = await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+            up.Direction.Should().Be(PlanChangeDirection.Upgrade, "free → team is an upgrade");
+        }
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            var down = await svc.AssignAsync(tenantId, PlansSeeder.FreePlanId, new AssignPlanOptions());
+            down.Direction.Should().Be(PlanChangeDirection.Downgrade, "team → free is a downgrade");
+        }
+    }
+
+    [Test]
+    public async Task Downgrade_OverLimit_Surfaces_Warnings_And_Sets_Event_Tag()
+    {
+        var tenantId = await SeedTenantAsync();
+
+        // Get onto team first (no warnings on the upgrade).
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        // Downgrade team → free with a usage reader reporting a huge current
+        // value ⇒ over EVERY finite free limit.
+        await using var ctx2 = NewContext();
+        var (svc2, events2, _, _) = Build(ctx2, usage: new StubUsageReader(1_000_000_000));
+        var result = await svc2.AssignAsync(tenantId, PlansSeeder.FreePlanId, new AssignPlanOptions());
+
+        result.Warnings.Should().NotBeEmpty("over-limit downgrade flags a warning per finite metric");
+        var evt = events2.Events.Single(e => e.Type == PlanAssignmentEventTypes.TenantPlanChanged);
+        evt.Tags.Should().Contain("\"entitlementWarnings\":\"true\"");
+    }
+
+    [Test]
+    public async Task Cancel_PeriodEnd_Schedules_Free_Row_And_Enqueues_Task()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        await using var ctx2 = NewContext();
+        var (svc2, events2, queue2, _) = Build(ctx2);
+        var result = await svc2.CancelAsync(tenantId, new CancelPlanOptions());
+
+        result.ScheduledEffectiveAt.Should().NotBeNull();
+        result.Assignment.Status.Should().Be("scheduled");
+        result.Assignment.PlanId.Should().Be(PlansSeeder.FreePlanId);
+
+        // The current active team row is still active but now has EffectiveTo set.
+        var team = await ctx2.TenantPlanAssignments.AsNoTracking()
+            .SingleAsync(a => a.TenantId == tenantId && a.PlanId == PlansSeeder.TeamPlanId);
+        team.Status.Should().Be("active");
+        team.EffectiveTo.Should().NotBeNull("period-end cancel stamps the boundary");
+
+        queue2.Enqueued.Should().ContainSingle(t =>
+            t.Type == Tamma.Api.Services.Provisioning.ActivateScheduledPlanTaskPayload.TaskType);
+        events2.Events.Should().ContainSingle(e => e.Type == PlanAssignmentEventTypes.TenantPlanCancelled);
+    }
+
+    [Test]
+    public async Task Cancel_Immediate_Drops_To_Free_Now()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        await using var ctx2 = NewContext();
+        var (svc2, events2, _, _) = Build(ctx2);
+        var result = await svc2.CancelAsync(tenantId, new CancelPlanOptions(Immediate: true));
+
+        result.Assignment.Status.Should().Be("active");
+        result.Assignment.PlanId.Should().Be(PlansSeeder.FreePlanId);
+        (await ctx2.TenantPlanAssignments.CountAsync(a => a.TenantId == tenantId && a.Status == "active"))
+            .Should().Be(1);
+        var evt = events2.Events.Single(e => e.Type == PlanAssignmentEventTypes.TenantPlanCancelled);
+        evt.Tags.Should().Contain("\"immediate\":\"true\"");
+    }
+
+    [Test]
+    public async Task Cancel_When_Already_Free_Is_Noop()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.FreePlanId, new AssignPlanOptions());
+        }
+
+        await using var ctx2 = NewContext();
+        var (svc2, events2, queue2, _) = Build(ctx2);
+        var result = await svc2.CancelAsync(tenantId, new CancelPlanOptions());
+
+        result.Direction.Should().Be(PlanChangeDirection.Lateral);
+        events2.Events.Should().BeEmpty("cancel on free is a no-op");
+        queue2.Enqueued.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task ActivateScheduled_Promotes_Due_Row_And_Emits()
+    {
+        var tenantId = await SeedTenantAsync();
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        Guid scheduledId;
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            var cancel = await svc.CancelAsync(tenantId, new CancelPlanOptions());
+            scheduledId = cancel.Assignment.Id;
+        }
+
+        await using var ctx2 = NewContext();
+        var (svc2, events2, _, _) = Build(ctx2);
+        var result = await svc2.ActivateScheduledAsync(tenantId, scheduledId);
+
+        result.Should().NotBeNull();
+        result!.Assignment.Status.Should().Be("active");
+        result.Assignment.PlanId.Should().Be(PlansSeeder.FreePlanId);
+
+        var rows = await ctx2.TenantPlanAssignments.AsNoTracking()
+            .Where(a => a.TenantId == tenantId).ToListAsync();
+        rows.Count(a => a.Status == "active").Should().Be(1);
+        rows.Single(a => a.Status == "active").PlanId.Should().Be(PlansSeeder.FreePlanId);
+        rows.Single(a => a.PlanId == PlansSeeder.TeamPlanId).Status.Should().Be("cancelled");
+
+        var evt = events2.Events.Single(e => e.Type == PlanAssignmentEventTypes.TenantPlanChanged);
+        evt.Tags.Should().Contain("\"source\":\"scheduled-activation\"");
+
+        // Idempotent re-run — no-op.
+        var again = await svc2.ActivateScheduledAsync(tenantId, scheduledId);
+        again!.Direction.Should().Be(PlanChangeDirection.Lateral);
+    }
+
+    /// <summary>Inserts a bare plan version row (no children) for guard tests.</summary>
+    private async Task<Guid> InsertPlanAsync(string slug, string status, bool isCustom)
+    {
+        await using var ctx = NewContext();
+        var plan = new Plan
+        {
+            Id = Guid.NewGuid(),
+            Slug = slug,
+            DisplayName = slug,
+            Version = 1,
+            Status = status,
+            IsCustom = isCustom,
+            BillingInterval = "monthly",
+            MonthlyPriceUsd = 0m,
+            Quotas = "{}",
+            IsActive = status == "active",
+            PlacementPolicy = "shared",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        ctx.Plans.Add(plan);
+        await ctx.SaveChangesAsync();
+        return plan.Id;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PlanAssignmentServiceTests.cs
@@ -441,6 +441,62 @@ public class PlanAssignmentServiceTests
         again!.Direction.Should().Be(PlanChangeDirection.Lateral);
     }
 
+    [Test]
+    public async Task ReAssign_After_PeriodEnd_Cancel_Voids_Scheduled_And_Boundary_Does_Not_Revert()
+    {
+        // Finding 1 — a scheduled period-end downgrade must be reconciled with a
+        // later re-assign. team → period-end cancel (schedules a free downgrade) →
+        // re-assign enterprise → at the boundary ActivateScheduledAsync must NOT
+        // drop the upgraded tenant to free.
+        var tenantId = await SeedTenantAsync();
+
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.TeamPlanId, new AssignPlanOptions());
+        }
+
+        Guid scheduledId;
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            var cancel = await svc.CancelAsync(tenantId, new CancelPlanOptions());
+            scheduledId = cancel.Assignment.Id;
+        }
+
+        // Re-assign enterprise BEFORE the boundary — this must void the pending
+        // scheduled free downgrade in the same swap.
+        await using (var ctx = NewContext())
+        {
+            var (svc, _, _, _) = Build(ctx);
+            await svc.AssignAsync(tenantId, PlansSeeder.EnterprisePlanId, new AssignPlanOptions());
+        }
+
+        // The scheduled free row is voided (cancelled), not left pending.
+        await using (var verify = NewContext())
+        {
+            var scheduledRow = await verify.TenantPlanAssignments.AsNoTracking()
+                .SingleAsync(a => a.Id == scheduledId);
+            scheduledRow.Status.Should().Be("cancelled",
+                "a re-assign voids the stale scheduled downgrade in the same transaction");
+        }
+
+        // Boundary fires: activating the (now voided) scheduled row is a no-op.
+        await using var ctx2 = NewContext();
+        var (svc2, _, _, _) = Build(ctx2);
+        var activated = await svc2.ActivateScheduledAsync(tenantId, scheduledId);
+        activated.Should().BeNull("the voided scheduled row is not promoted");
+
+        var rows = await ctx2.TenantPlanAssignments.AsNoTracking()
+            .Where(a => a.TenantId == tenantId).ToListAsync();
+        rows.Count(a => a.Status == "active").Should().Be(1, "exactly one active plan — no gap");
+        rows.Single(a => a.Status == "active").PlanId.Should().Be(PlansSeeder.EnterprisePlanId,
+            "the re-assigned enterprise plan survives — the tenant is NOT reverted to free");
+        rows.Where(a => a.PlanId == PlansSeeder.FreePlanId)
+            .Should().OnlyContain(a => a.Status == "cancelled",
+                "the scheduled free row is voided, never promoted");
+    }
+
     /// <summary>Inserts a bare plan version row (no children) for guard tests.</summary>
     private async Task<Guid> InsertPlanAsync(string slug, string status, bool isCustom)
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantPlacementServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Tenancy/TenantPlacementServiceTests.cs
@@ -282,6 +282,69 @@ public class TenantPlacementServiceTests
     }
 
     [Test]
+    public async Task Assign_CustomPlanTenant_ResolvesPinnedPlanId_NotStaleSlug()
+    {
+        // Finding 2 (Story 34-4) — a custom-plan tenant has its version-pinned
+        // Tenant.PlanId shadow FK set to a CUSTOM plan while the legacy Tenant.Plan
+        // slug stays stale/non-canonical (a custom slug can't sit in the
+        // ck_tenants_plan-constrained column). Placement must resolve the
+        // PlacementPolicy/tier from PlanId, not the stale slug. Here the stale slug
+        // is "team" (shared) but the pinned custom plan is 'dedicated'; only a
+        // dedicated pool row (eligible for the custom tier) is available, so
+        // placement SUCCEEDS only if it resolves the pinned custom plan — resolving
+        // the stale "team" slug ('shared') would find no eligible row and throw.
+        var dbName = nameof(Assign_CustomPlanTenant_ResolvesPinnedPlanId_NotStaleSlug);
+        var tenantId = Guid.NewGuid();
+        var customPlanId = Guid.NewGuid();
+        var customSlug = $"custom-{tenantId:N}"[..20];
+
+        await using (var seed = CreateContext(dbName))
+        {
+            await PlansSeeder.SeedAsync(seed);
+            var now = DateTime.UtcNow;
+            seed.Plans.Add(new Plan
+            {
+                Id = customPlanId,
+                Slug = customSlug,
+                DisplayName = "Bespoke Enterprise",
+                Version = 1,
+                Status = "active",
+                IsCustom = true,
+                BillingInterval = "monthly",
+                MonthlyPriceUsd = 999m,
+                PlacementPolicy = "dedicated",
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+
+            var tenant = new Tenant
+            {
+                Id = tenantId,
+                Name = "Custom Plan Tenant",
+                Slug = $"custom-t-{tenantId:N}"[..20],
+                Plan = "team", // STALE legacy slug (shared) — must be IGNORED
+                CreatedAt = now,
+                UpdatedAt = now,
+            };
+            seed.Tenants.Add(tenant);
+            seed.Entry(tenant).Property<Guid?>("PlanId").CurrentValue = customPlanId;
+            await seed.SaveChangesAsync();
+        }
+
+        // Only a DEDICATED row (eligible for the custom tier) exists. A stale-slug
+        // ("team" → 'shared') resolution would find no eligible row and throw.
+        var dedicated = PoolRow("dedicated-1", placementClass: "dedicated",
+            tiers: [customSlug]);
+        await AddPoolRowsAsync(dbName, dedicated);
+
+        var placement = await CreateService(dbName).AssignAsync(tenantId);
+
+        placement.DatabaseId.Should().Be(dedicated.Id,
+            "placement must resolve the version-pinned custom plan ('dedicated') from "
+            + "Tenant.PlanId, not the stale legacy slug ('team' → 'shared')");
+    }
+
+    [Test]
     public async Task Assign_CorruptState_OnePropSet_ReStamps()
     {
         var dbName = nameof(Assign_CorruptState_OnePropSet_ReStamps);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/TestDoubles/RecordingPlatformQueuedTaskRepository.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/TestDoubles/RecordingPlatformQueuedTaskRepository.cs
@@ -1,0 +1,44 @@
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.TestDoubles;
+
+/// <summary>
+/// Story 34-4 — recording double for <see cref="IPlatformQueuedTaskRepository"/>
+/// that captures every enqueued task (so tests can assert the boundary-activation
+/// task was queued) and is otherwise a no-op. The drain-side methods are not
+/// exercised by the assignment-service unit tests.
+/// </summary>
+internal sealed class RecordingPlatformQueuedTaskRepository : IPlatformQueuedTaskRepository
+{
+    public List<PlatformQueuedTask> Enqueued { get; } = new();
+
+    public Task<PlatformQueuedTask> EnqueueAsync(PlatformQueuedTask task, CancellationToken ct = default)
+    {
+        if (task.Id == Guid.Empty) task.Id = Guid.NewGuid();
+        if (task.CreatedAt == default) task.CreatedAt = DateTime.UtcNow;
+        Enqueued.Add(task);
+        return Task.FromResult(task);
+    }
+
+    public Task<PlatformQueuedTask?> ReserveNextAsync(string workerId, CancellationToken ct = default)
+        => Task.FromResult<PlatformQueuedTask?>(null);
+
+    public Task CompleteAsync(Guid id, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<PlatformQueuedTask?> FailAsync(Guid id, string error, int maxRetries, CancellationToken ct = default)
+        => Task.FromResult<PlatformQueuedTask?>(null);
+
+    public Task DeadLetterAsync(Guid id, string error, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<PlatformQueuedTask?> ParkUnprocessableAsync(Guid id, string reason, int maxRetries, CancellationToken ct = default)
+        => Task.FromResult<PlatformQueuedTask?>(null);
+
+    public Task DeferAsync(Guid id, DateTime visibleAt, CancellationToken ct = default) => Task.CompletedTask;
+
+    public Task<PlatformQueuedTask?> GetAsync(Guid id, CancellationToken ct = default)
+        => Task.FromResult<PlatformQueuedTask?>(Enqueued.FirstOrDefault(t => t.Id == id));
+
+    public Task<int> ReapStaleProcessingAsync(TimeSpan visibilityTimeout, int maxRetries, CancellationToken ct = default)
+        => Task.FromResult(0);
+}


### PR DESCRIPTION
## What

Story 34-4 (P0). `tenant_plan_assignments` (ControlPlaneDbContext) is the version-pinned source of truth per tenant; `Tenant.Plan`/`PlanId` kept in lockstep. Admin `PUT /plan` + `POST /plan/cancel` (**PlatformOwnerAccess**), tenant `POST /api/pricing/subscribe` (**SettingsManage**, tenant from context). Period-end vs immediate cancel; scheduled activation via a platform-queue task + `ActivateScheduledPlanTaskHandler`. Partial-unique one-active-per-tenant. **Wires Story 34-6** (swaps in the real `IActivePlanAssignmentSource` + emits `TENANT.PLAN.CHANGED` to evict the entitlement cache). Includes a migration **back-fill** (one active assignment per existing tenant).

## Review outcome

Adversarial review verified the transactional one-active swap, 409-on-concurrent, 34-6 wiring, RBAC, and the C#13-EF safety as SOLID. **Three data-correctness findings fixed** (TDD):
- **Scheduled downgrade not reconciled with a later re-assign** → the tenant could be silently reverted to `free` at the boundary. Now a re-assign **voids** pending scheduled rows in the same transaction, and `ActivateScheduledAsync` only promotes if the current active row is still the one that scheduled it.
- **Placement/Cranl/move read the stale legacy `Tenant.Plan` slug** → a custom-plan (dedicated-tier) tenant could be mis-placed onto shared infra. All three now resolve by the pinned `Tenant.PlanId` (fallback to slug only for legacy null-PlanId tenants).
- **Back-fill silently skipped unresolvable tenants** → 34-6 `NO_ASSIGNMENT` (404) post-deploy. Rewritten to cover **every** non-deleted tenant with a guaranteed `free` terminal fallback, and `RAISE EXCEPTION` (fail loud) if `free` is absent.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both; migration edit is raw-SQL back-fill only). Tests: 242 passed (incl. Postgres migration/back-fill + placement tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)