### PR TITLE
feat(epic-34): Story 34-9 (backend) — admin pricing overview read endpoint

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingDashboardEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminPricingDashboardEndpoints.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Api.Services.Pricing;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 34-9 — the platform-owner PRICING DASHBOARD read surface under
+/// <c>GET /api/admin/pricing/overview</c>. One read-only aggregation that powers
+/// the admin Pricing dashboard: the plan catalog (every version + custom), each
+/// plan version's live <c>active</c>-tenant assignment count, and a rollup of the
+/// platform margin configuration.
+///
+/// <para><b>RBAC / leak defence (AC7/AC13 mirror of the 34-5 estimate-leak fix):</b>
+/// gated <c>PlatformOwnerAccess</c> at the wiring site (Finding C1) — the price
+/// book and margin policies are platform-GLOBAL in both single-user and SaaS
+/// modes (no per-tenant override layer), and this surface reveals
+/// platform-internal economics (list prices + the margin knobs
+/// <c>MarkupMultiplier</c> / <c>FixedUsdPer1M</c>) that a TENANT caller must NEVER
+/// see. A tenant role gets 403 — the tenant-facing <c>/api/pricing/*</c> surface
+/// (34-5) only ever exposes the sell price, never cost/margin.</para>
+///
+/// <para><b>No new logic, no migration (AC13):</b> a pure read/projection over
+/// existing entities (<c>plans</c>, <c>tenant_plan_assignments</c>,
+/// <c>margin_policies</c>) via <see cref="IPlanCatalogService"/> +
+/// <see cref="ControlPlaneDbContext"/>. It re-implements NO pricing / margin /
+/// entitlement business logic (34-5 / 34-6 / 34-7 own that) and adds NO schema.</para>
+/// </summary>
+public static class AdminPricingDashboardEndpoints
+{
+    // ── GET /api/admin/pricing/overview ──
+    public static async Task<IResult> GetOverview(
+        IPlanCatalogService catalog,
+        ControlPlaneDbContext db,
+        CancellationToken ct)
+    {
+        // The full admin catalog — every status (active / deprecated / draft) and
+        // custom plans (an all-null filter applies no per-dimension filter). The
+        // public /api/pricing/plans surface is the active+non-custom subset; the
+        // admin dashboard needs the whole picture.
+        var plans = await catalog.ListAllForAdminAsync(new PlanListFilter(), ct);
+
+        // Live active-tenant assignment counts, grouped by the version-pinned
+        // PlanId (a tenant may sit on a now-deprecated version, so we count by
+        // PlanId, never by "the current active version of the slug"). Pure
+        // GroupBy/Count — no bare string[] in the EF predicate (C#13 guard).
+        var counts = await db.TenantPlanAssignments
+            .AsNoTracking()
+            .Where(a => a.Status == "active")
+            .GroupBy(a => a.PlanId)
+            .Select(g => new PlanAssignmentCount(g.Key, g.Count()))
+            .ToListAsync(ct);
+        var countByPlanId = counts.ToDictionary(x => x.PlanId, x => x.Count);
+
+        var planRows = plans
+            .Select(p => new PlanOverviewRow(
+                p.PlanId,
+                p.Slug,
+                p.DisplayName,
+                p.Version,
+                p.Status,
+                p.IsCustom,
+                p.BillingInterval,
+                // The recurring subscription list price (admin-only surface, so
+                // exposing it is intentional; a tenant never reaches this route).
+                p.Prices.Count > 0 ? p.Prices[0].RecurringUsd : null,
+                countByPlanId.TryGetValue(p.PlanId, out var c) ? c : 0))
+            .ToList();
+
+        // Margin config rollup — active policies only (superseded rows are
+        // history). The global markup is the always-present safety-net policy.
+        var activeMargins = await db.MarginPolicies
+            .AsNoTracking()
+            .Where(m => m.Status == "active")
+            .Select(m => new MarginRollupRow(m.Scope, m.MarkupMultiplier, m.FixedUsdPer1M))
+            .ToListAsync(ct);
+
+        var global = activeMargins.FirstOrDefault(m => m.Scope == "global");
+        var margins = new MarginSummary(
+            ActivePolicyCount: activeMargins.Count,
+            GlobalPolicyCount: activeMargins.Count(m => m.Scope == "global"),
+            PlanScopedPolicyCount: activeMargins.Count(m => m.Scope == "plan"),
+            ProviderScopedPolicyCount: activeMargins.Count(m => m.Scope == "provider"),
+            GlobalMarkupMultiplier: global?.MarkupMultiplier,
+            GlobalFixedUsdPer1M: global?.FixedUsdPer1M);
+
+        var totals = new PricingOverviewTotals(
+            ActivePlanCount: planRows.Count(r => r.Status == "active" && !r.IsCustom),
+            CustomPlanCount: planRows.Count(r => r.IsCustom),
+            DeprecatedPlanCount: planRows.Count(r => r.Status == "deprecated"),
+            TotalActiveAssignments: counts.Sum(x => x.Count),
+            PlansWithActiveAssignments: countByPlanId.Count);
+
+        return Results.Ok(new PricingOverviewResponse(planRows, margins, totals));
+    }
+
+    /// <summary>Internal projection row for the assignment-count GroupBy.</summary>
+    private sealed record PlanAssignmentCount(Guid PlanId, int Count);
+
+    /// <summary>Internal projection row for the active margin-policy rollup.</summary>
+    private sealed record MarginRollupRow(string Scope, decimal? MarkupMultiplier, decimal? FixedUsdPer1M);
+}
+
+/// <summary>
+/// Story 34-9 — top-level shape of <c>GET /api/admin/pricing/overview</c>: the
+/// per-plan catalog rows (with live assignment counts), the margin-config
+/// rollup, and headline totals.
+/// </summary>
+public sealed record PricingOverviewResponse(
+    IReadOnlyList<PlanOverviewRow> Plans,
+    MarginSummary Margins,
+    PricingOverviewTotals Totals);
+
+/// <summary>
+/// One plan version in the admin dashboard: header fields projected from the
+/// <see cref="PlanSnapshot"/> plus the count of tenants currently on an
+/// <c>active</c> assignment pinned to this exact <see cref="PlanId"/>.
+/// </summary>
+public sealed record PlanOverviewRow(
+    Guid PlanId,
+    string Slug,
+    string DisplayName,
+    int Version,
+    string Status,
+    bool IsCustom,
+    string BillingInterval,
+    decimal? RecurringUsd,
+    int ActiveTenantCount);
+
+/// <summary>
+/// A rollup of the platform's active margin policies (platform-internal
+/// economics — this DTO is only ever returned by the platform-owner surface).
+/// </summary>
+public sealed record MarginSummary(
+    int ActivePolicyCount,
+    int GlobalPolicyCount,
+    int PlanScopedPolicyCount,
+    int ProviderScopedPolicyCount,
+    decimal? GlobalMarkupMultiplier,
+    decimal? GlobalFixedUsdPer1M);
+
+/// <summary>Headline counters for the top of the admin pricing dashboard.</summary>
+public sealed record PricingOverviewTotals(
+    int ActivePlanCount,
+    int CustomPlanCount,
+    int DeprecatedPlanCount,
+    int TotalActiveAssignments,
+    int PlansWithActiveAssignments);

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1772,6 +1772,18 @@ admin.MapDelete("/pricing/plans/{slug}/versions/{version:int}",
         Tamma.Api.Endpoints.Admin.AdminPlanCatalogEndpoints.DeprecateVersion)
     .RequireAuthorization("PlatformOwnerAccess");
 
+// Story 34-9 — the platform-owner PRICING DASHBOARD read surface. One read-only
+// aggregation over the existing 34-x data (plan catalog + live per-plan active
+// tenant-assignment counts + a margin-config rollup) that powers the admin
+// Pricing dashboard. PlatformOwnerAccess (Finding C1 + the 34-5 estimate-leak
+// rule): this surface reveals platform-internal economics (list prices + margin
+// knobs) that a tenant caller must NEVER see, so it stays platform-owner-only —
+// the tenant-facing /api/pricing/* surface only ever exposes the sell price. No
+// new pricing logic and no schema (additive read; no EF migration).
+admin.MapGet("/pricing/overview",
+        Tamma.Api.Endpoints.Admin.AdminPricingDashboardEndpoints.GetOverview)
+    .RequireAuthorization("PlatformOwnerAccess");
+
 // Story 28-11 — platform-admin tenant-status UX. List + detail surface the
 // Epic-28 shadow columns on tenants (Status, PlanId, KekVersion,
 // FailureReason, DeleteRequestedAt); action endpoints re-drive the Story

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -178,6 +178,11 @@ public class PlatformOwnerAccessPolicyTests
         // who is not a platform admin must NOT list/create/version/deprecate
         // plans or mint custom plans (AC10).
         "/api/admin/pricing/plans",
+        // Story 34-9 — the pricing DASHBOARD overview reveals platform-internal
+        // economics (list prices + margin knobs). Same Finding-C1 gate: a
+        // tenant-owner who is not a platform admin must NOT read it (the
+        // tenant-facing /api/pricing/* surface only ever exposes the sell price).
+        "/api/admin/pricing/overview",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingDashboardEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/AdminPricingDashboardEndpointsTests.cs
@@ -1,0 +1,296 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Dtos.Pricing;
+using Tamma.Api.Endpoints.Admin;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Tests.TestDoubles;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-9 — <see cref="AdminPricingDashboardEndpoints.GetOverview"/> against a
+/// real Postgres testcontainer. Pins the read-only aggregation contract: the
+/// admin catalog rows (every status + custom), each version's live
+/// <c>active</c>-tenant assignment count (counted by the version-pinned PlanId,
+/// so a deprecated version still shows its stranded tenants), and the
+/// active-only margin-config rollup. Also covers the empty-state (AC11 — no
+/// throw when nothing is seeded). The PlatformOwnerAccess 403 gate is pinned by
+/// <c>PlatformOwnerAccessPolicyTests</c>, which lists /api/admin/pricing/overview.
+/// </summary>
+[TestFixture]
+public class AdminPricingDashboardEndpointsTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("admin_pricing_dashboard_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewContext();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var ctx = NewContext();
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE tenant_plan_assignments CASCADE;");
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE tenants CASCADE;");
+        await ctx.Database.ExecuteSqlRawAsync(
+            "TRUNCATE plan_prices, plan_entitlements, plan_features, plans CASCADE;");
+        await ctx.Database.ExecuteSqlRawAsync("TRUNCATE margin_policies CASCADE;");
+    }
+
+    private ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static ClaimsPrincipal Actor() =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, "user-34-9"),
+            new Claim(JwtRegisteredClaimNames.Email, "owner@tamma.dev"),
+            new Claim("platformRole", "platform_admin"),
+        }, "test"));
+
+    private static void AssertStatus(IResult result, int expected)
+    {
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>();
+        ((IStatusCodeHttpResult)result).StatusCode.Should().Be(expected);
+    }
+
+    private static PlanCatalogService Catalog(ControlPlaneDbContext db) =>
+        new(db, NullLogger<PlanCatalogService>.Instance);
+
+    private static PlanVersionEditor Editor(ControlPlaneDbContext db, RecordingPlatformEventPublisher pub) =>
+        new(db, pub, TimeProvider.System, NullLogger<PlanVersionEditor>.Instance);
+
+    private static CreatePlanRequest ValidCreate(string slug, decimal recurringUsd = 49m) => new(
+        slug, $"{slug} plan", "monthly",
+        Features: new[] { new PlanFeatureDto("byok_allowed", true, null) },
+        Entitlements: new[] { new PlanEntitlementDto("seats", 5, "total", "block") },
+        Prices: new[] { new PlanPriceDto("platform_provided", recurringUsd, 15m, null) });
+
+    /// <summary>Create a public plan version through the real editor; return its (PlanId, Version).</summary>
+    private async Task<(Guid PlanId, int Version)> CreatePublicPlanAsync(string slug, decimal recurringUsd = 49m)
+    {
+        await using var db = NewContext();
+        var result = await AdminPlanCatalogEndpoints.CreatePlan(
+            ValidCreate(slug, recurringUsd), Editor(db, new RecordingPlatformEventPublisher()),
+            Catalog(db), Actor(), default);
+        AssertStatus(result, StatusCodes.Status201Created);
+
+        var row = await db.Plans.AsNoTracking().SingleAsync(p => p.Slug == slug && p.Status == "active");
+        return (row.Id, row.Version);
+    }
+
+    /// <summary>Seed a tenant + an assignment row pinned to (planId, planVersion).</summary>
+    private async Task SeedAssignmentAsync(Guid planId, int planVersion, string status = "active")
+    {
+        await using var db = NewContext();
+        var now = DateTime.UtcNow;
+        var tenant = new Tenant
+        {
+            Id = Guid.NewGuid(),
+            Name = $"t-{Guid.NewGuid():N}",
+            Slug = $"t-{Guid.NewGuid():N}",
+            Type = "personal",
+            Plan = "free",           // legacy column is CHECK-constrained to seeded slugs
+            Settings = "{}",
+            CreatedAt = now,
+            UpdatedAt = now,
+            ProvisioningState = "none",
+        };
+        db.Tenants.Add(tenant);
+        db.TenantPlanAssignments.Add(new TenantPlanAssignment
+        {
+            Id = Guid.NewGuid(),
+            TenantId = tenant.Id,
+            PlanId = planId,
+            PlanVersion = planVersion,
+            Status = status,
+            EffectiveFrom = now,
+            CreatedAt = now,
+            UpdatedAt = now,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private async Task SeedGlobalMarginAsync(decimal multiplier)
+    {
+        await using var db = NewContext();
+        await AdminPricingEndpoints.VersionMargin(
+            new VersionMarginRequest("global", null, multiplier, null),
+            db, new RecordingPlatformEventPublisher(), Actor(), TimeProvider.System, default);
+    }
+
+    private async Task<PricingOverviewResponse> GetOverviewAsync()
+    {
+        await using var db = NewContext();
+        var result = await AdminPricingDashboardEndpoints.GetOverview(Catalog(db), db, default);
+        AssertStatus(result, StatusCodes.Status200OK);
+        return (PricingOverviewResponse)((IValueHttpResult)result).Value!;
+    }
+
+    // ── Empty state (AC11) — nothing seeded must not throw and returns zeros ──
+    [Test]
+    public async Task GetOverview_EmptyCatalog_ReturnsEmpty_NoThrow()
+    {
+        var overview = await GetOverviewAsync();
+
+        overview.Plans.Should().BeEmpty();
+        overview.Totals.ActivePlanCount.Should().Be(0);
+        overview.Totals.CustomPlanCount.Should().Be(0);
+        overview.Totals.TotalActiveAssignments.Should().Be(0);
+        overview.Totals.PlansWithActiveAssignments.Should().Be(0);
+        overview.Margins.ActivePolicyCount.Should().Be(0);
+        overview.Margins.GlobalMarkupMultiplier.Should().BeNull();
+    }
+
+    // ── Core aggregation — plans, per-plan counts, margins, totals ──
+    [Test]
+    public async Task GetOverview_Aggregates_Plans_Assignments_And_Margins()
+    {
+        var (planA, verA) = await CreatePublicPlanAsync("startup", 49m);
+        var (planB, verB) = await CreatePublicPlanAsync("team", 199m);
+
+        // Two tenants on A, one on B, one CANCELLED on A (must NOT be counted).
+        await SeedAssignmentAsync(planA, verA);
+        await SeedAssignmentAsync(planA, verA);
+        await SeedAssignmentAsync(planB, verB);
+        await SeedAssignmentAsync(planA, verA, status: "cancelled");
+
+        await SeedGlobalMarginAsync(1.3m);
+
+        var overview = await GetOverviewAsync();
+
+        overview.Plans.Should().HaveCount(2);
+        var rowA = overview.Plans.Single(p => p.Slug == "startup");
+        rowA.ActiveTenantCount.Should().Be(2);
+        rowA.RecurringUsd.Should().Be(49m);
+        rowA.IsCustom.Should().BeFalse();
+        rowA.Status.Should().Be("active");
+
+        overview.Plans.Single(p => p.Slug == "team").ActiveTenantCount.Should().Be(1);
+
+        overview.Totals.ActivePlanCount.Should().Be(2);
+        overview.Totals.TotalActiveAssignments.Should().Be(3); // cancelled excluded
+        overview.Totals.PlansWithActiveAssignments.Should().Be(2);
+
+        overview.Margins.ActivePolicyCount.Should().Be(1);
+        overview.Margins.GlobalPolicyCount.Should().Be(1);
+        overview.Margins.GlobalMarkupMultiplier.Should().Be(1.3m);
+    }
+
+    // ── Custom plans are surfaced + flagged (dashboard shows the whole catalog) ──
+    [Test]
+    public async Task GetOverview_IncludesCustomPlan_FlaggedAndCounted()
+    {
+        // A bound tenant for the custom plan.
+        var tenantId = Guid.NewGuid();
+        await using (var db = NewContext())
+        {
+            var now = DateTime.UtcNow;
+            db.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = "enterprise-co",
+                Slug = "enterprise-co",
+                Type = "org",
+                Plan = "free",
+                Settings = "{}",
+                CreatedAt = now,
+                UpdatedAt = now,
+                ProvisioningState = "none",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await CreatePublicPlanAsync("startup");
+
+        await using (var db = NewContext())
+        {
+            var result = await AdminPlanCatalogEndpoints.CreateCustomPlan(
+                new CreateCustomPlanRequest(
+                    tenantId, "Bespoke Enterprise", "monthly",
+                    Features: null,
+                    Entitlements: new[] { new PlanEntitlementDto("seats", null, "total", "allow") },
+                    Prices: new[] { new PlanPriceDto("platform_provided", 5000m, 0m, null) }),
+                Editor(db, new RecordingPlatformEventPublisher()), Catalog(db), Actor(), default);
+            AssertStatus(result, StatusCodes.Status201Created);
+        }
+
+        var overview = await GetOverviewAsync();
+
+        overview.Plans.Should().Contain(p => p.IsCustom);
+        overview.Plans.Count(p => p.IsCustom).Should().Be(1);
+        overview.Totals.CustomPlanCount.Should().Be(1);
+        // The public "startup" plan is not double-counted as custom.
+        overview.Totals.ActivePlanCount.Should().Be(1);
+    }
+
+    // ── Deprecated version still counts its version-pinned tenants ──
+    [Test]
+    public async Task GetOverview_DeprecatedVersion_StillCountsPinnedTenants()
+    {
+        var (planV1, ver1) = await CreatePublicPlanAsync("pro");
+        await SeedAssignmentAsync(planV1, ver1); // a tenant stuck on v1
+
+        // Version the plan → v1 becomes deprecated, a fresh v2 is active.
+        await using (var db = NewContext())
+        {
+            var result = await AdminPlanCatalogEndpoints.VersionPlan(
+                "pro", new VersionPlanRequest(DisplayName: "pro v2"),
+                Editor(db, new RecordingPlatformEventPublisher()), Catalog(db), Actor(), default);
+            AssertStatus(result, StatusCodes.Status200OK);
+        }
+
+        var overview = await GetOverviewAsync();
+
+        var v1 = overview.Plans.Single(p => p.PlanId == planV1);
+        v1.Status.Should().Be("deprecated");
+        v1.ActiveTenantCount.Should().Be(1);
+
+        var v2 = overview.Plans.Single(p => p.Slug == "pro" && p.Status == "active");
+        v2.ActiveTenantCount.Should().Be(0);
+
+        overview.Totals.ActivePlanCount.Should().Be(1);        // only v2 is active+public
+        overview.Totals.DeprecatedPlanCount.Should().Be(1);    // v1
+        overview.Totals.TotalActiveAssignments.Should().Be(1); // the stranded tenant
+    }
+
+    // ── Margin rollup reflects only the ACTIVE policy after a supersede ──
+    [Test]
+    public async Task GetOverview_MarginRollup_ExcludesSupersededPolicies()
+    {
+        await SeedGlobalMarginAsync(1.3m);
+        await SeedGlobalMarginAsync(1.5m); // supersedes 1.3
+
+        var overview = await GetOverviewAsync();
+
+        overview.Margins.ActivePolicyCount.Should().Be(1);
+        overview.Margins.GlobalMarkupMultiplier.Should().Be(1.5m);
+    }
+}


### PR DESCRIPTION
## Scope note (important)

The Story 34-9 spec (`docs/stories/epic-34/story-34-9/…`) is a **React frontend** story (~30 files across `packages/dashboard` + `dashboard-user`, all UI ACs) that consumes already-shipped pricing endpoints. This PR delivers only the **backend read surface** that such a dashboard needs (per the story's AC-13 escape hatch: "thin additive DTO/route wiring where a dependency did not already expose a needed read; MUST NOT re-implement pricing logic"). **The React UI itself is NOT built here** — it's a separate frontend effort, deferred.

## What

`GET /api/admin/pricing/overview` (**PlatformOwnerAccess**) — one read-only aggregation over the merged Epic-34 backend:
- Plan catalog rows (all statuses + custom) via `IPlanCatalogService.ListAllForAdminAsync`.
- Per-plan **live tenant counts** — active `TenantPlanAssignment`s grouped by version-pinned `PlanId` (a deprecated version still shows its stranded tenants).
- Margin config rollup (active `MarginPolicy` by scope + global knobs).
- Headline totals (active/custom/deprecated plans, total active assignments, plans-with-assignments).

Reuses `IPlanCatalogService` + `ControlPlaneDbContext` reads — no pricing logic duplicated, **no migration**.

## Safety

`PlatformOwnerAccess`-only (pinned in `PlatformOwnerAccessPolicyTests` → owner/member 403). The response exposes list prices + margin knobs (platform-internal economics) which a tenant must never see — consistent with the 34-5 estimate-leak rule (tenant `/estimate` still returns sell price only). No cost/margin leak to tenants.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Tests: 459 passed (5 new). No C#13 array-in-EF / forbidden-symbol issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)