### PR TITLE
feat(epic-37): Story 37-2 — Tamper-Evident Hash-Chain over Audit Records

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/DeleteTenantStepActivities.cs
@@ -363,7 +363,11 @@ public sealed class BackupTenantDatabaseForDeleteActivity : CleanupStepActivity
 ///     feed is read back for incident review), <c>platform_analytics_hourly</c>
 ///     (immutable cross-tenant analytics fact table; <c>TenantId</c> NULLABLE,
 ///     the platform-wide rollup rows carry <c>TenantId=null</c> — purging a
-///     gone tenant's hourly rows would corrupt historical platform totals).
+///     gone tenant's hourly rows would corrupt historical platform totals),
+///     <c>audit_chain_checkpoints</c> (Story 37-2 — signed tamper-evidence
+///     anchors of the tenant's audit chain; <c>TenantId</c> NULLABLE, no FK, so
+///     no dangle. They are the compliance proof that the retained
+///     <c>audit_records</c> were not rewritten and MUST outlive the tenant).
 ///     All retained intentionally; NOT touched here.</description></item>
 ///   <item><description><b>Out of scope (tenant-schema, not CP)</b> —
 ///     <c>prompt_overrides</c>, <c>secrets</c> (tenant KEK-encrypted),

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditChainVerifyResponse.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Audit/AuditChainVerifyResponse.cs
@@ -1,0 +1,51 @@
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Dtos.Audit;
+
+/// <summary>
+/// Story 37-2 (AC8) — the wire shape of a chain-verify response:
+/// <c>{ status, firstBrokenLink?, lastCheckpoint }</c>. No record payload
+/// contents are exposed — only coordinates + hashes.
+/// </summary>
+public sealed record AuditChainVerifyResponse(
+    string Status,
+    string Scope,
+    Guid? TenantId,
+    long HeadSequence,
+    long RecordsVerified,
+    AuditChainBrokenLinkDto? FirstBrokenLink,
+    AuditChainCheckpointDto? LastCheckpoint)
+{
+    public static AuditChainVerifyResponse From(AuditChainScope scope, ChainVerificationResult r)
+    {
+        var link = r.FirstBrokenLink is null
+            ? null
+            : new AuditChainBrokenLinkDto(
+                r.FirstBrokenLink.RecordId,
+                r.FirstBrokenLink.ChainSequence,
+                r.FirstBrokenLink.Reason.ToString());
+
+        var cp = r.LastCheckpoint is null
+            ? null
+            : new AuditChainCheckpointDto(
+                r.LastCheckpoint.Id,
+                r.LastCheckpoint.HeadSequence,
+                r.LastCheckpoint.HeadHash,
+                r.LastCheckpoint.SignedAt,
+                r.LastCheckpoint.KeyVersion);
+
+        return new AuditChainVerifyResponse(
+            Status: r.Status == ChainVerificationStatus.Ok ? "ok" : "tampered",
+            Scope: scope.Discriminator,
+            TenantId: scope.TenantId,
+            HeadSequence: r.LastSequence,
+            RecordsVerified: r.RecordsVerified,
+            FirstBrokenLink: link,
+            LastCheckpoint: cp);
+    }
+}
+
+public sealed record AuditChainBrokenLinkDto(Guid? RecordId, long ChainSequence, string Reason);
+
+public sealed record AuditChainCheckpointDto(
+    Guid Id, long HeadSequence, string HeadHash, DateTime SignedAt, int KeyVersion);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdminEndpoints.cs
@@ -3,8 +3,10 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Auth;
 using Tamma.Api.Dtos.Admin;
+using Tamma.Api.Dtos.Audit;
 using Tamma.Api.Services;
 using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
 using Tamma.Api.Services.PromptStore;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Services.Provisioning;
@@ -557,5 +559,45 @@ public static class AdminEndpoints
         var result = await auditQuery.QueryPlatformAsync(
             callerUserId, filter, modeProvider.Mode, ct);
         return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Story 37-2 (AC8) — verify the platform audit hash-chain, or (with
+    /// <c>?tenantId=</c>) any tenant's chain. Gated <c>PlatformOwnerAccess</c> at
+    /// the wiring site. Without <c>tenantId</c> this reads ONLY the control-plane
+    /// chain; with it, that tenant's schema-resident chain. Optional
+    /// <c>from</c>/<c>to</c> bound the range.
+    /// </summary>
+    public static async Task<IResult> VerifyPlatformAudit(
+        IAuditChainVerificationService verification,
+        [FromQuery] Guid? tenantId,
+        [FromQuery] long? from,
+        [FromQuery] long? to,
+        CancellationToken ct)
+    {
+        var scope = tenantId is Guid t ? AuditChainScope.ForTenant(t) : AuditChainScope.Platform;
+        var result = await verification.VerifyAsync(scope, from, to, ct);
+        return Results.Ok(AuditChainVerifyResponse.From(scope, result));
+    }
+
+    /// <summary>
+    /// Story 37-2 (AC6) — on-demand: write a signed checkpoint anchoring the
+    /// current head of the platform chain, or (with <c>?tenantId=</c>) a tenant's
+    /// chain. Gated <c>PlatformOwnerAccess</c>. Returns 202 with the written
+    /// checkpoint, or 200 with <c>written=false</c> when the chain is empty.
+    /// </summary>
+    public static async Task<IResult> CheckpointAudit(
+        IAuditChainCheckpointService checkpoints,
+        [FromQuery] Guid? tenantId,
+        CancellationToken ct)
+    {
+        var scope = tenantId is Guid t ? AuditChainScope.ForTenant(t) : AuditChainScope.Platform;
+        var written = await checkpoints.WriteCheckpointAsync(scope, ct);
+        if (written is null)
+        {
+            return Results.Ok(new { written = false, scope = scope.Discriminator, tenantId });
+        }
+        return Results.Accepted(value: new AuditChainCheckpointDto(
+            written.Id, written.HeadSequence, written.HeadHash, written.SignedAt, written.KeyVersion));
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OrgEndpoints.cs
@@ -5,8 +5,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Auth;
 using Tamma.Api.Authorization;
+using Tamma.Api.Dtos.Audit;
 using Tamma.Api.Dtos.Orgs;
 using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Api.Services.RateLimit;
@@ -603,6 +605,33 @@ public static class OrgEndpoints
         var result = await auditQuery.QueryTenantAsync(
             tenantId, callerUserId, filter, modeProvider.Mode, ct);
         return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Story 37-2 (AC8/AC13) — verify THIS tenant's tamper-evident audit
+    /// hash-chain. <see cref="RequireTenantMembershipFilter"/> rejects
+    /// non-members (403); this handler additionally requires admin+ (a SaaS
+    /// <c>member</c> gets 403). The verify reads ONLY this tenant's chain (its
+    /// own schema) and never the platform chain or another tenant's. Optional
+    /// <c>from</c>/<c>to</c> bound the <c>chain_sequence</c> range.
+    /// </summary>
+    public static async Task<IResult> VerifyTenantAudit(
+        Guid tenantId,
+        IAuditChainVerificationService verification,
+        HttpContext httpContext,
+        [FromQuery] long? from,
+        [FromQuery] long? to,
+        CancellationToken ct)
+    {
+        var requesterRole = httpContext.Items[RequireTenantMembershipFilter.TenantRoleItemKey] as string;
+        if (requesterRole is null)
+            return Results.Json(new { error = "Not a member of this organization" }, statusCode: 403);
+        if (!TenantRoleHierarchy.IsAtLeast(requesterRole, TenantRoleHierarchy.Admin))
+            return Results.Json(new { error = "Requires admin role or higher" }, statusCode: 403);
+
+        var scope = AuditChainScope.ForTenant(tenantId);
+        var result = await verification.VerifyAsync(scope, from, to, ct);
+        return Results.Ok(AuditChainVerifyResponse.From(scope, result));
     }
 
     public static async Task<IResult> AcceptInvite(

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditChainServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AuditChainServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 37-2 — DI registration for the tamper-evident audit hash-chain: the
+/// pure verifier, the record/checkpoint read seams, the cabinet-backed signer,
+/// the checkpoint writer, the verification service, and the event emitter.
+/// Single entry-point (mirrors <c>AddTammaAuditProjection</c>). Idempotent.
+///
+/// <para>All services are request-scoped: they hang off the scoped
+/// <c>ControlPlaneDbContext</c> and the per-tenant context factory. The
+/// scheduler/workflow (<c>Tamma.ElsaServer</c>) creates its own DI scope per
+/// tick, exactly like the projector host.</para>
+/// </summary>
+public static class AuditChainServiceCollectionExtensions
+{
+    public static IServiceCollection AddTammaAuditChain(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton(TimeProvider.System);
+
+        // Read seams over the correct physical store (CP vs tenant schema).
+        services.TryAddScoped<IAuditChainRecordSource, AuditChainRecordSource>();
+        services.TryAddScoped<IAuditChainCheckpointGateway, AuditChainCheckpointGateway>();
+
+        // Cabinet-backed HMAC signer (fail-closed).
+        services.TryAddScoped<IAuditChainSigner, SecretCabinetAuditChainSigner>();
+
+        // Pure verifier + the request-facing service that emits events/alerts.
+        services.TryAddScoped<IAuditChainVerifier, AuditChainVerifier>();
+        services.TryAddScoped<IAuditChainEventEmitter, AuditChainEventEmitter>();
+        services.TryAddScoped<IAuditChainVerificationService, AuditChainVerificationService>();
+
+        // Checkpoint writer (on demand + scheduled).
+        services.TryAddScoped<IAuditChainCheckpointService, AuditChainCheckpointService>();
+
+        // Scheduled checkpoint host — opt-in (RunOnStartup defaults false), so it
+        // stays inert during tests / un-opted deployments (mirrors the projector).
+        services.TryAddSingleton<AuditChainCheckpointOptions>();
+        services.AddHostedService<AuditChainCheckpointScheduler>();
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1015,6 +1015,12 @@ builder.Services.AddTammaAlertRuleEngine();
 // background loop is opt-in (AuditProjectorOptions.RunOnStartup defaults false).
 builder.Services.AddTammaAuditProjection();
 
+// Story 37-2 — tamper-evident audit hash-chain: canonical hasher/verifier,
+// cabinet-backed checkpoint signer, verification + checkpoint-writer services,
+// and the AUDIT.CHAIN.* event emitter (raises a critical tamper alert). Scoped;
+// the checkpoint scheduler (Tamma.ElsaServer) creates its own per-tick scope.
+builder.Services.AddTammaAuditChain();
+
 // Story 37-10 — curated sensitive-action EMISSION seam (write side): the single
 // ISensitiveActionEmitter every sensitive-action call site (auth login/refresh,
 // API-key auth, BYOK provider-key changes, ...) appends through, plus the
@@ -1923,6 +1929,14 @@ v1Admin.MapPost("/alert-rules/{id:guid}/_test", AlertRuleEndpoints.TestFireRule)
 v1Admin.MapGet("/audit", AdminEndpoints.ListPlatformAudit)
     .RequireAuthorization("PlatformOwnerAccess");
 
+// Story 37-2 (AC8) — platform (or ?tenantId) audit hash-chain verification +
+// on-demand checkpoint. PlatformOwnerAccess (same gate as the platform audit
+// read). The tenant-scope verify lives on the org route below (tenant_admin+).
+v1Admin.MapGet("/audit/verify", AdminEndpoints.VerifyPlatformAudit)
+    .RequireAuthorization("PlatformOwnerAccess");
+v1Admin.MapPost("/audit/checkpoint", AdminEndpoints.CheckpointAudit)
+    .RequireAuthorization("PlatformOwnerAccess");
+
 // Story 29-3 — platform-scope secret-cabinet create + rotate. Both
 // return the newly-minted plaintext via a one-shot reveal token in
 // the response (no plaintext bytes in the body); the caller must
@@ -2020,6 +2034,9 @@ orgs.MapPost("/{tenantId:guid}/invites/{inviteId:guid}/resend", OrgEndpoints.Res
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 // Story 18-7: tenant-scoped audit log read for tenant admins.
 orgs.MapGet("/{tenantId:guid}/audit", OrgEndpoints.ListTenantAudit)
+    .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
+// Story 37-2 (AC8): tenant-scoped audit hash-chain verification (tenant_admin+).
+orgs.MapGet("/{tenantId:guid}/audit/verify", OrgEndpoints.VerifyTenantAudit)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
 orgs.MapPost("/{tenantId:guid}/transfer-ownership", OrgEndpoints.TransferOwnership)
     .AddEndpointFilter<Tamma.Api.Authorization.RequireTenantMembershipFilter>();
@@ -2754,7 +2771,7 @@ using (var scope = app.Services.CreateScope())
                     admin_impersonations,
                     agents, agent_versions, agent_role_selections,
                     tenant_agent_enablements,
-                    audit_records, audit_projector_cursor,
+                    audit_records, audit_projector_cursor, audit_chain_checkpoints,
                     billing_customers, billing_plan_prices,
                     billing_webhook_events, billing_subscriptions,
                     alert_delivery_attempts, alert_channels, alerts,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Alerts/Rules/BuiltInAlertRules.cs
@@ -89,5 +89,22 @@ public static class BuiltInAlertRules
             EventType: "SECRET.ROTATION.FAILED",
             Predicate: """{"op":"always"}""",
             ThrottleSeconds: 0),
+
+        // Story 37-2 (AC10) — audit hash-chain tamper. Fires on every
+        // AUDIT.CHAIN.TAMPER_DETECTED so detection fans out with no manual
+        // rule setup. Throttled to avoid a storm if a scan re-detects the
+        // same break on repeated verifies.
+        new BuiltInAlertRuleSpec(
+            BuiltInKey: "audit-chain-tamper",
+            Name: "audit-chain-tamper",
+            Description:
+                "The tamper-evident audit hash-chain detected a broken link " +
+                "(a record was modified, deleted, reordered, or a checkpoint " +
+                "signature failed). Scope {scope}, sequence {chainSequence}. " +
+                "Treat as a potential integrity incident.",
+            Severity: AlertSeverity.Critical,
+            EventType: "AUDIT.CHAIN.TAMPER_DETECTED",
+            Predicate: """{"op":"always"}""",
+            ThrottleSeconds: 300),
     };
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointGateway.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointGateway.cs
@@ -40,6 +40,18 @@ public sealed class AuditChainCheckpointGateway : IAuditChainCheckpointGateway
     public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
         _signer.VerifyAsync(checkpoint, ct);
 
+    public async Task<long?> GetMaxHeadSequenceAsync(AuditChainScope scope, CancellationToken ct)
+    {
+        var discriminator = scope.Discriminator;
+        var tenantId = scope.Kind == AuditChainScopeKind.Tenant ? scope.TenantId : null;
+
+        // Max<long?> over an empty set is null (no checkpoints for this scope yet).
+        return await _cp.AuditChainCheckpoints.AsNoTracking()
+            .Where(c => c.Scope == discriminator && c.TenantId == tenantId)
+            .MaxAsync(c => (long?)c.HeadSequence, ct)
+            .ConfigureAwait(false);
+    }
+
     internal static AuditChainCheckpointView ToView(AuditChainCheckpoint row) =>
         new()
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointGateway.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointGateway.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5/AC7) — the <see cref="IAuditChainCheckpointGateway"/> the
+/// verifier confirms anchors through. Checkpoint rows are ALWAYS control-plane
+/// resident (for platform AND tenant scopes), so this reads only the CP context;
+/// signature validation delegates to <see cref="IAuditChainSigner"/> (cabinet key).
+/// </summary>
+public sealed class AuditChainCheckpointGateway : IAuditChainCheckpointGateway
+{
+    private readonly ControlPlaneDbContext _cp;
+    private readonly IAuditChainSigner _signer;
+
+    public AuditChainCheckpointGateway(ControlPlaneDbContext cp, IAuditChainSigner signer)
+    {
+        _cp = cp ?? throw new ArgumentNullException(nameof(cp));
+        _signer = signer ?? throw new ArgumentNullException(nameof(signer));
+    }
+
+    public async Task<AuditChainCheckpointView?> GetLastCoveringAsync(
+        AuditChainScope scope, long? to, CancellationToken ct)
+    {
+        var discriminator = scope.Discriminator;
+        var tenantId = scope.Kind == AuditChainScopeKind.Tenant ? scope.TenantId : null;
+
+        var q = _cp.AuditChainCheckpoints.AsNoTracking()
+            .Where(c => c.Scope == discriminator && c.TenantId == tenantId);
+        if (to is long t) q = q.Where(c => c.HeadSequence <= t);
+
+        var row = await q.OrderByDescending(c => c.HeadSequence)
+            .FirstOrDefaultAsync(ct).ConfigureAwait(false);
+        return row is null ? null : ToView(row);
+    }
+
+    public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
+        _signer.VerifyAsync(checkpoint, ct);
+
+    internal static AuditChainCheckpointView ToView(AuditChainCheckpoint row) =>
+        new()
+        {
+            Id = row.Id,
+            Scope = row.Scope,
+            TenantId = row.TenantId,
+            HeadSequence = row.HeadSequence,
+            HeadHash = row.HeadHash,
+            SignedAt = row.SignedAt,
+            Signature = row.Signature,
+            KeyVersion = row.KeyVersion,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointScheduler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointScheduler.cs
@@ -1,0 +1,185 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC6) — options for <see cref="AuditChainCheckpointScheduler"/>.
+/// </summary>
+public sealed class AuditChainCheckpointOptions
+{
+    public const string SectionName = "AuditChainCheckpoint";
+
+    /// <summary>
+    /// When <c>true</c> the scheduler's loop runs once the host starts. Default
+    /// <c>false</c> (opt-in), mirroring <see cref="AuditProjectorOptions.RunOnStartup"/>
+    /// so the loop does not fire during tests / un-opted deployments.
+    /// </summary>
+    public bool RunOnStartup { get; set; }
+
+    /// <summary>Minute of the hour (UTC) to write checkpoints. Default 15.</summary>
+    public int FireAtMinute { get; set; } = 15;
+
+    /// <summary>Clock poll cadence. Default 30s.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>
+/// Story 37-2 (AC6) — periodically writes one signed checkpoint per active
+/// scope. Structurally the <c>AuditProjectorBackgroundService</c> host (per-tick
+/// DI scope, <c>RunOnStartup</c> gate, WARN-and-continue) combined with the
+/// <c>HourlyAnalyticsRollupScheduler</c>'s multi-pod leader election
+/// (<c>pg_try_advisory_lock</c> on the CP connection keyed by the hour) and
+/// <c>_lastFired</c> hour dedup.
+///
+/// <para><b>Placement note.</b> The spec sketched this as an Elsa-dispatched
+/// workflow in <c>Tamma.ElsaServer</c>; but the checkpoint logic
+/// (<see cref="IAuditChainCheckpointService"/>) lives in <c>Tamma.Api</c>, which
+/// the Elsa host / activities layer does not (and must not) reference. So — like
+/// the audit projector host — it runs as a Tamma.Api <see cref="BackgroundService"/>
+/// that invokes the service directly. On-demand checkpointing reuses the same
+/// service from the admin endpoint.</para>
+/// </summary>
+public sealed class AuditChainCheckpointScheduler : BackgroundService
+{
+    // "TAUD" high-half namespace + "CKPT" low-half — greppable in pg_locks.
+    private const long AdvisoryLockBase = (0x5441_5544L << 32) | 0x434B_5054L;
+
+    private readonly IServiceProvider _services;
+    private readonly AuditChainCheckpointOptions _options;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<AuditChainCheckpointScheduler> _logger;
+
+    private (int Year, int DayOfYear, int Hour) _lastFired;
+
+    public AuditChainCheckpointScheduler(
+        IServiceProvider services,
+        AuditChainCheckpointOptions options,
+        TimeProvider clock,
+        ILogger<AuditChainCheckpointScheduler> logger)
+    {
+        _services = services ?? throw new ArgumentNullException(nameof(services));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.RunOnStartup)
+        {
+            _logger.LogDebug(
+                "AuditChainCheckpointScheduler gated off (RunOnStartup=false); loop will not start.");
+            return;
+        }
+
+        _logger.LogInformation(
+            "AuditChainCheckpointScheduler running fireAtMinute={Minute} poll={PollSeconds}s",
+            _options.FireAtMinute, _options.PollInterval.TotalSeconds);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await TickAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "AuditChainCheckpointScheduler tick threw; continuing.");
+            }
+
+            try
+            {
+                await Task.Delay(_options.PollInterval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { break; }
+        }
+
+        _logger.LogInformation("AuditChainCheckpointScheduler shut down.");
+    }
+
+    /// <summary>Test-only single-tick driver (bypasses the loop + fire-minute gate).</summary>
+    public Task RunOnceAsync(CancellationToken ct) => WriteAllAsync(ct);
+
+    private async Task TickAsync(CancellationToken ct)
+    {
+        var now = _clock.GetUtcNow();
+        if (now.Minute < _options.FireAtMinute) return;
+        var hourKey = (now.Year, now.DayOfYear, now.Hour);
+        if (hourKey == _lastFired) return;
+
+        using var scope = _services.CreateScope();
+        var cp = scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+
+        // Multi-pod leader election on the CP connection: only the pod that wins
+        // pg_try_advisory_lock for this hour writes checkpoints. Non-Postgres
+        // (tests) → single-pod, always leader.
+        var lockKey = AdvisoryLockBase ^ ((long)hourKey.Year << 20) ^ (hourKey.DayOfYear * 64L + hourKey.Hour);
+        var isPg = cp.Database.IsNpgsql();
+        var conn = isPg ? (NpgsqlConnection)cp.Database.GetDbConnection() : null;
+        var opened = false;
+        var acquired = !isPg;
+
+        try
+        {
+            if (isPg && conn is not null)
+            {
+                if (conn.State != ConnectionState.Open)
+                {
+                    await conn.OpenAsync(ct).ConfigureAwait(false);
+                    opened = true;
+                }
+                await using var lockCmd = conn.CreateCommand();
+                lockCmd.CommandText = "SELECT pg_try_advisory_lock(@k);";
+                lockCmd.Parameters.AddWithValue("k", lockKey);
+                acquired = (bool?)await lockCmd.ExecuteScalarAsync(ct).ConfigureAwait(false) == true;
+            }
+
+            if (!acquired)
+            {
+                _lastFired = hourKey; // another pod owns this hour
+                _logger.LogInformation(
+                    "audit.chain.checkpoint.skipped_not_leader hour={Hour}", $"{now:yyyy-MM-dd HH:00}");
+                return;
+            }
+
+            var checkpoints = scope.ServiceProvider.GetRequiredService<IAuditChainCheckpointService>();
+            var written = await checkpoints.WriteAllActiveScopesAsync(ct).ConfigureAwait(false);
+            _lastFired = hourKey;
+            _logger.LogInformation(
+                "audit.chain.checkpoint.tick_complete hour={Hour} checkpointsWritten={Written}",
+                $"{now:yyyy-MM-dd HH:00}", written);
+        }
+        finally
+        {
+            if (isPg && conn is not null && acquired)
+            {
+                try
+                {
+                    await using var unlock = conn.CreateCommand();
+                    unlock.CommandText = "SELECT pg_advisory_unlock(@k);";
+                    unlock.Parameters.AddWithValue("k", lockKey);
+                    await unlock.ExecuteScalarAsync(ct).ConfigureAwait(false);
+                }
+                catch { /* closing the connection releases it anyway */ }
+            }
+            if (opened && conn is not null)
+            {
+                await conn.CloseAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    private async Task WriteAllAsync(CancellationToken ct)
+    {
+        using var scope = _services.CreateScope();
+        var checkpoints = scope.ServiceProvider.GetRequiredService<IAuditChainCheckpointService>();
+        await checkpoints.WriteAllActiveScopesAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainCheckpointService.cs
@@ -1,0 +1,127 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5/AC6) — writes signed chain checkpoints. Reads a scope's
+/// current head, signs the canonical anchor with the cabinet key, and persists a
+/// CP-resident <c>audit_chain_checkpoints</c> row, then emits
+/// <c>AUDIT.CHAIN.CHECKPOINTED</c>. Used both on demand (admin endpoint) and by
+/// the scheduled workflow (one checkpoint per active scope).
+/// </summary>
+public sealed class AuditChainCheckpointService : IAuditChainCheckpointService
+{
+    private readonly ControlPlaneDbContext _cp;
+    private readonly IAuditChainRecordSource _records;
+    private readonly IAuditChainSigner _signer;
+    private readonly IAuditChainEventEmitter _emitter;
+    private readonly TimeProvider _clock;
+    private readonly ILogger<AuditChainCheckpointService> _logger;
+
+    public AuditChainCheckpointService(
+        ControlPlaneDbContext cp,
+        IAuditChainRecordSource records,
+        IAuditChainSigner signer,
+        IAuditChainEventEmitter emitter,
+        TimeProvider clock,
+        ILogger<AuditChainCheckpointService> logger)
+    {
+        _cp = cp ?? throw new ArgumentNullException(nameof(cp));
+        _records = records ?? throw new ArgumentNullException(nameof(records));
+        _signer = signer ?? throw new ArgumentNullException(nameof(signer));
+        _emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AuditChainCheckpoint?> WriteCheckpointAsync(
+        AuditChainScope scope, CancellationToken ct = default)
+    {
+        var head = await _records.GetHeadAsync(scope, ct).ConfigureAwait(false);
+        if (head is null)
+        {
+            _logger.LogInformation(
+                "audit.chain.checkpoint.skipped_empty scope={Scope} tenantId={TenantId}",
+                scope.Discriminator, scope.TenantId);
+            return null; // nothing to anchor yet
+        }
+
+        var signedAt = _clock.GetUtcNow().UtcDateTime;
+        var (signature, keyVersion) = await _signer.SignAsync(
+            scope.Discriminator, scope.TenantId, head.Sequence, head.RecordHash, signedAt, ct)
+            .ConfigureAwait(false);
+
+        var checkpoint = new AuditChainCheckpoint
+        {
+            Id = Guid.NewGuid(),
+            Scope = scope.Discriminator,
+            TenantId = scope.Kind == AuditChainScopeKind.Tenant ? scope.TenantId : null,
+            HeadSequence = head.Sequence,
+            HeadHash = head.RecordHash,
+            SignedAt = signedAt,
+            Signature = signature,
+            KeyVersion = keyVersion,
+            CreatedAt = signedAt,
+        };
+        _cp.AuditChainCheckpoints.Add(checkpoint);
+        await _cp.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "audit.chain.checkpoint.written scope={Scope} tenantId={TenantId} "
+            + "headSequence={HeadSequence} keyVersion={KeyVersion}",
+            scope.Discriminator, scope.TenantId, head.Sequence, keyVersion);
+
+        await _emitter.EmitCheckpointedAsync(scope, head.Sequence, keyVersion, ct)
+            .ConfigureAwait(false);
+        return checkpoint;
+    }
+
+    public async Task<int> WriteAllActiveScopesAsync(CancellationToken ct = default)
+    {
+        var written = 0;
+
+        // Platform / single-user chain (CP-resident audit_records).
+        try
+        {
+            if (await WriteCheckpointAsync(AuditChainScope.Platform, ct).ConfigureAwait(false) is not null)
+            {
+                written++;
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "audit.chain.checkpoint.platform_failed — continuing.");
+        }
+
+        // Each active tenant's chain.
+        var tenantIds = await _cp.Tenants.AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct).ConfigureAwait(false);
+
+        foreach (var tid in tenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+            try
+            {
+                if (await WriteCheckpointAsync(AuditChainScope.ForTenant(tid), ct)
+                    .ConfigureAwait(false) is not null)
+                {
+                    written++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "audit.chain.checkpoint.tenant_failed tenantId={TenantId} — continuing.", tid);
+            }
+        }
+
+        return written;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventEmitter.cs
@@ -1,0 +1,171 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Alerts;
+using Tamma.Core.Audit;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC9/AC10) — emits the <c>AUDIT.CHAIN.*</c> DCB events and raises
+/// the critical tamper alert. Plane routing mirrors <see cref="AlertEventEmitter"/>:
+/// tenant-scope events go to the tenant's <c>domain_events</c> via
+/// <see cref="IEventRepository"/>; platform-scope events go to
+/// <c>platform_events</c> via <see cref="IPlatformEventPublisher"/>. No record
+/// payload contents are ever copied into event data — only hashes + coordinates.
+/// </summary>
+public sealed class AuditChainEventEmitter : IAuditChainEventEmitter
+{
+    private static readonly JsonSerializerOptions JsonOpts = new() { WriteIndented = false };
+
+    private readonly IEventRepository _events;
+    private readonly IPlatformEventPublisher _platform;
+    private readonly IAlertSink _alerts;
+    private readonly ILogger<AuditChainEventEmitter> _logger;
+
+    public AuditChainEventEmitter(
+        IEventRepository events,
+        IPlatformEventPublisher platform,
+        IAlertSink alerts,
+        ILogger<AuditChainEventEmitter> logger)
+    {
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _platform = platform ?? throw new ArgumentNullException(nameof(platform));
+        _alerts = alerts ?? throw new ArgumentNullException(nameof(alerts));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task EmitVerifiedAsync(
+        AuditChainScope scope, ChainVerificationResult result, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["tenantId"] = scope.TenantId?.ToString(),
+            ["chainSequence"] = result.LastSequence.ToString(),
+        };
+        var data = new Dictionary<string, object?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["recordsVerified"] = result.RecordsVerified,
+            ["headSequence"] = result.LastSequence,
+            ["lastCheckpointSequence"] = result.LastCheckpoint?.HeadSequence,
+        };
+        await EmitAsync(AuditChainEventTypes.Verified, scope, tags, data, ct).ConfigureAwait(false);
+    }
+
+    public async Task EmitTamperAsync(
+        AuditChainScope scope, ChainVerificationResult result, CancellationToken ct)
+    {
+        var link = result.FirstBrokenLink;
+        var tags = new Dictionary<string, string?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["tenantId"] = scope.TenantId?.ToString(),
+            ["chainSequence"] = link?.ChainSequence.ToString(),
+            ["reason"] = link?.Reason.ToString(),
+        };
+        var data = new Dictionary<string, object?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["reason"] = link?.Reason.ToString(),
+            ["chainSequence"] = link?.ChainSequence,
+            ["recordId"] = link?.RecordId?.ToString(),
+            ["recordsVerified"] = result.RecordsVerified,
+        };
+        await EmitAsync(AuditChainEventTypes.TamperDetected, scope, tags, data, ct)
+            .ConfigureAwait(false);
+
+        // AC10 — a tamper always raises a CRITICAL alert. Tenant-scope tampering
+        // sets TenantId (tenant feed); platform-scope leaves it null (admin feed).
+        try
+        {
+            await _alerts.RaiseAsync(new AlertPayload(
+                Severity: AlertSeverity.Critical,
+                Title: $"Audit chain tamper detected ({scope.Discriminator})",
+                Description:
+                    $"Chain verification found a broken link — reason={link?.Reason}, "
+                    + $"chainSequence={link?.ChainSequence}. The audit trail for scope "
+                    + $"'{scope.Discriminator}'"
+                    + (scope.TenantId is Guid t ? $" (tenant {t})" : string.Empty)
+                    + " may have been modified, deleted, reordered, or its checkpoint forged.",
+                CorrelationId: null,
+                TenantId: scope.TenantId,
+                RuleId: null,
+                Metadata: new Dictionary<string, object?>
+                {
+                    ["scope"] = scope.Discriminator,
+                    ["reason"] = link?.Reason.ToString(),
+                    ["chainSequence"] = link?.ChainSequence,
+                }), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to raise critical alert for AUDIT.CHAIN.TAMPER_DETECTED (scope {Scope}).",
+                scope.Discriminator);
+        }
+    }
+
+    public async Task EmitCheckpointedAsync(
+        AuditChainScope scope, long headSequence, int keyVersion, CancellationToken ct)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["tenantId"] = scope.TenantId?.ToString(),
+            ["chainSequence"] = headSequence.ToString(),
+        };
+        var data = new Dictionary<string, object?>
+        {
+            ["scope"] = scope.Discriminator,
+            ["headSequence"] = headSequence,
+            ["keyVersion"] = keyVersion,
+        };
+        await EmitAsync(AuditChainEventTypes.Checkpointed, scope, tags, data, ct)
+            .ConfigureAwait(false);
+    }
+
+    private async Task EmitAsync(
+        string type, AuditChainScope scope,
+        Dictionary<string, string?> tags, Dictionary<string, object?> data,
+        CancellationToken ct)
+    {
+        try
+        {
+            if (scope.Kind == AuditChainScopeKind.Tenant && scope.TenantId is Guid tenantId)
+            {
+                await _events.AppendAsync(new DomainEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = type,
+                    TenantId = tenantId,
+                    Tags = JsonSerializer.Serialize(tags, JsonOpts),
+                    Metadata = """{"eventSource":"system","workflowVersion":"1.0.0"}""",
+                    Data = JsonSerializer.Serialize(data, JsonOpts),
+                }).ConfigureAwait(false);
+            }
+            else
+            {
+                await _platform.AppendAndPublishAsync(new PlatformEvent
+                {
+                    Id = Guid.NewGuid(),
+                    Type = type,
+                    TenantId = null,
+                    Tags = JsonSerializer.Serialize(tags, JsonOpts),
+                    Metadata = """{"eventSource":"system","workflowVersion":"1.0.0"}""",
+                    Data = JsonSerializer.Serialize(data, JsonOpts),
+                    CreatedAt = DateTime.UtcNow,
+                }, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "AUDIT.CHAIN event {Type} emission failed (scope {Scope}).",
+                type, scope.Discriminator);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainEventTypes.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC9/AC10) — DCB event-type constants for the audit hash-chain.
+/// Plane-routed like <c>AlertEventEmitter</c>: tenant-scope → the tenant's
+/// <c>domain_events</c>; platform-scope → <c>platform_events</c>.
+/// </summary>
+public static class AuditChainEventTypes
+{
+    /// <summary>A clean verification of a chain range.</summary>
+    public const string Verified = "AUDIT.CHAIN.VERIFIED";
+
+    /// <summary>A tamper (broken link) was detected — raises a critical alert.</summary>
+    public const string TamperDetected = "AUDIT.CHAIN.TAMPER_DETECTED";
+
+    /// <summary>A signed checkpoint was written for a scope.</summary>
+    public const string Checkpointed = "AUDIT.CHAIN.CHECKPOINTED";
+
+    /// <summary>Built-in alert rule key seeded for the tamper event.</summary>
+    public const string TamperAlertRuleKey = "audit-chain-tamper";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainRecordSource.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainRecordSource.cs
@@ -1,0 +1,122 @@
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 — the <see cref="IAuditChainRecordSource"/> the verifier reads
+/// through. Resolves the correct physical store per scope: the control-plane
+/// context for <see cref="AuditChainScopeKind.Platform"/> (the platform /
+/// single-user chain) and the tenant's own schema (via
+/// <see cref="ITenantDbContextFactory"/>) for
+/// <see cref="AuditChainScopeKind.Tenant"/>. Streams ascending by
+/// <c>chain_sequence</c> and never materializes the whole chain (AC4/AC12).
+/// </summary>
+public sealed class AuditChainRecordSource : IAuditChainRecordSource
+{
+    private readonly ControlPlaneDbContext _cp;
+    private readonly ITenantDbContextFactory? _tenantFactory;
+
+    public AuditChainRecordSource(
+        ControlPlaneDbContext cp, ITenantDbContextFactory? tenantFactory = null)
+    {
+        _cp = cp ?? throw new ArgumentNullException(nameof(cp));
+        _tenantFactory = tenantFactory;
+    }
+
+    public async IAsyncEnumerable<AuditChainRecordView> StreamAsync(
+        AuditChainScope scope, long? from, long? to,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        if (scope.Kind == AuditChainScopeKind.Tenant)
+        {
+            if (_tenantFactory is null || scope.TenantId is not Guid tid)
+            {
+                yield break;
+            }
+            await using var tenantCtx = await _tenantFactory.CreateAsync(tid, ct)
+                .ConfigureAwait(false);
+            await foreach (var v in QueryAsync(tenantCtx, scope, from, to, ct)
+                .ConfigureAwait(false))
+            {
+                yield return v;
+            }
+            yield break;
+        }
+
+        await foreach (var v in QueryAsync(_cp, scope, from, to, ct).ConfigureAwait(false))
+        {
+            yield return v;
+        }
+    }
+
+    public async Task<string?> GetRecordHashAtAsync(
+        AuditChainScope scope, long sequence, CancellationToken ct)
+    {
+        if (scope.Kind == AuditChainScopeKind.Tenant)
+        {
+            if (_tenantFactory is null || scope.TenantId is not Guid tid) return null;
+            await using var tenantCtx = await _tenantFactory.CreateAsync(tid, ct)
+                .ConfigureAwait(false);
+            return await HashAtAsync(tenantCtx, sequence, ct).ConfigureAwait(false);
+        }
+        return await HashAtAsync(_cp, sequence, ct).ConfigureAwait(false);
+    }
+
+    public async Task<AuditChainHead?> GetHeadAsync(AuditChainScope scope, CancellationToken ct)
+    {
+        if (scope.Kind == AuditChainScopeKind.Tenant)
+        {
+            if (_tenantFactory is null || scope.TenantId is not Guid tid) return null;
+            await using var tenantCtx = await _tenantFactory.CreateAsync(tid, ct)
+                .ConfigureAwait(false);
+            return await HeadAsync(tenantCtx, ct).ConfigureAwait(false);
+        }
+        return await HeadAsync(_cp, ct).ConfigureAwait(false);
+    }
+
+    private static async Task<AuditChainHead?> HeadAsync(DbContext ctx, CancellationToken ct)
+    {
+        var head = await ctx.Set<AuditRecord>().AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(r => r.ChainSequence != null)
+            .OrderByDescending(r => r.ChainSequence)
+            .Select(r => new { r.ChainSequence, r.RecordHash })
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+        return head?.ChainSequence is long seq && head.RecordHash is not null
+            ? new AuditChainHead(seq, head.RecordHash)
+            : null;
+    }
+
+    private static async IAsyncEnumerable<AuditChainRecordView> QueryAsync(
+        DbContext ctx, AuditChainScope scope, long? from, long? to,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        IQueryable<AuditRecord> q = ctx.Set<AuditRecord>().AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(r => r.ChainSequence != null);
+        if (from is long f) q = q.Where(r => r.ChainSequence >= f);
+        if (to is long t) q = q.Where(r => r.ChainSequence <= t);
+        q = q.OrderBy(r => r.ChainSequence);
+
+        await foreach (var r in q.AsAsyncEnumerable().WithCancellation(ct).ConfigureAwait(false))
+        {
+            yield return AuditRecordChainMapper.ToView(r, scope);
+        }
+    }
+
+    private static async Task<string?> HashAtAsync(
+        DbContext ctx, long sequence, CancellationToken ct) =>
+        await ctx.Set<AuditRecord>().AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(r => r.ChainSequence == sequence)
+            .Select(r => r.RecordHash)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainVerificationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/AuditChainVerificationService.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC4/AC8/AC9/AC10) — the request-facing verification entry point.
+/// Runs the pure <see cref="IAuditChainVerifier"/> over a scope's chain, then
+/// emits <c>AUDIT.CHAIN.VERIFIED</c> or <c>AUDIT.CHAIN.TAMPER_DETECTED</c> (the
+/// latter also raising a critical alert). Endpoints call this so the emit +
+/// alert side-effects happen in exactly one place.
+/// </summary>
+public sealed class AuditChainVerificationService : IAuditChainVerificationService
+{
+    private readonly IAuditChainVerifier _verifier;
+    private readonly IAuditChainEventEmitter _emitter;
+    private readonly ILogger<AuditChainVerificationService> _logger;
+
+    public AuditChainVerificationService(
+        IAuditChainVerifier verifier,
+        IAuditChainEventEmitter emitter,
+        ILogger<AuditChainVerificationService> logger)
+    {
+        _verifier = verifier ?? throw new ArgumentNullException(nameof(verifier));
+        _emitter = emitter ?? throw new ArgumentNullException(nameof(emitter));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ChainVerificationResult> VerifyAsync(
+        AuditChainScope scope, long? from, long? to, CancellationToken ct = default)
+    {
+        var result = await _verifier.VerifyAsync(scope, from, to, ct).ConfigureAwait(false);
+
+        if (result.Status == ChainVerificationStatus.Tampered)
+        {
+            _logger.LogError(
+                "audit.chain.tamper_detected scope={Scope} tenantId={TenantId} "
+                + "reason={Reason} chainSequence={ChainSequence}",
+                scope.Discriminator, scope.TenantId,
+                result.FirstBrokenLink?.Reason, result.FirstBrokenLink?.ChainSequence);
+            await _emitter.EmitTamperAsync(scope, result, ct).ConfigureAwait(false);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "audit.chain.verified scope={Scope} tenantId={TenantId} "
+                + "recordsVerified={Records} headSequence={Head}",
+                scope.Discriminator, scope.TenantId, result.RecordsVerified, result.LastSequence);
+            await _emitter.EmitVerifiedAsync(scope, result, ct).ConfigureAwait(false);
+        }
+
+        return result;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainCheckpointService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainCheckpointService.cs
@@ -1,0 +1,24 @@
+using Tamma.Core.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5/AC6) — writes signed chain checkpoints (on demand + scheduled).
+/// </summary>
+public interface IAuditChainCheckpointService
+{
+    /// <summary>
+    /// Write one signed checkpoint anchoring the current head of
+    /// <paramref name="scope"/>. Returns null (no-op) when the chain is empty.
+    /// </summary>
+    Task<AuditChainCheckpoint?> WriteCheckpointAsync(
+        AuditChainScope scope, CancellationToken ct = default);
+
+    /// <summary>
+    /// Write one checkpoint for the platform chain and one per active tenant
+    /// chain. Failure-isolated per scope. Returns the number of checkpoints
+    /// written.
+    /// </summary>
+    Task<int> WriteAllActiveScopesAsync(CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainEventEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainEventEmitter.cs
@@ -1,0 +1,15 @@
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC9/AC10) — emits <c>AUDIT.CHAIN.*</c> DCB events and raises the
+/// critical tamper alert. Plane-routed (tenant vs platform) like the alert
+/// pipeline.
+/// </summary>
+public interface IAuditChainEventEmitter
+{
+    Task EmitVerifiedAsync(AuditChainScope scope, ChainVerificationResult result, CancellationToken ct);
+    Task EmitTamperAsync(AuditChainScope scope, ChainVerificationResult result, CancellationToken ct);
+    Task EmitCheckpointedAsync(AuditChainScope scope, long headSequence, int keyVersion, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainSigner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainSigner.cs
@@ -1,0 +1,29 @@
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5) — signs / verifies audit-chain checkpoint anchors using a
+/// key from the Epic 29 secret cabinet. Fail-closed: signing throws and
+/// verification returns false when the key is unavailable — a missing key never
+/// silently produces an "unsigned but valid-looking" anchor.
+/// </summary>
+public interface IAuditChainSigner
+{
+    /// <summary>
+    /// Sign the canonical preimage of a checkpoint anchor. Returns the signature
+    /// bytes and the cabinet <c>key_version</c> that produced them (so rotation
+    /// does not strand historical checkpoints). Throws when no signing key is
+    /// available.
+    /// </summary>
+    Task<(byte[] Signature, int KeyVersion)> SignAsync(
+        string scope, Guid? tenantId, long headSequence, string headHashHex,
+        DateTime signedAt, CancellationToken ct = default);
+
+    /// <summary>
+    /// Validate a persisted checkpoint's signature against the cabinet key for
+    /// its <c>key_version</c>. Returns false on any mismatch OR when the key is
+    /// unavailable (fail-closed).
+    /// </summary>
+    Task<bool> VerifyAsync(AuditChainCheckpointView checkpoint, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainVerificationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/IAuditChainVerificationService.cs
@@ -1,0 +1,13 @@
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 — verifies a scope's chain AND emits the resulting DCB event +
+/// critical tamper alert. The single request-facing verification seam.
+/// </summary>
+public interface IAuditChainVerificationService
+{
+    Task<ChainVerificationResult> VerifyAsync(
+        AuditChainScope scope, long? from, long? to, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SecretCabinetAuditChainSigner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Audit/SecretCabinetAuditChainSigner.cs
@@ -1,0 +1,91 @@
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Services.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5) — default <see cref="IAuditChainSigner"/>. Resolves the
+/// HMAC-SHA256 signing key from the Epic 29 cabinet via
+/// <see cref="IRuntimeSecretResolver"/> — the same seam Story 35-5's Stripe
+/// signing secret uses (cabinet-first, with the Story 29-9 coexistence-window
+/// config fallback). The key material only ever travels the cabinet's
+/// out-of-band path; no plaintext env key is invented as the source of truth.
+///
+/// <para><b>Fail-closed (AC5):</b> when the cabinet has no key,
+/// <see cref="SignAsync"/> throws and <see cref="VerifyAsync"/> returns false —
+/// a missing key is never treated as "valid".</para>
+///
+/// <para><b>Key version.</b> Each checkpoint records the
+/// <see cref="AuditChainSigningKeyVersion"/> that signed it so a future rotation
+/// can validate historical anchors against the version that produced them. The
+/// resolver seam currently exposes only the ACTIVE version's plaintext, so
+/// verification uses the active key; multi-version key retention is a documented
+/// follow-up gated on the cabinet exposing versioned plaintext reads.</para>
+/// </summary>
+public sealed class SecretCabinetAuditChainSigner : IAuditChainSigner
+{
+    /// <summary>The key version stamped on new checkpoints (see class remarks).</summary>
+    public const int AuditChainSigningKeyVersion = 1;
+
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// DI ctor. Resolves <see cref="IRuntimeSecretResolver"/> LAZILY via the
+    /// provider (mirrors <c>StripeSigningSecretSource</c>) so the signer stays
+    /// constructible even in composition roots — e.g. tests — that do not wire
+    /// the stopgap resolver. When the resolver is absent, signing fails closed.
+    /// </summary>
+    public SecretCabinetAuditChainSigner(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+    }
+
+    public async Task<(byte[] Signature, int KeyVersion)> SignAsync(
+        string scope, Guid? tenantId, long headSequence, string headHashHex,
+        DateTime signedAt, CancellationToken ct = default)
+    {
+        var key = await ResolveKeyAsync(ct).ConfigureAwait(false);
+        if (key is null)
+        {
+            throw new InvalidOperationException(
+                "audit chain signing key is not available in the cabinet "
+                + $"('{StopgapSecretMap.PlatformAuditChainSigningKey}'); cannot sign a "
+                + "checkpoint. Provision the key (Story 29-9 migrate-secrets) — the chain "
+                + "must fail closed rather than emit an unsigned anchor.");
+        }
+
+        var preimage = AuditChainCheckpointCanonicalizer.PreimageBytes(
+            scope, tenantId, headSequence, headHashHex, signedAt);
+        var signature = HMACSHA256.HashData(key, preimage);
+        return (signature, AuditChainSigningKeyVersion);
+    }
+
+    public async Task<bool> VerifyAsync(
+        AuditChainCheckpointView checkpoint, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(checkpoint);
+
+        var key = await ResolveKeyAsync(ct).ConfigureAwait(false);
+        if (key is null) return false; // fail-closed
+
+        var preimage = AuditChainCheckpointCanonicalizer.PreimageBytes(
+            checkpoint.Scope, checkpoint.TenantId, checkpoint.HeadSequence,
+            checkpoint.HeadHash, checkpoint.SignedAt);
+        var expected = HMACSHA256.HashData(key, preimage);
+        return CryptographicOperations.FixedTimeEquals(expected, checkpoint.Signature);
+    }
+
+    private async Task<byte[]?> ResolveKeyAsync(CancellationToken ct)
+    {
+        var resolver = _serviceProvider.GetService<IRuntimeSecretResolver>();
+        if (resolver is null) return null; // resolver not wired → fail-closed
+
+        var material = await resolver
+            .GetAsync(StopgapSecretMap.PlatformAuditChainSigningKey, ct)
+            .ConfigureAwait(false);
+        return string.IsNullOrEmpty(material) ? null : Encoding.UTF8.GetBytes(material);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/StopgapSecretMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Secrets/Stopgap/StopgapSecretMap.cs
@@ -33,6 +33,14 @@ public static class StopgapSecretMap
     public const string PlatformTenantSharedSecret = "hmac/shared-engine";
 
     /// <summary>
+    /// Story 37-2 — HMAC key that signs audit hash-chain checkpoints. Sourced
+    /// from the cabinet (never a plaintext env key at rest); the config/env
+    /// fallback here exists only for the Story 29-9 coexistence window, exactly
+    /// like every other platform HMAC secret.
+    /// </summary>
+    public const string PlatformAuditChainSigningKey = "audit/chain-signing-key";
+
+    /// <summary>
     /// Table of every platform-scoped stopgap. The migration service
     /// walks this list in order, skipping entries already present in
     /// the cabinet, and emits one
@@ -91,6 +99,13 @@ public static class StopgapSecretMap
                 Purpose: SecretPurpose.HmacSharedSecret,
                 Consumer: new ConsumerRef("tamma-engine", "request-signing"),
                 RotationDays: 30),
+            new StopgapSecretDescriptor(
+                CabinetName: PlatformAuditChainSigningKey,
+                ConfigKeys: new[] { "Audit:ChainSigningKey" },
+                EnvVars: new[] { "AUDIT_CHAIN_SIGNING_KEY" },
+                Purpose: SecretPurpose.HmacSharedSecret,
+                Consumer: new ConsumerRef("audit-chain", "checkpoint-signing"),
+                RotationDays: 90),
         };
 }
 

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainCheckpointCanonicalizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainCheckpointCanonicalizer.cs
@@ -1,0 +1,47 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5) — builds the deterministic preimage a checkpoint signature
+/// is computed over: <c>canonical(scope ‖ head_sequence ‖ head_hash ‖ signed_at)</c>.
+/// Shared by the signer (write) and the verifier (read) so both sides sign /
+/// validate byte-identical input. Same length-prefixed, invariant-culture,
+/// version-pinned discipline as <see cref="AuditRecordCanonicalizer"/>.
+/// </summary>
+public static class AuditChainCheckpointCanonicalizer
+{
+    /// <summary>Deterministic bytes to sign / verify for one checkpoint anchor.</summary>
+    public static byte[] PreimageBytes(
+        string scope, Guid? tenantId, long headSequence, string headHashHex, DateTime signedAt)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        ArgumentNullException.ThrowIfNull(headHashHex);
+
+        using var ms = new MemoryStream(128);
+        ms.WriteByte(AuditChainGenesis.CanonicalVersion);
+        WriteString(ms, scope);
+        WriteString(ms, tenantId?.ToString("D") ?? string.Empty);
+        WriteInt64(ms, headSequence);
+        WriteString(ms, headHashHex);
+        WriteString(ms, AuditRecordCanonicalizer.FormatTimestamp(signedAt));
+        return ms.ToArray();
+    }
+
+    private static void WriteString(Stream s, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        Span<byte> len = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(len, bytes.Length);
+        s.Write(len);
+        s.Write(bytes, 0, bytes.Length);
+    }
+
+    private static void WriteInt64(Stream s, long value)
+    {
+        Span<byte> b = stackalloc byte[8];
+        BinaryPrimitives.WriteInt64BigEndian(b, value);
+        s.Write(b);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainCheckpointView.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainCheckpointView.cs
@@ -1,0 +1,25 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5) — a storage-agnostic view of one signed chain checkpoint: a
+/// cabinet-key-signed anchor of a chain head at a point in time. Used by the
+/// verifier to confirm the recomputed head matches the signed anchor.
+/// </summary>
+public sealed record AuditChainCheckpointView
+{
+    public required Guid Id { get; init; }
+    public required string Scope { get; init; }
+    public Guid? TenantId { get; init; }
+    public required long HeadSequence { get; init; }
+
+    /// <summary>The chain head hash (lowercase-hex) this checkpoint anchors.</summary>
+    public required string HeadHash { get; init; }
+
+    public required DateTime SignedAt { get; init; }
+
+    /// <summary>The HMAC signature bytes over the canonical checkpoint preimage.</summary>
+    public required byte[] Signature { get; init; }
+
+    /// <summary>Which cabinet signing-key version produced <see cref="Signature"/>.</summary>
+    public required int KeyVersion { get; init; }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainGenesis.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainGenesis.cs
@@ -1,0 +1,41 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 — the well-known, PUBLIC genesis anchor for every audit
+/// hash-chain (per-tenant and platform). It is NOT a secret; its only job is to
+/// give the first record in a scope a deterministic <c>prev_hash</c> so an
+/// external auditor can reproduce the whole chain from a documented starting
+/// point.
+///
+/// <para>The genesis hash is <c>SHA-256("tamma.audit.chain.genesis.v1")</c>,
+/// rendered lowercase-hex. Because the preimage is documented inline, anyone
+/// can recompute it and verify the chain independently.</para>
+///
+/// <para><see cref="CanonicalVersion"/> is mixed into every canonical
+/// serialization so a future format change is a NEW version (detectable),
+/// never a silent edit that would invalidate historical records.</para>
+/// </summary>
+public static class AuditChainGenesis
+{
+    /// <summary>The documented genesis preimage — a public constant string.</summary>
+    public const string Preimage = "tamma.audit.chain.genesis.v1";
+
+    /// <summary>
+    /// Canonicalization format version. Bump ONLY when the canonical field
+    /// order / encoding changes; a bump makes old records verify under the old
+    /// version and new records under the new one instead of silently breaking.
+    /// </summary>
+    public const byte CanonicalVersion = 1;
+
+    /// <summary>The 32-byte genesis hash, lowercase-hex (64 chars).</summary>
+    public static readonly string HashHex = ComputeGenesisHex();
+
+    private static string ComputeGenesisHex()
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(Preimage));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainHasher.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainHasher.cs
@@ -1,0 +1,49 @@
+using System.Security.Cryptography;
+
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 — composes a record's hash from the prior record's hash and the
+/// canonical bytes: <c>record_hash = SHA-256( prev_hash ‖ canonical(record) )</c>.
+///
+/// <para>The previous hash is folded in as its RAW 32 bytes (decoded from the
+/// stored lowercase-hex), so the chain binds to the actual prior digest rather
+/// than to its text encoding. The result is returned as lowercase-hex to match
+/// the reserved <c>record_hash</c>/<c>prev_hash</c> varchar columns.</para>
+/// </summary>
+public static class AuditChainHasher
+{
+    /// <summary>Length in hex chars of a SHA-256 digest.</summary>
+    public const int HexLength = 64;
+
+    /// <summary>
+    /// Compose the next hash from the previous hash (lowercase-hex) and the
+    /// canonical bytes. Returns lowercase-hex (64 chars).
+    /// </summary>
+    public static string ComposeHex(string prevHashHex, byte[] canonical)
+    {
+        ArgumentNullException.ThrowIfNull(prevHashHex);
+        ArgumentNullException.ThrowIfNull(canonical);
+
+        var prev = DecodeHex(prevHashHex);
+        using var sha = SHA256.Create();
+        sha.TransformBlock(prev, 0, prev.Length, null, 0);
+        sha.TransformFinalBlock(canonical, 0, canonical.Length);
+        return Convert.ToHexString(sha.Hash!).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Decode a lowercase/uppercase-hex 32-byte hash. Throws on malformed input
+    /// so a corrupt <c>prev_hash</c> surfaces loudly rather than silently
+    /// producing a wrong (but plausible) chain link.
+    /// </summary>
+    internal static byte[] DecodeHex(string hex)
+    {
+        if (hex.Length != HexLength)
+        {
+            throw new FormatException(
+                $"audit chain hash must be {HexLength} hex chars, got {hex.Length}.");
+        }
+        return Convert.FromHexString(hex);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainRecordView.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainRecordView.cs
@@ -1,0 +1,45 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 — the immutable, storage-agnostic projection of an
+/// <c>audit_records</c> row that the canonicalizer + verifier operate on.
+///
+/// <para><b>Why a view, not the EF entity:</b> <c>Tamma.Core</c> is a pure
+/// project with no EF dependency (the chain's determinism must not ride on any
+/// ORM behaviour). The <c>AuditRecord</c> entity in <c>Tamma.Data</c> maps into
+/// this view; the canonicalizer never sees the entity.</para>
+///
+/// <para>Every field here is part of the hashed identity of the record EXCEPT
+/// <see cref="PrevRecordHash"/> and <see cref="RecordHash"/> — those are the
+/// chain linkage, composed AROUND the canonical bytes, not inside them.</para>
+/// </summary>
+public sealed record AuditChainRecordView
+{
+    public required Guid Id { get; init; }
+    public required string Discriminator { get; init; }
+    public Guid? TenantId { get; init; }
+    public Guid? UserId { get; init; }
+    public required string ActionCode { get; init; }
+    public required string Category { get; init; }
+    public required string Severity { get; init; }
+    public Guid? ActorUserId { get; init; }
+    public string? ActorEmailSnapshot { get; init; }
+    public string? TargetType { get; init; }
+    public string? TargetId { get; init; }
+    public required string Outcome { get; init; }
+    public string? IpAddress { get; init; }
+    public string? UserAgent { get; init; }
+    public required DateTime OccurredAt { get; init; }
+    public required Guid SourceEventId { get; init; }
+    public required long SourceSequenceNumber { get; init; }
+    public required string PayloadJson { get; init; }
+
+    /// <summary>Per-scope monotonic chain position (1-based). Part of the hashed identity.</summary>
+    public required long ChainSequence { get; init; }
+
+    /// <summary>The previous record's hash (lowercase-hex) — the chain link. NOT hashed into the canonical.</summary>
+    public required string PrevRecordHash { get; init; }
+
+    /// <summary>The stored hash (lowercase-hex) the verifier recomputes and compares against.</summary>
+    public required string RecordHash { get; init; }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainScope.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainScope.cs
@@ -1,0 +1,68 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 — identifies WHICH hash-chain a record belongs to. A record is a
+/// member of exactly one chain; chains never cross-link (see the story Dev
+/// Notes "Why two chains, not one").
+///
+/// <list type="bullet">
+///   <item><description><see cref="AuditChainScopeKind.Platform"/> — the single
+///     chain over the control-plane <c>audit_records</c> table. In SaaS this is
+///     the platform-scope trail (tenant_id null); in single-user mode it is the
+///     sole user's whole trail. Persisted in <c>ControlPlaneDbContext</c>.</description></item>
+///   <item><description><see cref="AuditChainScopeKind.Tenant"/> — one chain per
+///     tenant, persisted in that tenant's <c>t_&lt;hex&gt;</c> schema
+///     (<c>TenantDbContext</c>). <see cref="TenantId"/> is set.</description></item>
+/// </list>
+/// </summary>
+public enum AuditChainScopeKind
+{
+    /// <summary>The control-plane chain (platform-scope in SaaS; the sole user in single-user).</summary>
+    Platform = 0,
+
+    /// <summary>A per-tenant chain living in the tenant's own schema.</summary>
+    Tenant = 1,
+}
+
+/// <summary>
+/// Immutable value identifying an audit hash-chain. Use <see cref="Platform"/>
+/// for the control-plane chain and <see cref="ForTenant"/> for a tenant chain.
+/// </summary>
+public readonly record struct AuditChainScope(AuditChainScopeKind Kind, Guid? TenantId)
+{
+    /// <summary>The single control-plane / single-user chain.</summary>
+    public static readonly AuditChainScope Platform = new(AuditChainScopeKind.Platform, null);
+
+    /// <summary>The chain for a specific tenant's schema-resident trail.</summary>
+    public static AuditChainScope ForTenant(Guid tenantId) =>
+        new(AuditChainScopeKind.Tenant, tenantId);
+
+    /// <summary>
+    /// The canonical scope discriminator string used in the checkpoint table
+    /// (<c>scope</c> column) and mixed into the canonical record serialization.
+    /// </summary>
+    public string Discriminator => Kind == AuditChainScopeKind.Tenant ? "tenant" : "platform";
+
+    /// <summary>
+    /// A stable 64-bit key for the per-scope Postgres advisory lock. Platform =
+    /// a fixed namespace constant; tenant = a deterministic fold of the tenant
+    /// GUID so two tenants sharing a pooled database do not serialize behind one
+    /// another (each schema has its own independent chain).
+    /// </summary>
+    public long AdvisoryLockKey()
+    {
+        // "TAUD" (Tamma AUDit chain) as the high-half namespace so pg_locks is
+        // greppable; the low half is 0 for platform or a fold of the tenant id.
+        const long ns = 0x5441_5544L << 32;
+        if (Kind != AuditChainScopeKind.Tenant || TenantId is not Guid tid) return ns;
+        Span<byte> b = stackalloc byte[16];
+        tid.TryWriteBytes(b);
+        long fold = 0;
+        for (var i = 0; i < 16; i += 8)
+        {
+            fold ^= BitConverter.ToInt64(b.Slice(i, 8));
+        }
+        // Keep it inside the low 32 bits so the namespace half stays intact.
+        return ns | (fold & 0xFFFF_FFFFL);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainVerifier.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainVerifier.cs
@@ -1,0 +1,144 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC4/AC7) — the pure chain-verification algorithm. Streams a
+/// scope's records in ascending <c>chain_sequence</c>, and for each one:
+/// <list type="number">
+///   <item><description>checks <c>chain_sequence</c> contiguity (gap → missing;
+///     backwards → reordered);</description></item>
+///   <item><description>checks <c>prev_hash</c> == the prior record's hash;</description></item>
+///   <item><description>recomputes <c>SHA-256(prev ‖ canonical(record))</c> and
+///     compares it to the stored <c>record_hash</c> (mismatch → mutated).</description></item>
+/// </list>
+/// Then it confirms any covering checkpoint's signature + anchored head hash.
+/// Returns at the FIRST broken link, localized to its <c>chain_sequence</c>.
+///
+/// <para>O(n) over the range and streaming (never materializes the whole chain)
+/// so a 100k-record verify stays within budget (AC12).</para>
+/// </summary>
+public sealed class AuditChainVerifier : IAuditChainVerifier
+{
+    private readonly IAuditChainRecordSource _records;
+    private readonly IAuditChainCheckpointGateway _checkpoints;
+
+    public AuditChainVerifier(
+        IAuditChainRecordSource records,
+        IAuditChainCheckpointGateway checkpoints)
+    {
+        _records = records ?? throw new ArgumentNullException(nameof(records));
+        _checkpoints = checkpoints ?? throw new ArgumentNullException(nameof(checkpoints));
+    }
+
+    public async Task<ChainVerificationResult> VerifyAsync(
+        AuditChainScope scope, long? from, long? to, CancellationToken ct)
+    {
+        // The checkpoint covering this range — fetched up front so we can capture
+        // the record hash AT its head sequence while streaming (single pass).
+        var checkpoint = await _checkpoints.GetLastCoveringAsync(scope, to, ct)
+            .ConfigureAwait(false);
+
+        // Anchor the expected prev_hash: genesis when starting at/ before the
+        // first record; otherwise the hash of the record just before `from`.
+        string? expectedPrev;
+        if (from is null || from.Value <= 1)
+        {
+            expectedPrev = AuditChainGenesis.HashHex;
+        }
+        else
+        {
+            expectedPrev = await _records.GetRecordHashAtAsync(scope, from.Value - 1, ct)
+                .ConfigureAwait(false);
+            // Null anchor → the record before the range is missing; we cannot
+            // confirm the first record's prev linkage, so skip that one check
+            // (the hash-recompute + contiguity still apply).
+        }
+
+        long? expectedSeq = from;
+        long lastSeq = 0;
+        string? lastHash = null;
+        long verified = 0;
+        string? hashAtCheckpointHead = null;
+
+        await foreach (var r in _records.StreamAsync(scope, from, to, ct).ConfigureAwait(false))
+        {
+            // ── contiguity ──
+            if (expectedSeq is long es && r.ChainSequence != es)
+            {
+                if (r.ChainSequence > es)
+                {
+                    // A slot in the middle is empty → a record was deleted.
+                    return ChainVerificationResult.Broken(
+                        ChainBreakReason.Missing, r.Id, es, verified, checkpoint);
+                }
+
+                // Sequence went backwards / duplicated → reordering.
+                return ChainVerificationResult.Broken(
+                    ChainBreakReason.Reordered, r.Id, r.ChainSequence, verified, checkpoint);
+            }
+
+            // ── prev linkage ──
+            if (expectedPrev is not null &&
+                !string.Equals(r.PrevRecordHash, expectedPrev, StringComparison.OrdinalIgnoreCase))
+            {
+                return ChainVerificationResult.Broken(
+                    ChainBreakReason.PrevHashMismatch, r.Id, r.ChainSequence, verified, checkpoint);
+            }
+
+            // ── content integrity ──
+            var recomputed = AuditChainHasher.ComposeHex(
+                r.PrevRecordHash, AuditRecordCanonicalizer.ToBytes(r));
+            if (!string.Equals(recomputed, r.RecordHash, StringComparison.OrdinalIgnoreCase))
+            {
+                return ChainVerificationResult.Broken(
+                    ChainBreakReason.Mutated, r.Id, r.ChainSequence, verified, checkpoint);
+            }
+
+            if (checkpoint is not null && r.ChainSequence == checkpoint.HeadSequence)
+            {
+                hashAtCheckpointHead = r.RecordHash;
+            }
+
+            expectedPrev = r.RecordHash;
+            expectedSeq = r.ChainSequence + 1;
+            lastSeq = r.ChainSequence;
+            lastHash = r.RecordHash;
+            verified++;
+        }
+
+        // ── checkpoint confirmation (AC7) ──
+        if (checkpoint is not null)
+        {
+            if (!await _checkpoints.VerifySignatureAsync(checkpoint, ct).ConfigureAwait(false))
+            {
+                return ChainVerificationResult.Broken(
+                    ChainBreakReason.CheckpointSignatureInvalid,
+                    checkpoint.Id, checkpoint.HeadSequence, verified, checkpoint);
+            }
+
+            var headInRange =
+                (from is null || from.Value <= checkpoint.HeadSequence) &&
+                (to is null || to.Value >= checkpoint.HeadSequence);
+
+            if (headInRange)
+            {
+                if (hashAtCheckpointHead is null)
+                {
+                    // The range should have contained the anchored head but the
+                    // record at that sequence is absent → tail clipped / missing.
+                    return ChainVerificationResult.Broken(
+                        ChainBreakReason.Missing, null, checkpoint.HeadSequence, verified, checkpoint);
+                }
+
+                if (!string.Equals(hashAtCheckpointHead, checkpoint.HeadHash,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return ChainVerificationResult.Broken(
+                        ChainBreakReason.CheckpointHeadMismatch,
+                        checkpoint.Id, checkpoint.HeadSequence, verified, checkpoint);
+                }
+            }
+        }
+
+        return ChainVerificationResult.Ok(lastSeq, lastHash, verified, checkpoint);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainVerifier.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditChainVerifier.cs
@@ -139,6 +139,27 @@ public sealed class AuditChainVerifier : IAuditChainVerifier
             }
         }
 
+        // ── tail-truncation / checkpoint-deletion detection ──
+        // record_hash is unkeyed, so deleting recent records leaves no trace in
+        // the chain itself. The only external anchor is a signed checkpoint — and
+        // checkpoints are append-only (DB trigger) + HMAC-signed, so the highest
+        // checkpoint head_sequence for the scope is a lower bound on how many
+        // records once existed. If the live chain head has regressed below it,
+        // the tail was clipped. This runs regardless of the requested [from,to]
+        // range because it reads the TRUE current head, not the range's last row.
+        var maxCheckpointHead = await _checkpoints.GetMaxHeadSequenceAsync(scope, ct)
+            .ConfigureAwait(false);
+        if (maxCheckpointHead is long maxCp)
+        {
+            var currentHead = await _records.GetHeadAsync(scope, ct).ConfigureAwait(false);
+            var currentHeadSeq = currentHead?.Sequence ?? 0;
+            if (currentHeadSeq < maxCp)
+            {
+                return ChainVerificationResult.Broken(
+                    ChainBreakReason.HeadBelowCheckpoint, null, maxCp, verified, checkpoint);
+            }
+        }
+
         return ChainVerificationResult.Ok(lastSeq, lastHash, verified, checkpoint);
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/AuditRecordCanonicalizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/AuditRecordCanonicalizer.cs
@@ -1,0 +1,140 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Text;
+
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC2) — produces the deterministic, culture-invariant, byte-stable
+/// serialization of an audit record that the hash-chain is computed over.
+///
+/// <para><b>Load-bearing determinism.</b> Verification only works if
+/// <c>canonical(record)</c> is byte-identical at write time and at every future
+/// verify, on every machine. This class therefore:</para>
+/// <list type="bullet">
+///   <item><description>Uses a FIXED field order (never reflection / dictionary
+///     enumeration order).</description></item>
+///   <item><description>Length-prefixes every field so no two distinct records
+///     can ever produce the same byte stream by concatenation ambiguity
+///     (e.g. actor <c>"ab"</c>+target <c>"c"</c> vs actor <c>"a"</c>+target
+///     <c>"bc"</c>).</description></item>
+///   <item><description>Formats timestamps as UTC ISO-8601 with millisecond
+///     precision (<c>yyyy-MM-ddTHH:mm:ss.fffZ</c>) under
+///     <see cref="CultureInfo.InvariantCulture"/> — never
+///     <c>DateTime.ToString()</c> with an ambient locale.</description></item>
+///   <item><description>Prefixes the stream with
+///     <see cref="AuditChainGenesis.CanonicalVersion"/> so a future format
+///     change is a new, detectable version rather than a silent break.</description></item>
+/// </list>
+///
+/// <para>The output is intentionally NOT JSON — JSON key ordering + whitespace +
+/// number formatting are exactly the non-determinism this must avoid.</para>
+/// </summary>
+public static class AuditRecordCanonicalizer
+{
+    private const byte FieldNull = 0x00;
+    private const byte FieldPresent = 0x01;
+
+    /// <summary>
+    /// Serialize the record's stable identity fields (everything EXCEPT the
+    /// chain-linkage hashes) into a deterministic byte array.
+    /// </summary>
+    public static byte[] ToBytes(AuditChainRecordView record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        using var ms = new MemoryStream(256);
+
+        // Format version first — pins the layout so a v2 canonicalizer never
+        // collides with a v1 stream.
+        ms.WriteByte(AuditChainGenesis.CanonicalVersion);
+
+        WriteString(ms, record.Discriminator);
+        WriteGuid(ms, record.Id);
+        WriteNullableGuid(ms, record.TenantId);
+        WriteNullableGuid(ms, record.UserId);
+        WriteString(ms, record.ActionCode);
+        WriteString(ms, record.Category);
+        WriteString(ms, record.Severity);
+        WriteNullableGuid(ms, record.ActorUserId);
+        WriteNullableString(ms, record.ActorEmailSnapshot);
+        WriteNullableString(ms, record.TargetType);
+        WriteNullableString(ms, record.TargetId);
+        WriteString(ms, record.Outcome);
+        WriteNullableString(ms, record.IpAddress);
+        WriteNullableString(ms, record.UserAgent);
+        WriteString(ms, FormatTimestamp(record.OccurredAt));
+        WriteGuid(ms, record.SourceEventId);
+        WriteInt64(ms, record.SourceSequenceNumber);
+        WriteString(ms, record.PayloadJson);
+        WriteInt64(ms, record.ChainSequence);
+
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// UTC ISO-8601 with millisecond precision under the invariant culture. The
+    /// record's <c>OccurredAt</c> is normalized to UTC first so a row read back
+    /// as <c>Unspecified</c>/<c>Local</c> still canonicalizes identically.
+    /// </summary>
+    internal static string FormatTimestamp(DateTime value)
+    {
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+        return utc.ToString("yyyy-MM-ddTHH:mm:ss.fffZ", CultureInfo.InvariantCulture);
+    }
+
+    private static void WriteNullableString(Stream s, string? value)
+    {
+        if (value is null)
+        {
+            s.WriteByte(FieldNull);
+            return;
+        }
+        s.WriteByte(FieldPresent);
+        WriteString(s, value);
+    }
+
+    private static void WriteString(Stream s, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteLengthPrefix(s, bytes.Length);
+        s.Write(bytes, 0, bytes.Length);
+    }
+
+    private static void WriteNullableGuid(Stream s, Guid? value)
+    {
+        if (value is not Guid g)
+        {
+            s.WriteByte(FieldNull);
+            return;
+        }
+        s.WriteByte(FieldPresent);
+        WriteGuid(s, g);
+    }
+
+    private static void WriteGuid(Stream s, Guid value)
+    {
+        Span<byte> b = stackalloc byte[16];
+        value.TryWriteBytes(b);
+        s.Write(b);
+    }
+
+    private static void WriteInt64(Stream s, long value)
+    {
+        Span<byte> b = stackalloc byte[8];
+        BinaryPrimitives.WriteInt64BigEndian(b, value);
+        s.Write(b);
+    }
+
+    private static void WriteLengthPrefix(Stream s, int length)
+    {
+        Span<byte> b = stackalloc byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(b, length);
+        s.Write(b);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/ChainVerificationResult.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/ChainVerificationResult.cs
@@ -23,6 +23,14 @@ public enum ChainBreakReason
 
     /// <summary>A checkpoint's <c>head_hash</c> != the recomputed chain head at its sequence.</summary>
     CheckpointHeadMismatch,
+
+    /// <summary>
+    /// The live chain head <c>chain_sequence</c> is BELOW the highest signed
+    /// checkpoint's <c>head_sequence</c> — records were deleted from the tail
+    /// (tail-truncation). A surviving append-only checkpoint proves those records
+    /// once existed, so a regressed head is proof of deletion.
+    /// </summary>
+    HeadBelowCheckpoint,
 }
 
 /// <summary>The status half of a <see cref="ChainVerificationResult"/>.</summary>

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/ChainVerificationResult.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/ChainVerificationResult.cs
@@ -1,0 +1,95 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC4/AC7) — why a chain verification failed, localized to the
+/// exact broken link.
+/// </summary>
+public enum ChainBreakReason
+{
+    /// <summary>A record's recomputed hash != its stored hash (in-place edit).</summary>
+    Mutated,
+
+    /// <summary>A gap in <c>chain_sequence</c> (a record was deleted / is missing).</summary>
+    Missing,
+
+    /// <summary>Records appear out of sequence order (reordering).</summary>
+    Reordered,
+
+    /// <summary>A record's <c>prev_hash</c> != the actual prior record's hash.</summary>
+    PrevHashMismatch,
+
+    /// <summary>A checkpoint's stored signature failed cabinet-key validation.</summary>
+    CheckpointSignatureInvalid,
+
+    /// <summary>A checkpoint's <c>head_hash</c> != the recomputed chain head at its sequence.</summary>
+    CheckpointHeadMismatch,
+}
+
+/// <summary>The status half of a <see cref="ChainVerificationResult"/>.</summary>
+public enum ChainVerificationStatus
+{
+    /// <summary>Every link verified; the chain (and any covering checkpoint) is intact.</summary>
+    Ok,
+
+    /// <summary>A tamper was detected; see <see cref="ChainVerificationResult.FirstBrokenLink"/>.</summary>
+    Tampered,
+}
+
+/// <summary>
+/// Story 37-2 (AC4) — the first broken link in a chain: enough to localize
+/// tampering without leaking record payload contents.
+/// </summary>
+public sealed record ChainBrokenLink(
+    Guid? RecordId,
+    long ChainSequence,
+    ChainBreakReason Reason);
+
+/// <summary>
+/// Story 37-2 (AC4/AC7) — the structured outcome of verifying a chain range:
+/// either <see cref="ChainVerificationStatus.Ok"/> or the first broken link.
+/// Also carries the head reached and the covering checkpoint (if any) so the
+/// endpoint can surface <c>lastCheckpoint</c>.
+/// </summary>
+public sealed record ChainVerificationResult
+{
+    public required ChainVerificationStatus Status { get; init; }
+
+    /// <summary>Set only when <see cref="Status"/> is <see cref="ChainVerificationStatus.Tampered"/>.</summary>
+    public ChainBrokenLink? FirstBrokenLink { get; init; }
+
+    /// <summary>The last (highest) <c>chain_sequence</c> the verify reached. 0 for an empty range.</summary>
+    public long LastSequence { get; init; }
+
+    /// <summary>The last verified record's hash (hex), or null for an empty range.</summary>
+    public string? LastHash { get; init; }
+
+    /// <summary>The covering checkpoint that was confirmed (or attempted), if one exists.</summary>
+    public AuditChainCheckpointView? LastCheckpoint { get; init; }
+
+    /// <summary>Number of records walked (for logging / perf assertions).</summary>
+    public long RecordsVerified { get; init; }
+
+    public static ChainVerificationResult Ok(
+        long lastSequence, string? lastHash, long recordsVerified,
+        AuditChainCheckpointView? checkpoint) =>
+        new()
+        {
+            Status = ChainVerificationStatus.Ok,
+            LastSequence = lastSequence,
+            LastHash = lastHash,
+            RecordsVerified = recordsVerified,
+            LastCheckpoint = checkpoint,
+        };
+
+    public static ChainVerificationResult Broken(
+        ChainBreakReason reason, Guid? recordId, long chainSequence,
+        long recordsVerified, AuditChainCheckpointView? checkpoint = null) =>
+        new()
+        {
+            Status = ChainVerificationStatus.Tampered,
+            FirstBrokenLink = new ChainBrokenLink(recordId, chainSequence, reason),
+            LastSequence = chainSequence,
+            RecordsVerified = recordsVerified,
+            LastCheckpoint = checkpoint,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainSources.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainSources.cs
@@ -1,0 +1,62 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 — the read seam the pure <see cref="AuditChainVerifier"/> pulls
+/// records from. Implemented in <c>Tamma.Data</c> over the correct store (CP for
+/// <see cref="AuditChainScopeKind.Platform"/>, the tenant schema for
+/// <see cref="AuditChainScopeKind.Tenant"/>). Streams in ascending
+/// <c>chain_sequence</c> order and NEVER materializes the whole chain in memory
+/// (AC4/AC12).
+/// </summary>
+public interface IAuditChainRecordSource
+{
+    /// <summary>
+    /// Stream the scope's chained records with <c>chain_sequence</c> in
+    /// <c>[from, to]</c> (inclusive; null = open bound), ascending. Only rows
+    /// that carry a <c>chain_sequence</c> are returned (un-backfilled legacy
+    /// rows are skipped by the source).
+    /// </summary>
+    IAsyncEnumerable<AuditChainRecordView> StreamAsync(
+        AuditChainScope scope, long? from, long? to, CancellationToken ct);
+
+    /// <summary>
+    /// The <c>record_hash</c> (hex) of the record at <paramref name="sequence"/>
+    /// in the scope, or null if none. Used to anchor <c>prev_hash</c> when a
+    /// verify starts mid-chain (<c>from &gt; 1</c>).
+    /// </summary>
+    Task<string?> GetRecordHashAtAsync(
+        AuditChainScope scope, long sequence, CancellationToken ct);
+
+    /// <summary>
+    /// The chain head — the highest <c>chain_sequence</c> and its
+    /// <c>record_hash</c> — for the scope, or null when the chain is empty. Used
+    /// by the checkpoint writer to anchor the current head.
+    /// </summary>
+    Task<AuditChainHead?> GetHeadAsync(AuditChainScope scope, CancellationToken ct);
+}
+
+/// <summary>Story 37-2 — the head of a chain: its highest sequence + hash.</summary>
+public sealed record AuditChainHead(long Sequence, string RecordHash);
+
+/// <summary>
+/// Story 37-2 (AC5/AC7) — the checkpoint read + signature-validation seam.
+/// Implemented in <c>Tamma.Api</c> (checkpoint rows are CP-resident; signature
+/// validation uses the Epic 29 cabinet key).
+/// </summary>
+public interface IAuditChainCheckpointGateway
+{
+    /// <summary>
+    /// The latest checkpoint whose <c>head_sequence &lt;= to</c> (or the latest
+    /// overall when <paramref name="to"/> is null) for the scope, or null when
+    /// no checkpoint covers the range.
+    /// </summary>
+    Task<AuditChainCheckpointView?> GetLastCoveringAsync(
+        AuditChainScope scope, long? to, CancellationToken ct);
+
+    /// <summary>
+    /// Validate a checkpoint's signature against the cabinet key for its
+    /// <c>key_version</c>. Fail-closed: returns false when the key is
+    /// unavailable (never treats "no key" as "valid").
+    /// </summary>
+    Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainSources.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainSources.cs
@@ -59,4 +59,13 @@ public interface IAuditChainCheckpointGateway
     /// unavailable (never treats "no key" as "valid").
     /// </summary>
     Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct);
+
+    /// <summary>
+    /// The highest <c>head_sequence</c> across ALL signed checkpoints for the
+    /// scope (ignoring any range bound), or null when the scope has no
+    /// checkpoints. The verifier compares this against the live chain head to
+    /// detect tail-truncation: a signed, append-only checkpoint proves records up
+    /// to its head once existed, so the live head must never regress below it.
+    /// </summary>
+    Task<long?> GetMaxHeadSequenceAsync(AuditChainScope scope, CancellationToken ct);
 }

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainVerifier.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/IAuditChainVerifier.cs
@@ -1,0 +1,19 @@
+namespace Tamma.Core.Audit;
+
+/// <summary>
+/// Story 37-2 (AC4) — walks a scope's hash-chain and reports OK or the first
+/// broken link. Pure logic (no EF/HTTP); data access is behind
+/// <see cref="IAuditChainRecordSource"/> / <see cref="IAuditChainCheckpointGateway"/>.
+/// </summary>
+public interface IAuditChainVerifier
+{
+    /// <summary>
+    /// Verify the chain for <paramref name="scope"/> over the inclusive
+    /// <c>chain_sequence</c> range <c>[from, to]</c> (null = open bound; the
+    /// default range is genesis→head). Confirms per-record hash integrity,
+    /// <c>prev_hash</c> linkage, and <c>chain_sequence</c> contiguity, then
+    /// validates any covering checkpoint's signature + head hash.
+    /// </summary>
+    Task<ChainVerificationResult> VerifyAsync(
+        AuditChainScope scope, long? from, long? to, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordChainMapper.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordChainMapper.cs
@@ -1,0 +1,47 @@
+using Tamma.Core.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Audit;
+
+/// <summary>
+/// Story 37-2 — maps the EF <see cref="AuditRecord"/> entity onto the pure
+/// <see cref="AuditChainRecordView"/> the canonicalizer + verifier operate on.
+/// Keeps the hashing determinism defined entirely in <c>Tamma.Core</c> (no EF
+/// behaviour in the hash preimage).
+/// </summary>
+public static class AuditRecordChainMapper
+{
+    /// <summary>
+    /// Project a persisted (or about-to-persist) record into the canonical view
+    /// for the given <paramref name="scope"/>. <paramref name="prevHash"/> /
+    /// <paramref name="recordHash"/> override the entity's stored values (used at
+    /// insert time before they are assigned onto the entity).
+    /// </summary>
+    public static AuditChainRecordView ToView(
+        AuditRecord record, AuditChainScope scope,
+        string? prevHash = null, string? recordHash = null) =>
+        new()
+        {
+            Id = record.Id,
+            Discriminator = scope.Discriminator,
+            TenantId = record.TenantId,
+            UserId = record.UserId,
+            ActionCode = record.ActionCode,
+            Category = record.Category,
+            Severity = record.Severity,
+            ActorUserId = record.ActorUserId,
+            ActorEmailSnapshot = record.ActorEmailSnapshot,
+            TargetType = record.TargetType,
+            TargetId = record.TargetId,
+            Outcome = record.Outcome,
+            IpAddress = record.IpAddress,
+            UserAgent = record.UserAgent,
+            OccurredAt = record.OccurredAt,
+            SourceEventId = record.SourceEventId,
+            SourceSequenceNumber = record.SourceSequenceNumber,
+            PayloadJson = record.PayloadJson,
+            ChainSequence = record.ChainSequence ?? 0,
+            PrevRecordHash = prevHash ?? record.PrevRecordHash ?? string.Empty,
+            RecordHash = recordHash ?? record.RecordHash ?? string.Empty,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Audit/AuditRecordRepository.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using Tamma.Core.Audit;
 using Tamma.Data.Entities;
 
 namespace Tamma.Data.Audit;
@@ -9,6 +10,13 @@ namespace Tamma.Data.Audit;
 /// on the UNIQUE <c>source_event_id</c> index makes the projection idempotent
 /// and replay-safe; cursor load/save mirrors <c>AlertRuleEvaluator</c>.
 /// Stateless — safe as a singleton; the caller supplies the per-call context.
+///
+/// <para>Story 37-2 — the insert path now CHAINS each record: under a per-scope
+/// Postgres advisory lock it reads the chain head, sets
+/// <see cref="AuditRecord.ChainSequence"/> / <see cref="AuditRecord.PrevRecordHash"/>,
+/// and computes <see cref="AuditRecord.RecordHash"/> =
+/// <c>SHA-256(prev ‖ canonical(record))</c> — atomically with the insert — so
+/// concurrent appends to one chain stay strictly monotonic and tamper-evident.</para>
 /// </summary>
 public sealed class AuditRecordRepository : IAuditRecordRepository
 {
@@ -27,6 +35,53 @@ public sealed class AuditRecordRepository : IAuditRecordRepository
             .ConfigureAwait(false);
         if (exists) return false;
 
+        var scope = ScopeFor(context, record);
+
+        // On real Postgres, serialize the head-read + insert for this chain under
+        // pg_advisory_xact_lock so two concurrent appends can't fork the sequence.
+        if (context.Database.IsNpgsql())
+        {
+            var strategy = context.Database.CreateExecutionStrategy();
+            return await strategy.ExecuteAsync(async () =>
+            {
+                await using var tx = await context.Database
+                    .BeginTransactionAsync(ct).ConfigureAwait(false);
+
+                await context.Database.ExecuteSqlRawAsync(
+                    "SELECT pg_advisory_xact_lock({0})",
+                    new object[] { scope.AdvisoryLockKey() }, ct).ConfigureAwait(false);
+
+                // Re-check inside the lock — a concurrent projector may have won.
+                var stillAbsent = !await context.Set<AuditRecord>().AsNoTracking()
+                    .AnyAsync(r => r.SourceEventId == record.SourceEventId, ct)
+                    .ConfigureAwait(false);
+                if (!stillAbsent)
+                {
+                    await tx.RollbackAsync(ct).ConfigureAwait(false);
+                    return false;
+                }
+
+                await AssignChainAsync(context, record, scope, ct).ConfigureAwait(false);
+                context.Set<AuditRecord>().Add(record);
+                try
+                {
+                    await context.SaveChangesAsync(ct).ConfigureAwait(false);
+                    await tx.CommitAsync(ct).ConfigureAwait(false);
+                    return true;
+                }
+                catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+                {
+                    context.Entry(record).State = EntityState.Detached;
+                    await tx.RollbackAsync(ct).ConfigureAwait(false);
+                    return false;
+                }
+            }).ConfigureAwait(false);
+        }
+
+        // Non-Postgres (in-memory/SQLite unit tests) — no advisory lock, no
+        // explicit transaction. Single-threaded test drivers, so a plain
+        // head-read + assign + save preserves the chain invariants.
+        await AssignChainAsync(context, record, scope, ct).ConfigureAwait(false);
         context.Set<AuditRecord>().Add(record);
         try
         {
@@ -35,12 +90,43 @@ public sealed class AuditRecordRepository : IAuditRecordRepository
         }
         catch (DbUpdateException ex) when (IsUniqueViolation(ex))
         {
-            // A concurrent projector won the race — already projected. Detach
-            // the rejected entry so the context can be reused cleanly.
             context.Entry(record).State = EntityState.Detached;
             return false;
         }
     }
+
+    /// <summary>
+    /// Read the chain head for the record's scope and assign
+    /// <c>ChainSequence</c> / <c>PrevRecordHash</c> / <c>RecordHash</c>. Only
+    /// already-chained rows count toward the head (a null <c>ChainSequence</c> is
+    /// a pre-37-2 legacy row awaiting backfill and must not anchor the head).
+    /// </summary>
+    private static async Task AssignChainAsync(
+        DbContext context, AuditRecord record, AuditChainScope scope, CancellationToken ct)
+    {
+        var head = await context.Set<AuditRecord>().AsNoTracking()
+            .Where(r => r.ChainSequence != null)
+            .OrderByDescending(r => r.ChainSequence)
+            .Select(r => new { r.ChainSequence, r.RecordHash })
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        record.ChainSequence = (head?.ChainSequence ?? 0) + 1;
+        record.PrevRecordHash = head?.RecordHash ?? AuditChainGenesis.HashHex;
+        var view = AuditRecordChainMapper.ToView(record, scope, prevHash: record.PrevRecordHash);
+        record.RecordHash = AuditChainHasher.ComposeHex(
+            record.PrevRecordHash, AuditRecordCanonicalizer.ToBytes(view));
+    }
+
+    /// <summary>
+    /// The chain scope of a record being inserted into <paramref name="context"/>.
+    /// A <see cref="TenantDbContext"/> insert is that tenant's chain; anything
+    /// else (control-plane platform + single-user rows) is the platform chain.
+    /// </summary>
+    private static AuditChainScope ScopeFor(DbContext context, AuditRecord record) =>
+        context is TenantDbContext && record.TenantId is Guid tid
+            ? AuditChainScope.ForTenant(tid)
+            : AuditChainScope.Platform;
 
     /// <inheritdoc />
     public async Task<AuditProjectorCursor> LoadCursorAsync(

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -696,6 +696,13 @@ public class ControlPlaneDbContext : DbContext
     public DbSet<AuditProjectorCursor> AuditProjectorCursors => Set<AuditProjectorCursor>();
 
     /// <summary>
+    /// Story 37-2 — signed chain checkpoints for BOTH platform and tenant
+    /// scopes. Always CP-resident (a tenant cannot rewrite an anchor stored
+    /// outside its own schema); <c>tenant_id</c> discriminates the scope.
+    /// </summary>
+    public DbSet<AuditChainCheckpoint> AuditChainCheckpoints => Set<AuditChainCheckpoint>();
+
+    /// <summary>
     /// Story 34-11 — the provider COST identity (platform-global, NOT
     /// tenant-scoped). Promotes the frozen <c>ProviderPricingService</c> rate
     /// sheet to a first-class, admin-editable entity behind the unchanged
@@ -818,6 +825,8 @@ public class ControlPlaneDbContext : DbContext
         // projector resumes both streams from one row.
         TammaModelConfiguration.ConfigureAuditEntities(modelBuilder, fixedTenantId: null);
         TammaModelConfiguration.ConfigureAuditProjectorCursor(modelBuilder);
+        // Story 37-2 — signed chain checkpoints (CP-resident for every scope).
+        TammaModelConfiguration.ConfigureAuditChainCheckpoint(modelBuilder);
 
         // Story 34-11 — provider COST price-book. CP-resident, platform-global
         // (no TenantId): cost is the provider's published rate, identical for

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AuditChainCheckpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AuditChainCheckpoint.cs
@@ -1,0 +1,45 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 37-2 (AC5) — a signed anchor of an audit hash-chain head at a point in
+/// time. The signature (HMAC-SHA256 over the canonical
+/// <c>scope ‖ head_sequence ‖ head_hash ‖ signed_at</c> preimage, using a key
+/// from the Epic 29 cabinet) makes the anchor forgery-resistant even against an
+/// attacker with direct DB write access to the records table.
+///
+/// <para><b>Always control-plane-resident</b>, for BOTH platform and tenant
+/// scopes. Keeping tenant checkpoints OUTSIDE the tenant's own schema means a
+/// tenant with DB write access to its schema cannot rewrite both its records AND
+/// its anchor — the anchor lives where the tenant cannot reach it. Tenant-scope
+/// rows set <see cref="TenantId"/>; platform-scope rows leave it null.</para>
+/// </summary>
+public class AuditChainCheckpoint
+{
+    /// <summary>Surrogate PK — Postgres <c>gen_random_uuid()</c> default.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary><c>'platform'</c> or <c>'tenant'</c> — which chain this anchors.</summary>
+    public string Scope { get; set; } = null!;
+
+    /// <summary>Set for tenant scope; null for platform scope (CHECK-enforced).</summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>The chain head <c>chain_sequence</c> this checkpoint anchors.</summary>
+    public long HeadSequence { get; set; }
+
+    /// <summary>The chain head <c>record_hash</c> (lowercase-hex) at <see cref="HeadSequence"/>.</summary>
+    public string HeadHash { get; set; } = null!;
+
+    /// <summary>When the anchor was signed (UTC).</summary>
+    public DateTime SignedAt { get; set; }
+
+    /// <summary>HMAC-SHA256 signature over the canonical checkpoint preimage.</summary>
+    public byte[] Signature { get; set; } = Array.Empty<byte>();
+
+    /// <summary>Which cabinet signing-key version produced <see cref="Signature"/>;
+    /// lets rotation not strand historical checkpoints (AC5).</summary>
+    public int KeyVersion { get; set; }
+
+    /// <summary>Row creation timestamp (Postgres <c>now()</c> default).</summary>
+    public DateTime CreatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AuditRecord.cs
@@ -90,13 +90,22 @@ public class AuditRecord
     /// <summary>Single-user-mode owner (the sole user). Null in SaaS mode.</summary>
     public Guid? UserId { get; set; }
 
-    // ── Reserved for Story 37-2 tamper-evidence (this story leaves both null) ──
+    // ── Story 37-2 tamper-evidence hash chain ──
 
-    /// <summary>Reserved for Story 37-2 — the hash of this record in the chain.
-    /// Story 37-1 leaves this null; 37-2 populates it. Do NOT compute here.</summary>
+    /// <summary>Story 37-2 — this record's hash in the chain, lowercase-hex
+    /// SHA-256 of <c>prev_hash ‖ canonical(record)</c>. Populated by the
+    /// projector at insert time (37-1 reserved it null). Nullable only for
+    /// pre-37-2 legacy rows awaiting backfill.</summary>
     public string? RecordHash { get; set; }
 
-    /// <summary>Reserved for Story 37-2 — the previous record's hash, linking the
-    /// chain. Story 37-1 leaves this null; 37-2 populates it.</summary>
+    /// <summary>Story 37-2 — the previous record's <see cref="RecordHash"/> in
+    /// this scope's chain (or <c>AuditChainGenesis.HashHex</c> for the first
+    /// record), lowercase-hex. Populated at insert time.</summary>
     public string? PrevRecordHash { get; set; }
+
+    /// <summary>Story 37-2 — per-scope monotonic chain position (1-based). One
+    /// chain per physical <c>audit_records</c> table (the CP table = the
+    /// platform / single-user chain; each tenant schema's table = that tenant's
+    /// chain). Nullable only for pre-37-2 legacy rows awaiting backfill.</summary>
+    public long? ChainSequence { get; set; }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/AuditChainCheckpointsAppendOnlyTrigger.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/AuditChainCheckpointsAppendOnlyTrigger.cs
@@ -1,0 +1,49 @@
+namespace Tamma.Data.Migrations;
+
+/// <summary>
+/// Story 37-2 (code-review fix, AC7 hardening) — the append-only defence-in-depth
+/// trigger on <c>audit_chain_checkpoints</c> (control-plane resident only). Signed
+/// checkpoints are the external anchor that makes tail-truncation detectable, so
+/// they must themselves be write-once: this trigger rejects every <c>DELETE</c>
+/// and every <c>UPDATE</c>, allowing only <c>INSERT</c>.
+///
+/// <para><b>Why this matters.</b> <c>record_hash</c> is unkeyed, so the ONLY thing
+/// that reveals deletion of recent records is a surviving signed checkpoint whose
+/// <c>head_sequence</c> exceeds the current chain head. If checkpoints were
+/// deletable, an attacker could delete the recent records AND the covering
+/// checkpoint and the chain would verify as <c>Ok</c>. Mirroring the
+/// <see cref="AuditRecordsAppendOnlyTrigger"/> on the checkpoint table closes
+/// that hole for accidental/ORM writes; the cryptographic HMAC signature closes
+/// it against forgery.</para>
+///
+/// <para><b>Not a security boundary.</b> A superuser / <c>ALTER TABLE … DISABLE
+/// TRIGGER</c> bypasses it — which is exactly why the checkpoints are signed with
+/// an out-of-cabinet key. The trigger stops accidental writes; the verification
+/// (head-sequence &gt;= max-checkpoint-head) + signature make deliberate tampering
+/// DETECTABLE. Document this in the runbook.</para>
+/// </summary>
+internal static class AuditChainCheckpointsAppendOnlyTrigger
+{
+    public const string UpSql = """
+        CREATE OR REPLACE FUNCTION audit_chain_checkpoints_append_only()
+        RETURNS trigger AS $$
+        BEGIN
+          IF (TG_OP = 'DELETE') THEN
+            RAISE EXCEPTION 'audit_chain_checkpoints is append-only: DELETE rejected (row %).', OLD."Id";
+          END IF;
+          -- Checkpoints are write-once; any UPDATE is forbidden.
+          RAISE EXCEPTION 'audit_chain_checkpoints is append-only: UPDATE rejected (row %).', OLD."Id";
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS trg_audit_chain_checkpoints_append_only ON audit_chain_checkpoints;
+        CREATE TRIGGER trg_audit_chain_checkpoints_append_only
+          BEFORE UPDATE OR DELETE ON audit_chain_checkpoints
+          FOR EACH ROW EXECUTE FUNCTION audit_chain_checkpoints_append_only();
+        """;
+
+    public const string DownSql = """
+        DROP TRIGGER IF EXISTS trg_audit_chain_checkpoints_append_only ON audit_chain_checkpoints;
+        DROP FUNCTION IF EXISTS audit_chain_checkpoints_append_only();
+        """;
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/AuditRecordsAppendOnlyTrigger.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/AuditRecordsAppendOnlyTrigger.cs
@@ -1,0 +1,63 @@
+namespace Tamma.Data.Migrations;
+
+/// <summary>
+/// Story 37-2 (AC11) — the append-only defence-in-depth trigger on
+/// <c>audit_records</c>, applied to BOTH the control-plane and per-tenant stores
+/// (each schema gets its own copy). Rejects <c>DELETE</c> and any <c>UPDATE</c>
+/// that mutates a core/immutable field or an ALREADY-SET chain column; it allows
+/// a one-time NULL→value backfill of the chain columns (37-2 backfill of pre-37-2
+/// legacy rows).
+///
+/// <para><b>Not a security boundary.</b> A superuser / <c>ALTER TABLE … DISABLE
+/// TRIGGER</c> bypasses it — which is exactly why the cryptographic hash-chain +
+/// signed external-key checkpoints exist. The trigger stops accidental ORM
+/// writes from silently rewriting history; the chain makes deliberate tampering
+/// DETECTABLE. Document this in the runbook.</para>
+/// </summary>
+internal static class AuditRecordsAppendOnlyTrigger
+{
+    public const string UpSql = """
+        CREATE OR REPLACE FUNCTION audit_records_append_only()
+        RETURNS trigger AS $$
+        BEGIN
+          IF (TG_OP = 'DELETE') THEN
+            RAISE EXCEPTION 'audit_records is append-only: DELETE rejected (row %).', OLD."Id";
+          END IF;
+          IF ( NEW."Id"                   IS DISTINCT FROM OLD."Id"
+            OR NEW."ActionCode"           IS DISTINCT FROM OLD."ActionCode"
+            OR NEW."Category"             IS DISTINCT FROM OLD."Category"
+            OR NEW."Severity"             IS DISTINCT FROM OLD."Severity"
+            OR NEW."ActorUserId"          IS DISTINCT FROM OLD."ActorUserId"
+            OR NEW."ActorEmailSnapshot"   IS DISTINCT FROM OLD."ActorEmailSnapshot"
+            OR NEW."TargetType"           IS DISTINCT FROM OLD."TargetType"
+            OR NEW."TargetId"             IS DISTINCT FROM OLD."TargetId"
+            OR NEW."Outcome"              IS DISTINCT FROM OLD."Outcome"
+            OR NEW."IpAddress"            IS DISTINCT FROM OLD."IpAddress"
+            OR NEW."UserAgent"            IS DISTINCT FROM OLD."UserAgent"
+            OR NEW."OccurredAt"           IS DISTINCT FROM OLD."OccurredAt"
+            OR NEW."SourceEventId"        IS DISTINCT FROM OLD."SourceEventId"
+            OR NEW."SourceSequenceNumber" IS DISTINCT FROM OLD."SourceSequenceNumber"
+            OR NEW."PayloadJson"          IS DISTINCT FROM OLD."PayloadJson"
+            OR NEW."TenantId"             IS DISTINCT FROM OLD."TenantId"
+            OR NEW."UserId"               IS DISTINCT FROM OLD."UserId"
+            OR (OLD."RecordHash"     IS NOT NULL AND NEW."RecordHash"     IS DISTINCT FROM OLD."RecordHash")
+            OR (OLD."PrevRecordHash" IS NOT NULL AND NEW."PrevRecordHash" IS DISTINCT FROM OLD."PrevRecordHash")
+            OR (OLD."ChainSequence"  IS NOT NULL AND NEW."ChainSequence"  IS DISTINCT FROM OLD."ChainSequence")
+          ) THEN
+            RAISE EXCEPTION 'audit_records is append-only: forbidden UPDATE to immutable/chain fields (row %).', OLD."Id";
+          END IF;
+          RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS trg_audit_records_append_only ON audit_records;
+        CREATE TRIGGER trg_audit_records_append_only
+          BEFORE UPDATE OR DELETE ON audit_records
+          FOR EACH ROW EXECUTE FUNCTION audit_records_append_only();
+        """;
+
+    public const string DownSql = """
+        DROP TRIGGER IF EXISTS trg_audit_records_append_only ON audit_records;
+        DROP FUNCTION IF EXISTS audit_records_append_only();
+        """;
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.Designer.cs
@@ -777,8 +777,8 @@ namespace Tamma.Data.Migrations.ControlPlane
                     b.Property<string>("PayloadJson")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("jsonb")
-                        .HasDefaultValueSql("'{}'::jsonb");
+                        .HasColumnType("text")
+                        .HasDefaultValueSql("'{}'");
 
                     b.Property<string>("PrevRecordHash")
                         .HasMaxLength(128)

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702234235_AddAuditChainCheckpoints")]
+    partial class AddAuditChainCheckpoints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.cs
@@ -11,6 +11,17 @@ namespace Tamma.Data.Migrations.ControlPlane
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Story 37-2 (code-review fix) — re-type PayloadJson jsonb -> text so the
+            // exact insert-time bytes the hash-chain is computed over round-trip
+            // identically on read-back (jsonb reorders keys / strips whitespace /
+            // normalizes numbers, which would make every chain verify as TAMPERED).
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" DROP DEFAULT;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" TYPE text USING \"PayloadJson\"::text;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" SET DEFAULT '{}';");
+
             migrationBuilder.AddColumn<long>(
                 name: "ChainSequence",
                 table: "audit_records",
@@ -50,11 +61,18 @@ namespace Tamma.Data.Migrations.ControlPlane
 
             // Story 37-2 (AC11) — append-only defence-in-depth trigger.
             migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.UpSql);
+
+            // Story 37-2 (code-review fix, AC7 hardening) — the signed checkpoints
+            // are the anchor that reveals tail-truncation, so make them write-once
+            // too. Without this, deleting recent records + the covering checkpoint
+            // would verify as Ok.
+            migrationBuilder.Sql(AuditChainCheckpointsAppendOnlyTrigger.UpSql);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql(AuditChainCheckpointsAppendOnlyTrigger.DownSql);
             migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.DownSql);
 
             migrationBuilder.DropTable(
@@ -67,6 +85,14 @@ namespace Tamma.Data.Migrations.ControlPlane
             migrationBuilder.DropColumn(
                 name: "ChainSequence",
                 table: "audit_records");
+
+            // Revert PayloadJson text -> jsonb.
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" DROP DEFAULT;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" TYPE jsonb USING \"PayloadJson\"::jsonb;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" SET DEFAULT '{}'::jsonb;");
         }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260702234235_AddAuditChainCheckpoints.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddAuditChainCheckpoints : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ChainSequence",
+                table: "audit_records",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "audit_chain_checkpoints",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    Scope = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    HeadSequence = table.Column<long>(type: "bigint", nullable: false),
+                    HeadHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    SignedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Signature = table.Column<byte[]>(type: "bytea", nullable: false),
+                    KeyVersion = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_audit_chain_checkpoints", x => x.Id);
+                    table.CheckConstraint("ck_audit_chain_checkpoints_scope_tenant", "(\"Scope\" = 'platform' AND \"TenantId\" IS NULL) OR (\"Scope\" = 'tenant' AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_audit_records_ChainSequence",
+                table: "audit_records",
+                column: "ChainSequence",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_audit_chain_checkpoints_scope_seq",
+                table: "audit_chain_checkpoints",
+                columns: new[] { "Scope", "TenantId", "HeadSequence" });
+
+            // Story 37-2 (AC11) — append-only defence-in-depth trigger.
+            migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.UpSql);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.DownSql);
+
+            migrationBuilder.DropTable(
+                name: "audit_chain_checkpoints");
+
+            migrationBuilder.DropIndex(
+                name: "UX_audit_records_ChainSequence",
+                table: "audit_records");
+
+            migrationBuilder.DropColumn(
+                name: "ChainSequence",
+                table: "audit_records");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/ControlPlaneDbContextModelSnapshot.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/ControlPlaneDbContextModelSnapshot.cs
@@ -774,8 +774,8 @@ namespace Tamma.Data.Migrations.ControlPlane
                     b.Property<string>("PayloadJson")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("jsonb")
-                        .HasDefaultValueSql("'{}'::jsonb");
+                        .HasColumnType("text")
+                        .HasDefaultValueSql("'{}'");
 
                     b.Property<string>("PrevRecordHash")
                         .HasMaxLength(128)

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260702234247_AddAuditChainColumns")]
+    partial class AddAuditChainColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.Designer.cs
@@ -730,8 +730,8 @@ namespace Tamma.Data.Migrations.Tenant
                     b.Property<string>("PayloadJson")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("jsonb")
-                        .HasDefaultValueSql("'{}'::jsonb");
+                        .HasColumnType("text")
+                        .HasDefaultValueSql("'{}'");
 
                     b.Property<string>("PrevRecordHash")
                         .HasMaxLength(128)

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.cs
@@ -10,6 +10,17 @@ namespace Tamma.Data.Migrations.Tenant
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // Story 37-2 (code-review fix) — re-type PayloadJson jsonb -> text so the
+            // exact insert-time bytes the hash-chain is computed over round-trip
+            // identically on read-back (jsonb reorders keys / strips whitespace /
+            // normalizes numbers, which would make every chain verify as TAMPERED).
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" DROP DEFAULT;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" TYPE text USING \"PayloadJson\"::text;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" SET DEFAULT '{}';");
+
             migrationBuilder.AddColumn<long>(
                 name: "ChainSequence",
                 table: "audit_records",
@@ -38,6 +49,14 @@ namespace Tamma.Data.Migrations.Tenant
             migrationBuilder.DropColumn(
                 name: "ChainSequence",
                 table: "audit_records");
+
+            // Revert PayloadJson text -> jsonb.
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" DROP DEFAULT;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" TYPE jsonb USING \"PayloadJson\"::jsonb;");
+            migrationBuilder.Sql(
+                "ALTER TABLE audit_records ALTER COLUMN \"PayloadJson\" SET DEFAULT '{}'::jsonb;");
         }
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260702234247_AddAuditChainColumns.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddAuditChainColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "ChainSequence",
+                table: "audit_records",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "UX_audit_records_ChainSequence",
+                table: "audit_records",
+                column: "ChainSequence",
+                unique: true);
+
+            // Story 37-2 (AC11) — append-only defence-in-depth trigger (per tenant schema).
+            migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.UpSql);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(AuditRecordsAppendOnlyTrigger.DownSql);
+
+            migrationBuilder.DropIndex(
+                name: "UX_audit_records_ChainSequence",
+                table: "audit_records");
+
+            migrationBuilder.DropColumn(
+                name: "ChainSequence",
+                table: "audit_records");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/TenantDbContextModelSnapshot.cs
@@ -727,8 +727,8 @@ namespace Tamma.Data.Migrations.Tenant
                     b.Property<string>("PayloadJson")
                         .IsRequired()
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("jsonb")
-                        .HasDefaultValueSql("'{}'::jsonb");
+                        .HasColumnType("text")
+                        .HasDefaultValueSql("'{}'");
 
                     b.Property<string>("PrevRecordHash")
                         .HasMaxLength(128)

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1242,9 +1242,18 @@ internal static class TammaModelConfiguration
             entity.Property(e => e.OccurredAt).HasColumnType("timestamp with time zone");
             entity.Property(e => e.PayloadJson)
                 .HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
-            // Reserved for Story 37-2 — nullable, never populated here.
+            // Story 37-2 — tamper-evidence hash chain. The hash columns were
+            // reserved by 37-1; 37-2 adds the per-scope monotonic sequence and a
+            // UNIQUE index over it (one chain per physical table — the CP table
+            // or a tenant schema's table). Nullable for pre-37-2 legacy rows
+            // awaiting backfill; Postgres treats NULLs as distinct so the unique
+            // index permits many un-backfilled rows.
             entity.Property(e => e.RecordHash).HasMaxLength(128);
             entity.Property(e => e.PrevRecordHash).HasMaxLength(128);
+            entity.Property(e => e.ChainSequence);
+            entity.HasIndex(e => e.ChainSequence)
+                .IsUnique()
+                .HasDatabaseName("UX_audit_records_ChainSequence");
 
             // Idempotency key — one curated row per raw event (AC8). The
             // projector inserts-if-absent; a re-scan after a crash is a no-op.
@@ -1287,6 +1296,40 @@ internal static class TammaModelConfiguration
     /// <c>TenantId</c>), which also carries the single-user / shared-DB
     /// <c>cp.domain_events</c> fallback.</para>
     /// </summary>
+    /// <summary>
+    /// Story 37-2 (AC5) — configure the <c>audit_chain_checkpoints</c> table.
+    /// CP-resident only (called from <see cref="ControlPlaneDbContext"/>). Holds
+    /// signed anchors for BOTH platform and tenant chains; <c>tenant_id</c>
+    /// discriminates. A CHECK ties <c>scope</c>↔<c>tenant_id</c> consistency.
+    /// </summary>
+    public static void ConfigureAuditChainCheckpoint(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<AuditChainCheckpoint>(entity =>
+        {
+            entity.ToTable("audit_chain_checkpoints", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_audit_chain_checkpoints_scope_tenant",
+                    "(\"Scope\" = 'platform' AND \"TenantId\" IS NULL) "
+                    + "OR (\"Scope\" = 'tenant' AND \"TenantId\" IS NOT NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.Scope).IsRequired().HasMaxLength(16);
+            entity.Property(e => e.HeadSequence).IsRequired();
+            entity.Property(e => e.HeadHash).IsRequired().HasMaxLength(128);
+            entity.Property(e => e.SignedAt).HasColumnType("timestamp with time zone");
+            entity.Property(e => e.Signature).IsRequired().HasColumnType("bytea");
+            entity.Property(e => e.KeyVersion).IsRequired();
+            entity.Property(e => e.CreatedAt)
+                .HasColumnType("timestamp with time zone").HasDefaultValueSql("now()");
+
+            // Latest-covering-checkpoint lookup: (scope, tenant_id, head_sequence DESC).
+            entity.HasIndex(e => new { e.Scope, e.TenantId, e.HeadSequence })
+                .HasDatabaseName("IX_audit_chain_checkpoints_scope_seq");
+        });
+    }
+
     public static void ConfigureAuditProjectorCursor(ModelBuilder modelBuilder)
     {
         modelBuilder.Entity<AuditProjectorCursor>(entity =>

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1240,8 +1240,18 @@ internal static class TammaModelConfiguration
             entity.Property(e => e.IpAddress).HasMaxLength(64);
             entity.Property(e => e.UserAgent).HasMaxLength(512);
             entity.Property(e => e.OccurredAt).HasColumnType("timestamp with time zone");
+            // Story 37-2 (code-review fix) — PayloadJson is stored as `text`, NOT
+            // `jsonb`. The hash-chain (AC2) is computed at insert over the in-memory
+            // payload STRING, and verification recomputes it over the value read
+            // back from this column. `jsonb` does not round-trip its input text —
+            // Postgres reorders object keys, strips whitespace, and normalizes
+            // numbers/unicode — so write-bytes != read-bytes and EVERY chain would
+            // verify as TAMPERED. `text` preserves the exact bytes, making the
+            // recompute deterministic. No code uses jsonb operators on this column
+            // (the only jsonb-aware read is `"PayloadJson"::text ILIKE` in
+            // AuditQueryService, and `text::text` is a no-op), so text is safe.
             entity.Property(e => e.PayloadJson)
-                .HasColumnType("jsonb").HasDefaultValueSql("'{}'::jsonb");
+                .HasColumnType("text").HasDefaultValueSql("'{}'");
             // Story 37-2 — tamper-evidence hash chain. The hash columns were
             // reserved by 37-1; 37-2 adds the per-scope monotonic sequence and a
             // UNIQUE index over it (one chain per physical table — the CP table

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainMigrationTests.cs
@@ -1,0 +1,202 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (AC1/AC5/AC11) — applies the ControlPlane migration bundle to a
+/// clean Postgres 17 testcontainer and asserts the hash-chain schema landed: the
+/// <c>chain_sequence</c> unique index, the <c>audit_chain_checkpoints</c> table +
+/// its scope↔tenant CHECK, and — the point of AC11 — that the append-only
+/// trigger REJECTS a DELETE / a forbidden UPDATE while allowing a one-time
+/// NULL→value chain backfill.
+/// </summary>
+[TestFixture]
+public class AuditChainMigrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_chain_migration_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = new ControlPlaneDbContext(
+            new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+        await ctx.Database.MigrateAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    [Test]
+    public async Task Migration_Creates_Checkpoint_Table_And_ChainSequence_Index()
+    {
+        await using var conn = await OpenAsync();
+
+        var tables = await Scalars(conn,
+            "SELECT table_name FROM information_schema.tables WHERE table_schema='public';");
+        tables.Should().Contain("audit_chain_checkpoints");
+
+        var idx = await Scalars(conn,
+            "SELECT indexname FROM pg_indexes WHERE tablename='audit_records';");
+        idx.Should().Contain("UX_audit_records_ChainSequence");
+
+        var checks = await Scalars(conn, "SELECT conname FROM pg_constraint WHERE contype='c';");
+        checks.Should().Contain("ck_audit_chain_checkpoints_scope_tenant");
+    }
+
+    [Test]
+    public async Task Checkpoint_ScopeTenant_Check_Rejects_Platform_With_TenantId()
+    {
+        await using var conn = await OpenAsync();
+        var act = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                """
+                INSERT INTO audit_chain_checkpoints
+                  ("Scope","TenantId","HeadSequence","HeadHash","SignedAt","Signature","KeyVersion")
+                VALUES ('platform', @tid, 1, 'x', now(), '\x01'::bytea, 1);
+                """, conn);
+            cmd.Parameters.AddWithValue("tid", Guid.NewGuid());
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await act.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be("23514");
+    }
+
+    [Test]
+    public async Task AppendOnly_Trigger_Rejects_Delete()
+    {
+        await using var conn = await OpenAsync();
+        var id = await InsertChainedRow(conn, seq: 100);
+
+        var act = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                "DELETE FROM audit_records WHERE \"Id\"=@id;", conn);
+            cmd.Parameters.AddWithValue("id", id);
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+    }
+
+    [Test]
+    public async Task AppendOnly_Trigger_Rejects_Mutating_A_Core_Field()
+    {
+        await using var conn = await OpenAsync();
+        var id = await InsertChainedRow(conn, seq: 200);
+
+        var act = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                "UPDATE audit_records SET \"PayloadJson\"='{\"tampered\":true}'::jsonb WHERE \"Id\"=@id;", conn);
+            cmd.Parameters.AddWithValue("id", id);
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+    }
+
+    [Test]
+    public async Task AppendOnly_Trigger_Allows_OneTime_Null_To_Value_Backfill()
+    {
+        await using var conn = await OpenAsync();
+        // Insert a LEGACY row (no chain columns yet).
+        var id = Guid.NewGuid();
+        var src = Guid.NewGuid();
+        await using (var insert = new NpgsqlCommand(
+            """
+            INSERT INTO audit_records
+              ("Id","ActionCode","Category","Severity","Outcome","OccurredAt",
+               "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId")
+            VALUES (@id,'SECRET.REVEAL','secret','high','success', now(),
+                    @src, 1, '{}'::jsonb, NULL, @uid);
+            """, conn))
+        {
+            insert.Parameters.AddWithValue("id", id);
+            insert.Parameters.AddWithValue("src", src);
+            insert.Parameters.AddWithValue("uid", Guid.NewGuid());
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        // Backfill the chain columns from NULL → value (allowed exactly once).
+        await using var backfill = new NpgsqlCommand(
+            """
+            UPDATE audit_records
+            SET "ChainSequence"=1,
+                "PrevRecordHash"='0000000000000000000000000000000000000000000000000000000000000000',
+                "RecordHash"='1111111111111111111111111111111111111111111111111111111111111111'
+            WHERE "Id"=@id;
+            """, conn);
+        backfill.Parameters.AddWithValue("id", id);
+        var affected = await backfill.ExecuteNonQueryAsync();
+        affected.Should().Be(1, "a one-time NULL→value chain backfill is permitted");
+
+        // But a SECOND update of an already-set chain column is rejected.
+        var act = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                "UPDATE audit_records SET \"RecordHash\"='2222222222222222222222222222222222222222222222222222222222222222' WHERE \"Id\"=@id;", conn);
+            cmd.Parameters.AddWithValue("id", id);
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await act.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+    }
+
+    private static async Task<Guid> InsertChainedRow(NpgsqlConnection conn, long seq)
+    {
+        var id = Guid.NewGuid();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO audit_records
+              ("Id","ActionCode","Category","Severity","Outcome","OccurredAt",
+               "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId",
+               "ChainSequence","PrevRecordHash","RecordHash")
+            VALUES (@id,'SECRET.REVEAL','secret','high','success', now(),
+                    @src, @seq, '{}'::jsonb, NULL, @uid,
+                    @seq,
+                    '0000000000000000000000000000000000000000000000000000000000000000',
+                    '1111111111111111111111111111111111111111111111111111111111111111');
+            """, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("src", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("seq", seq);
+        cmd.Parameters.AddWithValue("uid", Guid.NewGuid());
+        await cmd.ExecuteNonQueryAsync();
+        return id;
+    }
+
+    private static async Task<HashSet<string>> Scalars(NpgsqlConnection conn, string sql)
+    {
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            if (!reader.IsDBNull(0)) result.Add(reader.GetString(0));
+        return result;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainMigrationTests.cs
@@ -112,7 +112,7 @@ public class AuditChainMigrationTests
         var act = async () =>
         {
             await using var cmd = new NpgsqlCommand(
-                "UPDATE audit_records SET \"PayloadJson\"='{\"tampered\":true}'::jsonb WHERE \"Id\"=@id;", conn);
+                "UPDATE audit_records SET \"PayloadJson\"='{\"tampered\":true}' WHERE \"Id\"=@id;", conn);
             cmd.Parameters.AddWithValue("id", id);
             await cmd.ExecuteNonQueryAsync();
         };
@@ -133,7 +133,7 @@ public class AuditChainMigrationTests
               ("Id","ActionCode","Category","Severity","Outcome","OccurredAt",
                "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId")
             VALUES (@id,'SECRET.REVEAL','secret','high','success', now(),
-                    @src, 1, '{}'::jsonb, NULL, @uid);
+                    @src, 1, '{}', NULL, @uid);
             """, conn))
         {
             insert.Parameters.AddWithValue("id", id);
@@ -177,7 +177,7 @@ public class AuditChainMigrationTests
                "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId",
                "ChainSequence","PrevRecordHash","RecordHash")
             VALUES (@id,'SECRET.REVEAL','secret','high','success', now(),
-                    @src, @seq, '{}'::jsonb, NULL, @uid,
+                    @src, @seq, '{}', NULL, @uid,
                     @seq,
                     '0000000000000000000000000000000000000000000000000000000000000000',
                     '1111111111111111111111111111111111111111111111111111111111111111');

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainPostgresVerifyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainPostgresVerifyTests.cs
@@ -1,0 +1,249 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (code-review fixes) — end-to-end hash-chain integrity against a REAL
+/// Postgres 17, which the InMemory tests cannot exercise (InMemory stores
+/// <c>PayloadJson</c> verbatim and has no triggers).
+///
+/// <para><b>Finding 1 (CRITICAL).</b> A record inserted through
+/// <see cref="AuditRecordRepository"/> — whose chain hash is computed over the
+/// in-memory payload string — must verify as <c>Ok</c> after being READ BACK from
+/// the column. When <c>PayloadJson</c> was <c>jsonb</c>, Postgres reordered keys /
+/// stripped whitespace / normalized numbers on round-trip, so the recomputed hash
+/// never matched and EVERY chain verified as <c>Tampered</c> at sequence 1. The
+/// fix stores it as <c>text</c> (verbatim bytes).</para>
+///
+/// <para><b>Finding 2 (IMPORTANT).</b> The signed checkpoint anchor must itself be
+/// append-only, and a tail-truncation below a surviving checkpoint must verify as
+/// <c>Tampered</c>.</para>
+///
+/// <para>Uses a fresh container per test so the append-only chain state stays
+/// isolated (records cannot be deleted between tests).</para>
+/// </summary>
+[TestFixture]
+public class AuditChainPostgresVerifyTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _cs = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("audit_chain_verify_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _cs = _postgres.GetConnectionString();
+
+        await using var ctx = NewCp();
+        await ctx.Database.MigrateAsync();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_postgres is not null) await _postgres.DisposeAsync();
+    }
+
+    private ControlPlaneDbContext NewCp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_cs).Options);
+
+    private static AuditRecord NewRecord(string payloadJson) => new()
+    {
+        Id = Guid.NewGuid(),
+        ActionCode = "SECRET.REVEAL",
+        Category = "security",
+        Severity = "high",
+        Outcome = "success",
+        OccurredAt = DateTime.UtcNow,
+        SourceEventId = Guid.NewGuid(),
+        SourceSequenceNumber = Random.Shared.Next(1, 1_000_000),
+        PayloadJson = payloadJson,
+        TenantId = null,
+        UserId = Guid.NewGuid(),
+    };
+
+    // ── Finding 1 (CRITICAL) — jsonb round-trip broke canonicalization ───────────
+
+    [Test]
+    public async Task Record_With_Unsorted_MultiKey_Payload_Verifies_Ok_On_Real_Postgres()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+
+        // Keys NOT already sorted, nested objects, a float and a string — the exact
+        // shape jsonb would rewrite on storage. With `text` the bytes are verbatim.
+        var first = NewRecord("{\"tags\":{\"z\":1,\"a\":2},\"data\":{\"n\":1.0,\"m\":\"x\"}}");
+        (await repo.InsertIfAbsentAsync(cp, first)).Should().BeTrue();
+        (await repo.InsertIfAbsentAsync(cp, NewRecord("{\"b\":2,\"a\":1}"))).Should().BeTrue();
+        (await repo.InsertIfAbsentAsync(cp, NewRecord("{}"))).Should().BeTrue();
+
+        // Sanity: the payload was stored verbatim (no jsonb re-serialization).
+        await using (var readCp = NewCp())
+        {
+            var stored = await readCp.AuditRecords.AsNoTracking()
+                .Where(r => r.Id == first.Id).Select(r => r.PayloadJson).FirstAsync();
+            stored.Should().Be("{\"tags\":{\"z\":1,\"a\":2},\"data\":{\"n\":1.0,\"m\":\"x\"}}");
+        }
+
+        // The whole chain, read back from Postgres, recomputes byte-identically.
+        var result = await BuildVerifier(cp).VerifyAsync(AuditChainScope.Platform, null, null, default);
+
+        result.Status.Should().Be(ChainVerificationStatus.Ok,
+            "a record inserted through the repository must verify Ok against real Postgres "
+            + "(jsonb round-trip would have made it Tampered at sequence 1)");
+        result.RecordsVerified.Should().Be(3);
+    }
+
+    // ── Finding 2a — the checkpoint table is append-only ─────────────────────────
+
+    [Test]
+    public async Task Checkpoint_AppendOnly_Trigger_Rejects_Delete_And_Update()
+    {
+        var id = await InsertCheckpoint(headSequence: 5, headHash: new string('a', 64));
+
+        await using var conn = await OpenAsync();
+
+        var delete = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                "DELETE FROM audit_chain_checkpoints WHERE \"Id\"=@id;", conn);
+            cmd.Parameters.AddWithValue("id", id);
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await delete.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+
+        var update = async () =>
+        {
+            await using var cmd = new NpgsqlCommand(
+                "UPDATE audit_chain_checkpoints SET \"HeadSequence\"=1 WHERE \"Id\"=@id;", conn);
+            cmd.Parameters.AddWithValue("id", id);
+            await cmd.ExecuteNonQueryAsync();
+        };
+        (await update.Should().ThrowAsync<PostgresException>())
+            .Which.MessageText.Should().Contain("append-only");
+    }
+
+    // ── Finding 2b — tail-truncation below a surviving checkpoint is Tampered ─────
+
+    [Test]
+    public async Task Tail_Truncation_Below_A_Surviving_Checkpoint_Verifies_Tampered()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+
+        var records = new List<AuditRecord>();
+        for (var i = 0; i < 5; i++)
+        {
+            var r = NewRecord("{\"i\":" + i + "}");
+            (await repo.InsertIfAbsentAsync(cp, r)).Should().BeTrue();
+            records.Add(r);
+        }
+        var head = records.Single(r => r.ChainSequence == 5);
+
+        // A signed checkpoint anchors head=5 (written before the attack). It is
+        // append-only, so the attacker cannot delete it.
+        await InsertCheckpoint(headSequence: 5, headHash: head.RecordHash!);
+
+        // Attacker with direct DB access bypasses the ORM append-only trigger and
+        // deletes the two most recent records → the live head regresses to 3.
+        await TruncateRecordsAbove(sequence: 3);
+
+        var verifier = BuildVerifier(cp);
+
+        // Full verify: the covering (max) checkpoint at 5 is confirmed to anchor a
+        // now-missing head record → Tampered.
+        var full = await verifier.VerifyAsync(AuditChainScope.Platform, null, null, default);
+        full.Status.Should().Be(ChainVerificationStatus.Tampered,
+            "the surviving checkpoint reveals that records were deleted from the tail");
+
+        // Bounded verify to the truncated head (3): the covering-checkpoint filter
+        // finds nothing <= 3, so the explicit head < max-checkpoint check must fire.
+        var bounded = await verifier.VerifyAsync(AuditChainScope.Platform, null, 3, default);
+        bounded.Status.Should().Be(ChainVerificationStatus.Tampered);
+        bounded.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.HeadBelowCheckpoint);
+        bounded.FirstBrokenLink.ChainSequence.Should().Be(5);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────
+
+    private IAuditChainVerifier BuildVerifier(ControlPlaneDbContext cp) =>
+        new AuditChainVerifier(
+            new AuditChainRecordSource(cp, tenantFactory: null),
+            new AuditChainCheckpointGateway(cp, new AlwaysValidSigner()));
+
+    private async Task<Guid> InsertCheckpoint(long headSequence, string headHash)
+    {
+        var id = Guid.NewGuid();
+        await using var conn = await OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO audit_chain_checkpoints
+              ("Id","Scope","TenantId","HeadSequence","HeadHash","SignedAt","Signature","KeyVersion")
+            VALUES (@id,'platform',NULL,@seq,@hash, now(), '\x01'::bytea, 1);
+            """, conn);
+        cmd.Parameters.AddWithValue("id", id);
+        cmd.Parameters.AddWithValue("seq", headSequence);
+        cmd.Parameters.AddWithValue("hash", headHash);
+        await cmd.ExecuteNonQueryAsync();
+        return id;
+    }
+
+    /// <summary>
+    /// Simulate an attacker with direct DB write access clipping the tail: the ORM
+    /// append-only trigger is a defence against accidental writes, not a security
+    /// boundary (a table owner can DISABLE TRIGGER), so we do exactly that to model
+    /// the threat the hash-chain + checkpoint anchor must still detect.
+    /// </summary>
+    private async Task TruncateRecordsAbove(long sequence)
+    {
+        await using var conn = await OpenAsync();
+        await using var disable = new NpgsqlCommand(
+            "ALTER TABLE audit_records DISABLE TRIGGER trg_audit_records_append_only;", conn);
+        await disable.ExecuteNonQueryAsync();
+
+        await using (var del = new NpgsqlCommand(
+            "DELETE FROM audit_records WHERE \"ChainSequence\" > @seq;", conn))
+        {
+            del.Parameters.AddWithValue("seq", sequence);
+            await del.ExecuteNonQueryAsync();
+        }
+
+        await using var enable = new NpgsqlCommand(
+            "ALTER TABLE audit_records ENABLE TRIGGER trg_audit_records_append_only;", conn);
+        await enable.ExecuteNonQueryAsync();
+    }
+
+    private async Task<NpgsqlConnection> OpenAsync()
+    {
+        var conn = new NpgsqlConnection(_cs);
+        await conn.OpenAsync();
+        return conn;
+    }
+
+    private sealed class AlwaysValidSigner : IAuditChainSigner
+    {
+        public Task<(byte[] Signature, int KeyVersion)> SignAsync(
+            string scope, Guid? tenantId, long headSequence, string headHashHex,
+            DateTime signedAt, CancellationToken ct = default) =>
+            Task.FromResult((new byte[] { 1 }, 1));
+
+        public Task<bool> VerifyAsync(AuditChainCheckpointView checkpoint, CancellationToken ct = default) =>
+            Task.FromResult(true);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainRepositoryChainingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainRepositoryChainingTests.cs
@@ -1,0 +1,139 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Core.Audit;
+using Tamma.Data;
+using Tamma.Data.Audit;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (AC1/AC3/AC4) — insert-time chaining + end-to-end verification
+/// against an in-memory <see cref="ControlPlaneDbContext"/> (the platform chain).
+/// The advisory-lock path is Postgres-only; the in-memory driver exercises the
+/// deterministic single-threaded chaining + the pure verifier over real rows.
+/// </summary>
+[TestFixture]
+public class AuditChainRepositoryChainingTests
+{
+    private static ControlPlaneDbContext NewCp() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
+            .Options);
+
+    private static AuditRecord NewRecord() => new()
+    {
+        Id = Guid.NewGuid(),
+        ActionCode = "SECRET.REVEAL",
+        Category = "security",
+        Severity = "high",
+        Outcome = "success",
+        OccurredAt = DateTime.UtcNow,
+        SourceEventId = Guid.NewGuid(),
+        SourceSequenceNumber = Random.Shared.Next(1, 1_000_000),
+        PayloadJson = "{}",
+        TenantId = null,
+        UserId = Guid.NewGuid(), // single-user platform-chain row
+    };
+
+    [Test]
+    public async Task Sequential_Inserts_Form_A_Contiguous_Genesis_Anchored_Chain()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+
+        var ids = new List<Guid>();
+        for (var i = 0; i < 4; i++)
+        {
+            var r = NewRecord();
+            (await repo.InsertIfAbsentAsync(cp, r)).Should().BeTrue();
+            ids.Add(r.Id);
+        }
+
+        var rows = await cp.AuditRecords.AsNoTracking()
+            .OrderBy(r => r.ChainSequence).ToListAsync();
+
+        rows.Select(r => r.ChainSequence).Should().Equal(1L, 2L, 3L, 4L);
+        rows[0].PrevRecordHash.Should().Be(AuditChainGenesis.HashHex, "the first record chains to genesis");
+        for (var i = 1; i < rows.Count; i++)
+        {
+            rows[i].PrevRecordHash.Should().Be(rows[i - 1].RecordHash,
+                "each record's prev_hash links to the prior record's hash");
+        }
+        rows.Should().OnlyContain(r => r.RecordHash != null && r.RecordHash.Length == 64);
+    }
+
+    [Test]
+    public async Task Duplicate_SourceEvent_Is_Idempotent_And_Does_Not_Advance_The_Chain()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+
+        var r1 = NewRecord();
+        (await repo.InsertIfAbsentAsync(cp, r1)).Should().BeTrue();
+
+        var dup = NewRecord();
+        dup.SourceEventId = r1.SourceEventId; // same source event
+        (await repo.InsertIfAbsentAsync(cp, dup)).Should().BeFalse();
+
+        (await cp.AuditRecords.CountAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task Inserted_Chain_Verifies_Ok_End_To_End()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+        for (var i = 0; i < 5; i++)
+        {
+            (await repo.InsertIfAbsentAsync(cp, NewRecord())).Should().BeTrue();
+        }
+
+        var result = await BuildVerifier(cp).VerifyAsync(AuditChainScope.Platform, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Ok);
+        result.RecordsVerified.Should().Be(5);
+    }
+
+    [Test]
+    public async Task Tampering_A_Persisted_Row_Breaks_Verification_At_Its_Sequence()
+    {
+        await using var cp = NewCp();
+        var repo = new AuditRecordRepository();
+        for (var i = 0; i < 5; i++)
+        {
+            (await repo.InsertIfAbsentAsync(cp, NewRecord())).Should().BeTrue();
+        }
+
+        // Simulate a DB-level tamper (the append-only trigger is Postgres-only;
+        // in-memory lets us mutate a persisted row to model an attacker with
+        // direct write access).
+        var victim = await cp.AuditRecords.FirstAsync(r => r.ChainSequence == 3);
+        victim.TargetId = "rewritten-by-attacker";
+        await cp.SaveChangesAsync();
+
+        var result = await BuildVerifier(cp).VerifyAsync(AuditChainScope.Platform, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.ChainSequence.Should().Be(3);
+        result.FirstBrokenLink.Reason.Should().Be(ChainBreakReason.Mutated);
+    }
+
+    private static IAuditChainVerifier BuildVerifier(ControlPlaneDbContext cp)
+    {
+        var source = new AuditChainRecordSource(cp, tenantFactory: null);
+        return new AuditChainVerifier(source, new NoCheckpointGateway());
+    }
+
+    private sealed class NoCheckpointGateway : IAuditChainCheckpointGateway
+    {
+        public Task<AuditChainCheckpointView?> GetLastCoveringAsync(
+            AuditChainScope scope, long? to, CancellationToken ct) =>
+            Task.FromResult<AuditChainCheckpointView?>(null);
+
+        public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
+            Task.FromResult(true);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainRepositoryChainingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainRepositoryChainingTests.cs
@@ -135,5 +135,8 @@ public class AuditChainRepositoryChainingTests
 
         public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
             Task.FromResult(true);
+
+        public Task<long?> GetMaxHeadSequenceAsync(AuditChainScope scope, CancellationToken ct) =>
+            Task.FromResult<long?>(null);
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainSignerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditChainSignerTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.Secrets.Stopgap;
+using Tamma.Core.Audit;
+
+namespace Tamma.Api.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (AC5) — cabinet-backed checkpoint signer: HMAC round-trip, tamper
+/// rejection, and fail-closed behaviour when the key is absent.
+/// </summary>
+[TestFixture]
+public class AuditChainSignerTests
+{
+    private static AuditChainCheckpointView Checkpoint(byte[] sig) => new()
+    {
+        Id = Guid.NewGuid(),
+        Scope = "platform",
+        TenantId = null,
+        HeadSequence = 42,
+        HeadHash = new string('a', 64),
+        SignedAt = new DateTime(2026, 7, 2, 10, 0, 0, DateTimeKind.Utc),
+        Signature = sig,
+        KeyVersion = 1,
+    };
+
+    private static SecretCabinetAuditChainSigner SignerWith(string? key)
+    {
+        var services = new ServiceCollection();
+        if (key is not null)
+        {
+            services.AddSingleton<IRuntimeSecretResolver>(new FakeResolver(key));
+        }
+        return new SecretCabinetAuditChainSigner(services.BuildServiceProvider());
+    }
+
+    [Test]
+    public async Task Sign_Then_Verify_Round_Trips()
+    {
+        var signer = SignerWith("s3cr3t-key-material");
+        var cp = Checkpoint(Array.Empty<byte>());
+
+        var (sig, keyVersion) = await signer.SignAsync(
+            cp.Scope, cp.TenantId, cp.HeadSequence, cp.HeadHash, cp.SignedAt);
+        keyVersion.Should().Be(SecretCabinetAuditChainSigner.AuditChainSigningKeyVersion);
+
+        var valid = await signer.VerifyAsync(cp with { Signature = sig });
+        valid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Corrupt_Signature_Fails_Verification()
+    {
+        var signer = SignerWith("s3cr3t-key-material");
+        var cp = Checkpoint(Array.Empty<byte>());
+        var (sig, _) = await signer.SignAsync(cp.Scope, cp.TenantId, cp.HeadSequence, cp.HeadHash, cp.SignedAt);
+
+        sig[0] ^= 0xFF; // flip a byte
+        (await signer.VerifyAsync(cp with { Signature = sig })).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Different_Key_Fails_Verification()
+    {
+        var a = SignerWith("key-A");
+        var b = SignerWith("key-B");
+        var cp = Checkpoint(Array.Empty<byte>());
+        var (sig, _) = await a.SignAsync(cp.Scope, cp.TenantId, cp.HeadSequence, cp.HeadHash, cp.SignedAt);
+
+        (await b.VerifyAsync(cp with { Signature = sig })).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Missing_Key_Sign_Throws_And_Verify_Returns_False_FailClosed()
+    {
+        var signer = SignerWith(null);
+
+        var sign = async () => await signer.SignAsync("platform", null, 1, new string('a', 64), DateTime.UtcNow);
+        await sign.Should().ThrowAsync<InvalidOperationException>();
+
+        (await signer.VerifyAsync(Checkpoint(new byte[] { 1, 2, 3 }))).Should().BeFalse();
+    }
+
+    private sealed class FakeResolver : IRuntimeSecretResolver
+    {
+        private readonly string? _key;
+        public FakeResolver(string? key) => _key = key;
+
+        public Task<string?> GetAsync(string cabinetName, CancellationToken ct = default)
+        {
+            cabinetName.Should().Be(StopgapSecretMap.PlatformAuditChainSigningKey);
+            return Task.FromResult(_key);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordMigrationTests.cs
@@ -247,7 +247,7 @@ public class AuditRecordMigrationTests
                "SourceEventId","SourceSequenceNumber","PayloadJson","TenantId","UserId")
             VALUES
               ('SECRET.REVEAL','secret','critical','success', now(),
-               @src, 1, '{}'::jsonb, @tid, @uid);
+               @src, 1, '{}', @tid, @uid);
             """, conn);
         cmd.Parameters.AddWithValue("src", sourceId);
         cmd.Parameters.AddWithValue("tid", (object?)tenantId ?? DBNull.Value);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
@@ -95,14 +95,17 @@ public class AuditRecordModelTests
         entity.FindProperty("ChainSequence")!.IsNullable.Should().BeTrue();
     }
 
-    // ── AC4 — payload is jsonb; occurred_at is timestamptz ──
+    // ── AC4 — payload is text (Story 37-2 fix); occurred_at is timestamptz ──
 
     [Test]
-    public void Payload_Is_Jsonb_And_OccurredAt_Is_TimestampTz()
+    public void Payload_Is_Text_And_OccurredAt_Is_TimestampTz()
     {
         using var ctx = Cp();
         var entity = ctx.Model.FindEntityType(typeof(AuditRecord))!;
-        entity.FindProperty("PayloadJson")!.GetColumnType().Should().Be("jsonb");
+        // Story 37-2 (code-review fix) — PayloadJson is stored as text, not jsonb,
+        // so the hash-chain preimage round-trips byte-for-byte (jsonb would reorder
+        // keys / normalize and make every chain verify as TAMPERED).
+        entity.FindProperty("PayloadJson")!.GetColumnType().Should().Be("text");
         entity.FindProperty("OccurredAt")!.GetColumnType().Should().Be("timestamp with time zone");
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Audit/AuditRecordModelTests.cs
@@ -76,7 +76,8 @@ public class AuditRecordModelTests
             "IpAddress", "UserAgent", "OccurredAt",
             "SourceEventId", "SourceSequenceNumber", "PayloadJson",
             "TenantId", "UserId",
-            "RecordHash", "PrevRecordHash",
+            // Story 37-2 tamper-evidence hash chain.
+            "RecordHash", "PrevRecordHash", "ChainSequence",
         });
     }
 
@@ -89,6 +90,9 @@ public class AuditRecordModelTests
         var entity = ctx.Model.FindEntityType(typeof(AuditRecord))!;
         entity.FindProperty("RecordHash")!.IsNullable.Should().BeTrue();
         entity.FindProperty("PrevRecordHash")!.IsNullable.Should().BeTrue();
+        // Story 37-2 — ChainSequence is nullable only for pre-37-2 legacy rows
+        // (new inserts always populate it).
+        entity.FindProperty("ChainSequence")!.IsNullable.Should().BeTrue();
     }
 
     // ── AC4 — payload is jsonb; occurred_at is timestamptz ──

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -137,6 +137,10 @@ public class ControlPlaneDbContextModelTests
             // CP-resident high-water marks).
             "audit_records",
             "audit_projector_cursor",
+            // Story 37-2 — signed hash-chain checkpoints. CP-resident for BOTH
+            // platform and tenant scopes (a tenant cannot rewrite an anchor
+            // stored outside its own schema); tenant_id discriminates the scope.
+            "audit_chain_checkpoints",
             // Story 34-11 — provider COST price-book. Platform-global (no
             // TenantId): cost is the provider's published rate, identical for
             // every tenant. Promotes the frozen ProviderPricingService rate
@@ -168,7 +172,8 @@ public class ControlPlaneDbContextModelTests
             + "Story 34-11 adds providers + provider_model_prices. "
             + "Story 34-5 adds margin_policies. "
             + "Story 34-4 adds tenant_plan_assignments. "
-            + "Story 38-3 adds slack_outbox.");
+            + "Story 38-3 adds slack_outbox. "
+            + "Story 37-2 adds audit_chain_checkpoints.");
     }
 
     // ── Story 34-11 — provider cost price-book model shape ──

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainHasherTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainHasherTests.cs
@@ -1,0 +1,63 @@
+using System.Security.Cryptography;
+using System.Text;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Audit;
+
+namespace Tamma.Core.Tests.Audit;
+
+/// <summary>Story 37-2 (AC2) — hasher determinism + avalanche + genesis.</summary>
+[TestFixture]
+public class AuditChainHasherTests
+{
+    private static readonly string Prev = AuditChainGenesis.HashHex;
+
+    [Test]
+    public void Compose_Returns_64_Lowercase_Hex_Chars()
+    {
+        var hex = AuditChainHasher.ComposeHex(Prev, new byte[] { 1, 2, 3 });
+        hex.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Test]
+    public void Compose_Is_Deterministic()
+    {
+        var a = AuditChainHasher.ComposeHex(Prev, Encoding.UTF8.GetBytes("canon"));
+        var b = AuditChainHasher.ComposeHex(Prev, Encoding.UTF8.GetBytes("canon"));
+        a.Should().Be(b);
+    }
+
+    [Test]
+    public void Flipping_One_Bit_Of_Canonical_Changes_The_Hash()
+    {
+        var canon = new byte[] { 0x10, 0x20, 0x30 };
+        var flipped = new byte[] { 0x10, 0x21, 0x30 };
+        AuditChainHasher.ComposeHex(Prev, canon)
+            .Should().NotBe(AuditChainHasher.ComposeHex(Prev, flipped));
+    }
+
+    [Test]
+    public void Changing_Prev_Hash_Changes_The_Result()
+    {
+        var otherPrev = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("x"))).ToLowerInvariant();
+        var canon = Encoding.UTF8.GetBytes("canon");
+        AuditChainHasher.ComposeHex(Prev, canon)
+            .Should().NotBe(AuditChainHasher.ComposeHex(otherPrev, canon));
+    }
+
+    [Test]
+    public void Genesis_Is_Reproducible_From_Documented_Preimage()
+    {
+        var expected = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(AuditChainGenesis.Preimage))).ToLowerInvariant();
+        AuditChainGenesis.HashHex.Should().Be(expected);
+        AuditChainGenesis.HashHex.Should().HaveLength(64);
+    }
+
+    [Test]
+    public void Malformed_Prev_Hash_Throws()
+    {
+        var act = () => AuditChainHasher.ComposeHex("too-short", new byte[] { 1 });
+        act.Should().Throw<FormatException>();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainVerifierTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainVerifierTests.cs
@@ -215,6 +215,35 @@ public class AuditChainVerifierTests
     }
 
     [Test]
+    public async Task Tail_Truncated_Below_A_Surviving_Checkpoint_Is_Detected()
+    {
+        // Records 4 and 5 were deleted (attacker with DB write access), leaving a
+        // clean, self-consistent 1..3. But a signed, append-only checkpoint still
+        // anchors head=5 — proof those records once existed.
+        var chain = BuildChain(3);
+        var cp = new AuditChainCheckpointView
+        {
+            Id = Guid.NewGuid(),
+            Scope = Scope.Discriminator,
+            TenantId = null,
+            HeadSequence = 5,
+            HeadHash = new string('a', 64),
+            SignedAt = DateTime.UtcNow,
+            Signature = new byte[] { 1 },
+            KeyVersion = 1,
+        };
+
+        // Verify with to=3 so the covering-checkpoint block (which filters
+        // head_sequence <= to) finds nothing — the surviving max checkpoint at 5
+        // is what must reveal the truncation.
+        var result = await VerifierFor(chain, cp).VerifyAsync(Scope, from: null, to: 3, default);
+
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.HeadBelowCheckpoint);
+        result.FirstBrokenLink.ChainSequence.Should().Be(5, "the checkpoint proves head reached 5");
+    }
+
+    [Test]
     public async Task Mid_Chain_Range_Anchors_Prev_From_Prior_Record()
     {
         var chain = BuildChain(5);
@@ -270,5 +299,8 @@ public class AuditChainVerifierTests
 
         public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
             Task.FromResult(_signatureValid);
+
+        public Task<long?> GetMaxHeadSequenceAsync(AuditChainScope scope, CancellationToken ct) =>
+            Task.FromResult(_cp?.HeadSequence);
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainVerifierTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditChainVerifierTests.cs
@@ -1,0 +1,274 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Audit;
+
+namespace Tamma.Core.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (AC4/AC7/AC14) — the tamper-detection matrix, run against an
+/// in-memory chain built with the REAL canonicalizer + hasher so the verifier
+/// recomputes byte-identical hashes.
+/// </summary>
+[TestFixture]
+public class AuditChainVerifierTests
+{
+    private static readonly AuditChainScope Scope = AuditChainScope.Platform;
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static AuditChainRecordView Content(long seq) => new()
+    {
+        Id = Guid.NewGuid(),
+        Discriminator = Scope.Discriminator,
+        TenantId = null,
+        UserId = null,
+        ActionCode = "SECRET.REVEAL",
+        Category = "security",
+        Severity = "high",
+        ActorUserId = null,
+        ActorEmailSnapshot = $"user{seq}@example.com",
+        TargetType = "secret",
+        TargetId = $"target-{seq}",
+        Outcome = "success",
+        IpAddress = null,
+        UserAgent = null,
+        OccurredAt = new DateTime(2026, 7, 2, 0, 0, 0, DateTimeKind.Utc).AddSeconds(seq),
+        SourceEventId = Guid.NewGuid(),
+        SourceSequenceNumber = seq,
+        PayloadJson = $"{{\"seq\":{seq}}}",
+        ChainSequence = seq,
+        PrevRecordHash = string.Empty,
+        RecordHash = string.Empty,
+    };
+
+    /// <summary>Build a valid chain 1..n with correct prev/record hashes.</summary>
+    private static List<AuditChainRecordView> BuildChain(int n)
+    {
+        var chain = new List<AuditChainRecordView>();
+        var prev = AuditChainGenesis.HashHex;
+        for (long seq = 1; seq <= n; seq++)
+        {
+            var withPrev = Content(seq) with { PrevRecordHash = prev };
+            var hash = AuditChainHasher.ComposeHex(
+                prev, AuditRecordCanonicalizer.ToBytes(withPrev));
+            var final = withPrev with { RecordHash = hash };
+            chain.Add(final);
+            prev = hash;
+        }
+        return chain;
+    }
+
+    private static AuditChainVerifier VerifierFor(
+        List<AuditChainRecordView> chain,
+        AuditChainCheckpointView? cp = null,
+        bool signatureValid = true) =>
+        new(new FakeRecordSource(chain), new FakeCheckpointGateway(cp, signatureValid));
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Clean_Chain_Verifies_Ok()
+    {
+        var chain = BuildChain(5);
+        var result = await VerifierFor(chain).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Ok);
+        result.RecordsVerified.Should().Be(5);
+        result.LastSequence.Should().Be(5);
+    }
+
+    [Test]
+    public async Task Empty_Chain_Verifies_Ok()
+    {
+        var result = await VerifierFor(new List<AuditChainRecordView>()).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Ok);
+        result.RecordsVerified.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Mutated_Record_Is_Detected_At_Its_Sequence()
+    {
+        var chain = BuildChain(5);
+        // In-place edit of record #3's payload — hash no longer matches.
+        chain[2] = chain[2] with { PayloadJson = "{\"seq\":3,\"tampered\":true}" };
+
+        var result = await VerifierFor(chain).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.Mutated);
+        result.FirstBrokenLink.ChainSequence.Should().Be(3);
+    }
+
+    [Test]
+    public async Task Deleted_Middle_Record_Is_Detected_As_Missing_Gap()
+    {
+        var chain = BuildChain(5);
+        chain.RemoveAt(2); // drop sequence 3 → 1,2,4,5
+
+        var result = await VerifierFor(chain).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.Missing);
+        result.FirstBrokenLink.ChainSequence.Should().Be(3, "sequence 3 is the missing slot");
+    }
+
+    [Test]
+    public async Task Reordered_Records_Are_Detected()
+    {
+        var chain = BuildChain(5);
+        // Swap the sequence numbers of #2 and #3 without fixing hashes → the
+        // stream now yields 1,3,2,... (source orders by ChainSequence).
+        var a = chain[1] with { ChainSequence = 3 };
+        var b = chain[2] with { ChainSequence = 2 };
+        chain[1] = b; // seq 2 slot now holds record with old content #3
+        chain[2] = a;
+
+        var result = await VerifierFor(chain).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should()
+            .BeOneOf(ChainBreakReason.PrevHashMismatch, ChainBreakReason.Mutated);
+    }
+
+    [Test]
+    public async Task Clipped_Tail_Against_Checkpoint_Is_Detected()
+    {
+        var chain = BuildChain(5);
+        var head = chain[^1];
+        var cp = new AuditChainCheckpointView
+        {
+            Id = Guid.NewGuid(),
+            Scope = Scope.Discriminator,
+            TenantId = null,
+            HeadSequence = 5,
+            HeadHash = head.RecordHash,
+            SignedAt = DateTime.UtcNow,
+            Signature = new byte[] { 1 },
+            KeyVersion = 1,
+        };
+        // Attacker clips the tail: records 4 and 5 removed, but the checkpoint
+        // still anchors head=5.
+        chain.RemoveRange(3, 2); // now 1,2,3
+
+        var result = await VerifierFor(chain, cp).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.Missing);
+    }
+
+    [Test]
+    public async Task Valid_Checkpoint_Confirms_Ok()
+    {
+        var chain = BuildChain(5);
+        var head = chain[^1];
+        var cp = new AuditChainCheckpointView
+        {
+            Id = Guid.NewGuid(),
+            Scope = Scope.Discriminator,
+            TenantId = null,
+            HeadSequence = 5,
+            HeadHash = head.RecordHash,
+            SignedAt = DateTime.UtcNow,
+            Signature = new byte[] { 1 },
+            KeyVersion = 1,
+        };
+        var result = await VerifierFor(chain, cp).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Ok);
+        result.LastCheckpoint.Should().NotBeNull();
+    }
+
+    [Test]
+    public async Task Invalid_Checkpoint_Signature_Is_Reported_Distinctly()
+    {
+        var chain = BuildChain(3);
+        var head = chain[^1];
+        var cp = new AuditChainCheckpointView
+        {
+            Id = Guid.NewGuid(),
+            Scope = Scope.Discriminator,
+            TenantId = null,
+            HeadSequence = 3,
+            HeadHash = head.RecordHash,
+            SignedAt = DateTime.UtcNow,
+            Signature = new byte[] { 9 },
+            KeyVersion = 1,
+        };
+        var result = await VerifierFor(chain, cp, signatureValid: false)
+            .VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.CheckpointSignatureInvalid);
+    }
+
+    [Test]
+    public async Task Checkpoint_Head_Hash_Mismatch_Is_Detected()
+    {
+        var chain = BuildChain(3);
+        var cp = new AuditChainCheckpointView
+        {
+            Id = Guid.NewGuid(),
+            Scope = Scope.Discriminator,
+            TenantId = null,
+            HeadSequence = 3,
+            HeadHash = new string('a', 64), // wrong head hash, valid signature
+            SignedAt = DateTime.UtcNow,
+            Signature = new byte[] { 1 },
+            KeyVersion = 1,
+        };
+        var result = await VerifierFor(chain, cp).VerifyAsync(Scope, null, null, default);
+        result.Status.Should().Be(ChainVerificationStatus.Tampered);
+        result.FirstBrokenLink!.Reason.Should().Be(ChainBreakReason.CheckpointHeadMismatch);
+    }
+
+    [Test]
+    public async Task Mid_Chain_Range_Anchors_Prev_From_Prior_Record()
+    {
+        var chain = BuildChain(5);
+        // Verify only 3..5 — the verifier anchors prev from record 2's hash.
+        var result = await VerifierFor(chain).VerifyAsync(Scope, from: 3, to: 5, default);
+        result.Status.Should().Be(ChainVerificationStatus.Ok);
+        result.RecordsVerified.Should().Be(3);
+    }
+
+    // ── fakes ────────────────────────────────────────────────────────────────
+
+    private sealed class FakeRecordSource : IAuditChainRecordSource
+    {
+        private readonly List<AuditChainRecordView> _records;
+        public FakeRecordSource(List<AuditChainRecordView> records) => _records = records;
+
+        public async IAsyncEnumerable<AuditChainRecordView> StreamAsync(
+            AuditChainScope scope, long? from, long? to,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var r in _records
+                .Where(r => (from is null || r.ChainSequence >= from) && (to is null || r.ChainSequence <= to))
+                .OrderBy(r => r.ChainSequence))
+            {
+                yield return r;
+            }
+            await Task.CompletedTask;
+        }
+
+        public Task<string?> GetRecordHashAtAsync(AuditChainScope scope, long sequence, CancellationToken ct) =>
+            Task.FromResult(_records.FirstOrDefault(r => r.ChainSequence == sequence)?.RecordHash);
+
+        public Task<AuditChainHead?> GetHeadAsync(AuditChainScope scope, CancellationToken ct)
+        {
+            var head = _records.OrderByDescending(r => r.ChainSequence).FirstOrDefault();
+            return Task.FromResult(head is null ? null : new AuditChainHead(head.ChainSequence, head.RecordHash));
+        }
+    }
+
+    private sealed class FakeCheckpointGateway : IAuditChainCheckpointGateway
+    {
+        private readonly AuditChainCheckpointView? _cp;
+        private readonly bool _signatureValid;
+        public FakeCheckpointGateway(AuditChainCheckpointView? cp, bool signatureValid)
+        {
+            _cp = cp;
+            _signatureValid = signatureValid;
+        }
+
+        public Task<AuditChainCheckpointView?> GetLastCoveringAsync(
+            AuditChainScope scope, long? to, CancellationToken ct) =>
+            Task.FromResult(_cp is not null && (to is null || _cp.HeadSequence <= to) ? _cp : null);
+
+        public Task<bool> VerifySignatureAsync(AuditChainCheckpointView checkpoint, CancellationToken ct) =>
+            Task.FromResult(_signatureValid);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditRecordCanonicalizerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Audit/AuditRecordCanonicalizerTests.cs
@@ -1,0 +1,113 @@
+using System.Globalization;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Audit;
+
+namespace Tamma.Core.Tests.Audit;
+
+/// <summary>
+/// Story 37-2 (AC2) — byte-stability of the canonicalizer. The whole chain's
+/// determinism rests on these.
+/// </summary>
+[TestFixture]
+public class AuditRecordCanonicalizerTests
+{
+    private static AuditChainRecordView Sample(long seq = 1) => new()
+    {
+        Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+        Discriminator = "tenant",
+        TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        UserId = null,
+        ActionCode = "SECRET.REVEAL",
+        Category = "security",
+        Severity = "high",
+        ActorUserId = Guid.Parse("33333333-3333-3333-3333-333333333333"),
+        ActorEmailSnapshot = "actor@example.com",
+        TargetType = "secret",
+        TargetId = "abc-123",
+        Outcome = "success",
+        IpAddress = "203.0.113.7",
+        UserAgent = "curl/8.0",
+        OccurredAt = new DateTime(2026, 7, 2, 12, 34, 56, 789, DateTimeKind.Utc),
+        SourceEventId = Guid.Parse("44444444-4444-4444-4444-444444444444"),
+        SourceSequenceNumber = 4242,
+        PayloadJson = """{"tags":{"a":1},"data":{"b":2}}""",
+        ChainSequence = seq,
+        PrevRecordHash = "ignored-not-in-canonical",
+        RecordHash = "ignored-not-in-canonical",
+    };
+
+    [Test]
+    public void Canonical_Is_Identical_Across_Two_Runs()
+    {
+        AuditRecordCanonicalizer.ToBytes(Sample())
+            .Should().Equal(AuditRecordCanonicalizer.ToBytes(Sample()));
+    }
+
+    [Test]
+    public void Canonical_Ignores_The_Chain_Linkage_Hashes()
+    {
+        var a = Sample() with { PrevRecordHash = "aaaa", RecordHash = "bbbb" };
+        var b = Sample() with { PrevRecordHash = "cccc", RecordHash = "dddd" };
+        AuditRecordCanonicalizer.ToBytes(a).Should().Equal(AuditRecordCanonicalizer.ToBytes(b),
+            "prev/record hashes are the chain link, composed AROUND the canonical, not inside it");
+    }
+
+    [Test]
+    public void Different_Payload_Produces_Different_Bytes()
+    {
+        var a = Sample();
+        var b = Sample() with { PayloadJson = """{"tags":{"a":9},"data":{"b":2}}""" };
+        AuditRecordCanonicalizer.ToBytes(a).Should().NotEqual(AuditRecordCanonicalizer.ToBytes(b));
+    }
+
+    [Test]
+    public void Different_ChainSequence_Produces_Different_Bytes()
+    {
+        AuditRecordCanonicalizer.ToBytes(Sample(1))
+            .Should().NotEqual(AuditRecordCanonicalizer.ToBytes(Sample(2)));
+    }
+
+    [Test]
+    public void Concatenation_Ambiguity_Is_Prevented_By_Length_Prefix()
+    {
+        // Moving a character across two adjacent string fields must change the
+        // bytes (length-prefixing defeats "ab"+"c" == "a"+"bc").
+        var a = Sample() with { TargetType = "ab", TargetId = "c" };
+        var b = Sample() with { TargetType = "a", TargetId = "bc" };
+        AuditRecordCanonicalizer.ToBytes(a).Should().NotEqual(AuditRecordCanonicalizer.ToBytes(b));
+    }
+
+    [Test]
+    public void Canonical_Is_Culture_Invariant()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR"); // dotted-I, comma decimals
+            var turkish = AuditRecordCanonicalizer.ToBytes(Sample());
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            var invariant = AuditRecordCanonicalizer.ToBytes(Sample());
+            turkish.Should().Equal(invariant);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Test]
+    public void Timestamp_Kind_Is_Normalized_To_Utc()
+    {
+        var utc = Sample() with
+        {
+            OccurredAt = new DateTime(2026, 7, 2, 12, 34, 56, 789, DateTimeKind.Utc),
+        };
+        var unspecified = Sample() with
+        {
+            OccurredAt = new DateTime(2026, 7, 2, 12, 34, 56, 789, DateTimeKind.Unspecified),
+        };
+        AuditRecordCanonicalizer.ToBytes(utc).Should().Equal(AuditRecordCanonicalizer.ToBytes(unspecified),
+            "an Unspecified kind read back from Postgres must canonicalize as UTC");
+    }
+}

--- a/docs/stories/epic-37/story-37-2/37-2-tamper-evident-hash-chain-over-audit-records.md
+++ b/docs/stories/epic-37/story-37-2/37-2-tamper-evident-hash-chain-over-audit-records.md
@@ -294,6 +294,19 @@ Verification only works if `canonical(record)` is byte-identical at write time a
 
 The Postgres trigger blocks accidental ORM writes but a DBA with `ALTER TABLE` can disable it. That is acceptable: the cryptographic chain + signed external-key checkpoints are what make tampering *detectable*. State this in the runbook so operators don't treat the trigger as the security boundary.
 
+### Payload column is `text`, not `jsonb` (code-review fix — CRITICAL)
+
+`audit_records.PayloadJson` is stored as **`text`**, NOT `jsonb`. The chain hash (AC2) is computed at INSERT over the in-memory payload STRING, and verification recomputes it over the value read back from the column — so the stored representation must round-trip byte-for-byte. `jsonb` does **not**: Postgres reorders object keys, strips whitespace, and normalizes numbers/unicode, so write-bytes ≠ read-bytes and **every** chain would verify as `Tampered` at `chain_sequence = 1`. `text` preserves the exact bytes. No code uses jsonb operators on this column (the only jsonb-aware read is `"PayloadJson"::text ILIKE` in `AuditQueryService`, and `text::text` is a no-op cast), so `text` is safe. If a future feature needs server-side JSON operators on the payload, add a separate computed/generated `jsonb` column — do NOT change the hashed column back to `jsonb`. There is a Postgres round-trip verify test (`AuditChainPostgresVerifyTests`) guarding this.
+
+### Checkpointing MUST be enabled for the full tamper-evidence guarantee (op-note — code-review fix)
+
+`record_hash` is unkeyed, so the chain alone cannot detect **tail-truncation** (deletion of the most recent records) — the remaining records still form a self-consistent chain. The only thing that reveals a clipped tail is a **signed checkpoint** whose `head_sequence` exceeds the current chain head. Two hardening pieces make this work:
+
+1. `audit_chain_checkpoints` has its **own append-only trigger** (rejects `DELETE`/`UPDATE`) so an attacker cannot delete the covering checkpoint after clipping records.
+2. The verifier asserts the live chain head `>= MAX(checkpoint.head_sequence)` for the scope; a regression is reported as `ChainBreakReason.HeadBelowCheckpoint`.
+
+**Operational dependency:** these only bite if checkpoints actually exist. `AuditChainCheckpointScheduler.RunOnStartup` is **opt-in (`false`)** — mirroring the projector — so periodic checkpointing MUST be explicitly enabled in each deployment (or checkpoints written on demand via `POST /api/admin/audit/checkpoint`) for the full tamper-evidence guarantee against tail-truncation. Document this in the runbook. The default is intentionally left opt-in in this fix (flipping it is an operational change, not a code fix).
+
 ### Signing key, not env key (AC5)
 
 Per the spec boundary, the checkpoint signature key comes from the Epic 29 cabinet via `ISecretStore`, encrypted at rest by `TenantSecretProtector` (AES-GCM). Do NOT add a `appsettings`/`env` signing key — that would make a config-file reader able to forge checkpoints. The cabinet read is itself audited (`ISecretAccessAuditor`), so signing-key access leaves a trail.


### PR DESCRIPTION
## What

Story 37-2 (P0, SOC2 keystone). Each `audit_records` row gets `record_hash = SHA-256(prev_hash ‖ canonical(record))` + `chain_sequence`, forming a per-scope chain (CP table = platform/single-user; each tenant schema = that tenant's chain), computed at insert under a per-scope `pg_advisory_xact_lock` atomic with the 37-1 insert. HMAC-signed checkpoints (`audit_chain_checkpoints`, CP-resident, cabinet key via `IRuntimeSecretResolver`, fail-closed). Append-only Postgres triggers on both `audit_records` **and** `audit_chain_checkpoints`. `AuditChainVerifier` streams a scope and reports the first broken link; verify/checkpoint endpoints (tenant-admin for own scope, `PlatformOwnerAccess` for platform); `AUDIT.CHAIN.VERIFIED|TAMPER_DETECTED|CHECKPOINTED` events + critical alert.

## Review outcome

Adversarial security review verified the append-only trigger, advisory-lock serialization, DateTime handling, length-prefixed framing, and RBAC scoping as sound. **Two findings fixed** (TDD, Postgres-testcontainer):
- **Critical — jsonb round-trip inverted the guarantee:** `PayloadJson` was a CLR string in a `jsonb` column; jsonb reorders keys / normalizes on read, so the insert-time hash (in-memory string) never matched the verify-time hash (jsonb-read-back) → **every** chain falsely verified as TAMPERED (fired a critical alert on untampered data). Fixed by storing `PayloadJson` as **`text`** (grep-confirmed zero jsonb-operator dependency; 37-3's `::text` search is unaffected), so bytes round-trip exactly. Proven by a real-Postgres verify test (fail-before Tampered → pass-after Ok).
- **Important — tail-truncation was undetectable:** unkeyed hash + checkpoints off-by-default and deletable. Added an append-only trigger on `audit_chain_checkpoints`, and the verifier now asserts `head_sequence >= MAX(checkpoint.head_sequence)` (new `HeadBelowCheckpoint` reason) so a truncation below a surviving checkpoint is caught. Op-note: periodic checkpointing must be enabled for the full guarantee (kept opt-in like the projector).

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). Tests: Core Audit 24 + Api Audit 190 (incl. 3 new Postgres tests: round-trip verify, checkpoint trigger, tail-truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)