### PR TITLE
feat(deploy): CreateReleaseActivity — mediated git release in DeploymentPipelineWorkflow

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateReleaseActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateReleaseActivity.cs
@@ -1,0 +1,256 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Epic 38 follow-up #21 — creates a git-platform release (and its tag) for the
+/// shipped version at the tail of the <c>deployment-pipeline</c> workflow (after a
+/// successful production deploy). Replaces the prior <c>releaseStatus="deferred"</c>
+/// placeholder with a real release cut through the MEDIATED integration seam.
+///
+/// <para><b>Mediation (TAMMA001):</b> the activity holds NO git credential and no
+/// <c>IGitHubIntegrationService</c> / Octokit reference. The release is created via
+/// <c>POST /api/v1/git/{owner}/{repo}/releases</c> through <see cref="TammaApiClient"/>,
+/// where the per-tenant token is resolved and used server-side (the same seam the
+/// PR / merge / branch ADL activities use). The tag / title / notes are composed
+/// engine-side (pure, token-free).</para>
+///
+/// <para><b>Audit:</b> emits a <c>RELEASE.CREATED.SUCCESS</c> or
+/// <c>RELEASE.CREATED.FAILED</c> DCB event into the workflow's <c>tamma:events</c>
+/// transient list (drained durably to the tenant <c>domain_events</c> store) —
+/// mirroring <see cref="EmitDeploymentEventActivity"/>. A failed release is NEVER
+/// silently swallowed: the FAILED event is loud (error-status) and the error is
+/// surfaced on the <see cref="ErrorCode"/> output.</para>
+///
+/// Outcomes:
+///   - Created: the release was created (proceed to the pipeline-success terminal).
+///   - Error:   the release create failed (the deploy still succeeded; the pipeline
+///              records <c>releaseStatus=failed</c> and the loud FAILED event).
+/// </summary>
+[Activity(
+    "Tamma.ADL",
+    "Create Release",
+    "Create a git-platform release/tag for the shipped version (mediated, token-free)",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Created", "Error")]
+public class CreateReleaseActivity : Activity
+{
+    private readonly ILogger<CreateReleaseActivity>? _logger;
+    private readonly TammaApiClient? _apiClient;
+
+    [Input(Description = "Repository in owner/repo format")]
+    public Input<string> Repository { get; set; } = default!;
+
+    [Input(Description = "Release tag / version to create (e.g. deploy-a1b2c3d)")]
+    public Input<string> TagName { get; set; } = default!;
+
+    [Input(Description = "Target commit-ish (SHA or branch) the tag is cut from; empty = default branch")]
+    public Input<string?> TargetRef { get; set; } = new((string?)null);
+
+    [Input(Description = "Release title; empty = the tag name")]
+    public Input<string?> ReleaseName { get; set; } = new((string?)null);
+
+    [Input(Description = "Release notes / body (Markdown)")]
+    public Input<string?> Body { get; set; } = new((string?)null);
+
+    [Input(Description = "Create as a draft (unpublished) release")]
+    public Input<bool> Draft { get; set; } = new(false);
+
+    [Input(Description = "Mark the release as a pre-release")]
+    public Input<bool> Prerelease { get; set; } = new(false);
+
+    [Input(Description = "Issue number this deployment resolves (for the audit event)")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Tenant id (GUID string) for BYOK token resolution; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Output(Description = "Public URL of the created release")]
+    public Output<string?> ReleaseUrl { get; set; } = default!;
+
+    [Output(Description = "Numeric id of the created release")]
+    public Output<string?> ReleaseId { get; set; } = default!;
+
+    [Output(Description = "Tag the release points at")]
+    public Output<string?> ReleaseTag { get; set; } = default!;
+
+    [Output(Description = "Failure classification when the Error outcome fires")]
+    public Output<string?> ErrorCode { get; set; } = default!;
+
+    [JsonConstructor]
+    public CreateReleaseActivity() { }
+
+    /// <summary>
+    /// Thin-client DI constructor. No <c>IGitHubIntegrationService</c> and no git
+    /// token: the release create routes through
+    /// <c>POST /api/v1/git/{owner}/{repo}/releases</c> via <see cref="TammaApiClient"/>.
+    /// </summary>
+    public CreateReleaseActivity(
+        ILogger<CreateReleaseActivity>? logger,
+        TammaApiClient? apiClient)
+    {
+        _logger = logger;
+        _apiClient = apiClient;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var repository = Repository.Get(context) ?? "";
+        var tag = TagName.Get(context) ?? "";
+        var targetRef = TargetRef.Get(context);
+        var name = ReleaseName.Get(context);
+        var body = Body.Get(context);
+        var draft = Draft.Get(context);
+        var prerelease = Prerelease.Get(context);
+        var issueNumber = IssueNumber.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+
+        var request = new GitCreateReleaseRequest
+        {
+            TagName = tag,
+            TargetRef = string.IsNullOrWhiteSpace(targetRef) ? null : targetRef,
+            Name = string.IsNullOrWhiteSpace(name) ? tag : name,
+            Body = body,
+            Draft = draft,
+            Prerelease = prerelease,
+            IssueNumber = issueNumber,
+            CorrelationId = context.WorkflowExecutionContext.Id,
+        };
+
+        _logger?.LogInformation(
+            "Creating release {Tag} in {Repo} for issue #{Issue}", tag, repository, issueNumber);
+
+        var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+        var response = await apiClient.CreateReleaseAsync(repository, request, tenantId, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        var outcome = MapResponse(response);
+        if (outcome.Outcome == "Created")
+        {
+            ReleaseUrl.Set(context, outcome.ReleaseUrl);
+            ReleaseId.Set(context, outcome.ReleaseId?.ToString());
+            ReleaseTag.Set(context, outcome.ReleaseTag ?? tag);
+
+            var evt = BuildReleaseEvent(
+                success: true, issueNumber, repository, outcome.ReleaseTag ?? tag,
+                outcome.ReleaseUrl, outcome.ReleaseId, tenantId, error: null);
+            TammaEventEmitter.Emit(context, this, _logger, evt);
+
+            _logger?.LogInformation(
+                "Created release {Tag} in {Repo} ({Url})", outcome.ReleaseTag ?? tag, repository, outcome.ReleaseUrl);
+
+            await context.CompleteActivityWithOutcomesAsync("Created");
+        }
+        else
+        {
+            ErrorCode.Set(context, outcome.ErrorCode ?? "release-creation-failed");
+
+            var evt = BuildReleaseEvent(
+                success: false, issueNumber, repository, tag,
+                releaseUrl: null, releaseId: null, tenantId,
+                error: outcome.FailureReason ?? outcome.ErrorCode ?? "release creation failed");
+            TammaEventEmitter.Emit(context, this, _logger, evt);
+
+            _logger?.LogWarning(
+                "Failed to create release {Tag} in {Repo}: {Error}",
+                tag, repository, outcome.FailureReason ?? outcome.ErrorCode);
+
+            await context.CompleteActivityWithOutcomesAsync("Error");
+        }
+    }
+
+    /// <summary>
+    /// Project the git-mediation wire response into a typed outcome that maps
+    /// directly to the activity's Elsa outcome (Created / Error). A null response
+    /// (guard 403 / token 503 / auth 401 / transport) fails closed to Error — never
+    /// a fabricated success. Pure — exposed for unit testing.
+    /// </summary>
+    public static ReleaseCreationOutcome MapResponse(GitCallResponse? response)
+    {
+        if (response is null)
+            return ReleaseCreationOutcome.Failed("git-mediation-unavailable", "git mediation endpoint unavailable");
+
+        if (response.Success && response.Outcome == "Created")
+            return ReleaseCreationOutcome.Created(response.ReleaseId, response.ReleaseUrl, response.ReleaseTag);
+
+        return ReleaseCreationOutcome.Failed(
+            response.FailureCode ?? "release-creation-failed",
+            response.FailureReason ?? "release creation failed");
+    }
+
+    /// <summary>
+    /// Build the <c>RELEASE.CREATED.SUCCESS</c> / <c>RELEASE.CREATED.FAILED</c> DCB
+    /// event. Tags carry the queryable DCB index keys (issue / repository / tag /
+    /// tenant); Data carries the release payload (url / id) or the failure reason.
+    /// Pure (no Elsa context) — exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildReleaseEvent(
+        bool success,
+        int issueNumber,
+        string repository,
+        string tag,
+        string? releaseUrl,
+        long? releaseId,
+        string? tenantId,
+        string? error)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(repository)) tags["repository"] = repository;
+        if (!string.IsNullOrWhiteSpace(tag)) tags["tag"] = tag;
+        if (!string.IsNullOrWhiteSpace(tenantId)) tags["tenantId"] = tenantId;
+
+        var data = new Dictionary<string, object?> { ["tag"] = tag };
+        if (success)
+        {
+            if (!string.IsNullOrWhiteSpace(releaseUrl)) data["releaseUrl"] = releaseUrl;
+            if (releaseId is not null) data["releaseId"] = releaseId;
+        }
+        else if (!string.IsNullOrWhiteSpace(error))
+        {
+            data["reason"] = error;
+        }
+
+        return new TammaEvent
+        {
+            EventType = success ? DeployEvents.ReleaseCreatedSuccess : DeployEvents.ReleaseCreatedFailed,
+            Status = success ? "success" : "error",
+            Error = success ? null : error,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}
+
+/// <summary>
+/// Typed result of <see cref="CreateReleaseActivity.MapResponse"/> — maps directly
+/// to the activity's Elsa outcome (Created / Error).
+/// </summary>
+public sealed class ReleaseCreationOutcome
+{
+    public string Outcome { get; init; } = "Error";
+    public long? ReleaseId { get; init; }
+    public string? ReleaseUrl { get; init; }
+    public string? ReleaseTag { get; init; }
+    public string? ErrorCode { get; init; }
+    public string? FailureReason { get; init; }
+
+    public static ReleaseCreationOutcome Created(long? id, string? url, string? tag)
+        => new() { Outcome = "Created", ReleaseId = id, ReleaseUrl = url, ReleaseTag = tag };
+
+    public static ReleaseCreationOutcome Failed(string errorCode, string? reason = null)
+        => new() { Outcome = "Error", ErrorCode = errorCode, FailureReason = reason };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DeployEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DeployEvents.cs
@@ -70,6 +70,20 @@ public static class DeployEvents
     public const string RollbackFailed = "DEPLOY.ROLLBACK.FAILED";
 
     /// <summary>
+    /// Epic 38 follow-up #21 — a git-platform release/tag was created for the
+    /// shipped version (the deployment-pipeline release step). Emitted by
+    /// <see cref="CreateReleaseActivity"/> after a successful production deploy.
+    /// </summary>
+    public const string ReleaseCreatedSuccess = "RELEASE.CREATED.SUCCESS";
+
+    /// <summary>
+    /// Epic 38 follow-up #21 — the release/tag create failed. Loud (error-status) —
+    /// the deploy itself still succeeded, but the release annotation is surfaced as
+    /// a failure (never silently swallowed).
+    /// </summary>
+    public const string ReleaseCreatedFailed = "RELEASE.CREATED.FAILED";
+
+    /// <summary>
     /// A <c>*.FAILED</c> / <c>*.REJECTED</c> deploy event carries an
     /// <c>error</c> status; everything else (<c>*.SUCCESS</c> /
     /// <c>*.STARTED</c> / <c>*.APPROVED</c> / <c>*.APPROVAL_REQUESTED</c>) is
@@ -77,7 +91,7 @@ public static class DeployEvents
     /// success (no-silent-failure rule).
     /// </summary>
     public static bool IsFailureType(string type)
-        => type is StageFailed or PipelineFailed or ProductionRejected or RollbackFailed;
+        => type is StageFailed or PipelineFailed or ProductionRejected or RollbackFailed or ReleaseCreatedFailed;
 
     /// <summary>
     /// Parse a tenant id from the loose string form threaded through the workflow

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -319,6 +319,24 @@ public sealed record GitUpdateIssueRequest
 }
 
 /// <summary>
+/// Epic 38 follow-up #21 — engine→API wire request for
+/// <c>POST /api/v1/git/{owner}/{repo}/releases</c> (deployment-pipeline release
+/// step). Mirrors <c>Tamma.Api.Services.Git.CreateReleaseRequest</c>. Carries NO
+/// token — the API resolves the per-tenant credential server-side.
+/// </summary>
+public sealed record GitCreateReleaseRequest
+{
+    [JsonPropertyName("tagName")] public string TagName { get; init; } = string.Empty;
+    [JsonPropertyName("targetRef")] public string? TargetRef { get; init; }
+    [JsonPropertyName("name")] public string? Name { get; init; }
+    [JsonPropertyName("body")] public string? Body { get; init; }
+    [JsonPropertyName("draft")] public bool Draft { get; init; }
+    [JsonPropertyName("prerelease")] public bool Prerelease { get; init; }
+    [JsonPropertyName("issueNumber")] public int IssueNumber { get; init; }
+    [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+}
+
+/// <summary>
 /// Engine→API wire response for the git-mediation endpoints. Mirrors
 /// <c>Tamma.Api.Services.Git.GitMediationResult</c>. KEY-FREE: only the
 /// <see cref="CredentialSource"/> LABEL is ever present — never the token.
@@ -351,6 +369,11 @@ public sealed record GitCallResponse
     // Story 38 (Phase 1) — GitHub extra-op reads.
     [JsonPropertyName("commits")] public IReadOnlyList<GitCommitSummaryDto>? Commits { get; init; }
     [JsonPropertyName("fileChanges")] public IReadOnlyList<GitFileChangeDto>? FileChanges { get; init; }
+
+    // Epic 38 follow-up #21 — release create.
+    [JsonPropertyName("releaseId")] public long? ReleaseId { get; init; }
+    [JsonPropertyName("releaseUrl")] public string? ReleaseUrl { get; init; }
+    [JsonPropertyName("releaseTag")] public string? ReleaseTag { get; init; }
 
     [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
     [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -156,6 +156,21 @@ public class TammaApiClient
         return PatchAsync<GitCallResponse>(url, request, tenantId, ct);
     }
 
+    /// <summary>
+    /// Epic 38 follow-up #21 — create a git-platform release for the shipped version
+    /// via <c>POST /api/v1/git/{owner}/{repo}/releases</c> (the deployment-pipeline
+    /// release step). The tag / notes are composed engine-side; the per-tenant git
+    /// token is resolved + used server-side, it never travels here. Returns null on
+    /// any non-2xx / transport failure (the thin activity maps it to its Error edge,
+    /// fail-closed).
+    /// </summary>
+    public virtual Task<GitCallResponse?> CreateReleaseAsync(
+        string repo, GitCreateReleaseRequest request, string? tenantId = null, CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/v1/git/{RepoPath(repo)}/releases";
+        return PostAsync<GitCallResponse>(url, request, tenantId, ct);
+    }
+
     /// <summary>Story 38-1 (AC5) — <c>GET /api/v1/git/{owner}/{repo}/pull-requests/{n}/comments</c>.</summary>
     public Task<GitCallResponse?> GetPullRequestCommentsAsync(
         string repo, int prNumber, string? correlationId = null, string? tenantId = null, CancellationToken ct = default)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/GitEndpoints.cs
@@ -99,5 +99,13 @@ public static class GitEndpoints
         return result.ToHttpResult();
     }
 
+    public static async Task<IResult> CreateRelease(
+        string owner, string repo, CreateReleaseRequest body,
+        ITenantContext tenantContext, IGitMediationService git, CancellationToken ct)
+    {
+        var result = await git.CreateReleaseAsync(tenantContext.TenantId, Repo(owner, repo), body, ct).ConfigureAwait(false);
+        return result.ToHttpResult();
+    }
+
     private static string Repo(string owner, string repo) => $"{owner}/{repo}";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2627,6 +2627,13 @@ app.MapDelete("/api/v1/git/{owner}/{repo}/branches", GitEndpoints.DeleteBranch)
     .RequireAuthorization("EngineServiceOnly")
     .WithName("GitDeleteBranch");
 
+// ── Epic 38 follow-up #21 — deployment-pipeline release step. Create a GitHub
+// release/tag for the shipped version. Same engine-only plane + guard→token→
+// platform→one-event mediation as the git-platform ops above.
+app.MapPost("/api/v1/git/{owner}/{repo}/releases", GitEndpoints.CreateRelease)
+    .RequireAuthorization("EngineServiceOnly")
+    .WithName("GitCreateRelease");
+
 // ── Story 38 (Phase 1) — CI (GitHub Actions) step mediation ──
 // Same engine-only plane + guard→token→platform→one-event mediation as git.
 app.MapPost("/api/v1/ci/{owner}/{repo}/test-runs", CiEndpoints.TriggerTests)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitEventTypes.cs
@@ -24,6 +24,11 @@ public static class GitEventTypes
     public const string FileChangesReadOperation = "file_changes_read";
     public const string BranchDeleteOperation = "branch_delete";
 
+    // Epic 38 follow-up #21 — the deployment-pipeline release step (create a
+    // GitHub release/tag for the shipped version). Same guard→token→platform→
+    // one-event mediation plane as the git-platform ops above.
+    public const string ReleaseCreateOperation = "release_create";
+
     public const string BranchCreatedSuccess = "GIT.BRANCH_CREATED.SUCCESS";
     public const string BranchCreatedFailed = "GIT.BRANCH_CREATED.FAILED";
 
@@ -47,6 +52,9 @@ public static class GitEventTypes
 
     public const string BranchDeletedSuccess = "GIT.BRANCH_DELETED.SUCCESS";
     public const string BranchDeletedFailed = "GIT.BRANCH_DELETED.FAILED";
+
+    public const string ReleaseCreatedSuccess = "GIT.RELEASE_CREATED.SUCCESS";
+    public const string ReleaseCreatedFailed = "GIT.RELEASE_CREATED.FAILED";
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitMediationService.cs
@@ -93,6 +93,13 @@ public sealed class GitMediationService : IGitMediationService
         => ExecuteGuardedAsync(tenantId, repo, GitEventTypes.BranchDeleteOperation, GitEventTypes.BranchDeletedFailed, correlationId, ct,
             () => DeleteBranchCoreAsync(tenantId, repo, branchName, correlationId, ct));
 
+    public Task<GitMediationResult> CreateReleaseAsync(Guid? tenantId, string repo, CreateReleaseRequest body, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        return ExecuteGuardedAsync(tenantId, repo, GitEventTypes.ReleaseCreateOperation, GitEventTypes.ReleaseCreatedFailed, body.CorrelationId, ct,
+            () => CreateReleaseCoreAsync(tenantId, repo, body, ct));
+    }
+
     /// <summary>
     /// F3 — run one mediation op body; convert any unexpected exception (DB read,
     /// secret decrypt, client mint, transport) into a typed key-free
@@ -577,6 +584,53 @@ public sealed class GitMediationService : IGitMediationService
         };
         await EmitAsync(GitEventTypes.BranchDeletedSuccess, op, tenantId, repo, correlationId, cred.Source, null,
             new { branchName }, ct).ConfigureAwait(false);
+        return ok;
+    }
+
+    // ===================================================================
+    // Create release (Epic 38 follow-up #21) — deployment-pipeline release step
+    // ===================================================================
+
+    private async Task<GitMediationResult> CreateReleaseCoreAsync(Guid? tenantId, string repo, CreateReleaseRequest body, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(body);
+        var op = GitEventTypes.ReleaseCreateOperation;
+
+        var gate = await GuardOrDenyAsync(tenantId, repo, op, GitEventTypes.ReleaseCreatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+        if (gate is not null) return gate;
+
+        var cred = await _tokenResolver.ResolveAsync(tenantId, repo, ct).ConfigureAwait(false);
+        if (cred is null)
+            return await TokenUnavailableAsync(tenantId, repo, op, GitEventTypes.ReleaseCreatedFailed, body.CorrelationId, ct).ConfigureAwait(false);
+
+        var github = _githubFactory.Create(cred.Token);
+        var request = new Tamma.Core.Interfaces.ReleaseCreationRequest
+        {
+            TagName = body.TagName,
+            TargetCommitish = body.TargetRef,
+            Name = string.IsNullOrWhiteSpace(body.Name) ? body.TagName : body.Name,
+            Body = body.Body,
+            Draft = body.Draft,
+            Prerelease = body.Prerelease,
+        };
+
+        var res = await github.CreateGitHubReleaseAsync(repo, request).ConfigureAwait(false);
+
+        if (!res.Success)
+            return await ReadFailAsync(tenantId, repo, op, GitEventTypes.ReleaseCreatedFailed, body.CorrelationId, cred.Source, res.Error, new { tag = body.TagName }, ct).ConfigureAwait(false);
+
+        var ok = new GitMediationResult
+        {
+            Success = true,
+            CredentialSource = cred.Source,
+            Outcome = "Created",
+            ReleaseId = res.Data!.Id,
+            ReleaseUrl = res.Data.HtmlUrl,
+            ReleaseTag = res.Data.TagName ?? body.TagName,
+            CorrelationId = body.CorrelationId,
+        };
+        await EmitAsync(GitEventTypes.ReleaseCreatedSuccess, op, tenantId, repo, body.CorrelationId, cred.Source, null,
+            new { tag = ok.ReleaseTag, releaseId = res.Data.Id }, ct).ConfigureAwait(false);
         return ok;
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRequests.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRequests.cs
@@ -71,3 +71,21 @@ public sealed record UpdateIssueRequest
     public string? Status { get; init; } // open | closed (optional; today: no state change)
     public string CorrelationId { get; init; } = string.Empty;
 }
+
+/// <summary>
+/// <c>POST /api/v1/git/{owner}/{repo}/releases</c> (Epic 38 follow-up #21 —
+/// deployment-pipeline release step). The tag / title / notes are composed
+/// engine-side (pure, token-free); the API creates the release with the resolved
+/// per-tenant token. Carries NO token.
+/// </summary>
+public sealed record CreateReleaseRequest
+{
+    public string TagName { get; init; } = string.Empty;
+    public string? TargetRef { get; init; }   // SHA / branch the tag is created from
+    public string? Name { get; init; }         // release title (empty ⇒ TagName)
+    public string? Body { get; init; }         // release notes (Markdown)
+    public bool Draft { get; init; }
+    public bool Prerelease { get; init; }
+    public int IssueNumber { get; init; }
+    public string CorrelationId { get; init; } = string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitResponses.cs
@@ -51,6 +51,11 @@ public sealed record GitMediationResult
     public IReadOnlyList<GitCommitDto>? Commits { get; init; }
     public IReadOnlyList<GitFileChangeDto>? FileChanges { get; init; }
 
+    // ── release (Epic 38 follow-up #21 — deployment-pipeline release step) ──
+    public long? ReleaseId { get; init; }
+    public string? ReleaseUrl { get; init; }
+    public string? ReleaseTag { get; init; }
+
     // ── failure-only (key-free) ──
     public string? FailureCode { get; init; }   // REPO_NOT_AUTHORIZED | GIT_CONFLICT | NOT_MERGEABLE | NOT_FOUND | PLATFORM_ERROR | GIT_TOKEN_UNAVAILABLE
     public string? FailureReason { get; init; }  // key-free

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitMediationService.cs
@@ -30,4 +30,11 @@ public interface IGitMediationService
     /// <summary>Delete <paramref name="branchName"/> (the standalone delete the
     /// composite exposes, distinct from the verified post-merge delete). Write op.</summary>
     Task<GitMediationResult> DeleteBranchAsync(Guid? tenantId, string repo, string branchName, string correlationId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Epic 38 follow-up #21 — create a GitHub release/tag for the shipped version
+    /// (the deployment-pipeline release step). Write op —
+    /// guard→token→platform→one-event.
+    /// </summary>
+    Task<GitMediationResult> CreateReleaseAsync(Guid? tenantId, string repo, CreateReleaseRequest body, CancellationToken ct = default);
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/GitHubIntegrationService.cs
@@ -758,4 +758,69 @@ public class GitHubIntegrationService : IGitHubIntegrationService
             return IntegrationResult<bool>.Fail(ex.Message);
         }
     }
+
+    public async Task<IntegrationResult<GitHubReleaseResult>> CreateGitHubReleaseAsync(string repository, ReleaseCreationRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var httpClient = CreateGitHubClient();
+        // A request-scoped override (BYOK, resolved by the mediation layer) IS the
+        // token; only require the static GitHub:Token when no override is bound.
+        var token = _tokenOverride ?? _configuration["GitHub:Token"];
+        if (string.IsNullOrEmpty(token))
+        {
+            _logger.LogWarning("GitHub token not configured");
+            return IntegrationResult<GitHubReleaseResult>.Fail("GitHub token not configured");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.TagName))
+            return IntegrationResult<GitHubReleaseResult>.Fail("a non-empty release tag is required");
+
+        try
+        {
+            _logger.LogInformation("Creating release {Tag} in {Repo}", request.TagName, repository);
+
+            // Snake-case GitHub REST payload. target_commitish is only sent when
+            // supplied (GitHub defaults it to the repo's default branch otherwise,
+            // and ignores it entirely when the tag already exists).
+            var payload = new Dictionary<string, object?>
+            {
+                ["tag_name"] = request.TagName,
+                ["name"] = string.IsNullOrWhiteSpace(request.Name) ? request.TagName : request.Name,
+                ["body"] = request.Body ?? string.Empty,
+                ["draft"] = request.Draft,
+                ["prerelease"] = request.Prerelease,
+            };
+            if (!string.IsNullOrWhiteSpace(request.TargetCommitish))
+                payload["target_commitish"] = request.TargetCommitish;
+
+            var response = await httpClient.PostAsJsonAsync($"/repos/{repository}/releases", payload);
+            if (!response.IsSuccessStatusCode)
+            {
+                // Surface the status code + body so the mediation layer can classify
+                // the failure (422 tag exists / 403 permission / 404 repo) rather than
+                // collapsing every error into a bare throw.
+                var body = await response.Content.ReadAsStringAsync();
+                _logger.LogError(
+                    "Failed to create release {Tag} in {Repo}: {Status} {Body}",
+                    request.TagName, repository, (int)response.StatusCode, body);
+                return IntegrationResult<GitHubReleaseResult>.Fail($"{(int)response.StatusCode}: {body}");
+            }
+
+            var data = await response.Content.ReadFromJsonAsync<JsonElement>();
+            var result = new GitHubReleaseResult
+            {
+                Success = true,
+                Id = data.TryGetProperty("id", out var id) && id.ValueKind == JsonValueKind.Number ? id.GetInt64() : null,
+                HtmlUrl = data.TryGetProperty("html_url", out var url) ? url.GetString() : null,
+                TagName = data.TryGetProperty("tag_name", out var t) ? t.GetString() ?? request.TagName : request.TagName,
+            };
+            return IntegrationResult<GitHubReleaseResult>.Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create GitHub release {Tag} in {Repo}", request.TagName, repository);
+            return IntegrationResult<GitHubReleaseResult>.Fail(ex.Message);
+        }
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IntegrationService.cs
@@ -134,6 +134,14 @@ public class IntegrationService : IIntegrationService
             : new GitHubMergeResult { Success = false, Error = result.Error };
     }
 
+    public async Task<GitHubReleaseResult> CreateGitHubReleaseAsync(string repository, ReleaseCreationRequest request)
+    {
+        var result = await _github.CreateGitHubReleaseAsync(repository, request);
+        return result.Success
+            ? result.Data!
+            : new GitHubReleaseResult { Success = false, Error = result.Error };
+    }
+
     public async Task<GitHubPullRequestDetail> GetGitHubPullRequestAsync(string repository, int pullRequestNumber)
     {
         var result = await _github.GetGitHubPullRequestAsync(repository, pullRequestNumber);

--- a/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Interfaces/IIntegrationService.cs
@@ -129,6 +129,16 @@ public interface IGitHubIntegrationService
     /// <summary>Story 38-1 — remove a single label from an issue (idempotent: a 404
     /// "label not present" is treated as removed).</summary>
     Task<IntegrationResult<bool>> RemoveIssueLabelAsync(string repository, int issueNumber, string label);
+
+    /// <summary>
+    /// Epic 38 follow-up #21 (deployment-pipeline release step) — create a GitHub
+    /// release (and its tag) for the shipped version. Backs
+    /// <c>POST /api/v1/git/{owner}/{repo}/releases</c>. The release title / notes are
+    /// composed engine-side (pure, token-free); the API performs the create with the
+    /// resolved per-tenant token. An expected platform failure surfaces via
+    /// <c>Fail</c> (never a fabricated success) so the ADL pipeline can branch on it.
+    /// </summary>
+    Task<IntegrationResult<GitHubReleaseResult>> CreateGitHubReleaseAsync(string repository, ReleaseCreationRequest request);
 }
 
 /// <summary>
@@ -245,6 +255,10 @@ public interface IIntegrationService
 
     /// <summary>Get JIRA ticket details</summary>
     Task<JiraTicket?> GetJiraTicketAsync(string ticketId);
+
+    /// <summary>Create a GitHub release (and its tag) for a shipped version
+    /// (Epic 38 follow-up #21 — deployment-pipeline release step).</summary>
+    Task<GitHubReleaseResult> CreateGitHubReleaseAsync(string repository, ReleaseCreationRequest request);
 }
 
 // ============================================
@@ -308,6 +322,50 @@ public class GitHubMergeResult
 {
     public bool Success { get; set; }
     public string? MergeSha { get; set; }
+    public string? Error { get; set; }
+}
+
+/// <summary>
+/// Epic 38 follow-up #21 — the request to create a GitHub release for a shipped
+/// version. Composed engine-side (pure, token-free); the API performs the create
+/// with the resolved per-tenant token.
+/// </summary>
+public class ReleaseCreationRequest
+{
+    /// <summary>The git tag to create/point the release at (e.g. <c>deploy-a1b2c3d</c>).</summary>
+    public string TagName { get; set; } = string.Empty;
+
+    /// <summary>The commit-ish (SHA or branch) the tag is created from. Null/empty ⇒
+    /// the repository default branch (GitHub behaviour). Unused if the tag exists.</summary>
+    public string? TargetCommitish { get; set; }
+
+    /// <summary>The release title. Empty ⇒ the API falls back to <see cref="TagName"/>.</summary>
+    public string? Name { get; set; }
+
+    /// <summary>The release notes / body (Markdown).</summary>
+    public string? Body { get; set; }
+
+    /// <summary>Create as a draft (not published) release.</summary>
+    public bool Draft { get; set; }
+
+    /// <summary>Mark the release as a pre-release.</summary>
+    public bool Prerelease { get; set; }
+}
+
+/// <summary>Epic 38 follow-up #21 — the result of a create-release platform call.</summary>
+public class GitHubReleaseResult
+{
+    public bool Success { get; set; }
+
+    /// <summary>The GitHub release id (numeric).</summary>
+    public long? Id { get; set; }
+
+    /// <summary>The release's public HTML URL.</summary>
+    public string? HtmlUrl { get; set; }
+
+    /// <summary>The tag the release points at.</summary>
+    public string? TagName { get; set; }
+
     public string? Error { get; set; }
 }
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
@@ -64,14 +64,17 @@ namespace Tamma.ElsaServer.Workflows;
 /// continue-with-incidents and the pre-seeded <c>deploymentStatus = "failed"</c>
 /// so an internal fault never reports a silent success.</para>
 ///
-/// <para><b>Deferred (P1 item 5 — release/tag):</b> no GitHub-release / git-tag
-/// activity exists anywhere in <c>apps/tamma-elsa/src</c> (a real seam is a
-/// follow-up — a <c>CreateReleaseActivity</c> wrapping the platform's GitHub
-/// client). Rather than FAKE a release, the successful-prod terminal surfaces
-/// <c>releaseStatus = "deferred"</c> + a computed <c>releaseTag</c> output and
-/// records it in the pipeline-success event, so the gap is explicit and queryable
-/// instead of silently claimed-done. P2/P3 items (post-deploy health probe, typed
-/// mediation contract, per-stage timeout, notifications) remain follow-ups.</para>
+/// <para><b>Release/tag (Epic 38 follow-up #21 — IMPLEMENTED):</b> after a
+/// successful production deploy the pipeline cuts a REAL git-platform release via
+/// <see cref="Tamma.Activities.ADL.CreateReleaseActivity"/> — the MEDIATED release
+/// step (the engine holds NO git credential; the release create routes through
+/// <c>POST /api/v1/git/{owner}/{repo}/releases</c> via <c>TammaApiClient</c>, where
+/// the per-tenant token lives, so <c>TAMMA001</c> stays satisfied). The successful
+/// terminal now surfaces <c>releaseStatus = "created"</c> + <c>releaseUrl</c>; a
+/// release-create failure surfaces <c>releaseStatus = "failed"</c> + a loud
+/// <c>RELEASE.CREATED.FAILED</c> event (never silently swallowed) without undoing
+/// the successful deploy. P2/P3 items (post-deploy health probe, per-stage timeout,
+/// notifications) remain follow-ups.</para>
 ///
 /// Flow:
 ///   Init (status=failed default) → QA STARTED → QA Deploy (llm-call) → Extract → QA OK?
@@ -82,7 +85,7 @@ namespace Tamma.ElsaServer.Workflows;
 ///     │   │   │     ├─ Reject  → REJECTED → SetProdFailed
 ///     │   │   │     └─ Invalid → REJECTED → SetProdFailed
 ///     │   │   └─ No(dev) → Prod STARTED → Prod Deploy → Extract → Prod OK?
-///     │   │         ├─ Yes → Prod SUCCESS → PIPELINE.SUCCESS (releaseStatus=deferred) → Output
+///     │   │         ├─ Yes → Prod SUCCESS → Compute Tag → CreateRelease (mediated) → PIPELINE.SUCCESS (releaseStatus=created|failed) → Output
 ///     │   │         └─ No  → Prod FAILED → Rollback (ROLLBACK.*) → SetProdFailed
 ///     │   └─ No → UAT FAILED → SetUATFailed
 ///     └─ No → QA FAILED → SetQAFailed
@@ -90,7 +93,7 @@ namespace Tamma.ElsaServer.Workflows;
 ///
 /// Inputs: repository, mergeSha, issueNumber, branchName, mode, tenantId, requireProdApproval
 /// Outputs: deploymentStatus (success/failed:&lt;stage&gt;), completedStages (JSON array),
-///          releaseTag, releaseStatus (deferred), rollbackStatus
+///          releaseTag, releaseStatus (created|failed), releaseUrl, rollbackStatus
 /// </summary>
 public class DeploymentPipelineWorkflow : WorkflowBase
 {
@@ -103,7 +106,7 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         builder.Name = "Deployment Pipeline";
         builder.DefinitionId = "deployment-pipeline";
         builder.Version = WorkflowVersions.ComputedVersion;
-        builder.Description = "Deploy through QA -> UAT -> Prod with a fail-closed gate per stage, a Business-Mode production approval gate, rollback on prod failure, and a full DCB audit trail. Release/tag deferred (no seam).";
+        builder.Description = "Deploy through QA -> UAT -> Prod with a fail-closed gate per stage, a Business-Mode production approval gate, rollback on prod failure, a full DCB audit trail, and a real git-platform release cut via the mediated integration seam after a successful prod deploy.";
 
         // Fail-closed on internal fault — a faulted activity must not halt the
         // instance with no output. Continue-with-incidents keeps the flow alive;
@@ -131,6 +134,10 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         var stageError = builder.WithVariable<string>("StageError", "");
         var rollbackStatus = builder.WithVariable<string>("RollbackStatus", "");
         var releaseTag = builder.WithVariable<string>("ReleaseTag", "");
+        // Epic 38 follow-up #21 — the real release-step outputs (was the hardcoded
+        // "deferred"). CreateReleaseActivity sets these on its outcome.
+        var releaseStatus = builder.WithVariable<string>("ReleaseStatus", "");
+        var releaseUrl = builder.WithVariable<string>("ReleaseUrl", "");
 
         var decisionVar = builder.WithVariable<string>("Decision", "");
         var feedbackVar = builder.WithVariable<string>("Feedback", "");
@@ -316,17 +323,15 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             isRollback: true);
 
         // ================================================================
-        // 7. Success terminal — compute the (deferred) release tag, emit
-        //    PIPELINE.SUCCESS, set status=success.
+        // 7. Success terminal — compute the release tag, CUT the real release
+        //    (Epic 38 follow-up #21, mediated), emit PIPELINE.SUCCESS, status=success.
         // ================================================================
         var setReleaseTag = new SetVariable
         {
             Id = "SetReleaseTag", Name = "Compute Release Tag",
             Variable = releaseTag,
-            // P1 item 5 (deferred): no release/tag activity exists; we compute a
-            // candidate tag from the merged SHA so the audit row and output carry
-            // it, but DO NOT cut a real release (releaseStatus=deferred). Never a
-            // fake "release created".
+            // Compute the version tag from the merged SHA; CreateRelease (below) cuts
+            // the real git-platform release from it via the mediated integration seam.
             Value = new Input<object?>(ctx =>
             {
                 var sha = mergeSha.Get(ctx) ?? "";
@@ -335,6 +340,58 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             })
         };
         setReleaseTag.SetDisplayText("Compute Release Tag");
+
+        // Epic 38 follow-up #21 — the real release step. Cuts a git-platform release
+        // for the shipped version through the MEDIATED integration seam (the engine
+        // holds NO git credential — the release create routes through
+        // POST /api/v1/git/{owner}/{repo}/releases via TammaApiClient, where the
+        // per-tenant token lives). Emits RELEASE.CREATED.SUCCESS/FAILED itself.
+        var createRelease = new CreateReleaseActivity
+        {
+            Id = "CreateRelease", Name = "Create Release",
+            Repository = new Input<string>(ctx => repository.Get(ctx)),
+            TagName = new Input<string>(ctx => releaseTag.Get(ctx)),
+            TargetRef = new Input<string?>(ctx => mergeSha.Get(ctx)),
+            ReleaseName = new Input<string?>(ctx => $"Release {releaseTag.Get(ctx)}"),
+            Body = new Input<string?>(ctx =>
+            {
+                var sha = mergeSha.Get(ctx) ?? "";
+                var shortSha = sha.Length >= 7 ? sha[..7] : sha;
+                var issue = issueNumber.Get(ctx);
+                var stages = completedStages.Get(ctx);
+                return $"Automated release for the shipped version." +
+                       (issue > 0 ? $" Resolves #{issue}." : "") +
+                       (string.IsNullOrEmpty(shortSha) ? "" : $"\n\nMerge commit: `{shortSha}`.") +
+                       $"\n\nDeployed through: {stages}.";
+            }),
+            Draft = new Input<bool>(false),
+            Prerelease = new Input<bool>(false),
+            IssueNumber = new Input<int>(ctx => issueNumber.Get(ctx)),
+            TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
+            ReleaseUrl = new Output<string?>(releaseUrl),
+            ReleaseTag = new Output<string?>(releaseTag),
+            ErrorCode = new Output<string?>(stageError),
+        };
+        createRelease.SetDisplayText("Create Release");
+
+        // The deploy itself already succeeded; a release-create failure is surfaced
+        // (releaseStatus=failed + the loud RELEASE.CREATED.FAILED event the activity
+        // emits) but does NOT flip the deploy to failed — never silently swallowed.
+        var setReleaseCreated = new SetVariable
+        {
+            Id = "SetReleaseCreated", Name = "Release Created",
+            Variable = releaseStatus,
+            Value = new Input<object?>(_ => (object)"created")
+        };
+        setReleaseCreated.SetDisplayText("Release Created");
+
+        var setReleaseFailed = new SetVariable
+        {
+            Id = "SetReleaseFailed", Name = "Release Failed",
+            Variable = releaseStatus,
+            Value = new Input<object?>(_ => (object)"failed")
+        };
+        setReleaseFailed.SetDisplayText("Release Failed");
 
         var setSuccess = new SetVariable
         {
@@ -347,7 +404,7 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         var emitPipelineSuccess = EmitDeployEvent("EmitPipelineSuccess", "Emit PIPELINE.SUCCESS",
             DeployEvents.PipelineSuccess, /*stage*/ "",
             repository, mergeSha, issueNumber, mode, tenantId, stageResult, stageError, completedStages, rollbackStatus,
-            releaseTag: releaseTag);
+            releaseTag: releaseTag, releaseStatus: releaseStatus, releaseUrl: releaseUrl);
 
         // ================================================================
         // 8. Failure terminals (one per stage) → PIPELINE.FAILED → outputs
@@ -374,9 +431,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                     { Id = "OutStages", OutputName = new("completedStages"), OutputValue = new(ctx => (object)completedStages.Get(ctx)) },
                 new SetOutput
                     { Id = "OutReleaseTag", OutputName = new("releaseTag"), OutputValue = new(ctx => (object)releaseTag.Get(ctx)) },
-                // P1 item 5 deferral surfaced explicitly so the gap is queryable.
+                // Epic 38 follow-up #21 — the REAL release status (created|failed),
+                // replacing the prior hardcoded "deferred", plus the release URL.
                 new SetOutput
-                    { Id = "OutReleaseStatus", OutputName = new("releaseStatus"), OutputValue = new(_ => (object)"deferred") },
+                    { Id = "OutReleaseStatus", OutputName = new("releaseStatus"), OutputValue = new(ctx => (object)releaseStatus.Get(ctx)) },
+                new SetOutput
+                    { Id = "OutReleaseUrl", OutputName = new("releaseUrl"), OutputValue = new(ctx => (object)releaseUrl.Get(ctx)) },
                 new SetOutput
                     { Id = "OutRollbackStatus", OutputName = new("rollbackStatus"), OutputValue = new(ctx => (object)rollbackStatus.Get(ctx)) },
             }
@@ -410,8 +470,9 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                 // Rollback
                 emitRollbackStarted, rollbackCall, extractRollbackResult, rollbackOk,
                 emitRollbackSuccess, emitRollbackFailed,
-                // Success terminal
-                setReleaseTag, setSuccess, emitPipelineSuccess,
+                // Success terminal (+ Epic 38 follow-up #21 release step)
+                setReleaseTag, createRelease, setReleaseCreated, setReleaseFailed,
+                setSuccess, emitPipelineSuccess,
                 // Failure terminals
                 setQaFailed, setUatFailed, setProdFailed, emitPipelineFailed,
                 setOutputs, finish,
@@ -481,8 +542,16 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                 ConnectOutcome(rollbackOk, "False", emitRollbackFailed),
                 Connect(emitRollbackFailed, setProdFailed),
 
-                // ── Success terminal ──
-                Connect(setReleaseTag, setSuccess),
+                // ── Success terminal (+ Epic 38 follow-up #21 release step) ──
+                // Prod succeeded → compute tag → cut the real release (mediated).
+                // A release failure is surfaced (releaseStatus=failed + the loud
+                // RELEASE.CREATED.FAILED event) but does NOT undo the successful
+                // deploy — both outcomes proceed to the success terminal.
+                Connect(setReleaseTag, createRelease),
+                ConnectOutcome(createRelease, "Created", setReleaseCreated),
+                ConnectOutcome(createRelease, "Error", setReleaseFailed),
+                Connect(setReleaseCreated, setSuccess),
+                Connect(setReleaseFailed, setSuccess),
                 Connect(setSuccess, emitPipelineSuccess),
                 Connect(emitPipelineSuccess, setOutputs),
 
@@ -734,7 +803,8 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         Variable<string> stageResult, Variable<string> stageError,
         Variable<string> completedStages, Variable<string> rollbackStatus,
         Variable<string>? approver = null, Variable<string>? feedback = null,
-        Variable<string>? releaseTag = null, bool isRollback = false)
+        Variable<string>? releaseTag = null, Variable<string>? releaseStatus = null,
+        Variable<string>? releaseUrl = null, bool isRollback = false)
     {
         var emit = new EmitDeploymentEventActivity
         {
@@ -762,10 +832,18 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                 if (!string.IsNullOrEmpty(rb)) data["rollbackStatus"] = rb;
                 if (approver != null) data["approver"] = approver.Get(ctx);
                 if (feedback != null) data["feedback"] = feedback.Get(ctx);
-                if (releaseTag != null)
+                if (releaseTag != null) data["releaseTag"] = releaseTag.Get(ctx);
+                if (releaseStatus != null)
                 {
-                    data["releaseTag"] = releaseTag.Get(ctx);
-                    data["releaseStatus"] = "deferred"; // P1 item 5 — no real release seam yet.
+                    // Epic 38 follow-up #21 — the REAL release status (created|failed)
+                    // set by CreateReleaseActivity, replacing the prior "deferred".
+                    var rs = releaseStatus.Get(ctx);
+                    if (!string.IsNullOrEmpty(rs)) data["releaseStatus"] = rs;
+                }
+                if (releaseUrl != null)
+                {
+                    var ru = releaseUrl.Get(ctx);
+                    if (!string.IsNullOrEmpty(ru)) data["releaseUrl"] = ru;
                 }
                 return JsonSerializer.Serialize(data);
             }),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/CreateReleaseActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/CreateReleaseActivityTests.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Epic 38 follow-up #21 — <see cref="CreateReleaseActivity"/> is a thin
+/// <see cref="Tamma.Activities.LlmCall.TammaApiClient"/> client (the mediated
+/// release step). These cover the wire-response → outcome mapping, the fail-closed
+/// null-response path, the RELEASE.CREATED.SUCCESS/FAILED event build, and the
+/// cutover proof: the engine activity injects NO credential-holding vendor service
+/// (so <c>TAMMA001</c> stays satisfied).
+/// </summary>
+[TestFixture]
+public class CreateReleaseActivityTests
+{
+    // ===================================================================
+    // MapResponse (wire → outcome)
+    // ===================================================================
+
+    [Test]
+    public void Map_Created_ProjectsReleaseOutputs()
+    {
+        var outcome = CreateReleaseActivity.MapResponse(new GitCallResponse
+        {
+            Success = true, Outcome = "Created",
+            ReleaseId = 55, ReleaseUrl = "https://gh/releases/55", ReleaseTag = "deploy-abc1234",
+        });
+
+        outcome.Outcome.Should().Be("Created");
+        outcome.ReleaseId.Should().Be(55);
+        outcome.ReleaseUrl.Should().Be("https://gh/releases/55");
+        outcome.ReleaseTag.Should().Be("deploy-abc1234");
+    }
+
+    [Test]
+    public void Map_Failure_ProjectsErrorCode_AndReason()
+    {
+        var outcome = CreateReleaseActivity.MapResponse(new GitCallResponse
+        {
+            Success = false, Outcome = "Error", FailureCode = "PLATFORM_ERROR", FailureReason = "422: tag exists",
+        });
+
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("PLATFORM_ERROR");
+        outcome.FailureReason.Should().Be("422: tag exists");
+    }
+
+    [Test]
+    public void Map_NullResponse_FailsClosed()
+    {
+        var outcome = CreateReleaseActivity.MapResponse(null);
+        outcome.Outcome.Should().Be("Error");
+        outcome.ErrorCode.Should().Be("git-mediation-unavailable");
+    }
+
+    [Test]
+    public void Map_SuccessButNotCreatedOutcome_FailsClosed()
+    {
+        // A success envelope with an unexpected outcome must NOT be treated as a
+        // created release (no fabricated success).
+        var outcome = CreateReleaseActivity.MapResponse(new GitCallResponse { Success = true, Outcome = "Done" });
+        outcome.Outcome.Should().Be("Error");
+    }
+
+    // ===================================================================
+    // BuildReleaseEvent (DCB audit event)
+    // ===================================================================
+
+    [Test]
+    public void BuildReleaseEvent_Success_Emits_ReleaseCreatedSuccess_WithTagsAndData()
+    {
+        var evt = CreateReleaseActivity.BuildReleaseEvent(
+            success: true, issueNumber: 7, repository: "acme/widgets", tag: "deploy-abc1234",
+            releaseUrl: "https://gh/releases/55", releaseId: 55, tenantId: "t-1", error: null);
+
+        evt.EventType.Should().Be(DeployEvents.ReleaseCreatedSuccess);
+        evt.Status.Should().Be("success");
+        evt.Error.Should().BeNull();
+        evt.Tags.Should().ContainKey("repository").WhoseValue.Should().Be("acme/widgets");
+        evt.Tags.Should().ContainKey("tag").WhoseValue.Should().Be("deploy-abc1234");
+        evt.Tags.Should().ContainKey("issueNumber").WhoseValue.Should().Be("7");
+        evt.Tags.Should().ContainKey("tenantId").WhoseValue.Should().Be("t-1");
+        evt.Data.Should().ContainKey("releaseUrl").WhoseValue.Should().Be("https://gh/releases/55");
+        evt.Data.Should().ContainKey("releaseId").WhoseValue.Should().Be(55L);
+    }
+
+    [Test]
+    public void BuildReleaseEvent_Failure_Emits_ReleaseCreatedFailed_LoudWithReason()
+    {
+        var evt = CreateReleaseActivity.BuildReleaseEvent(
+            success: false, issueNumber: 7, repository: "acme/widgets", tag: "deploy-abc1234",
+            releaseUrl: null, releaseId: null, tenantId: null, error: "422: tag exists");
+
+        evt.EventType.Should().Be(DeployEvents.ReleaseCreatedFailed);
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("422: tag exists");
+        evt.Data.Should().ContainKey("reason").WhoseValue.Should().Be("422: tag exists");
+        DeployEvents.IsFailureType(evt.EventType).Should().BeTrue(
+            "a failed release is a loud (error-status) audit row, never a silent success");
+    }
+
+    // ===================================================================
+    // Cutover proof (TAMMA001) — no credential-holding vendor injection
+    // ===================================================================
+
+    [Test]
+    public void CreateReleaseActivity_InjectsNoCredentialHoldingVendorService()
+    {
+        var type = typeof(CreateReleaseActivity);
+
+        foreach (var ctor in type.GetConstructors())
+        {
+            ctor.GetParameters()
+                .Any(p => typeof(IGitHubIntegrationService).IsAssignableFrom(p.ParameterType)
+                          || typeof(IIntegrationService).IsAssignableFrom(p.ParameterType))
+                .Should().BeFalse("CreateReleaseActivity must not inject a credential-holding integration service");
+        }
+
+        type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Any(f => typeof(IGitHubIntegrationService).IsAssignableFrom(f.FieldType)
+                      || typeof(IIntegrationService).IsAssignableFrom(f.FieldType))
+            .Should().BeFalse("CreateReleaseActivity must hold no credential-holding integration-service field");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
@@ -395,12 +395,70 @@ public class DeploymentPipelineWorkflowTests
     public void HappyPath_ReachesSuccess_ThroughPipelineSuccessEvent()
     {
         // QA success → UAT success → (dev) prod start → prod success → release tag
-        // → set success → PIPELINE.SUCCESS → outputs → finish.
+        // → CreateRelease → set success → PIPELINE.SUCCESS → outputs → finish.
         HasEdge("EmitProdSuccess", null, "SetReleaseTag").Should().BeTrue();
-        HasEdge("SetReleaseTag", null, "SetSuccess").Should().BeTrue();
+        HasEdge("SetReleaseTag", null, "CreateRelease").Should().BeTrue();
+        HasEdge("CreateRelease", "Created", "SetReleaseCreated").Should().BeTrue();
+        HasEdge("SetReleaseCreated", null, "SetSuccess").Should().BeTrue();
         HasEdge("SetSuccess", null, "EmitPipelineSuccess").Should().BeTrue();
         HasEdge("EmitPipelineSuccess", null, "SetOutputs").Should().BeTrue();
         HasEdge("SetOutputs", null, "Finish").Should().BeTrue();
+    }
+
+    // ================================================================
+    // Epic 38 follow-up #21 — the mediated release step (after prod success).
+    // ================================================================
+
+    [Test]
+    public void ReleaseStep_ExistsAsMediatedActivity_AfterASuccessfulProdDeploy()
+    {
+        // The real release is cut by CreateReleaseActivity (a thin TammaApiClient
+        // client — the engine holds NO git credential), and ONLY after prod success.
+        var release = _flowchart.Activities
+            .OfType<CreateReleaseActivity>()
+            .FirstOrDefault(a => a.Id == "CreateRelease");
+        release.Should().NotBeNull("a real CreateReleaseActivity must exist (the release is no longer 'deferred')");
+
+        // It sits on the prod-success path: prod success → compute tag → create release.
+        HasEdge("EmitProdSuccess", null, "SetReleaseTag").Should().BeTrue();
+        HasEdge("SetReleaseTag", null, "CreateRelease").Should().BeTrue();
+    }
+
+    [Test]
+    public void ReleaseStep_BothOutcomesReachSuccessTerminal_FailureIsSurfacedNotSilent()
+    {
+        // The deploy already succeeded; a release-create failure is surfaced
+        // (releaseStatus=failed via SetReleaseFailed) but does NOT undo the deploy —
+        // both outcomes proceed to the success terminal.
+        HasEdge("CreateRelease", "Created", "SetReleaseCreated").Should().BeTrue();
+        HasEdge("CreateRelease", "Error", "SetReleaseFailed").Should().BeTrue();
+        HasEdge("SetReleaseCreated", null, "SetSuccess").Should().BeTrue();
+        HasEdge("SetReleaseFailed", null, "SetSuccess").Should().BeTrue();
+
+        // The failure edge still records the loud FAILED signal + reaches the
+        // pipeline-success terminal, never a silent drop.
+        var reach = ReachableFromPort("CreateRelease", "Error");
+        reach.Should().Contain("SetReleaseFailed");
+        reach.Should().Contain("EmitPipelineSuccess");
+    }
+
+    [Test]
+    public void ReleaseStep_NeverReachedWhenProdFails()
+    {
+        // A failed prod deploy (retry exhausted) rolls back and terminates — it must
+        // NOT cut a release for a version that never shipped.
+        var reach = ReachableFromPort("ProdRetryCheck", "False");
+        reach.Should().NotContain("CreateRelease", "a failed prod deploy must never cut a release");
+    }
+
+    [Test]
+    public void ReleaseStep_OutputsCarryStatusAndUrl()
+    {
+        var outputSeq = _flowchart.Activities.OfType<Sequence>().FirstOrDefault(s => s.Id == "SetOutputs");
+        outputSeq.Should().NotBeNull();
+        var outputIds = outputSeq!.Activities.OfType<SetOutput>().Select(o => o.Id ?? "").ToList();
+        outputIds.Should().Contain("OutReleaseStatus");
+        outputIds.Should().Contain("OutReleaseUrl");
     }
 
     // ================================================================

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitEndpointsTests.cs
@@ -214,6 +214,38 @@ public class GitEndpointsTests
     }
 
     [Test]
+    public async Task Post_Release_ValidBearer_ReconstructsRepo_And_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        _tenantContext.SetTenantId(tenant);
+        _git.NextRelease = new GitMediationResult
+        {
+            Success = true, Outcome = "Created", ReleaseTag = "deploy-abc1234",
+            ReleaseUrl = "https://gh/releases/1", ReleaseId = 1, CredentialSource = "byok",
+        };
+
+        using var client = AuthedClient();
+        client.DefaultRequestHeaders.Add("X-Tenant-Id", tenant.ToString());
+
+        var resp = await client.PostAsJsonAsync("/api/v1/git/acme/widgets/releases", new
+        {
+            tagName = "deploy-abc1234",
+            targetRef = "abc1234def",
+            name = "Release deploy-abc1234",
+            body = "notes",
+            issueNumber = 7,
+            correlationId = "wf-3",
+        });
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        _git.LastRepo.Should().Be("acme/widgets");
+        _git.LastTenantId.Should().Be(tenant, "the acting tenant comes from ITenantContext (X-Tenant-Id), not the body");
+        var body = await resp.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetProperty("success").GetBoolean().Should().BeTrue();
+        body.GetProperty("releaseUrl").GetString().Should().Be("https://gh/releases/1");
+    }
+
+    [Test]
     public async Task Get_Comments_Success_Returns200()
     {
         _git.NextComments = new GitMediationResult
@@ -285,6 +317,17 @@ public class GitEndpointsTests
         {
             LastTenantId = tenantId; LastRepo = repo;
             return Task.FromResult(new GitMediationResult { Success = true, Outcome = "Deleted", BranchDeleted = true });
+        }
+
+        public GitMediationResult? NextRelease { get; set; }
+
+        public Task<GitMediationResult> CreateReleaseAsync(Guid? tenantId, string repo, CreateReleaseRequest body, CancellationToken ct = default)
+        {
+            LastTenantId = tenantId; LastRepo = repo;
+            return Task.FromResult(NextRelease ?? new GitMediationResult
+            {
+                Success = true, Outcome = "Created", ReleaseTag = body.TagName, ReleaseUrl = "https://gh/releases/1", ReleaseId = 1,
+            });
         }
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitMediationServiceTests.cs
@@ -76,6 +76,12 @@ public class GitMediationServiceTests
         MergeStrategy = "squash", IssueNumber = 7, BranchName = "feature", CorrelationId = "corr-merge",
     };
 
+    private static CreateReleaseRequest ReleaseBody() => new()
+    {
+        TagName = "deploy-abc1234", TargetRef = "abc1234def", Name = "Release deploy-abc1234",
+        Body = "notes", IssueNumber = 7, CorrelationId = "corr-release",
+    };
+
     // ===================================================================
     // Cross-tenant guard (AC2) — FIRST, fail-closed
     // ===================================================================
@@ -334,6 +340,79 @@ public class GitMediationServiceTests
         result.Outcome.Should().Be("Failed");
         result.PlatformStatusCode.Should().Be(403);
         _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.IssueUpdatedFailed);
+    }
+
+    // ===================================================================
+    // Create release (Epic 38 follow-up #21) — deployment-pipeline release step
+    // ===================================================================
+
+    [Test]
+    public async Task CreateRelease_Success_Byok_UsesResolvedToken_EmitsOneSuccessEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Byok);
+        _github.Setup(g => g.CreateGitHubReleaseAsync(Repo, It.IsAny<ReleaseCreationRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubReleaseResult>.Ok(
+                new GitHubReleaseResult { Success = true, Id = 55, HtmlUrl = "https://gh/releases/55", TagName = "deploy-abc1234" }));
+
+        var result = await _sut.CreateReleaseAsync(_tenant, Repo, ReleaseBody());
+
+        result.Success.Should().BeTrue();
+        result.Outcome.Should().Be("Created");
+        result.ReleaseId.Should().Be(55);
+        result.ReleaseUrl.Should().Be("https://gh/releases/55");
+        result.ReleaseTag.Should().Be("deploy-abc1234");
+        result.CredentialSource.Should().Be(GitCredentialSources.Byok);
+
+        // The invariant: the token USED (minted into the client) == the token RESOLVED.
+        _factory.Verify(f => f.Create(SecretToken), Times.Once);
+
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.ReleaseCreatedSuccess);
+    }
+
+    [Test]
+    public async Task CreateRelease_PlatformError_200SuccessFalse_OneFailedEvent()
+    {
+        Allow();
+        ResolveToken(GitCredentialSources.Platform);
+        _github.Setup(g => g.CreateGitHubReleaseAsync(Repo, It.IsAny<ReleaseCreationRequest>()))
+            .ReturnsAsync(IntegrationResult<GitHubReleaseResult>.Fail("422: tag already exists"));
+
+        var result = await _sut.CreateReleaseAsync(_tenant, Repo, ReleaseBody());
+
+        result.Success.Should().BeFalse();
+        result.Outcome.Should().Be("Error");
+        result.FailureCode.Should().Be(GitFailureCodes.PlatformError);
+        result.ToHttpResult().Let(StatusOf).Should().Be(200, "an expected platform failure rides inside 200 success:false");
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.ReleaseCreatedFailed);
+    }
+
+    [Test]
+    public async Task CreateRelease_GuardDenied_403_PlatformNeverCalled()
+    {
+        Deny();
+
+        var result = await _sut.CreateReleaseAsync(_tenant, Repo, ReleaseBody());
+
+        result.FailureCode.Should().Be(GitFailureCodes.RepoNotAuthorized);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        _github.VerifyNoOtherCalls();
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.ReleaseCreatedFailed);
+    }
+
+    [Test]
+    public async Task CreateRelease_TokenUnavailable_503_FailClosed_PlatformNeverCalled()
+    {
+        Allow();
+        NoToken();
+
+        var result = await _sut.CreateReleaseAsync(_tenant, Repo, ReleaseBody());
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(GitFailureCodes.TokenUnavailable);
+        _factory.Verify(f => f.Create(It.IsAny<string>()), Times.Never);
+        result.ToHttpResult().Let(StatusOf).Should().Be(503);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(GitEventTypes.ReleaseCreatedFailed);
     }
 
     // ===================================================================


### PR DESCRIPTION
## What

Adds a `CreateReleaseActivity` to the deployment pipeline: after a successful **prod** deploy, cut a git-platform Release (tag + notes).

- **Engine** `CreateReleaseActivity` (Tamma.Activities) is a thin `TammaApiClient` client → `POST /api/v1/git/{owner}/{repo}/releases`. Inputs (repo, tag, target ref, name, body, draft/prerelease); outputs (url, id, tag, errorCode); outcomes `Created`/`Error`; emits `GIT.RELEASE_CREATED.SUCCESS`/`.FAILED` (DCB). A failed release is loud, never swallowed.
- **Api** `GitMediationService.CreateReleaseAsync` runs the same rule-1 sequence as PR/merge/branch: cross-tenant guard → per-tenant token resolve → platform call → exactly one DCB event → new `IGitHubIntegrationService.CreateGitHubReleaseAsync` (`POST /repos/{repo}/releases`).
- **Wiring** `DeploymentPipelineWorkflow`: `prodOk → emitProdSuccess → setReleaseTag → createRelease`; a failed prod deploy never reaches it; both release outcomes converge to the pipeline-success terminal (a release failure surfaces `releaseStatus=failed` without flipping the successful deploy to failed). Replaced the hardcoded `releaseStatus="deferred"` with real `created|failed` + a `releaseUrl` output.

## Safety (TAMMA001)

The engine holds **no credential** — `CreateReleaseActivity` references only `TammaApiClient` + wire DTOs (locked by a reflection test); the token lives in Tamma.Api and is resolved per calling tenant. Verified: engine assembly rebuild = **0 TAMMA001**.

## Review outcome

Adversarial review (guard-parity, event-count/status, injection, wiring, cutover) → **no findings at/above threshold**: the cross-tenant guard runs first (before token + platform call), exactly one event per terminal path (no SUCCESS-on-failure), inputs travel in the JSON body (no CRLF/URL injection), and the release step is unreachable on prod failure. One tracked cosmetic follow-up: route the release error off the shared `stageError` var so a `PIPELINE.SUCCESS` row's `reason` isn't populated by a release-step error (status/`releaseStatus` already disambiguate).

## Verification

- Build: 0 errors, 0 TAMMA001. `has-pending-model-changes` → "No changes" (both). **No migration.**
- Tests: `Tamma.Activities.Tests` 50/50 (activity map + no-credential cutover + workflow), `Tamma.Api.Tests` Release/Git/Deployment/Integration 367 passed (byok success+one-event, platform-error 200/false, guard 403, token 503), guardrail 32/32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)