### PR TITLE
feat(blocker): secure resume endpoint for BlockerDiagnosisWorkflow (progress/escalation bookmarks)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerResumeInput.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerResumeInput.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Activities.Blocker;
+
+/// <summary>
+/// Read-back coercion for values arriving on a bookmark resume input
+/// (<c>context.WorkflowInput</c>) for the blocker-diagnosis resume callbacks.
+///
+/// <para>The in-process workflow runtime keeps a resumed value as a boxed CLR type
+/// (a boxed <see cref="bool"/> for a flag). A SERIALIZING dispatcher
+/// (distributed / MassTransit / ProtoActor) instead delivers the same value as a
+/// <see cref="string"/> or a <see cref="System.Text.Json.JsonElement"/> after a
+/// round-trip. A bare <c>value is true</c> pattern-match only matches the boxed-bool
+/// path — under serialization it silently evaluates <c>false</c> and the resume
+/// advances the wrong branch while still returning HTTP 200 (a silent failure).</para>
+///
+/// <para>This mirrors the merge/deploy house convention of reading resumed values via
+/// <c>.ToString()</c> then parsing (see <c>WaitForMergeApprovalActivity</c>).</para>
+/// </summary>
+internal static class BlockerResumeInput
+{
+    /// <summary>
+    /// Coerce a resumed value to <see cref="bool"/> tolerant of the in-process
+    /// boxed-<see cref="bool"/> path AND a serializing runtime that delivers the value
+    /// as a <see cref="string"/> (<c>"true"</c>/<c>"false"</c>) or a
+    /// <see cref="System.Text.Json.JsonElement"/>. <c>true</c> iff a real boxed
+    /// <see cref="bool"/> <c>true</c>, or the value's string form is <c>"true"</c>
+    /// (case-insensitive) — <see cref="System.Text.Json.JsonElement.ToString"/> yields
+    /// <c>"True"</c>/<c>"False"</c> for a JSON boolean, so a JsonElement flows through the
+    /// string comparison. A <c>null</c> / missing value is <c>false</c>.
+    /// </summary>
+    internal static bool AsBool(object? value)
+        => value is bool b
+            ? b
+            : string.Equals(value?.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
@@ -94,6 +94,19 @@ public class DetectProgressActivity : Activity
         _configuration = configuration;
     }
 
+    /// <summary>
+    /// The SINGLE canonical progress-bookmark name (<c>blocker-progress-{session}-{level}</c>).
+    /// Shared by the suspend side (<see cref="Execute"/>) and the resume side
+    /// (<c>BlockerResumeEndpoint</c>) so the two match byte-for-byte — the same
+    /// suspend/resume-name-parity discipline as
+    /// <c>WaitForMergeApprovalActivity.BookmarkName</c>. The name is keyed by the
+    /// (globally-unique, unguessable) mentorship session id + resolution level; the
+    /// resume endpoint additionally verifies the caller's tenant OWNS that session
+    /// before it ever resolves this name (IDOR guard on the Tamma.Api tier).
+    /// </summary>
+    public static string ProgressBookmarkName(Guid sessionId, string level)
+        => $"blocker-progress-{sessionId}-{level}";
+
     protected override void Execute(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
@@ -109,7 +122,7 @@ public class DetectProgressActivity : Activity
         //    below fires, whichever happens first.
         context.CreateBookmark(new CreateBookmarkArgs
         {
-            BookmarkName = $"blocker-progress-{sessionId}-{currentLevel}",
+            BookmarkName = ProgressBookmarkName(sessionId, currentLevel),
             Callback = OnResumeAsync,
             AutoBurn = true
         });

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/DetectProgressActivity.cs
@@ -141,28 +141,41 @@ public class DetectProgressActivity : Activity
     /// </summary>
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
     {
-        var input = context.WorkflowInput;
+        var result = ReadProgressResult(context.WorkflowInput);
 
-        var progressDetected = input.TryGetValue("ProgressDetected", out var pd) && pd is true;
+        _logger?.LogInformation(
+            "Progress detection resumed (external): Detected={Detected}, Type={Type}",
+            result.ProgressDetected, result.ProgressType);
+
+        context.Set(ProgressDetected, result.ProgressDetected);
+        context.Set(TimedOut, false);
+        context.Set(Result, result);
+
+        await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Pure read-back of the progress fields from the bookmark resume input (exposed for unit
+    /// testing; mirrors the <see cref="ResolveWaitMinutes(int, int?, string)"/> extraction).
+    /// <see cref="ProgressDetectionResult.ProgressDetected"/> is coerced via
+    /// <see cref="BlockerResumeInput.AsBool"/> so it is correct whether the runtime delivers the
+    /// flag as a boxed <see cref="bool"/> (in-process) or as a <see cref="string"/> /
+    /// <see cref="System.Text.Json.JsonElement"/> (serializing dispatcher). The string fields
+    /// (<c>ProgressType</c>, <c>Details</c>) are informational and read via <c>.ToString()</c>,
+    /// which is already serialization-tolerant.
+    /// </summary>
+    internal static ProgressDetectionResult ReadProgressResult(IDictionary<string, object> input)
+    {
+        var progressDetected = input.TryGetValue("ProgressDetected", out var pd) && BlockerResumeInput.AsBool(pd);
         var progressType = input.TryGetValue("ProgressType", out var pt) ? pt?.ToString() : null;
         var details = input.TryGetValue("Details", out var d) ? d?.ToString() : null;
 
-        var result = new ProgressDetectionResult
+        return new ProgressDetectionResult
         {
             ProgressDetected = progressDetected,
             ProgressType = progressType,
             Details = details
         };
-
-        _logger?.LogInformation(
-            "Progress detection resumed (external): Detected={Detected}, Type={Type}",
-            progressDetected, progressType);
-
-        context.Set(ProgressDetected, progressDetected);
-        context.Set(TimedOut, false);
-        context.Set(Result, result);
-
-        await context.CompleteActivityAsync();
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -95,6 +95,19 @@ public class EscalateToSeniorActivity : Activity
         _configuration = configuration;
     }
 
+    /// <summary>
+    /// The SINGLE canonical escalation-bookmark name (<c>blocker-escalation-{session}</c>).
+    /// Shared by the suspend side (<see cref="ExecuteAsync"/>) and the resume side
+    /// (<c>BlockerResumeEndpoint</c>) so the two match byte-for-byte — the same
+    /// suspend/resume-name-parity discipline as
+    /// <c>WaitForMergeApprovalActivity.BookmarkName</c>. The name is keyed by the
+    /// (globally-unique, unguessable) mentorship session id; the resume endpoint
+    /// additionally verifies the caller's tenant OWNS that session before it ever
+    /// resolves this name (IDOR guard on the Tamma.Api tier).
+    /// </summary>
+    public static string EscalationBookmarkName(Guid sessionId)
+        => $"blocker-escalation-{sessionId}";
+
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
@@ -135,7 +148,7 @@ public class EscalateToSeniorActivity : Activity
         //    suspends here until this resumes OR the durable SLA delay below fires.
         context.CreateBookmark(new CreateBookmarkArgs
         {
-            BookmarkName = $"blocker-escalation-{sessionId}",
+            BookmarkName = EscalationBookmarkName(sessionId),
             Callback = OnResumeAsync,
             AutoBurn = true
         });

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -214,10 +214,7 @@ Please respond to this escalation via the Tamma API or reply in this thread.";
     /// </summary>
     private async ValueTask OnResumeAsync(ActivityExecutionContext context)
     {
-        var input = context.WorkflowInput;
-
-        var resolved = input.TryGetValue("Resolved", out var r) && r is true;
-        var seniorResponse = input.TryGetValue("SeniorResponse", out var sr) ? sr?.ToString() : null;
+        var (resolved, seniorResponse) = ReadSeniorOutcome(context.WorkflowInput);
 
         _logger?.LogInformation("Senior escalation resumed (external): Resolved={Resolved}", resolved);
 
@@ -226,6 +223,21 @@ Please respond to this escalation via the Tamma API or reply in this thread.";
         context.Set(SeniorResponse, seniorResponse);
 
         await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Pure read-back of the senior outcome from the bookmark resume input (exposed for unit
+    /// testing). <c>Resolved</c> is coerced via <see cref="BlockerResumeInput.AsBool"/> so it is
+    /// correct whether the runtime delivers the flag as a boxed <see cref="bool"/> (in-process)
+    /// or as a <see cref="string"/> / <see cref="System.Text.Json.JsonElement"/> (serializing
+    /// dispatcher). <c>SeniorResponse</c> is a string read via <c>.ToString()</c>, which is
+    /// already serialization-tolerant.
+    /// </summary>
+    internal static (bool Resolved, string? SeniorResponse) ReadSeniorOutcome(IDictionary<string, object> input)
+    {
+        var resolved = input.TryGetValue("Resolved", out var r) && BlockerResumeInput.AsBool(r);
+        var seniorResponse = input.TryGetValue("SeniorResponse", out var sr) ? sr?.ToString() : null;
+        return (resolved, seniorResponse);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Services;
+using Tamma.Core.Interfaces;
 using Tamma.Core.Logging;
 using Tamma.Data;
 
@@ -218,6 +219,136 @@ public static class AdlEndpoints
                 statusCode: StatusCodes.Status502BadGateway);
         }
     }
+
+    // ================================================================
+    // Blocker-diagnosis progressive-resolution ladder (follow-up #15) —
+    // POST /api/adl/blocker/resume. Same RBAC (WorkflowsManage) + I2
+    // (server-derived resolver) posture as the merge/deploy gates. The
+    // cross-tenant guard differs in MECHANISM only: the blocker bookmark is
+    // keyed by the (unguessable) session id, not the tenant, so we enforce
+    // ownership by a tenant-scoped session lookup BEFORE forwarding (a
+    // cross-tenant / unknown session 404s and never reaches the engine).
+    // ================================================================
+
+    /// <summary>The blocker ladder resume kinds accepted (case-insensitive).</summary>
+    private static readonly HashSet<string> AllowedBlockerKinds =
+        new(StringComparer.OrdinalIgnoreCase) { "progress", "escalation" };
+
+    /// <summary>The progress-ladder levels accepted (case-insensitive; canonicalised to the
+    /// workflow's PascalCase before forwarding).</summary>
+    private static readonly HashSet<string> AllowedBlockerLevels =
+        new(StringComparer.OrdinalIgnoreCase) { "Hint", "Guidance", "Assistance" };
+
+    /// <summary>
+    /// Resume request for the blocker-diagnosis ladder. <c>Resolver</c> is intentionally
+    /// absent — the acting identity is derived from the authenticated caller (I2), never
+    /// trusted from the client.
+    /// </summary>
+    public sealed record BlockerResolutionRequest(
+        Guid SessionId,
+        string Kind,              // "progress" | "escalation"
+        string? Level,            // required for progress: Hint | Guidance | Assistance
+        bool? Resolved,           // escalation: did the senior resolve it (default true)
+        string? ProgressType,     // progress: commit | ci | manual | ...
+        string? Details,          // progress: free-text detail
+        string? SeniorResponse);  // escalation: senior's response note
+
+    /// <summary>
+    /// Resume the blocker-diagnosis progressive-resolution ladder for a mentorship session.
+    /// Route: <c>POST /api/adl/blocker/resume</c>.
+    /// </summary>
+    public static async Task<IResult> ResumeBlocker(
+        [FromBody] BlockerResolutionRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] IMentorshipService mentorship,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
+
+        if (req.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+        if (string.IsNullOrWhiteSpace(req.Kind) || !AllowedBlockerKinds.Contains(req.Kind.Trim()))
+            return Results.BadRequest(new { error = "kind must be one of: progress, escalation" });
+
+        var kind = req.Kind.Trim().ToLowerInvariant();
+        string? level = null;
+        if (kind == "progress")
+        {
+            if (string.IsNullOrWhiteSpace(req.Level) || !AllowedBlockerLevels.Contains(req.Level.Trim()))
+                return Results.BadRequest(new { error = "level must be one of: Hint, Guidance, Assistance (for kind=progress)" });
+            level = CanonicalBlockerLevel(req.Level);
+        }
+
+        // I2 — the resolver is the authenticated caller, derived server-side. A
+        // client-supplied resolver is never honoured so the audit trail can't be forged.
+        var resolver = ResolveApprover(principal);
+
+        try
+        {
+            // IDOR guard (mirrors the merge/deploy "cross-tenant → 404, never acts"):
+            // GetSessionAsync is tenant-scoped (per-tenant schema), so a session that does
+            // not belong to the caller's ambient tenant simply resolves to null. We refuse
+            // to forward a resume for a session the caller does not own — the resume can only
+            // ever target the caller's OWN blocker gate.
+            var session = await mentorship.GetSessionAsync(req.SessionId);
+            if (session is null)
+            {
+                logger.LogWarning(
+                    "Blocker resume for session {SessionId} not found in caller tenant {Tenant} — refusing",
+                    req.SessionId, tenantContext.TenantId);
+                return Results.NotFound(new
+                {
+                    error = "session_not_found",
+                    detail = "No blocker-diagnosis session with this id exists in your scope.",
+                });
+            }
+
+            var result = await elsa.ResumeBlockerResolutionAsync(
+                req.SessionId, kind, level, req.Resolved ?? true,
+                req.ProgressType, req.Details, req.SeniorResponse, resolver);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No blocker-diagnosis wait is currently suspended for this session/level.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove blocker gate for session {SessionId} (kind {Kind}, level {Level}, resolver {Resolver})",
+                req.SessionId, LogSanitizer.Clean(kind), LogSanitizer.Clean(level ?? ""), LogSanitizer.Clean(resolver));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+                kind,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to resume blocker gate for session {SessionId}", req.SessionId);
+            return Results.Problem(
+                detail: "Failed to resume the blocker-diagnosis gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
+    /// <summary>Map a case-insensitive level onto the workflow's exact PascalCase segment
+    /// ("Hint"/"Guidance"/"Assistance"); null for anything else.</summary>
+    internal static string? CanonicalBlockerLevel(string? level)
+        => level?.Trim().ToLowerInvariant() switch
+        {
+            "hint" => "Hint",
+            "guidance" => "Guidance",
+            "assistance" => "Assistance",
+            _ => null,
+        };
 
     /// <summary>
     /// Derive the approver identity from the authenticated principal (I2):

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2518,6 +2518,13 @@ adl.MapPost("/merge-approval/resume", AdlEndpoints.ResumeMergeApproval);
 // tenant+repo+SHA-scoped adl-deploy-prod-approval-{tenant}-{repo}-{issue}-{sha}
 // bookmark; approver derived server-side (I2); tenant-scoped (cross-tenant → 404).
 adl.MapPost("/deploy-approval/resume", AdlEndpoints.ResumeDeploymentApproval);
+// Blocker-diagnosis progressive-resolution ladder (follow-up #15). Resumes the
+// session-scoped blocker-progress-{session}-{level} / blocker-escalation-{session}
+// bookmark so a run can reach the Resolved terminal. WorkflowsManage = tenant
+// owner/admin (members 403); resolver derived server-side (I2). IDOR guard: the
+// handler verifies the caller's ambient tenant OWNS the session (tenant-scoped
+// session lookup) before forwarding — a cross-tenant/unknown session → 404.
+adl.MapPost("/blocker/resume", AdlEndpoints.ResumeBlocker);
 
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -195,15 +195,13 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
     /// Resume a paused workflow.
     /// </summary>
     /// <remarks>
-    /// FOLLOW-UP (blocker-diagnosis Resolved terminal): this hits Elsa's GENERIC
-    /// <c>/resume</c> with no bookmark id and no input, so it cannot supply the
-    /// <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c> keys the
-    /// blocker-diagnosis progress / escalation bookmarks read. As a result a blocker run can
-    /// only reach the Escalated or (durable) Timeout terminal in production, never Resolved.
-    /// Reaching Resolved requires a blocker-specific resume endpoint that targets the bookmark
-    /// and passes that input, mirroring the secure MergeApprovalResumeEndpoint — a tracked
-    /// follow-up (deliberately NOT added here: it touches Program.cs and would collide with a
-    /// sibling endpoint-wiring PR).
+    /// This hits Elsa's GENERIC <c>/resume</c> with no bookmark id and no input, so it cannot
+    /// supply the <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c> keys the
+    /// blocker-diagnosis progress / escalation bookmarks read. To reach the blocker
+    /// <c>Resolved</c> terminal use the blocker-specific
+    /// <see cref="ResumeBlockerResolutionAsync"/> (follow-up #15) instead — it targets the
+    /// session-scoped bookmark and injects that input, mirroring the secure
+    /// MergeApprovalResumeEndpoint.
     /// </remarks>
     public async Task ResumeWorkflowAsync(string instanceId)
     {
@@ -405,6 +403,58 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
         {
             _logger.LogWarning(
                 "No deploy-approval gate waiting for issue #{Issue}", issueNumber);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
+    /// <summary>
+    /// Follow-up #15 — forward a blocker-diagnosis ladder resume to the engine's in-process
+    /// resume endpoint, which looks up the session-scoped progress
+    /// (<c>blocker-progress-{session}-{level}</c>) or escalation
+    /// (<c>blocker-escalation-{session}</c>) bookmark and runs the owning instance with the
+    /// payload injected as input. A 404 (no wait suspended) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown, so the
+    /// controller can map it to a 404 for the caller.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeBlockerResolutionAsync(
+        Guid sessionId, string kind, string? level, bool resolved,
+        string? progressType, string? details, string? seniorResponse, string? resolver)
+    {
+        _logger.LogInformation(
+            "Resuming blocker gate for session {SessionId} (kind={Kind}, level={Level})",
+            sessionId, SanitizeForLog(kind), SanitizeForLog(level));
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            sessionId,
+            kind,
+            level,
+            resolved,
+            progressType,
+            details,
+            seniorResponse,
+            // I2 — server-derived acting identity, forwarded for the engine's audit log.
+            resolver,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/adl/blocker/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No blocker gate waiting for session {SessionId} (kind={Kind}, level={Level})",
+                sessionId, SanitizeForLog(kind), SanitizeForLog(level));
             return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
         }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -58,6 +58,32 @@ public interface IElsaWorkflowService
     Task<MergeApprovalResumeResult> ResumeDeploymentApprovalAsync(
         int issueNumber, string? tenantId, string? repository, string? mergeSha,
         string decision, string? feedback, string? approver);
+
+    /// <summary>
+    /// Follow-up #15 — resume the <c>blocker-diagnosis</c> progressive resolution ladder
+    /// suspended on a session-scoped bookmark, injecting the payload the suspend-side
+    /// activity callback reads:
+    /// <list type="bullet">
+    ///   <item><description><c>kind == "progress"</c> → the per-level progress bookmark
+    ///     <c>blocker-progress-{session}-{level}</c> with
+    ///     <c>{ProgressDetected=true, ProgressType, Details}</c>; and</description></item>
+    ///   <item><description><c>kind == "escalation"</c> → the escalation bookmark
+    ///     <c>blocker-escalation-{session}</c> with
+    ///     <c>{Resolved, SeniorResponse}</c>.</description></item>
+    /// </list>
+    /// Forwards to the engine's in-process resume endpoint (which owns
+    /// <c>IBookmarkStore</c>/<c>IWorkflowRuntime</c>). A 404 (no wait suspended) is surfaced
+    /// as <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    ///
+    /// <para>SECURITY — the blocker bookmark is keyed by the (unguessable) session id only,
+    /// so the cross-tenant guard is enforced by the caller (<c>AdlEndpoints</c>): it verifies
+    /// the caller's ambient tenant OWNS <paramref name="sessionId"/> (tenant-scoped session
+    /// lookup) BEFORE invoking this. <paramref name="resolver"/> is the server-derived acting
+    /// identity (I2), logged by the engine for the audit trail.</para>
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeBlockerResolutionAsync(
+        Guid sessionId, string kind, string? level, bool resolved,
+        string? progressType, string? details, string? seniorResponse, string? resolver);
 }
 
 /// <summary>Outcome of a merge-approval (or deploy-approval) gate resume.</summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/BlockerResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/BlockerResumeEndpoint.cs
@@ -1,0 +1,213 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.Blocker;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// Follow-up #15 — in-process resume seam for the <c>blocker-diagnosis</c> progressive
+/// resolution ladder. Mirrors <see cref="MergeApprovalResumeEndpoint"/>.
+///
+/// <para>The blocker workflow suspends on ONE of two named bookmarks:
+/// <list type="bullet">
+///   <item><description><b>progress</b> — <c>blocker-progress-{session}-{level}</c>
+///     (<see cref="DetectProgressActivity"/>), resumed when the junior makes progress at
+///     the Hint / Guidance / Assistance rung; the callback reads
+///     <c>ProgressDetected</c> / <c>ProgressType</c> / <c>Details</c> from the workflow
+///     input and flips the ladder to the <c>Resolved</c> terminal.</description></item>
+///   <item><description><b>escalation</b> — <c>blocker-escalation-{session}</c>
+///     (<see cref="EscalateToSeniorActivity"/>), resumed when a senior responds to the
+///     Level-4 escalation; the callback reads <c>Resolved</c> / <c>SeniorResponse</c>
+///     and flips to the <c>Resolved</c> (or, on the durable SLA, <c>Timeout</c>)
+///     terminal.</description></item>
+/// </list>
+/// Until this endpoint existed, the ONLY resumer (<c>MentorshipController.ResumeSession</c>
+/// → generic <c>/resume</c>) supplied NO bookmark id and NO input, so a run could never
+/// reach <c>Resolved</c> — only <c>Escalated</c> / <c>Timeout</c>. This endpoint looks the
+/// bookmark up by name and runs the owning instance from that bookmark with the progress /
+/// escalation payload INJECTED as workflow input (<c>IWorkflowClient.RunInstanceAsync</c>
+/// with <c>RunWorkflowInstanceRequest.Input</c>, which lands in
+/// <c>ActivityExecutionContext.WorkflowInput</c> that the activity callbacks read).</para>
+///
+/// <para>This lives in the engine process because <c>IBookmarkStore</c> /
+/// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the RBAC-gated,
+/// tenant-scoped public surface (<c>POST /api/adl/blocker/resume</c>) and forwards to this
+/// engine endpoint.</para>
+///
+/// <para><b>SECURITY (mirrors the merge/deploy gate posture):</b>
+/// <list type="bullet">
+///   <item><description><b>No IDOR</b> — the bookmark name is keyed by the mentorship
+///   session id (a 128-bit unguessable Guid). Unlike the merge gate (which folds the
+///   tenant into the bookmark name), the blocker bookmark carries only the session id, so
+///   the cross-tenant guard is enforced ONE TIER UP: the <c>Tamma.Api</c> caller verifies
+///   the caller's ambient tenant OWNS the session (tenant-scoped
+///   <c>IMentorshipService.GetSessionAsync</c>) BEFORE forwarding here — a cross-tenant /
+///   unknown session 404s at the API tier and never reaches this seam. Resolving the
+///   bookmark by that already-tenant-verified session id is therefore only ever the
+///   caller's own gate.</description></item>
+///   <item><description><b>Collision refusal</b> — the name is unique per session (+ level
+///   for progress); &gt;1 match is an integrity violation, so we REFUSE with 409 rather
+///   than resume an arbitrary <c>bookmarks[0]</c>.</description></item>
+///   <item><description><b>Engine-service-only</b> — the route is mapped with
+///   <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only the Tamma.Api→engine hop
+///   (presenting the Elsa admin API key) reaches it; anonymous public callers get 401. It
+///   is also excluded from the public nginx <c>/elsa/api/</c> block (internal hop only).
+///   </description></item>
+/// </list></para>
+/// </summary>
+public static class BlockerResumeEndpoint
+{
+    /// <summary>The two bookmark families this seam can drive (case-insensitive).</summary>
+    private const string KindProgress = "progress";
+    private const string KindEscalation = "escalation";
+
+    public sealed record ResumeRequest(
+        Guid SessionId,
+        // "progress" (Hint/Guidance/Assistance rung) | "escalation" (Level-4 senior response).
+        string Kind,
+        // Required for Kind=="progress": Hint | Guidance | Assistance.
+        string? Level,
+        // Kind=="escalation": did the senior actually resolve the blocker (default true).
+        bool Resolved,
+        // Kind=="progress": how progress was observed (commit | ci | manual | ...).
+        string? ProgressType,
+        // Kind=="progress": free-text detail.
+        string? Details,
+        // Kind=="escalation": the senior's response note.
+        string? SeniorResponse,
+        // Non-repudiation (I2) — the acting identity, derived server-side by Tamma.Api from
+        // the authenticated principal. Logged here for the audit trail; never trusted from a
+        // client (the public request record carries no resolver field).
+        string? Resolver);
+
+    /// <summary>Compute the bookmark name for a request via the SINGLE canonical builders
+    /// shared with the suspend-side activities, so suspend and resume match byte-for-byte.
+    /// Returns null when the request is malformed (unknown kind / missing-or-bad level).</summary>
+    public static string? BookmarkName(ResumeRequest request)
+    {
+        if (string.Equals(request.Kind, KindEscalation, StringComparison.OrdinalIgnoreCase))
+            return EscalateToSeniorActivity.EscalationBookmarkName(request.SessionId);
+
+        if (string.Equals(request.Kind, KindProgress, StringComparison.OrdinalIgnoreCase))
+        {
+            var level = CanonicalLevel(request.Level);
+            return level is null ? null : DetectProgressActivity.ProgressBookmarkName(request.SessionId, level);
+        }
+
+        return null;
+    }
+
+    /// <summary>Map a case-insensitive level onto the workflow's exact PascalCase segment
+    /// ("Hint"/"Guidance"/"Assistance"); null for anything else.</summary>
+    internal static string? CanonicalLevel(string? level)
+        => level?.Trim().ToLowerInvariant() switch
+        {
+            "hint" => "Hint",
+            "guidance" => "Guidance",
+            "assistance" => "Assistance",
+            _ => null,
+        };
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.BlockerResume");
+
+        if (request.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+
+        var isProgress = string.Equals(request.Kind, KindProgress, StringComparison.OrdinalIgnoreCase);
+        var isEscalation = string.Equals(request.Kind, KindEscalation, StringComparison.OrdinalIgnoreCase);
+        if (!isProgress && !isEscalation)
+            return Results.BadRequest(new { error = "kind must be one of: progress, escalation" });
+        if (isProgress && CanonicalLevel(request.Level) is null)
+            return Results.BadRequest(new { error = "level must be one of: Hint, Guidance, Assistance (for kind=progress)" });
+
+        // Compute the (session-scoped) bookmark name via the shared canonical builder — the
+        // same name the suspend-side activity registered.
+        var name = BookmarkName(request);
+        if (name is null)
+            return Results.BadRequest(new { error = "malformed blocker resume request" });
+
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended blocker bookmark {Bookmark} — gate not waiting (already resolved/advanced, wrong session/level, or timed out)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No blocker-diagnosis wait is currently suspended for this session/level.",
+            });
+        }
+
+        // The name is unique per session (+ level); >1 match is an integrity violation, not a
+        // "pick the first" situation. REFUSE rather than resume an arbitrary instance.
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous blocker bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this blocker bookmark; refusing to resume an arbitrary one.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        // Inject the payload as workflow input using the EXACT keys the suspend-side callback
+        // reads (DetectProgressActivity.OnResumeAsync / EscalateToSeniorActivity.OnResumeAsync).
+        var input = new Dictionary<string, object>();
+        if (isProgress)
+        {
+            // A progress resume means the junior made progress → flip the ladder to Resolved.
+            input["ProgressDetected"] = true;
+            if (request.ProgressType is not null) input["ProgressType"] = request.ProgressType;
+            if (request.Details is not null) input["Details"] = request.Details;
+        }
+        else
+        {
+            input["Resolved"] = request.Resolved;
+            if (request.SeniorResponse is not null) input["SeniorResponse"] = request.SeniorResponse;
+        }
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed blocker gate {Bookmark} (instance {InstanceId}) kind={Kind} by {Resolver}",
+            name, bookmark.WorkflowInstanceId, request.Kind, request.Resolver ?? "unknown");
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+            kind = request.Kind,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -405,6 +405,18 @@ app.MapPost("/elsa/api/adl/deploy-approval/resume",
     Tamma.ElsaServer.Endpoints.DeploymentApprovalResumeEndpoint.Resume)
     .RequireAuthorization();
 
+// Follow-up #15 — in-process resume seam for the blocker-diagnosis progressive
+// resolution ladder. Tamma.Api's RBAC-gated, tenant-scoped POST /api/adl/blocker/resume
+// forwards here (after verifying the caller's tenant OWNS the mentorship session);
+// this endpoint looks up the session-scoped progress / escalation bookmark and runs the
+// owning instance with the {ProgressDetected,...} / {Resolved,SeniorResponse} payload
+// injected. It closes the "Resolved terminal is unreachable in production" gap called out
+// in BlockerDiagnosisWorkflow. Same engine-control-surface / RequireAuthorization rationale
+// as the merge/deploy gates.
+app.MapPost("/elsa/api/adl/blocker/resume",
+    Tamma.ElsaServer.Endpoints.BlockerResumeEndpoint.Resume)
+    .RequireAuthorization();
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
@@ -53,19 +53,22 @@ namespace Tamma.ElsaServer.Workflows;
 /// resolution-history threading) remains a noted follow-up — out of scope for this
 /// correctness pass.</para>
 ///
-/// <para><b>Honest reachability of the <c>Resolved</c> terminal (FOLLOW-UP).</b> The
+/// <para><b>Reachability of the <c>Resolved</c> terminal (follow-up #15 — DONE).</b> The
 /// in-graph wiring for <c>Resolved</c> is correct: a <c>ProgressDetected</c> /
 /// <c>Resolved</c> / <c>SeniorResponse</c> resume at any level flips <c>isResolved</c> and
-/// short-circuits the ladder. However, the ONLY external resumer in the codebase today
+/// short-circuits the ladder. The generic resumer
 /// (<c>MentorshipController.ResumeSession</c> → <c>ElsaWorkflowService.ResumeWorkflowAsync</c>)
-/// hits Elsa's generic <c>/resume</c> with NO bookmark id and NO input, so it never supplies
-/// those keys. Until a blocker-specific resume endpoint exists — one that passes
-/// <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c> input and targets the
-/// progress / escalation bookmark, mirroring the secure <c>MergeApprovalResumeEndpoint</c> —
-/// a production run can only reach the <c>Escalated</c> or (durable) <c>Timeout</c> terminal,
-/// never <c>Resolved</c>. That endpoint is a tracked FOLLOW-UP (it touches Program.cs and is
-/// intentionally NOT added here to avoid colliding with a sibling endpoint-wiring PR); the
-/// graph fix stands as-is.</para>
+/// still hits Elsa's generic <c>/resume</c> with NO bookmark id and NO input, so it cannot
+/// supply those keys — but the blocker-specific resume endpoint that DOES now exists:
+/// <c>POST /api/adl/blocker/resume</c> (<c>AdlEndpoints.ResumeBlocker</c>) →
+/// <c>ElsaWorkflowService.ResumeBlockerResolutionAsync</c> → the engine seam
+/// <c>BlockerResumeEndpoint</c>. It targets the progress
+/// (<c>blocker-progress-{session}-{level}</c>) / escalation (<c>blocker-escalation-{session}</c>)
+/// bookmark and injects the <c>ProgressDetected</c> / <c>Resolved</c> / <c>SeniorResponse</c>
+/// input, mirroring the secure <c>MergeApprovalResumeEndpoint</c> (WorkflowsManage RBAC;
+/// server-derived resolver for I2; tenant-ownership check on the session so a cross-tenant
+/// resume 404s and never acts). A production run can therefore now reach the <c>Resolved</c>
+/// terminal, not only <c>Escalated</c> / (durable) <c>Timeout</c>.</para>
 /// </summary>
 public class BlockerDiagnosisWorkflow : WorkflowBase
 {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerResumeReadBackTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Blocker/BlockerResumeReadBackTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Blocker;
+
+namespace Tamma.Activities.Tests.Blocker;
+
+/// <summary>
+/// Hardening 2026-07-03 — the blocker-diagnosis resume callbacks must read their control-flow
+/// boolean (<c>ProgressDetected</c> / <c>Resolved</c>) tolerant of a SERIALIZING workflow
+/// runtime. The in-process runtime keeps the resumed value a boxed <see cref="bool"/>, but a
+/// distributed / MassTransit / ProtoActor dispatcher round-trips it to a <see cref="string"/>
+/// or a <see cref="JsonElement"/>. The prior <c>value is true</c> pattern only matched the
+/// boxed-bool path — under serialization it silently evaluated <c>false</c>, returning HTTP 200
+/// while advancing the WRONG branch (progress → not-resolved; escalation → not-resolved),
+/// reintroducing the exact "never reaches Resolved" bug this branch fixes, masked by success.
+///
+/// <para>These tests drive the resume-input read path (<see cref="DetectProgressActivity.ReadProgressResult"/>,
+/// <see cref="EscalateToSeniorActivity.ReadSeniorOutcome"/>, and the shared
+/// <see cref="BlockerResumeInput.AsBool"/> coercion) with the flag supplied as (a) a boxed
+/// <c>bool</c>, (b) the string <c>"true"</c>/<c>"false"</c>, and (c) a <see cref="JsonElement"/>,
+/// plus a missing key. The string + JsonElement cases fail before the read-back fix and pass
+/// after; the boxed-bool path is unchanged.</para>
+/// </summary>
+[TestFixture]
+public class BlockerResumeReadBackTests
+{
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    // ---------------------------------------------------------------------
+    // Shared coercion — BlockerResumeInput.AsBool
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void AsBool_BoxedBool_ReadsThrough()
+    {
+        BlockerResumeInput.AsBool(true).Should().BeTrue();
+        BlockerResumeInput.AsBool(false).Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_String_IsTolerant()
+    {
+        BlockerResumeInput.AsBool("true").Should().BeTrue();
+        BlockerResumeInput.AsBool("True").Should().BeTrue();
+        BlockerResumeInput.AsBool("TRUE").Should().BeTrue();
+        BlockerResumeInput.AsBool("false").Should().BeFalse();
+        BlockerResumeInput.AsBool("nonsense").Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_JsonElement_IsTolerant()
+    {
+        BlockerResumeInput.AsBool(JsonBool(true)).Should().BeTrue();
+        BlockerResumeInput.AsBool(JsonBool(false)).Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_NullOrMissing_IsFalse()
+    {
+        BlockerResumeInput.AsBool(null).Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------------
+    // DetectProgressActivity.ReadProgressResult — ProgressDetected coercion
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void ReadProgressResult_BoxedBoolTrue_ReachesDetected()
+    {
+        var input = Input(("ProgressDetected", true), ("ProgressType", "Commit"), ("Details", "new commit"));
+        var result = DetectProgressActivity.ReadProgressResult(input);
+        result.ProgressDetected.Should().BeTrue();
+        result.ProgressType.Should().Be("Commit");
+        result.Details.Should().Be("new commit");
+    }
+
+    [Test]
+    public void ReadProgressResult_StringTrue_ReachesDetected()
+    {
+        var input = Input(("ProgressDetected", "true"));
+        DetectProgressActivity.ReadProgressResult(input).ProgressDetected.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadProgressResult_JsonElementTrue_ReachesDetected()
+    {
+        var input = Input(("ProgressDetected", JsonBool(true)));
+        DetectProgressActivity.ReadProgressResult(input).ProgressDetected.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadProgressResult_FalseRepresentations_ReachNotDetected()
+    {
+        DetectProgressActivity.ReadProgressResult(Input(("ProgressDetected", false))).ProgressDetected.Should().BeFalse();
+        DetectProgressActivity.ReadProgressResult(Input(("ProgressDetected", "false"))).ProgressDetected.Should().BeFalse();
+        DetectProgressActivity.ReadProgressResult(Input(("ProgressDetected", JsonBool(false)))).ProgressDetected.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadProgressResult_MissingKey_ReachesNotDetected()
+    {
+        var input = Input(("ProgressType", "Commit"));
+        DetectProgressActivity.ReadProgressResult(input).ProgressDetected.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadProgressResult_JsonElementStringFields_ReadThrough()
+    {
+        // A serializing runtime also delivers the informational strings as JsonElement.
+        var input = Input(
+            ("ProgressDetected", JsonBool(true)),
+            ("ProgressType", (object)JsonDocument.Parse("\"CIPassed\"").RootElement),
+            ("Details", (object)JsonDocument.Parse("\"all green\"").RootElement));
+        var result = DetectProgressActivity.ReadProgressResult(input);
+        result.ProgressDetected.Should().BeTrue();
+        result.ProgressType.Should().Be("CIPassed");
+        result.Details.Should().Be("all green");
+    }
+
+    // ---------------------------------------------------------------------
+    // EscalateToSeniorActivity.ReadSeniorOutcome — Resolved coercion
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void ReadSeniorOutcome_BoxedBoolTrue_ReachesResolved()
+    {
+        var input = Input(("Resolved", true), ("SeniorResponse", "fixed it"));
+        var (resolved, seniorResponse) = EscalateToSeniorActivity.ReadSeniorOutcome(input);
+        resolved.Should().BeTrue();
+        seniorResponse.Should().Be("fixed it");
+    }
+
+    [Test]
+    public void ReadSeniorOutcome_StringTrue_ReachesResolved()
+    {
+        var (resolved, _) = EscalateToSeniorActivity.ReadSeniorOutcome(Input(("Resolved", "true")));
+        resolved.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadSeniorOutcome_JsonElementTrue_ReachesResolved()
+    {
+        var (resolved, _) = EscalateToSeniorActivity.ReadSeniorOutcome(Input(("Resolved", JsonBool(true))));
+        resolved.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadSeniorOutcome_FalseRepresentations_ReachNotResolved()
+    {
+        EscalateToSeniorActivity.ReadSeniorOutcome(Input(("Resolved", false))).Resolved.Should().BeFalse();
+        EscalateToSeniorActivity.ReadSeniorOutcome(Input(("Resolved", "false"))).Resolved.Should().BeFalse();
+        EscalateToSeniorActivity.ReadSeniorOutcome(Input(("Resolved", JsonBool(false)))).Resolved.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadSeniorOutcome_MissingKey_ReachesNotResolved()
+    {
+        var (resolved, seniorResponse) = EscalateToSeniorActivity.ReadSeniorOutcome(Input(("SeniorResponse", "n/a")));
+        resolved.Should().BeFalse();
+        seniorResponse.Should().Be("n/a");
+    }
+
+    [Test]
+    public void ReadSeniorOutcome_JsonElementSeniorResponse_ReadsThrough()
+    {
+        var input = Input(
+            ("Resolved", JsonBool(true)),
+            ("SeniorResponse", (object)JsonDocument.Parse("\"see thread\"").RootElement));
+        var (resolved, seniorResponse) = EscalateToSeniorActivity.ReadSeniorOutcome(input);
+        resolved.Should().BeTrue();
+        seniorResponse.Should().Be("see thread");
+    }
+
+    // ---------------------------------------------------------------------
+
+    private static IDictionary<string, object> Input(params (string Key, object Value)[] entries)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/BlockerResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/BlockerResumeEndpointTests.cs
@@ -1,0 +1,190 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Blocker;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// Follow-up #15 — the engine-side blocker resume seam
+/// (<c>POST /elsa/api/adl/blocker/resume</c>). Verifies it:
+///   - computes the SAME session-scoped bookmark name as the suspend-side activity
+///     (progress <c>blocker-progress-{session}-{level}</c> / escalation
+///     <c>blocker-escalation-{session}</c>) and resumes the matching (single) instance
+///     with the EXACT input keys the callback reads;
+///   - REFUSES with 409 when more than one instance matches a (unique) name rather than
+///     resuming an arbitrary <c>bookmarks[0]</c>;
+///   - 404s when no bookmark matches (already advanced / resolved / timed out);
+///   - 400s a malformed request (empty session, unknown kind, missing progress level).
+/// </summary>
+[TestFixture]
+public class BlockerResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static BlockerResumeEndpoint.ResumeRequest Progress(
+        Guid session, string? level, string? progressType = null, string? details = null)
+        => new(session, "progress", level, Resolved: false, progressType, details, SeniorResponse: null, Resolver: "who@x.test");
+
+    private static BlockerResumeEndpoint.ResumeRequest Escalation(
+        Guid session, bool resolved, string? seniorResponse = null)
+        => new(session, "escalation", Level: null, resolved, ProgressType: null, Details: null, seniorResponse, Resolver: "who@x.test");
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    private Task<IResult> Invoke(BlockerResumeEndpoint.ResumeRequest req)
+        => BlockerResumeEndpoint.Resume(
+            req, _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+    [Test]
+    public async Task Resume_Progress_UsesProgressBookmarkName_InjectsProgressDetected_ResumesMatch()
+    {
+        var session = Guid.NewGuid();
+        var expected = DetectProgressActivity.ProgressBookmarkName(session, "Guidance");
+        SetupFind(expected, Bookmark(expected, "wf-p1"));
+
+        var result = await Invoke(Progress(session, "Guidance", "commit", "pushed a fix"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (bool)r.Input!["ProgressDetected"] == true
+                && (string)r.Input!["ProgressType"] == "commit"
+                && (string)r.Input!["Details"] == "pushed a fix"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _runtime.Verify(r => r.CreateClientAsync("wf-p1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_Progress_CanonicalisesLevelCasing_ToWorkflowSegment()
+    {
+        // A lower-case "hint" on the wire must resolve the SAME bookmark the workflow armed
+        // with the canonical "Hint" segment.
+        var session = Guid.NewGuid();
+        var expected = DetectProgressActivity.ProgressBookmarkName(session, "Hint");
+        SetupFind(expected, Bookmark(expected, "wf-hint"));
+
+        var result = await Invoke(Progress(session, "hint"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _runtime.Verify(r => r.CreateClientAsync("wf-hint", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_Escalation_UsesEscalationBookmarkName_InjectsResolvedAndSeniorResponse()
+    {
+        var session = Guid.NewGuid();
+        var expected = EscalateToSeniorActivity.EscalationBookmarkName(session);
+        SetupFind(expected, Bookmark(expected, "wf-e1"));
+
+        var result = await Invoke(Escalation(session, resolved: true, seniorResponse: "fixed the config"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (bool)r.Input!["Resolved"] == true
+                && (string)r.Input!["SeniorResponse"] == "fixed the config"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        var session = Guid.NewGuid();
+        var name = EscalateToSeniorActivity.EscalationBookmarkName(session);
+        SetupFind(name /* zero matches */);
+
+        var result = await Invoke(Escalation(session, resolved: true));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a miss must never resume any instance");
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        // The name is unique per session (+ level); >1 match is an integrity violation.
+        var session = Guid.NewGuid();
+        var name = DetectProgressActivity.ProgressBookmarkName(session, "Assistance");
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await Invoke(Progress(session, "Assistance"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptySession_Returns400()
+    {
+        var result = await Invoke(Escalation(Guid.Empty, resolved: true));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [TestCase("resolve")]
+    [TestCase("")]
+    public async Task Resume_UnknownKind_Returns400(string kind)
+    {
+        var req = new BlockerResumeEndpoint.ResumeRequest(
+            Guid.NewGuid(), kind, "Hint", Resolved: true,
+            ProgressType: null, Details: null, SeniorResponse: null, Resolver: null);
+
+        var result = await Invoke(req);
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [TestCase(null)]
+    [TestCase("nope")]
+    public async Task Resume_ProgressMissingOrBadLevel_Returns400(string? level)
+    {
+        var result = await Invoke(Progress(Guid.NewGuid(), level));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public void CanonicalLevel_MapsCaseInsensitively_ElseNull()
+    {
+        BlockerResumeEndpoint.CanonicalLevel("hint").Should().Be("Hint");
+        BlockerResumeEndpoint.CanonicalLevel(" Guidance ").Should().Be("Guidance");
+        BlockerResumeEndpoint.CanonicalLevel("ASSISTANCE").Should().Be("Assistance");
+        BlockerResumeEndpoint.CanonicalLevel("escalation").Should().BeNull();
+        BlockerResumeEndpoint.CanonicalLevel(null).Should().BeNull();
+    }
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/AdlEndpointsTests.cs
@@ -7,6 +7,8 @@ using Moq;
 using NUnit.Framework;
 using Tamma.Api.Endpoints;
 using Tamma.Api.Services;
+using Tamma.Core.Entities;
+using Tamma.Core.Interfaces;
 using Tamma.Data;
 
 namespace Tamma.Api.Tests.Endpoints;
@@ -311,6 +313,221 @@ public class AdlEndpointsTests
             It.IsAny<int>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(),
             It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never, "invalid input must be rejected up front, not forwarded");
+
+    // ================================================================
+    // Blocker-diagnosis progressive-resolution ladder (follow-up #15) —
+    // POST /api/adl/blocker/resume. Same RBAC (WorkflowsManage, enforced at the
+    // adl group registration) + I2 (server-derived resolver) posture as the
+    // merge/deploy gates. IDOR guard differs in MECHANISM only: the blocker
+    // bookmark is keyed by the (unguessable) session id, so ownership is enforced
+    // by a tenant-scoped session lookup (GetSessionAsync) BEFORE forwarding — a
+    // cross-tenant / unknown session 404s and never reaches the engine.
+    // ================================================================
+
+    /// <summary>A mentorship service that OWNS <paramref name="knownSessionId"/> (returns a
+    /// session for it) and treats every other id as cross-tenant / unknown (null).</summary>
+    private static Mock<IMentorshipService> MentorshipOwning(Guid knownSessionId)
+    {
+        var mentorship = new Mock<IMentorshipService>();
+        mentorship
+            .Setup(m => m.GetSessionAsync(knownSessionId))
+            .ReturnsAsync(new MentorshipSession { Id = knownSessionId });
+        mentorship
+            .Setup(m => m.GetSessionAsync(It.Is<Guid>(g => g != knownSessionId)))
+            .ReturnsAsync((MentorshipSession?)null);
+        return mentorship;
+    }
+
+    [Test]
+    public async Task ResumeBlocker_ProgressValid_ChecksOwnership_ForwardsCanonicalLevelAndDerivedResolver_Returns200()
+    {
+        var session = Guid.NewGuid();
+        var mentorship = MentorshipOwning(session);
+        _elsa
+            .Setup(s => s.ResumeBlockerResolutionAsync(
+                session, "progress", "Guidance", true, "commit", "pushed a fix", null, "alice@example.com"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-b1"));
+
+        // Lower-case level on the wire must be canonicalised to the workflow's PascalCase.
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            session, "progress", "guidance", null, "commit", "pushed a fix", null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("alice@example.com"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        // Ownership was checked, and the canonical level + principal-derived resolver forwarded.
+        mentorship.Verify(m => m.GetSessionAsync(session), Times.Once);
+        _elsa.Verify(s => s.ResumeBlockerResolutionAsync(
+            session, "progress", "Guidance", true, "commit", "pushed a fix", null, "alice@example.com"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeBlocker_EscalationValid_ForwardsResolvedAndDerivedResolver_Returns200()
+    {
+        var session = Guid.NewGuid();
+        var mentorship = MentorshipOwning(session);
+        _elsa
+            .Setup(s => s.ResumeBlockerResolutionAsync(
+                session, "escalation", null, false, null, null, "handled offline", "sr@corp.test"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-b2"));
+
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            session, "escalation", null, Resolved: false, null, null, "handled offline");
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("sr@corp.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _elsa.Verify(s => s.ResumeBlockerResolutionAsync(
+            session, "escalation", null, false, null, null, "handled offline", "sr@corp.test"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeBlocker_ResolverDerivedFromPrincipal_NotForgeable()
+    {
+        // I2 — the resolver forwarded to the engine is the authenticated principal's identity.
+        // The request type carries no resolver field, so a client cannot forge it.
+        var session = Guid.NewGuid();
+        var mentorship = MentorshipOwning(session);
+        string? capturedResolver = null;
+        _elsa
+            .Setup(s => s.ResumeBlockerResolutionAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<Guid, string, string?, bool, string?, string?, string?, string?>(
+                (_, _, _, _, _, _, _, resolver) => capturedResolver = resolver)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-b3"));
+
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            session, "escalation", null, true, null, null, null);
+
+        await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("bob@corp.test"), _loggerFactory);
+
+        capturedResolver.Should().Be("bob@corp.test",
+            "the resolver must be derived from the authenticated principal for non-repudiation");
+    }
+
+    [Test]
+    public async Task ResumeBlocker_CrossTenantOrUnknownSession_Returns404_NeverForwards()
+    {
+        // IDOR — a caller supplies a session id their tenant does NOT own. GetSessionAsync is
+        // tenant-scoped, so it resolves null → 404, and the resume is NEVER forwarded to the
+        // engine (no action on another tenant's blocker gate). Mirrors the merge/deploy
+        // cross-tenant → 404 guarantee.
+        var owned = Guid.NewGuid();
+        var mentorship = MentorshipOwning(owned);
+        var victimSession = Guid.NewGuid();
+
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            victimSession, "progress", "Hint", null, "commit", null, null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("attacker@evil.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a resume for a session the caller does not own must 404, never act");
+        VerifyBlockerNeverForwarded();
+    }
+
+    [Test]
+    public async Task ResumeBlocker_GateNotWaiting_Returns404()
+    {
+        // Caller owns the session, but no blocker wait is currently suspended (already
+        // advanced / resolved / timed out) — the engine reports GateNotFound → 404.
+        var session = Guid.NewGuid();
+        var mentorship = MentorshipOwning(session);
+        _elsa
+            .Setup(s => s.ResumeBlockerResolutionAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            session, "escalation", null, true, null, null, null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a resume for a gate that is not suspended must 404, not 500");
+    }
+
+    [Test]
+    public async Task ResumeBlocker_EmptySession_Returns400_NoForward()
+    {
+        var mentorship = new Mock<IMentorshipService>();
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            Guid.Empty, "progress", "Hint", null, null, null, null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        VerifyBlockerNeverForwarded();
+        // A bad payload must be rejected BEFORE the ownership lookup is even attempted.
+        mentorship.Verify(m => m.GetSessionAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [TestCase("resolve")]
+    [TestCase("resume")]
+    [TestCase("progress; drop table")]
+    public async Task ResumeBlocker_UnknownKind_Returns400_NoForward(string kind)
+    {
+        var mentorship = new Mock<IMentorshipService>();
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            Guid.NewGuid(), kind, "Hint", null, null, null, null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest,
+            "only progress|escalation are accepted");
+        VerifyBlockerNeverForwarded();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("Level5")]
+    [TestCase("escalation")] // not a progress level
+    public async Task ResumeBlocker_ProgressMissingOrBadLevel_Returns400_NoForward(string? level)
+    {
+        var mentorship = new Mock<IMentorshipService>();
+        var req = new AdlEndpoints.BlockerResolutionRequest(
+            Guid.NewGuid(), "progress", level, null, null, null, null);
+
+        var result = await AdlEndpoints.ResumeBlocker(
+            req, _elsa.Object, mentorship.Object, TenantContext(Guid.NewGuid()),
+            Principal("a@b.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest,
+            "kind=progress requires a Hint|Guidance|Assistance level");
+        VerifyBlockerNeverForwarded();
+    }
+
+    [Test]
+    public void CanonicalBlockerLevel_MapsCaseInsensitively_ElseNull()
+    {
+        AdlEndpoints.CanonicalBlockerLevel("hint").Should().Be("Hint");
+        AdlEndpoints.CanonicalBlockerLevel("  GUIDANCE ").Should().Be("Guidance");
+        AdlEndpoints.CanonicalBlockerLevel("Assistance").Should().Be("Assistance");
+        AdlEndpoints.CanonicalBlockerLevel("escalation").Should().BeNull();
+        AdlEndpoints.CanonicalBlockerLevel(null).Should().BeNull();
+    }
+
+    private void VerifyBlockerNeverForwarded() =>
+        _elsa.Verify(s => s.ResumeBlockerResolutionAsync(
+            It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<bool>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>()),
+            Times.Never, "invalid / unauthorized input must be rejected up front, not forwarded");
 
     private void VerifyNeverForwarded() =>
         _elsa.Verify(s => s.ResumeMergeApprovalAsync(

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
@@ -172,5 +172,7 @@ public sealed class RotationTriggerServiceTests
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
         public Task<MergeApprovalResumeResult> ResumeDeploymentApprovalAsync(int i, string? t, string? r, string? sha, string d, string? f, string? a) =>
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+        public Task<MergeApprovalResumeResult> ResumeBlockerResolutionAsync(Guid sid, string k, string? l, bool res, string? pt, string? det, string? sr, string? resolver) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
     }
 }


### PR DESCRIPTION
## What

Adds the blocker-diagnosis resume endpoint the workflow's own doc asked for — a secure way to resume a suspended `blocker-diagnosis` run (progress or escalation bookmark), mirroring `MergeApprovalResumeEndpoint` exactly.

- **API tier** `AdlEndpoints.ResumeBlocker` (`POST .../adl/blocker/resume`, `WorkflowsManage` policy) — checks session ownership via tenant-scoped `IMentorshipService.GetSessionAsync` (cross-tenant/unknown → 404, never forwarded), resolver derived server-side (non-forgeable), then calls the engine tier.
- **Engine tier** `BlockerResumeEndpoint` (internal Api→engine hop, admin-API-key only) — resolves the bookmark via canonical builders now shared by the suspend + resume sides (`DetectProgressActivity.ProgressBookmarkName` / `EscalateToSeniorActivity.EscalationBookmarkName`); 0 matches → 404, >1 → 409 (no `bookmarks[0]` fallback); injects only the exact keys each callback reads.
- `IElsaWorkflowService.ResumeBlockerResolutionAsync` (the generic resume can't pass a bookmark id + input).

## Review + hardening

Adversarial security review → **no exploitable vulnerability** (confidence ≥80): engine-tier bypass blocked by three independent controls (Elsa server not host-published; nginx `return 404` on the whole `/elsa/api/adl/` prefix; engine accepts only the admin API key — a tenant JWT can't authenticate there); IDOR sound in both modes; bookmark-name parity exact; resolver non-forgeable; double-submit clean (AutoBurn → second resume 404s).

Applied one below-threshold hardening the reviewer flagged: the resume callbacks read the resumed bool as `is true` (boxed-`bool` pattern), which would silently mis-branch (return 200 while advancing the wrong path) if the runtime ever serialized resume input (bool → `JsonElement`). Added a shared `BlockerResumeInput.AsBool` (tolerant of bool/string/JsonElement) on both control-flow reads, mirroring the merge/deploy `.ToString()` convention.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). **No migration.**
- Tests: `Tamma.Api.Tests` Blocker/Resume/Mentorship 55/55; `Tamma.Activities.Tests` Blocker 82/82 (incl. 16 new read-back cases, fail-before/pass-after for string+JsonElement) + 11 engine-tier resume tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)