### PR TITLE
feat(epic-32): Story 32-23 — Streaming Run Tap (SSE) for dashboard/CLI

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ToolExecution/ToolLoopEventEmitter.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ToolExecution/ToolLoopEventEmitter.cs
@@ -39,7 +39,11 @@ public class ToolLoopEventEmitter
         {
             turnNumber,
             messageCount,
-            estimatedTokens
+            estimatedTokens,
+            // Story 32-23 — thread the correlationId (== workflowInstanceId) into the
+            // sink payload so a bus-backed IToolLoopEventSink can route the event to
+            // the right per-run stream. The NullToolLoopEventSink ignores it.
+            workflowInstanceId
         };
 
         _logger.LogDebug(
@@ -60,7 +64,9 @@ public class ToolLoopEventEmitter
         {
             turnNumber,
             toolName,
-            toolCallId
+            toolCallId,
+            // Story 32-23 — correlationId (== workflowInstanceId) for bus routing.
+            workflowInstanceId
         };
 
         _logger.LogDebug(
@@ -84,7 +90,9 @@ public class ToolLoopEventEmitter
             toolName,
             toolCallId,
             success,
-            durationMs
+            durationMs,
+            // Story 32-23 — correlationId (== workflowInstanceId) for bus routing.
+            workflowInstanceId
         };
 
         _logger.LogDebug(
@@ -106,7 +114,9 @@ public class ToolLoopEventEmitter
             turnNumber,
             totalTools,
             totalDurationMs,
-            cumulativeTokens
+            cumulativeTokens,
+            // Story 32-23 — correlationId (== workflowInstanceId) for bus routing.
+            workflowInstanceId
         };
 
         _logger.LogDebug(
@@ -129,7 +139,9 @@ public class ToolLoopEventEmitter
             totalToolCalls,
             totalDurationMs,
             totalTokens,
-            exhausted
+            exhausted,
+            // Story 32-23 — correlationId (== workflowInstanceId) for bus routing.
+            workflowInstanceId
         };
 
         _logger.LogDebug(

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs
@@ -1,0 +1,306 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Streaming;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using SseWriter = Tamma.Api.Services.Engine.Lifecycle.SseWriter;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 32-23 (AC1/AC2/AC8) — <c>GET /api/v1/llm/runs/{correlationId}/stream</c>,
+/// the human-facing streaming run tap. Dashboard (JWT) / <c>tamma</c> CLI
+/// (ApiKey) callers subscribe to a live SSE view of a managed LLM run — each
+/// <c>tool_call</c>/<c>tool_result</c>/<c>token</c>/<c>question</c>/<c>answer</c>/<c>final</c>
+/// frame as it happens — fed by the decoupled in-process
+/// <see cref="ILlmRunStreamBus"/>. The tap is READ-ONLY observability: it never
+/// holds up, retries, or influences the engine's buffered <c>/llm/call</c>.
+///
+/// <para><b>Auth is the human plane (AC2)</b>: the route rides
+/// <c>AuthenticatedAny</c> (JWT + ApiKey), NOT the engine bearer. In SaaS the
+/// caller may only tap runs its tenant owns — a <c>correlationId</c> for another
+/// tenant returns <b>404</b> (never a cross-tenant existence oracle). In
+/// single-user the sole user may tap any local run. Missing/invalid auth ⇒ 401
+/// (from the policy, before this handler runs).</para>
+///
+/// <para><b>SSE hardening</b> is copied from
+/// <see cref="Admin.AdminTenantEventsSseEndpoint"/>: <see cref="SseWriter"/>
+/// headers, 30s <c>: keepalive</c> heartbeats during quiet turns, a
+/// <see cref="MaxStreamDurationSeconds"/> ceiling that kicks an abandoned tab,
+/// and a clean <c>event: end</c> close.</para>
+/// </summary>
+public static class LlmRunStreamEndpoints
+{
+    /// <summary>Maximum stream lifetime — the server closes the tap at this
+    /// point so an abandoned dashboard tab doesn't pin a connection. Matches
+    /// the admin SSE ceiling.</summary>
+    public const int MaxStreamDurationSeconds = 30 * 60;
+
+    /// <summary>Keepalive cadence so proxies don't drop the connection during a
+    /// quiet run (matches the admin SSE cadence).</summary>
+    private static readonly TimeSpan KeepaliveInterval = TimeSpan.FromSeconds(30);
+
+    /// <summary>How many recent <c>AGENT.*</c> rows the ownership guard / replay
+    /// scan reads from the tenant store. A live run's <c>AGENT.RUN.STARTED</c>
+    /// (emitted before the loop) is always within this window.</summary>
+    private const int OwnershipScanLimit = 200;
+
+    public static async Task StreamRun(
+        string correlationId,
+        [FromServices] ILlmRunStreamBus bus,
+        [FromServices] ITenantContext tenantContext,
+        [FromServices] ITammaModeProvider modeProvider,
+        [FromServices] IEventRepository eventRepo,
+        [FromServices] ILoggerFactory loggerFactory,
+        [FromServices] TimeProvider timeProvider,
+        HttpContext http,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.LlmRunStreamEndpoints");
+
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            http.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await http.Response.WriteAsync("correlationId required", ct).ConfigureAwait(false);
+            return;
+        }
+
+        // AC2 — SaaS ownership guard. A correlationId not owned by the caller's
+        // tenant returns 404 (never confirm existence cross-tenant). The read is
+        // structurally tenant-scoped (t_<hex>.domain_events), so a foreign run is
+        // physically absent from the caller's store. Single-user owns every run.
+        Guid? tenantId = tenantContext.TenantId;
+        if (modeProvider.Mode == TammaMode.SaaS)
+        {
+            if (tenantId is null
+                || !await OwnsRunAsync(eventRepo, tenantId.Value, correlationId).ConfigureAwait(false))
+            {
+                logger.LogWarning(
+                    "run-tap denied (cross-tenant / unknown run) => 404. correlationId={CorrelationId} callerTenantId={TenantId}",
+                    correlationId, tenantId);
+                http.Response.StatusCode = StatusCodes.Status404NotFound;
+                return;
+            }
+        }
+
+        SseWriter.WriteHeaders(http.Response);
+
+        using var streamCts = CancellationTokenSource.CreateLinkedTokenSource(ct, http.RequestAborted);
+        streamCts.CancelAfter(TimeSpan.FromSeconds(MaxStreamDurationSeconds));
+        var token = streamCts.Token;
+
+        var startedAt = timeProvider.GetUtcNow();
+        var framesSent = 0;
+        var reason = "run_complete";
+
+        logger.LogInformation(
+            "run-tap opened. correlationId={CorrelationId} tenantId={TenantId} replay={Replay}",
+            correlationId, tenantId, IsReplayRequested(http));
+
+        // Subscribe BEFORE the (optional) replay read so no live frame produced
+        // between the catch-up read and the live tail is missed (the admin SSE
+        // resume idiom). Dispose detaches the channel — nothing leaks on
+        // disconnect.
+        using var subscription = bus.Subscribe(correlationId);
+
+        try
+        {
+            await WriteRawAsync(http, $": stream-open correlationId={correlationId}\n\n", token).ConfigureAwait(false);
+
+            // AC8 — optional catch-up from the tenant's DCB store, then live tail.
+            if (IsReplayRequested(http) && tenantId is not null)
+            {
+                framesSent += await ReplayAsync(eventRepo, tenantId.Value, correlationId, http, token)
+                    .ConfigureAwait(false);
+            }
+
+            var reader = subscription.Reader;
+            Task<bool>? waitTask = null;
+            var closedOnFinal = false;
+
+            while (!token.IsCancellationRequested)
+            {
+                // A single pending wait reused across heartbeats — never abandoned
+                // (so waiters don't accumulate on a long quiet run).
+                waitTask ??= reader.WaitToReadAsync(token).AsTask();
+
+                using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                var delayTask = Task.Delay(KeepaliveInterval, heartbeatCts.Token);
+
+                var winner = await Task.WhenAny(waitTask, delayTask).ConfigureAwait(false);
+                if (winner == delayTask)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    await WriteRawAsync(http, ": keepalive\n\n", token).ConfigureAwait(false);
+                    continue; // keep waitTask pending for the next iteration
+                }
+
+                heartbeatCts.Cancel(); // the reader won the race — stop the timer
+
+                bool more;
+                try
+                {
+                    more = await waitTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                waitTask = null; // consumed — renew next iteration
+
+                if (!more)
+                {
+                    break; // channel completed => the run published `final`
+                }
+
+                while (reader.TryRead(out var frame))
+                {
+                    var safe = RunStreamFrameScrubber.Scrub(frame); // AC9 — key-free
+                    await SseWriter.WriteEventAsync(http.Response, frame.Type, safe, token).ConfigureAwait(false);
+                    framesSent++;
+                    if (string.Equals(frame.Type, RunStreamFrameType.Final, StringComparison.Ordinal))
+                    {
+                        closedOnFinal = true;
+                        break;
+                    }
+                }
+
+                if (closedOnFinal)
+                {
+                    break;
+                }
+            }
+
+            if (!closedOnFinal)
+            {
+                reason = http.RequestAborted.IsCancellationRequested ? "client_disconnect" : "max_duration";
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            reason = "client_disconnect";
+        }
+        finally
+        {
+            // Clean close marker — matches AdminTenantEventsSseEndpoint's
+            // convention so a still-reading client sees a clean termination.
+            try
+            {
+                await WriteRawAsync(
+                    http,
+                    $"event: end\ndata: {{\"reason\":\"{reason}\"}}\n\n",
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch
+            {
+                /* client already gone */
+            }
+
+            logger.LogInformation(
+                "run-tap closed. correlationId={CorrelationId} framesSent={FramesSent} durationMs={DurationMs} reason={Reason}",
+                correlationId, framesSent, (timeProvider.GetUtcNow() - startedAt).TotalMilliseconds, reason);
+        }
+    }
+
+    /// <summary>AC2 — does <paramref name="correlationId"/> belong to a run the
+    /// tenant owns? True iff at least one tenant-scoped <c>AGENT.*</c> event
+    /// carries this correlationId. A foreign run is physically absent from the
+    /// caller's schema, so this fails closed to 404.</summary>
+    internal static async Task<bool> OwnsRunAsync(
+        IEventRepository events, Guid tenantId, string correlationId)
+    {
+        var matches = await FindRunEventsAsync(events, tenantId, correlationId).ConfigureAwait(false);
+        return matches.Count > 0;
+    }
+
+    /// <summary>AC8 — replay the run's already-emitted DCB events (scrubbed,
+    /// key-free) as catch-up frames, oldest-first, then the caller switches to
+    /// the live tail. Returns the number of catch-up frames written.</summary>
+    private static async Task<int> ReplayAsync(
+        IEventRepository events, Guid tenantId, string correlationId, HttpContext http, CancellationToken ct)
+    {
+        var matches = await FindRunEventsAsync(events, tenantId, correlationId).ConfigureAwait(false);
+        // ListByTenantAsync returns most-recent-first; replay chronologically.
+        var ordered = matches.OrderBy(e => e.SequenceNumber).ToList();
+
+        var count = 0;
+        foreach (var e in ordered)
+        {
+            // Key-free catch-up payload: the fixed-vocabulary event type +
+            // correlationId + the DCB sequence. Tags/Data bodies are NOT emitted.
+            var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+            {
+                ["correlationId"] = correlationId,
+                ["seq"] = e.SequenceNumber,
+                ["type"] = e.Type,
+                ["replay"] = true,
+            };
+            await SseWriter.WriteEventAsync(http.Response, "replay", payload, ct).ConfigureAwait(false);
+            count++;
+        }
+
+        return count;
+    }
+
+    /// <summary>Reads the caller-tenant's recent <c>AGENT.*</c> events and keeps
+    /// those whose <c>Tags.correlationId</c> matches. The read is structurally
+    /// scoped to the tenant's <c>t_&lt;hex&gt;</c> schema by the repository —
+    /// there is no cross-tenant read path.</summary>
+    private static async Task<IReadOnlyList<DomainEvent>> FindRunEventsAsync(
+        IEventRepository events, Guid tenantId, string correlationId)
+    {
+        var (rows, _) = await events
+            .ListByTenantAsync(tenantId, "AGENT", OwnershipScanLimit, 0)
+            .ConfigureAwait(false);
+
+        var result = new List<DomainEvent>();
+        foreach (var e in rows)
+        {
+            if (string.Equals(TagsCorrelationId(e.Tags), correlationId, StringComparison.Ordinal))
+            {
+                result.Add(e);
+            }
+        }
+        return result;
+    }
+
+    private static string? TagsCorrelationId(string? tagsJson)
+    {
+        if (string.IsNullOrWhiteSpace(tagsJson) || tagsJson == "{}")
+        {
+            return null;
+        }
+        try
+        {
+            using var doc = JsonDocument.Parse(tagsJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("correlationId", out var c)
+                && c.ValueKind == JsonValueKind.String)
+            {
+                return c.GetString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed tags never leak an exception to the client.
+        }
+        return null;
+    }
+
+    private static bool IsReplayRequested(HttpContext http)
+        => string.Equals(http.Request.Query["replay"].ToString(), "true", StringComparison.OrdinalIgnoreCase);
+
+    private static async Task WriteRawAsync(HttpContext http, string frame, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(frame);
+        await http.Response.Body.WriteAsync(bytes, ct).ConfigureAwait(false);
+        await http.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmRunStreamEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.PromptStore;
@@ -44,10 +43,11 @@ public static class LlmRunStreamEndpoints
     /// quiet run (matches the admin SSE cadence).</summary>
     private static readonly TimeSpan KeepaliveInterval = TimeSpan.FromSeconds(30);
 
-    /// <summary>How many recent <c>AGENT.*</c> rows the ownership guard / replay
-    /// scan reads from the tenant store. A live run's <c>AGENT.RUN.STARTED</c>
-    /// (emitted before the loop) is always within this window.</summary>
-    private const int OwnershipScanLimit = 200;
+    /// <summary>The terminal <c>AGENT.RUN.*</c> event types. Their presence in the
+    /// tenant store means the run has already finished — the tap must NOT park on a
+    /// live <c>final</c> that will never come.</summary>
+    private static readonly string[] TerminalRunEventTypes =
+        { "AGENT.RUN.SUCCESS", "AGENT.RUN.FAILED" };
 
     public static async Task StreamRun(
         string correlationId,
@@ -69,15 +69,30 @@ public static class LlmRunStreamEndpoints
             return;
         }
 
+        // The run correlationId is the workflow-instance Guid. Reject a non-Guid
+        // route value with 400: it can never match a real run, it keeps the value
+        // newline-free (no SSE-line injection into the `: stream-open` comment below),
+        // and it hardens the tenant-scoped `Tags->>'correlationId'` lookups.
+        if (!Guid.TryParse(correlationId, out _))
+        {
+            http.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await http.Response.WriteAsync("correlationId must be a GUID", ct).ConfigureAwait(false);
+            return;
+        }
+
         // AC2 — SaaS ownership guard. A correlationId not owned by the caller's
-        // tenant returns 404 (never confirm existence cross-tenant). The read is
-        // structurally tenant-scoped (t_<hex>.domain_events), so a foreign run is
-        // physically absent from the caller's store. Single-user owns every run.
+        // tenant returns 404 (never confirm existence cross-tenant). The check is a
+        // targeted, tenant-scoped EXISTS on Tags.correlationId — volume-independent,
+        // so a busy tenant's live run whose AGENT.RUN.STARTED has aged past any
+        // recent-N window is STILL recognised as owned (no false 404 on one's own
+        // in-flight run). The read is structurally tenant-scoped
+        // (t_<hex>.domain_events), so a foreign run is physically absent from the
+        // caller's store. Single-user owns every run.
         Guid? tenantId = tenantContext.TenantId;
         if (modeProvider.Mode == TammaMode.SaaS)
         {
             if (tenantId is null
-                || !await OwnsRunAsync(eventRepo, tenantId.Value, correlationId).ConfigureAwait(false))
+                || !await eventRepo.ExistsByCorrelationIdAsync(tenantId.Value, correlationId).ConfigureAwait(false))
             {
                 logger.LogWarning(
                     "run-tap denied (cross-tenant / unknown run) => 404. correlationId={CorrelationId} callerTenantId={TenantId}",
@@ -96,25 +111,53 @@ public static class LlmRunStreamEndpoints
         var startedAt = timeProvider.GetUtcNow();
         var framesSent = 0;
         var reason = "run_complete";
+        var replayRequested = IsReplayRequested(http);
 
         logger.LogInformation(
             "run-tap opened. correlationId={CorrelationId} tenantId={TenantId} replay={Replay}",
-            correlationId, tenantId, IsReplayRequested(http));
-
-        // Subscribe BEFORE the (optional) replay read so no live frame produced
-        // between the catch-up read and the live tail is missed (the admin SSE
-        // resume idiom). Dispose detaches the channel — nothing leaks on
-        // disconnect.
-        using var subscription = bus.Subscribe(correlationId);
+            correlationId, tenantId, replayRequested);
 
         try
         {
             await WriteRawAsync(http, $": stream-open correlationId={correlationId}\n\n", token).ConfigureAwait(false);
 
-            // AC8 — optional catch-up from the tenant's DCB store, then live tail.
-            if (IsReplayRequested(http) && tenantId is not null)
+            // Read the run's stored DCB events once (when we have a tenant). Used for
+            // BOTH the early-terminal short-circuit and the optional replay catch-up.
+            // Single-user with a null tenant has no tenant-scoped read path, so it
+            // falls through to the live tail (unchanged).
+            IReadOnlyList<DomainEvent> stored = tenantId is not null
+                ? await eventRepo.ListByCorrelationIdAsync(tenantId.Value, correlationId).ConfigureAwait(false)
+                : Array.Empty<DomainEvent>();
+
+            // Early terminal check — if a terminal AGENT.RUN.SUCCESS/FAILED is already
+            // persisted, the run has finished. The terminal DCB event is written BEFORE
+            // the bus `final` frame (ManagedAgent), so if we can see it the live topic
+            // is already gone (or will be, without another subscriber). Do NOT Subscribe
+            // (that would recreate a zombie topic that never gets a `final`) and do NOT
+            // park on WaitToReadAsync for a live `final` that will never come — that is
+            // the 30-minute hang on a finished run. A replay tap streams the stored
+            // frames first; then both close promptly.
+            if (stored.Any(IsTerminalRunEvent))
             {
-                framesSent += await ReplayAsync(eventRepo, tenantId.Value, correlationId, http, token)
+                if (replayRequested)
+                {
+                    framesSent += await ReplayStoredAsync(stored, correlationId, http, token)
+                        .ConfigureAwait(false);
+                }
+                reason = "already_complete";
+                return; // finally writes the terminal `event: end`
+            }
+
+            // Live (not-yet-terminal) run. Subscribe BEFORE the (optional) replay read
+            // so no live frame produced between the catch-up read and the live tail is
+            // missed (the admin SSE resume idiom). Dispose detaches the channel and —
+            // with remove-on-empty — reclaims the topic, so nothing leaks on disconnect.
+            using var subscription = bus.Subscribe(correlationId);
+
+            // AC8 — optional catch-up from the tenant's DCB store, then live tail.
+            if (replayRequested)
+            {
+                framesSent += await ReplayStoredAsync(stored, correlationId, http, token)
                     .ConfigureAwait(false);
             }
 
@@ -209,29 +252,22 @@ public static class LlmRunStreamEndpoints
         }
     }
 
-    /// <summary>AC2 — does <paramref name="correlationId"/> belong to a run the
-    /// tenant owns? True iff at least one tenant-scoped <c>AGENT.*</c> event
-    /// carries this correlationId. A foreign run is physically absent from the
-    /// caller's schema, so this fails closed to 404.</summary>
-    internal static async Task<bool> OwnsRunAsync(
-        IEventRepository events, Guid tenantId, string correlationId)
-    {
-        var matches = await FindRunEventsAsync(events, tenantId, correlationId).ConfigureAwait(false);
-        return matches.Count > 0;
-    }
+    /// <summary>Is <paramref name="e"/> a terminal <c>AGENT.RUN.SUCCESS</c>/
+    /// <c>AGENT.RUN.FAILED</c> event? Its presence means the run has already
+    /// finished, so the tap must not wait for a live <c>final</c>.</summary>
+    private static bool IsTerminalRunEvent(DomainEvent e)
+        => Array.IndexOf(TerminalRunEventTypes, e.Type) >= 0;
 
     /// <summary>AC8 — replay the run's already-emitted DCB events (scrubbed,
-    /// key-free) as catch-up frames, oldest-first, then the caller switches to
-    /// the live tail. Returns the number of catch-up frames written.</summary>
-    private static async Task<int> ReplayAsync(
-        IEventRepository events, Guid tenantId, string correlationId, HttpContext http, CancellationToken ct)
+    /// key-free) as catch-up frames from <paramref name="stored"/> (already
+    /// oldest-first, tenant-scoped, and matched to this correlationId by
+    /// <see cref="IEventRepository.ListByCorrelationIdAsync"/> — the FULL set, never
+    /// truncated). Returns the number of catch-up frames written.</summary>
+    private static async Task<int> ReplayStoredAsync(
+        IReadOnlyList<DomainEvent> stored, string correlationId, HttpContext http, CancellationToken ct)
     {
-        var matches = await FindRunEventsAsync(events, tenantId, correlationId).ConfigureAwait(false);
-        // ListByTenantAsync returns most-recent-first; replay chronologically.
-        var ordered = matches.OrderBy(e => e.SequenceNumber).ToList();
-
         var count = 0;
-        foreach (var e in ordered)
+        foreach (var e in stored)
         {
             // Key-free catch-up payload: the fixed-vocabulary event type +
             // correlationId + the DCB sequence. Tags/Data bodies are NOT emitted.
@@ -247,51 +283,6 @@ public static class LlmRunStreamEndpoints
         }
 
         return count;
-    }
-
-    /// <summary>Reads the caller-tenant's recent <c>AGENT.*</c> events and keeps
-    /// those whose <c>Tags.correlationId</c> matches. The read is structurally
-    /// scoped to the tenant's <c>t_&lt;hex&gt;</c> schema by the repository —
-    /// there is no cross-tenant read path.</summary>
-    private static async Task<IReadOnlyList<DomainEvent>> FindRunEventsAsync(
-        IEventRepository events, Guid tenantId, string correlationId)
-    {
-        var (rows, _) = await events
-            .ListByTenantAsync(tenantId, "AGENT", OwnershipScanLimit, 0)
-            .ConfigureAwait(false);
-
-        var result = new List<DomainEvent>();
-        foreach (var e in rows)
-        {
-            if (string.Equals(TagsCorrelationId(e.Tags), correlationId, StringComparison.Ordinal))
-            {
-                result.Add(e);
-            }
-        }
-        return result;
-    }
-
-    private static string? TagsCorrelationId(string? tagsJson)
-    {
-        if (string.IsNullOrWhiteSpace(tagsJson) || tagsJson == "{}")
-        {
-            return null;
-        }
-        try
-        {
-            using var doc = JsonDocument.Parse(tagsJson);
-            if (doc.RootElement.ValueKind == JsonValueKind.Object
-                && doc.RootElement.TryGetProperty("correlationId", out var c)
-                && c.ValueKind == JsonValueKind.String)
-            {
-                return c.GetString();
-            }
-        }
-        catch (JsonException)
-        {
-            // Malformed tags never leak an exception to the client.
-        }
-        return null;
     }
 
     private static bool IsReplayRequested(HttpContext http)

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -617,6 +617,33 @@ builder.Services.TryAddSingleton<Tamma.Activities.LlmCall.Tools.ContextCompactor
 // defaults to the no-op NullToolLoopEventSink when none is registered).
 builder.Services.TryAddSingleton<Tamma.Activities.ToolExecution.ToolLoopEventEmitter>();
 builder.Services.TryAddSingleton<Tamma.Activities.ToolExecution.ParallelToolExecutor>();
+
+// ── Story 32-23 — the streaming run tap (SSE for dashboard / CLI) ──
+// The in-process run-stream bus is ALWAYS registered (a cheap in-memory
+// singleton). ManagedAgent publishes the terminal `final` frame to it as a
+// decoupled SIDE-EFFECT; the human tap (GET /api/v1/llm/runs/{cid}/stream)
+// subscribes. The bus is fire-and-forget: a no-op with zero subscribers, and it
+// never blocks or throws into the buffered run, so the engine's /llm/call
+// contract stays byte-for-byte unchanged (AC5/AC6).
+builder.Services.TryAddSingleton<Tamma.Api.Services.Streaming.ILlmRunStreamBus,
+    Tamma.Api.Services.Streaming.LlmRunStreamBus>();
+// The LIVE tool-loop sink is gated behind the app-level streaming flag. When
+// enabled, TOOL_LOOP.* events map to tool_call/tool_result frames on the bus;
+// when disabled the registration stays NullToolLoopEventSink (a graceful no-op —
+// the tap still shows the terminal `final`, never an error). This makes live the
+// IToolLoopEventSink seam 32-5 shipped inert.
+var runTapStreamingEnabled = string.Equals(
+    builder.Configuration["Tamma:Streaming:Enabled"], "true", StringComparison.OrdinalIgnoreCase);
+if (runTapStreamingEnabled)
+{
+    builder.Services.TryAddSingleton<Tamma.Activities.ToolExecution.IToolLoopEventSink,
+        Tamma.Api.Services.Streaming.BusToolLoopEventSink>();
+}
+else
+{
+    builder.Services.TryAddSingleton<Tamma.Activities.ToolExecution.IToolLoopEventSink>(
+        Tamma.Activities.ToolExecution.NullToolLoopEventSink.Instance);
+}
 // The extracted runner — the SINGLE home of the loop (no fork). Scoped so each
 // call binds a request-scoped provider config. Its IProviderCredentialResolver
 // dep is the cabinet-backed DefaultProviderCredentialResolver (registered above
@@ -2589,6 +2616,18 @@ app.MapPost("/api/v1/llm/chat", SaaSEndpoints.LlmChat).RequireAuthorization();
 app.MapPost("/api/v1/llm/call", LlmCallEndpoints.CallLlm)
     .RequireAuthorization("EngineServiceOnly")
     .WithName("CallLlm");
+
+// ── Story 32-23 — the streaming run tap (human SSE plane) ──
+// GET /api/v1/llm/runs/{correlationId}/stream — a live, READ-ONLY view of a
+// managed run for the dashboard (JWT) / tamma CLI (ApiKey). Rides AuthenticatedAny
+// (the HUMAN plane), NOT the engine bearer: unlike POST /api/v1/llm/call this is
+// consumed by people. In SaaS the caller may only tap runs its tenant owns (a
+// foreign correlationId ⇒ 404, never a cross-tenant existence oracle); in
+// single-user the sole user taps any local run. Decoupled from the buffered call:
+// it can never break RetryCheck/SkipIfSucceeded/the circuit breaker.
+app.MapGet("/api/v1/llm/runs/{correlationId}/stream", LlmRunStreamEndpoints.StreamRun)
+    .RequireAuthorization("AuthenticatedAny")
+    .WithName("StreamRunTap");
 
 // ── Story 38-1 (Epic 38) — git-platform step mediation (Class A) ──
 // Same engine-only plane as /api/v1/llm/call: the engine's thin ADL git

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
@@ -66,6 +66,13 @@ public sealed class ManagedAgent : IManagedAgent
     // the API host so production always emits the trail. NEVER throws into the run
     // (the emitter swallows + breadcrumbs — AC7).
     private readonly IAgentTrailEmitter? _trail;
+    // Story 32-23 — the in-process run-stream bus. Optional (null ⇒ no tap
+    // publishes) so the existing unit-test ctors are unchanged; DI-registered in
+    // the API host. Publishing the terminal `final` frame is a fire-and-forget
+    // SIDE-EFFECT — never control flow — so the buffered AgentRunResult is
+    // byte-for-byte identical whether 0 or N tap subscribers are attached (AC6),
+    // and a publish failure NEVER faults the run (AC5, log-and-swallow).
+    private readonly Tamma.Api.Services.Streaming.ILlmRunStreamBus? _runStreamBus;
     private readonly ILogger<ManagedAgent> _logger;
 
     // NOTE: the process mode (single-user vs SaaS) is NOT a dependency here — the
@@ -84,7 +91,8 @@ public sealed class ManagedAgent : IManagedAgent
         IEventRepository events,
         ILogger<ManagedAgent> logger,
         Tamma.Activities.Security.IContentSanitizer? sanitizer = null,
-        IAgentTrailEmitter? trail = null)
+        IAgentTrailEmitter? trail = null,
+        Tamma.Api.Services.Streaming.ILlmRunStreamBus? runStreamBus = null)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
@@ -103,6 +111,10 @@ public sealed class ManagedAgent : IManagedAgent
         // Optional (Story 32-6): the action-trail emitter. DI-registered in the API
         // host; absent in the minimal unit-test ctor. Its writes never affect the run.
         _trail = trail;
+        // Optional (Story 32-23): the run-stream bus for the human tap. When present,
+        // the terminal `final` frame is published as a side-effect after the run
+        // completes. Absent ⇒ no publish (older unit-test ctors).
+        _runStreamBus = runStreamBus;
     }
 
     /// <inheritdoc />
@@ -111,6 +123,22 @@ public sealed class ManagedAgent : IManagedAgent
         // The ONLY case that may throw (a contract violation, AC10).
         ArgumentNullException.ThrowIfNull(request);
 
+        // Run the buffered composition to a typed result (the engine's contract —
+        // unchanged). THEN publish the terminal `final` frame to the run-stream bus
+        // as a decoupled side-effect (Story 32-23, AC6). Cancellation propagates out
+        // of RunCoreAsync (the host aborts) WITHOUT a `final` publish — an aborted
+        // run has no terminal summary to tap.
+        var result = await RunCoreAsync(request, ct).ConfigureAwait(false);
+        await PublishFinalFrameAsync(request.CorrelationId, result).ConfigureAwait(false);
+        return result;
+    }
+
+    /// <summary>Story 32-23 (AC6) — the buffered composition. Its return value is
+    /// the engine's source of truth and is IDENTICAL regardless of tap subscribers;
+    /// the tap publishes are layered on OUTSIDE this method so they can never touch
+    /// its control flow.</summary>
+    private async Task<AgentRunResult> RunCoreAsync(ManagedAgentRequest request, CancellationToken ct)
+    {
         var sw = Stopwatch.StartNew();
 
         // ── carries the identity stamped as composition advances, so a failure
@@ -604,6 +632,47 @@ public sealed class ManagedAgent : IManagedAgent
             _logger.LogError(ex,
                 "Usage emission failed; the run result still returns. correlationId={CorrelationId}",
                 run.CorrelationId);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 32-23 — run-stream tap (side-effect only; never touches the run)
+    // -----------------------------------------------------------------------
+
+    /// <summary>Publish the terminal <c>final</c> frame to the run-stream bus so a
+    /// human tap sees the run close. Pure side-effect: fire-and-forget, key-free,
+    /// and wrapped log-and-swallow so a streaming failure can NEVER fault or alter
+    /// the buffered run (AC5/AC6). No-op when the bus is absent (older ctors) — and
+    /// the bus itself is a no-op when there are zero subscribers.</summary>
+    private async Task PublishFinalFrameAsync(string correlationId, AgentRunResult result)
+    {
+        if (_runStreamBus is null || string.IsNullOrEmpty(correlationId))
+        {
+            return;
+        }
+
+        try
+        {
+            // Key-free turn summary (AC4/AC9): no prompt body, no key, no tool bodies.
+            var payload = new
+            {
+                success = result.Success,
+                totalTurns = result.ToolLoopTurns,
+                totalTokens = result.InputTokens + result.OutputTokens,
+                exhausted = result.ToolLoopExhausted,
+                durationMs = result.DurationMs,
+            };
+            var frame = new Tamma.Api.Services.Streaming.RunStreamFrame(
+                Tamma.Api.Services.Streaming.RunStreamFrameType.Final, correlationId, 0, payload);
+            await _runStreamBus.PublishAsync(correlationId, frame, CancellationToken.None).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The bus is contracted never to throw; this is a bug guard. Logged at
+            // ERROR per the story's logging requirements, NEVER propagated to the run.
+            _logger.LogError(ex,
+                "run-stream `final` publish threw despite the swallow guard; the run result still returns. "
+                + "correlationId={CorrelationId}", correlationId);
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/BusToolLoopEventSink.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/BusToolLoopEventSink.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.ToolExecution;
+
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC3) — the LIVE <see cref="IToolLoopEventSink"/> that replaces
+/// <c>NullToolLoopEventSink</c> when streaming is enabled. Instead of dropping
+/// each <c>TOOL_LOOP.*</c> event, it maps it to the run-tap frame vocabulary
+/// and publishes it onto the in-process <see cref="ILlmRunStreamBus"/>, keyed
+/// by the <c>workflowInstanceId</c> (== <c>correlationId</c>) the emitter
+/// threads through every event payload.
+///
+/// <para>Registered in <c>Tamma.Api</c> behind the app-level streaming flag; when
+/// the flag is off the registration stays <c>NullToolLoopEventSink</c> (a
+/// graceful no-op — the tap simply shows no live tool frames, never an error).</para>
+///
+/// <para><b>Fire-and-forget:</b> the bus never blocks or throws into the
+/// producer; this sink adds a defensive swallow so a mapping/serialisation
+/// hiccup can never fault the tool loop.</para>
+///
+/// <para><b>Credential safety (AC9):</b> only fixed-vocabulary fields
+/// (<c>toolName</c>/<c>toolCallId</c>/<c>turn</c>/<c>success</c>/<c>durationMs</c>)
+/// are copied into the frame — never tool arguments or outputs. Every frame is
+/// additionally re-scrubbed at write time by the tap endpoint.</para>
+/// </summary>
+public sealed class BusToolLoopEventSink : IToolLoopEventSink
+{
+    private readonly ILlmRunStreamBus _bus;
+    private readonly ILogger<BusToolLoopEventSink>? _logger;
+
+    public BusToolLoopEventSink(ILlmRunStreamBus bus, ILogger<BusToolLoopEventSink>? logger = null)
+    {
+        _bus = bus ?? throw new ArgumentNullException(nameof(bus));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task WriteEventAsync(string eventType, object data, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            JsonElement el;
+            try
+            {
+                el = JsonSerializer.SerializeToElement(data);
+            }
+            catch
+            {
+                return; // unserialisable payload — nothing safe to route
+            }
+
+            if (el.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+
+            var correlationId = ReadString(el, "workflowInstanceId");
+            if (string.IsNullOrEmpty(correlationId))
+            {
+                // No correlationId => can't route to a per-run stream. The
+                // buffered run is unaffected (this is pure observability).
+                return;
+            }
+
+            var mapped = Map(eventType, el);
+            if (mapped is null)
+            {
+                return; // TURN_STARTED / TURN_COMPLETED / unknown => ignored
+            }
+
+            var frame = new RunStreamFrame(mapped.Value.FrameType, correlationId, 0, mapped.Value.Payload);
+            await _bus.PublishAsync(correlationId, frame, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // A sink failure must NEVER fault the tool loop (AC5) — swallow + log.
+            _logger?.LogWarning(ex,
+                "BusToolLoopEventSink swallowed a publish error; the run is unaffected. eventType={EventType}",
+                eventType);
+        }
+    }
+
+    /// <summary>
+    /// Map a <c>TOOL_LOOP.*</c> event to a run-tap frame. Returns <c>null</c> for
+    /// events with no tap representation (turn progress). Exposed for unit tests.
+    /// </summary>
+    internal static (string FrameType, object Payload)? Map(string eventType, JsonElement data)
+        => eventType switch
+        {
+            "TOOL_LOOP.TOOL_EXECUTING" => (RunStreamFrameType.ToolCall, new
+            {
+                toolName = ReadString(data, "toolName"),
+                toolCallId = ReadString(data, "toolCallId"),
+                turn = ReadLong(data, "turnNumber"),
+            }),
+            "TOOL_LOOP.TOOL_COMPLETED" => (RunStreamFrameType.ToolResult, new
+            {
+                toolName = ReadString(data, "toolName"),
+                toolCallId = ReadString(data, "toolCallId"),
+                success = ReadBool(data, "success"),
+                durationMs = ReadLong(data, "durationMs"),
+            }),
+            "TOOL_LOOP.COMPLETED" => (RunStreamFrameType.Final, new
+            {
+                success = !ReadBool(data, "exhausted"),
+                totalTurns = ReadLong(data, "totalTurns"),
+                totalTokens = ReadLong(data, "totalTokens"),
+                exhausted = ReadBool(data, "exhausted"),
+                durationMs = ReadLong(data, "totalDurationMs"),
+            }),
+            _ => null,
+        };
+
+    private static string? ReadString(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static long ReadLong(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.Number
+           && v.TryGetInt64(out var l)
+            ? l
+            : 0L;
+
+    private static bool ReadBool(JsonElement obj, string name)
+        => obj.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.True;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/ILlmRunStreamBus.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/ILlmRunStreamBus.cs
@@ -1,0 +1,55 @@
+using System.Threading.Channels;
+
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC5) — the in-process pub/sub that decouples a live human tap
+/// from the engine's buffered <c>/llm/call</c>. Keyed by <c>correlationId</c>
+/// (== the workflow instance id threaded through the tool-loop emitter and the
+/// <c>LlmCallRequest</c>). Single-instance only — mirrors
+/// <c>WebhookSignalRegistry</c>'s in-process registry discipline; cross-process
+/// fan-out (Redis / Postgres LISTEN-NOTIFY) is a deferred open decision.
+///
+/// <para><b>Load-bearing invariant:</b> the producer side (ManagedAgent /
+/// runner / sink) treats the bus as fire-and-forget. Publishing with ZERO
+/// subscribers is a no-op; <see cref="PublishAsync"/> NEVER throws into the
+/// producer and NEVER blocks it — so the buffered run is never slowed, failed,
+/// or retried because of an observer's absence or slowness (AC5 / AC6).</para>
+/// </summary>
+public interface ILlmRunStreamBus
+{
+    /// <summary>
+    /// Publish one frame for <paramref name="correlationId"/>. Fire-and-forget:
+    /// a no-op when there are no subscribers, non-blocking, and it never throws
+    /// into the caller. The bus stamps the frame's per-run monotonic
+    /// <see cref="RunStreamFrame.Seq"/>. When the frame is
+    /// <see cref="RunStreamFrameType.Final"/> the run's topic is torn down and
+    /// every subscriber channel is completed (clean live-tail termination).
+    /// </summary>
+    ValueTask PublishAsync(string correlationId, RunStreamFrame frame, CancellationToken ct = default);
+
+    /// <summary>
+    /// Subscribe to the live tail for <paramref name="correlationId"/>. Returns
+    /// a disposable subscription over a bounded per-subscriber channel
+    /// (capacity ~256, DropOldest back-pressure — a slow/abandoned subscriber
+    /// drops oldest frames rather than stalling the producer). Dispose to
+    /// detach (removes the channel so nothing leaks on disconnect).
+    /// </summary>
+    IRunStreamSubscription Subscribe(string correlationId);
+
+    /// <summary>Current subscriber count for a run — diagnostics / tests.</summary>
+    int SubscriberCount(string correlationId);
+}
+
+/// <summary>
+/// A live-tail subscription handle. Dispose to detach the underlying channel
+/// from the bus (so an SSE handler that returns / a disconnected client never
+/// leaks its subscription).
+/// </summary>
+public interface IRunStreamSubscription : IDisposable
+{
+    /// <summary>The bounded reader the SSE handler pumps. Drained
+    /// single-reader; completes when the run publishes its <c>final</c> frame
+    /// or the subscription is disposed.</summary>
+    ChannelReader<RunStreamFrame> Reader { get; }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/LlmRunStreamBus.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/LlmRunStreamBus.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC5) — the default in-process <see cref="ILlmRunStreamBus"/>.
+/// Singleton. Thread-safe. A <c>ConcurrentDictionary</c> of per-run topics,
+/// each holding a monotonic seq counter and a set of bounded per-subscriber
+/// channels (DropOldest, capacity <see cref="Capacity"/>).
+///
+/// <para><b>Decoupling guarantees (the reason the tap can never break the
+/// engine):</b></para>
+/// <list type="bullet">
+///   <item>Publishing with no topic (no subscribers) is a TRUE no-op — no
+///     allocation, no seq, nothing — so an un-watched run pays nothing.</item>
+///   <item><see cref="PublishAsync"/> writes with <c>TryWrite</c> to
+///     DropOldest channels: it never blocks and never throws into the
+///     producer.</item>
+///   <item>A <c>final</c> frame tears the topic down + completes every
+///     subscriber channel, so live enumerations end cleanly and the topic's
+///     seq counter + channel set don't linger.</item>
+/// </list>
+/// </summary>
+public sealed class LlmRunStreamBus : ILlmRunStreamBus
+{
+    /// <summary>Bounded per-subscriber channel capacity. Mirrors the admin SSE
+    /// endpoint's per-tick back-pressure discipline: a slow subscriber drops
+    /// oldest frames rather than stalling the run.</summary>
+    public const int Capacity = 256;
+
+    private readonly ConcurrentDictionary<string, Topic> _topics =
+        new(StringComparer.Ordinal);
+
+    private readonly ILogger<LlmRunStreamBus>? _logger;
+
+    public LlmRunStreamBus(ILogger<LlmRunStreamBus>? logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ValueTask PublishAsync(string correlationId, RunStreamFrame frame, CancellationToken ct = default)
+    {
+        // Fire-and-forget contract: NEVER throw into the producer. Any
+        // unexpected failure is swallowed + logged; the buffered run always
+        // proceeds (AC5 / AC6).
+        try
+        {
+            if (string.IsNullOrEmpty(correlationId) || frame is null)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            // No topic => no subscribers => a TRUE no-op (an un-watched run is
+            // never blocked, slowed, or failed by the absence of observers).
+            if (!_topics.TryGetValue(correlationId, out var topic))
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            var seq = Interlocked.Increment(ref topic.Seq);
+            var stamped = frame with { Seq = seq };
+
+            foreach (var kv in topic.Subscribers)
+            {
+                // DropOldest bounded channel: TryWrite is non-blocking and (short
+                // of a completed channel) always accepts, dropping the oldest
+                // queued frame under back-pressure. No producer stall, ever.
+                if (!kv.Value.Writer.TryWrite(stamped))
+                {
+                    _logger?.LogWarning(
+                        "run-stream subscriber channel refused a frame (completed/saturated); dropping. "
+                        + "correlationId={CorrelationId} frameType={FrameType} seq={Seq}",
+                        correlationId, frame.Type, seq);
+                }
+            }
+
+            if (string.Equals(frame.Type, RunStreamFrameType.Final, StringComparison.Ordinal))
+            {
+                // The run is over: tear the topic down and complete every
+                // subscriber channel so live-tail enumerations end cleanly and
+                // the seq counter + channel set don't linger in memory.
+                if (_topics.TryRemove(correlationId, out var removed))
+                {
+                    foreach (var kv in removed.Subscribers)
+                    {
+                        kv.Value.Writer.TryComplete();
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // A publish must NEVER surface to the run. This branch is a bug guard
+            // (the paths above don't throw) — logged at ERROR per the story's
+            // logging requirements, never propagated.
+            _logger?.LogError(ex,
+                "run-stream publish threw despite the swallow guard; frame dropped, run unaffected. "
+                + "correlationId={CorrelationId}", correlationId);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public IRunStreamSubscription Subscribe(string correlationId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(correlationId);
+
+        var topic = _topics.GetOrAdd(correlationId, static _ => new Topic());
+
+        var channel = Channel.CreateBounded<RunStreamFrame>(
+            new BoundedChannelOptions(Capacity)
+            {
+                FullMode = BoundedChannelFullMode.DropOldest,
+                SingleReader = false,   // the SSE handler races WaitToReadAsync vs a heartbeat timer
+                SingleWriter = false,   // many producers (sink + ManagedAgent + inline runner)
+            });
+
+        var id = Guid.NewGuid();
+        topic.Subscribers[id] = channel;
+
+        _logger?.LogDebug(
+            "run-stream subscriber attached. correlationId={CorrelationId} subscriberCount={Count}",
+            correlationId, topic.Subscribers.Count);
+
+        return new Subscription(this, correlationId, id, channel);
+    }
+
+    /// <inheritdoc />
+    public int SubscriberCount(string correlationId)
+        => _topics.TryGetValue(correlationId, out var topic) ? topic.Subscribers.Count : 0;
+
+    private void Detach(string correlationId, Guid id)
+    {
+        if (_topics.TryGetValue(correlationId, out var topic)
+            && topic.Subscribers.TryRemove(id, out var ch))
+        {
+            ch.Writer.TryComplete();
+            // Intentionally DO NOT remove an empty topic here: keeping it until
+            // the run's `final` frame preserves per-run seq monotonicity across a
+            // subscriber that disconnects + reconnects mid-run. The topic is torn
+            // down deterministically on `final` (or bounded by process lifetime
+            // for a run that dies before emitting `final`).
+            _logger?.LogDebug(
+                "run-stream subscriber detached. correlationId={CorrelationId} subscriberCount={Count}",
+                correlationId, topic.Subscribers.Count);
+        }
+    }
+
+    /// <summary>Per-run fan-out state: a monotonic seq + the live subscriber
+    /// channels keyed by an opaque id.</summary>
+    private sealed class Topic
+    {
+        public long Seq;
+        public readonly ConcurrentDictionary<Guid, Channel<RunStreamFrame>> Subscribers = new();
+    }
+
+    private sealed class Subscription : IRunStreamSubscription
+    {
+        private readonly LlmRunStreamBus _bus;
+        private readonly string _correlationId;
+        private readonly Guid _id;
+        private readonly Channel<RunStreamFrame> _channel;
+        private int _disposed;
+
+        public Subscription(LlmRunStreamBus bus, string correlationId, Guid id, Channel<RunStreamFrame> channel)
+        {
+            _bus = bus;
+            _correlationId = correlationId;
+            _id = id;
+            _channel = channel;
+        }
+
+        public ChannelReader<RunStreamFrame> Reader => _channel.Reader;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+            _bus.Detach(_correlationId, _id);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/LlmRunStreamBus.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/LlmRunStreamBus.cs
@@ -109,8 +109,6 @@ public sealed class LlmRunStreamBus : ILlmRunStreamBus
     {
         ArgumentException.ThrowIfNullOrEmpty(correlationId);
 
-        var topic = _topics.GetOrAdd(correlationId, static _ => new Topic());
-
         var channel = Channel.CreateBounded<RunStreamFrame>(
             new BoundedChannelOptions(Capacity)
             {
@@ -120,7 +118,28 @@ public sealed class LlmRunStreamBus : ILlmRunStreamBus
             });
 
         var id = Guid.NewGuid();
-        topic.Subscribers[id] = channel;
+
+        // Retry loop closes the Detach remove-on-empty race: if the topic we joined
+        // was concurrently reclaimed (its previous last subscriber detached between
+        // our GetOrAdd and our registration), re-create a fresh one and re-register.
+        // A concurrent Subscribe re-creating the topic is fine — the run gets a fresh
+        // seq. In practice this loops at most once (human dashboard taps, low fan-out).
+        Topic topic;
+        while (true)
+        {
+            topic = _topics.GetOrAdd(correlationId, static _ => new Topic());
+            topic.Subscribers[id] = channel;
+
+            if (_topics.TryGetValue(correlationId, out var current)
+                && ReferenceEquals(current, topic))
+            {
+                break;
+            }
+
+            // Lost the race — our topic was reclaimed out from under us. Drop the
+            // stale registration and retry against a fresh topic.
+            topic.Subscribers.TryRemove(id, out _);
+        }
 
         _logger?.LogDebug(
             "run-stream subscriber attached. correlationId={CorrelationId} subscriberCount={Count}",
@@ -133,17 +152,42 @@ public sealed class LlmRunStreamBus : ILlmRunStreamBus
     public int SubscriberCount(string correlationId)
         => _topics.TryGetValue(correlationId, out var topic) ? topic.Subscribers.Count : 0;
 
+    /// <summary>Test-only (InternalsVisibleTo) — the number of live topics. A topic
+    /// exists from its first <see cref="Subscribe"/> until its last subscriber
+    /// detaches (remove-on-empty) or a <c>final</c> frame tears it down. Used to
+    /// assert the singleton never leaks a zombie topic.</summary>
+    internal int TopicCount => _topics.Count;
+
+    /// <summary>Test-only (InternalsVisibleTo) — is there a live topic for
+    /// <paramref name="correlationId"/>?</summary>
+    internal bool HasTopic(string correlationId) => _topics.ContainsKey(correlationId);
+
     private void Detach(string correlationId, Guid id)
     {
         if (_topics.TryGetValue(correlationId, out var topic)
             && topic.Subscribers.TryRemove(id, out var ch))
         {
             ch.Writer.TryComplete();
-            // Intentionally DO NOT remove an empty topic here: keeping it until
-            // the run's `final` frame preserves per-run seq monotonicity across a
-            // subscriber that disconnects + reconnects mid-run. The topic is torn
-            // down deterministically on `final` (or bounded by process lifetime
-            // for a run that dies before emitting `final`).
+
+            // Story 32-23 (review fix) — reclaim the topic when its LAST subscriber
+            // leaves. The old behaviour (retain empty topics until `final`) leaked one
+            // entry per tapped-then-finished run into this process-global singleton: a
+            // run that finished (or aborted/cancelled) never publishes a `final`, so the
+            // topic was never torn down → permanent growth. Remove-on-empty accepts a
+            // seq reset if a subscriber disconnects and reconnects mid-run (a fresh
+            // Subscribe re-creates the topic with seq starting at 1).
+            //
+            // Race safety: TryRemove(KeyValuePair) removes the mapping ONLY if it still
+            // points at THIS exact topic instance, so a concurrent Subscribe that
+            // installed a new topic is never clobbered; Subscribe's own re-check/retry
+            // handles the inverse. A late PublishAsync to a since-removed topic stays a
+            // no-op (TryGetValue miss).
+            if (topic.Subscribers.IsEmpty)
+            {
+                ((ICollection<KeyValuePair<string, Topic>>)_topics)
+                    .Remove(new KeyValuePair<string, Topic>(correlationId, topic));
+            }
+
             _logger?.LogDebug(
                 "run-stream subscriber detached. correlationId={CorrelationId} subscriberCount={Count}",
                 correlationId, topic.Subscribers.Count);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrame.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrame.cs
@@ -1,0 +1,23 @@
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC4) — one frame published onto the in-process run bus and
+/// written to a subscriber as a single SSE <c>event:/data:</c> frame.
+///
+/// <para><see cref="Seq"/> is a per-run monotonic counter the bus assigns on
+/// publish — it is NOT the per-tenant <c>domain_events.SequenceNumber</c>
+/// (a separate per-schema BIGSERIAL that would be meaningless as a stream
+/// cursor). Producers construct a frame with <c>Seq = 0</c>; the bus stamps
+/// the real value in <c>ILlmRunStreamBus.PublishAsync</c>.</para>
+///
+/// <para><see cref="Payload"/> MUST be key-free — it is run through
+/// <see cref="RunStreamFrameScrubber"/> (an allowlist mirroring
+/// <c>AdminTenantEventsSseEndpoint.ScrubEvent</c>) before it is written to
+/// the wire so a leaked secret / prompt body / tool argument can never reach
+/// an observer (AC9).</para>
+/// </summary>
+public sealed record RunStreamFrame(
+    string Type,
+    string CorrelationId,
+    long Seq,
+    object Payload);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameScrubber.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameScrubber.cs
@@ -1,0 +1,102 @@
+using System.Text.Json;
+
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC9, load-bearing) — the credential-safety choke point for the
+/// run tap. Mirrors <c>AdminTenantEventsSseEndpoint.ScrubEvent</c>: every frame
+/// payload written to the wire is rebuilt from an ALLOWLIST of safe keys, so a
+/// secret / <c>BaseUrl</c> auth / raw provider header / raw prompt body / tool
+/// argument or output that leaked into a payload upstream can NEVER reach an
+/// observer. Anything off the allowlist is dropped.
+///
+/// <para>The safe surface is deliberately tiny: model-output <c>token</c>
+/// deltas, tool <c>name</c>/<c>id</c>/<c>success</c>/<c>durationMs</c> (never
+/// tool arguments/outputs), the 32-20 question/answer shape, and the terminal
+/// turn summary. Plus the always-present <c>correlationId</c> + per-run
+/// <c>seq</c>, which are not secrets.</para>
+/// </summary>
+public static class RunStreamFrameScrubber
+{
+    /// <summary>
+    /// The allowlist of payload keys that survive the scrub. Documented as a
+    /// constant so a reviewer can audit the entire streamed surface in one
+    /// place (any future PR that widens it must review the secret-safety
+    /// implications — and update the pinning test).
+    /// </summary>
+    public static readonly IReadOnlySet<string> AllowedPayloadKeys = new HashSet<string>(StringComparer.Ordinal)
+    {
+        // tool_call
+        "toolName",
+        "toolCallId",
+        "turn",
+        // tool_result
+        "success",
+        "durationMs",
+        // token
+        "delta",
+        // question / answer (Story 32-20 shape)
+        "question",
+        "kind",
+        "options",
+        "answerer",
+        "answer",
+        // final (turn summary)
+        "totalTurns",
+        "totalTokens",
+        "exhausted",
+    };
+
+    /// <summary>
+    /// Rebuild <paramref name="frame"/> into a key-free wire payload:
+    /// <c>{ correlationId, seq, ...allowlisted payload fields }</c>. The raw
+    /// <see cref="RunStreamFrame.Payload"/> is serialised then filtered — only
+    /// scalar/array values under an allowlisted key survive; nested objects and
+    /// off-list keys are dropped.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object?> Scrub(RunStreamFrame frame)
+    {
+        var bag = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["correlationId"] = frame.CorrelationId,
+            ["seq"] = frame.Seq,
+        };
+
+        if (frame.Payload is null)
+        {
+            return bag;
+        }
+
+        JsonElement element;
+        try
+        {
+            element = JsonSerializer.SerializeToElement(frame.Payload);
+        }
+        catch (Exception)
+        {
+            // A payload that can't even be serialised carries nothing safe — the
+            // frame still ships with its correlationId + seq (never an exception
+            // to the client).
+            return bag;
+        }
+
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return bag;
+        }
+
+        foreach (var prop in element.EnumerateObject())
+        {
+            if (!AllowedPayloadKeys.Contains(prop.Name))
+            {
+                continue;
+            }
+
+            // Clone so the value stays valid after the source document is GC'd,
+            // and so the SSE serializer re-emits it verbatim.
+            bag[prop.Name] = prop.Value.Clone();
+        }
+
+        return bag;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameType.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Streaming/RunStreamFrameType.cs
@@ -1,0 +1,38 @@
+namespace Tamma.Api.Services.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC4) — the closed frame vocabulary of the streaming run tap.
+/// Every SSE frame emitted by <c>GET /api/v1/llm/runs/{correlationId}/stream</c>
+/// carries one of these as its <c>event:</c> name. Payloads are key-free
+/// (credential-safety, AC9) and correlated by <c>correlationId</c>.
+/// </summary>
+public static class RunStreamFrameType
+{
+    /// <summary>A model-output token delta (produced only when the runner
+    /// enables provider token streaming). Payload: <c>{ delta }</c>.</summary>
+    public const string Token = "token";
+
+    /// <summary>A tool invocation started. Payload: <c>{ toolName, toolCallId, turn }</c>.
+    /// Bridged from <c>TOOL_LOOP.TOOL_EXECUTING</c> via the sink. The tool
+    /// arguments are NEVER streamed (they may carry secrets — AC9).</summary>
+    public const string ToolCall = "tool_call";
+
+    /// <summary>A tool invocation finished. Payload: <c>{ toolName, toolCallId,
+    /// success, durationMs }</c>. Bridged from <c>TOOL_LOOP.TOOL_COMPLETED</c>.
+    /// The tool output is NEVER streamed (AC9).</summary>
+    public const string ToolResult = "tool_result";
+
+    /// <summary>An interactive question raised by the run (produced by Story
+    /// 32-20; this story defines the shape + transport). Payload:
+    /// <c>{ question, kind, options?, answerer? }</c>.</summary>
+    public const string Question = "question";
+
+    /// <summary>An answer to a prior question (Story 32-20). Payload:
+    /// <c>{ answer, answerer }</c>.</summary>
+    public const string Answer = "answer";
+
+    /// <summary>The terminal turn summary the engine already received. Payload:
+    /// <c>{ success, totalTurns, totalTokens, exhausted, durationMs }</c>. The
+    /// tap closes cleanly (<c>event: end</c>) when this is published.</summary>
+    public const string Final = "final";
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs
@@ -367,6 +367,66 @@ public class EventRepository(
         return (rows, total);
     }
 
+    /// <inheritdoc />
+    public async Task<bool> ExistsByCorrelationIdAsync(Guid tenantId, string correlationId)
+    {
+        if (string.IsNullOrEmpty(correlationId))
+        {
+            return false;
+        }
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId);
+
+        // The correlationId predicate lives in the Tags JSONB. It is a PARAMETERIZED
+        // raw-SQL `->>` extraction (the column is jsonb) so it translates on Postgres
+        // against the values written into Tags — {correlationId} is bound as a
+        // parameter, never interpolated into the SQL text. The unqualified
+        // `domain_events` name resolves to the tenant schema via the per-tenant
+        // connection's search_path. The tenant defence-in-depth predicate + the
+        // EXISTS (from AnyAsync) compose in LINQ over the raw-SQL subquery.
+        //
+        // TODO(perf): expression index on ((Tags->>'correlationId')) — separate
+        // migration, mirroring ix_domain_events_tags_agentid on ((Tags->>'agentId'))
+        // (see AddAgentTrailAgentIdIndex). Without it this is a seq scan, but AnyAsync
+        // compiles to EXISTS(SELECT 1 …) so Postgres short-circuits on the first match —
+        // the lookup is volume-independent regardless, unlike the retired recent-200 scan.
+        return await db.DomainEvents
+            .FromSqlInterpolated($@"
+                SELECT * FROM domain_events
+                WHERE ""Tags""->>'correlationId' = {correlationId}")
+            .Where(e => e.TenantId == tenantId)
+            .AnyAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<DomainEvent>> ListByCorrelationIdAsync(
+        Guid tenantId, string correlationId)
+    {
+        if (string.IsNullOrEmpty(correlationId))
+        {
+            return Array.Empty<DomainEvent>();
+        }
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId);
+
+        // Same tenant-scoped PARAMETERIZED `->>` lookup as ExistsByCorrelationIdAsync,
+        // but returns EVERY event for the run (NOT capped) ordered oldest-first for
+        // replay. Volume-independent: the target run's events are returned regardless
+        // of how many other AGENT.* events the tenant has.
+        //
+        // TODO(perf): expression index on ((Tags->>'correlationId')) — separate
+        // migration (see ExistsByCorrelationIdAsync / AddAgentTrailAgentIdIndex).
+        var rows = await db.DomainEvents
+            .FromSqlInterpolated($@"
+                SELECT * FROM domain_events
+                WHERE ""Tags""->>'correlationId' = {correlationId}")
+            .Where(e => e.TenantId == tenantId)
+            .OrderBy(e => e.SequenceNumber)
+            .ToListAsync();
+
+        return rows;
+    }
+
     /// <summary>Map the <c>outcome</c> filter (<c>success|failed|partial</c>) to
     /// the terminal <c>AGENT.TASK.*</c> event type. Returns <c>null</c> when no
     /// (or an unrecognized) outcome is supplied — the caller then does not

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs
@@ -90,4 +90,45 @@ public interface IEventRepository
             "QueryAgentTrailAsync is not implemented by this IEventRepository. " +
             "The per-agent action trail (Story 32-6) reads only through the " +
             "tenant-scoped EventRepository, which routes via ITenantDbContextFactory.");
+
+    /// <summary>
+    /// Story 32-23 (review fix) — tenant-scoped EXISTENCE check for a run by its
+    /// <paramref name="correlationId"/> (the workflow-instance id stamped into every
+    /// <c>AGENT.*</c> event's <c>Tags.correlationId</c>). Backs the run-tap ownership
+    /// guard: <c>true</c> iff at least one tenant-scoped event carries this
+    /// correlationId.
+    ///
+    /// <para><b>Volume-independent</b> — a single targeted <c>EXISTS</c> lookup that
+    /// returns the answer regardless of how many <c>AGENT.*</c> events the tenant has.
+    /// This replaces the retired recent-N (200) window scan that could age a busy
+    /// tenant's live run out of the window and false-404 the OWNER on their own run.</para>
+    ///
+    /// <para>The read is structurally scoped to the tenant's <c>t_&lt;hex&gt;</c>
+    /// schema — there is no cross-tenant read path. Default throws so a repository that
+    /// does not implement it is never a valid ownership source; the real
+    /// <c>EventRepository</c> overrides it.</para>
+    /// </summary>
+    Task<bool> ExistsByCorrelationIdAsync(Guid tenantId, string correlationId)
+        => throw new NotSupportedException(
+            "ExistsByCorrelationIdAsync is not implemented by this IEventRepository. " +
+            "The run-tap ownership guard (Story 32-23) reads only through the " +
+            "tenant-scoped EventRepository.");
+
+    /// <summary>
+    /// Story 32-23 (review fix) — ALL tenant-scoped events carrying
+    /// <paramref name="correlationId"/>, ordered oldest-first (by
+    /// <see cref="DomainEvent.SequenceNumber"/>) for replay catch-up + early-terminal
+    /// detection.
+    ///
+    /// <para><b>NOT capped</b> — returns every frame for the run regardless of how
+    /// many <c>AGENT.*</c> events the tenant has, so <c>?replay=true</c> never
+    /// truncates (unlike the retired recent-200 window scan). Tenant-scoped to the
+    /// caller's schema; there is no cross-tenant read path. Default throws — see
+    /// <see cref="ExistsByCorrelationIdAsync"/>.</para>
+    /// </summary>
+    Task<IReadOnlyList<DomainEvent>> ListByCorrelationIdAsync(Guid tenantId, string correlationId)
+        => throw new NotSupportedException(
+            "ListByCorrelationIdAsync is not implemented by this IEventRepository. " +
+            "The run-tap replay (Story 32-23) reads only through the tenant-scoped " +
+            "EventRepository.");
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs
@@ -1,0 +1,238 @@
+using System.Text;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Streaming;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// Story 32-23 (AC1/AC2/AC8) — the streaming run tap endpoint. Pumps the static
+/// handler with a hand-rolled <see cref="HttpContext"/> (the same idiom as
+/// <c>AdminTenantEventsSseLoopTests</c>) to lock the SaaS ownership guard
+/// (cross-tenant ⇒ 404), the SSE protocol (headers, clean <c>event: end</c> close
+/// on <c>final</c>), single-user "any local run", and <c>?replay=true</c> catch-up.
+///
+/// <para>401 for missing/invalid auth is enforced by the route policy
+/// (<c>.RequireAuthorization("AuthenticatedAny")</c>) BEFORE the handler runs —
+/// the same JWT+ApiKey pipeline covered by the auth suite — so it is not
+/// re-asserted at the handler level here.</para>
+/// </summary>
+[TestFixture]
+public class LlmRunStreamEndpointsTests
+{
+    [Test]
+    public async Task EmptyCorrelationId_Returns400()
+    {
+        var http = BuildContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        await LlmRunStreamEndpoints.StreamRun(
+            "  ", new LlmRunStreamBus(), Tenant(null), Mode(TammaMode.SingleUser),
+            Repo(), NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task Saas_ForeignCorrelationId_Returns404_NoStream()
+    {
+        var http = BuildContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // The caller's tenant store has NO event carrying this correlationId — the
+        // run belongs to another tenant. No cross-tenant existence oracle ⇒ 404.
+        await LlmRunStreamEndpoints.StreamRun(
+            "corr-foreign", new LlmRunStreamBus(), Tenant(Guid.NewGuid()),
+            Mode(TammaMode.SaaS), Repo(/* empty */), NullLoggerFactory.Instance,
+            TimeProvider.System, http, cts.Token);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        http.Response.ContentType.Should().NotBe("text/event-stream", "the SSE stream never opened");
+    }
+
+    [Test]
+    public async Task Saas_OwnedRun_Streams_LiveFrames_And_ClosesOnFinal()
+    {
+        var tenantId = Guid.NewGuid();
+        var http = BuildContext();
+        var bus = new LlmRunStreamBus();
+
+        // The caller's own tenant store carries the run's AGENT.RUN.STARTED —
+        // ownership passes.
+        var repo = Repo(RunEvent(tenantId, "corr-owned", "AGENT.RUN.STARTED", seq: 1));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var task = LlmRunStreamEndpoints.StreamRun(
+            "corr-owned", bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+
+        await WaitUntilAsync(() => bus.SubscriberCount("corr-owned") > 0, cts.Token);
+        await bus.PublishAsync("corr-owned",
+            new RunStreamFrame(RunStreamFrameType.ToolCall, "corr-owned", 0, new { toolName = "file_read", toolCallId = "c1", turn = 0L }));
+        await bus.PublishAsync("corr-owned",
+            new RunStreamFrame(RunStreamFrameType.Final, "corr-owned", 0, new { success = true }));
+
+        await task;
+
+        var body = ReadBody(http);
+        http.Response.Headers["X-Accel-Buffering"].ToString().Should().Be("no");
+        http.Response.ContentType.Should().Be("text/event-stream");
+        body.Should().Contain("event: tool_call");
+        body.Should().Contain("\"toolName\":\"file_read\"");
+        body.Should().Contain("event: final");
+        body.Should().Contain("event: end");
+        body.Should().Contain("\"reason\":\"run_complete\"", "the tap closes cleanly on the final frame");
+    }
+
+    [Test]
+    public async Task SingleUser_AnyLocalRun_Streams_WithoutOwnershipCheck()
+    {
+        var http = BuildContext();
+        var bus = new LlmRunStreamBus();
+
+        // Single-user: tenantId is null and the ownership guard is skipped — the
+        // sole user taps any local run. The repo is empty and never consulted.
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var task = LlmRunStreamEndpoints.StreamRun(
+            "corr-local", bus, Tenant(null), Mode(TammaMode.SingleUser), Repo(),
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+
+        await WaitUntilAsync(() => bus.SubscriberCount("corr-local") > 0, cts.Token);
+        await bus.PublishAsync("corr-local",
+            new RunStreamFrame(RunStreamFrameType.Final, "corr-local", 0, new { success = true }));
+
+        await task;
+
+        var body = ReadBody(http);
+        body.Should().Contain("event: final");
+        body.Should().Contain("event: end");
+    }
+
+    [Test]
+    public async Task Replay_CatchesUpFromDcbStore_ThenLiveTail()
+    {
+        var tenantId = Guid.NewGuid();
+        var http = BuildContext(query: "?replay=true");
+        var bus = new LlmRunStreamBus();
+
+        var repo = Repo(
+            RunEvent(tenantId, "corr-replay", "AGENT.RUN.STARTED", seq: 5),
+            RunEvent(tenantId, "corr-replay", "AGENT.RUN.SUCCESS", seq: 9),
+            // an event for a DIFFERENT run must NOT be replayed (isolation within the tenant)
+            RunEvent(tenantId, "corr-other", "AGENT.RUN.STARTED", seq: 7));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var task = LlmRunStreamEndpoints.StreamRun(
+            "corr-replay", bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+
+        await WaitUntilAsync(() => bus.SubscriberCount("corr-replay") > 0, cts.Token);
+        await bus.PublishAsync("corr-replay",
+            new RunStreamFrame(RunStreamFrameType.Final, "corr-replay", 0, new { success = true }));
+
+        await task;
+
+        var body = ReadBody(http);
+        body.Should().Contain("event: replay", "?replay=true first replays the run's DCB events");
+        body.Should().Contain("AGENT.RUN.STARTED");
+        body.Should().Contain("AGENT.RUN.SUCCESS");
+        body.Should().NotContain("corr-other", "another run's events are never replayed");
+        body.Should().Contain("event: final", "then it switches to the live tail");
+    }
+
+    // -------------------------------------------------------------------
+    // helpers / fakes
+    // -------------------------------------------------------------------
+
+    private static DefaultHttpContext BuildContext(string? query = null)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Response.Body = new MemoryStream();
+        if (!string.IsNullOrEmpty(query))
+        {
+            ctx.Request.QueryString = new QueryString(query);
+        }
+        return ctx;
+    }
+
+    private static string ReadBody(HttpContext ctx)
+    {
+        ctx.Response.Body.Position = 0;
+        using var reader = new StreamReader(ctx.Response.Body, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, CancellationToken ct)
+    {
+        while (!condition())
+        {
+            ct.ThrowIfCancellationRequested();
+            await Task.Delay(10, ct);
+        }
+    }
+
+    private static FakeTenantContext Tenant(Guid? id) => new(id);
+    private static FakeModeProvider Mode(TammaMode mode) => new(mode);
+    private static StubEventRepository Repo(params DomainEvent[] events) => new(events);
+
+    private static DomainEvent RunEvent(Guid tenantId, string correlationId, string type, long seq) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = type,
+        TenantId = tenantId,
+        Tags = $"{{\"correlationId\":\"{correlationId}\",\"provider\":\"anthropic\"}}",
+        Metadata = "{}",
+        Data = "{}",
+        CreatedAt = DateTime.UtcNow,
+        SequenceNumber = seq,
+    };
+
+    private sealed class FakeTenantContext : ITenantContext
+    {
+        public FakeTenantContext(Guid? id) => TenantId = id;
+        public Guid? TenantId { get; private set; }
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class FakeModeProvider : ITammaModeProvider
+    {
+        public FakeModeProvider(TammaMode mode) => Mode = mode;
+        public TammaMode Mode { get; }
+    }
+
+    private sealed class StubEventRepository : IEventRepository
+    {
+        private readonly List<DomainEvent> _events;
+        public StubEventRepository(IEnumerable<DomainEvent> events) => _events = events.ToList();
+
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset)
+        {
+            var rows = _events
+                .Where(e => e.TenantId == tenantId
+                    && (typePrefix is null || e.Type.StartsWith(typePrefix, StringComparison.Ordinal)))
+                .OrderByDescending(e => e.SequenceNumber) // repo contract: most-recent first
+                .Take(limit)
+                .ToList();
+            return Task.FromResult(((IReadOnlyList<DomainEvent>)rows, rows.Count));
+        }
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) => Task.FromResult(evt);
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit)
+            => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/LlmRunStreamEndpointsTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,6 +20,13 @@ namespace Tamma.Api.Tests.Endpoints;
 /// <c>AdminTenantEventsSseLoopTests</c>) to lock the SaaS ownership guard
 /// (cross-tenant ⇒ 404), the SSE protocol (headers, clean <c>event: end</c> close
 /// on <c>final</c>), single-user "any local run", and <c>?replay=true</c> catch-up.
+///
+/// <para>Also locks the review fixes: the owner of a busy tenant's run whose
+/// <c>AGENT.RUN.STARTED</c> has aged past any recent-N window is STILL recognised as
+/// owner (targeted correlationId lookup, not a recent-200 scan) — no false 404, no
+/// replay truncation; and a tap on an already-finished run closes PROMPTLY (terminal
+/// <c>event: end</c>) instead of parking 30 minutes for a live <c>final</c> that will
+/// never come, and never (re)creates a bus topic.</para>
 ///
 /// <para>401 for missing/invalid auth is enforced by the route policy
 /// (<c>.RequireAuthorization("AuthenticatedAny")</c>) BEFORE the handler runs —
@@ -41,6 +50,24 @@ public class LlmRunStreamEndpointsTests
     }
 
     [Test]
+    public async Task NonGuidCorrelationId_Returns400_NoStream()
+    {
+        var http = BuildContext();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+        // The run correlationId is the workflow-instance Guid. A non-Guid route value
+        // can never match a real run and is rejected before any stream/DB work — this
+        // also closes the SSE-line-injection nit (raw value echoed into `: stream-open`).
+        await LlmRunStreamEndpoints.StreamRun(
+            "not-a-guid\ninjected", new LlmRunStreamBus(), Tenant(null),
+            Mode(TammaMode.SingleUser), Repo(), NullLoggerFactory.Instance,
+            TimeProvider.System, http, cts.Token);
+
+        http.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        http.Response.ContentType.Should().NotBe("text/event-stream", "the SSE stream never opened");
+    }
+
+    [Test]
     public async Task Saas_ForeignCorrelationId_Returns404_NoStream()
     {
         var http = BuildContext();
@@ -49,7 +76,7 @@ public class LlmRunStreamEndpointsTests
         // The caller's tenant store has NO event carrying this correlationId — the
         // run belongs to another tenant. No cross-tenant existence oracle ⇒ 404.
         await LlmRunStreamEndpoints.StreamRun(
-            "corr-foreign", new LlmRunStreamBus(), Tenant(Guid.NewGuid()),
+            NewCorr(), new LlmRunStreamBus(), Tenant(Guid.NewGuid()),
             Mode(TammaMode.SaaS), Repo(/* empty */), NullLoggerFactory.Instance,
             TimeProvider.System, http, cts.Token);
 
@@ -61,23 +88,24 @@ public class LlmRunStreamEndpointsTests
     public async Task Saas_OwnedRun_Streams_LiveFrames_And_ClosesOnFinal()
     {
         var tenantId = Guid.NewGuid();
+        var corr = NewCorr();
         var http = BuildContext();
         var bus = new LlmRunStreamBus();
 
         // The caller's own tenant store carries the run's AGENT.RUN.STARTED —
-        // ownership passes.
-        var repo = Repo(RunEvent(tenantId, "corr-owned", "AGENT.RUN.STARTED", seq: 1));
+        // ownership passes. The run is NOT terminal, so the tap subscribes + live-tails.
+        var repo = Repo(RunEvent(tenantId, corr, "AGENT.RUN.STARTED", seq: 1));
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var task = LlmRunStreamEndpoints.StreamRun(
-            "corr-owned", bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            corr, bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
             NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
 
-        await WaitUntilAsync(() => bus.SubscriberCount("corr-owned") > 0, cts.Token);
-        await bus.PublishAsync("corr-owned",
-            new RunStreamFrame(RunStreamFrameType.ToolCall, "corr-owned", 0, new { toolName = "file_read", toolCallId = "c1", turn = 0L }));
-        await bus.PublishAsync("corr-owned",
-            new RunStreamFrame(RunStreamFrameType.Final, "corr-owned", 0, new { success = true }));
+        await WaitUntilAsync(() => bus.SubscriberCount(corr) > 0, cts.Token);
+        await bus.PublishAsync(corr,
+            new RunStreamFrame(RunStreamFrameType.ToolCall, corr, 0, new { toolName = "file_read", toolCallId = "c1", turn = 0L }));
+        await bus.PublishAsync(corr,
+            new RunStreamFrame(RunStreamFrameType.Final, corr, 0, new { success = true }));
 
         await task;
 
@@ -96,17 +124,18 @@ public class LlmRunStreamEndpointsTests
     {
         var http = BuildContext();
         var bus = new LlmRunStreamBus();
+        var corr = NewCorr();
 
         // Single-user: tenantId is null and the ownership guard is skipped — the
         // sole user taps any local run. The repo is empty and never consulted.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var task = LlmRunStreamEndpoints.StreamRun(
-            "corr-local", bus, Tenant(null), Mode(TammaMode.SingleUser), Repo(),
+            corr, bus, Tenant(null), Mode(TammaMode.SingleUser), Repo(),
             NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
 
-        await WaitUntilAsync(() => bus.SubscriberCount("corr-local") > 0, cts.Token);
-        await bus.PublishAsync("corr-local",
-            new RunStreamFrame(RunStreamFrameType.Final, "corr-local", 0, new { success = true }));
+        await WaitUntilAsync(() => bus.SubscriberCount(corr) > 0, cts.Token);
+        await bus.PublishAsync(corr,
+            new RunStreamFrame(RunStreamFrameType.Final, corr, 0, new { success = true }));
 
         await task;
 
@@ -119,37 +148,153 @@ public class LlmRunStreamEndpointsTests
     public async Task Replay_CatchesUpFromDcbStore_ThenLiveTail()
     {
         var tenantId = Guid.NewGuid();
+        var corr = NewCorr();
+        var other = NewCorr();
         var http = BuildContext(query: "?replay=true");
         var bus = new LlmRunStreamBus();
 
+        // A LIVE run (STARTED but no terminal event) with ?replay=true: replay the
+        // stored STARTED, then switch to the live tail for the published final.
         var repo = Repo(
-            RunEvent(tenantId, "corr-replay", "AGENT.RUN.STARTED", seq: 5),
-            RunEvent(tenantId, "corr-replay", "AGENT.RUN.SUCCESS", seq: 9),
+            RunEvent(tenantId, corr, "AGENT.RUN.STARTED", seq: 5),
             // an event for a DIFFERENT run must NOT be replayed (isolation within the tenant)
-            RunEvent(tenantId, "corr-other", "AGENT.RUN.STARTED", seq: 7));
+            RunEvent(tenantId, other, "AGENT.RUN.STARTED", seq: 7));
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var task = LlmRunStreamEndpoints.StreamRun(
-            "corr-replay", bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            corr, bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
             NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
 
-        await WaitUntilAsync(() => bus.SubscriberCount("corr-replay") > 0, cts.Token);
-        await bus.PublishAsync("corr-replay",
-            new RunStreamFrame(RunStreamFrameType.Final, "corr-replay", 0, new { success = true }));
+        await WaitUntilAsync(() => bus.SubscriberCount(corr) > 0, cts.Token);
+        await bus.PublishAsync(corr,
+            new RunStreamFrame(RunStreamFrameType.Final, corr, 0, new { success = true }));
 
         await task;
 
         var body = ReadBody(http);
         body.Should().Contain("event: replay", "?replay=true first replays the run's DCB events");
         body.Should().Contain("AGENT.RUN.STARTED");
-        body.Should().Contain("AGENT.RUN.SUCCESS");
-        body.Should().NotContain("corr-other", "another run's events are never replayed");
+        body.Should().NotContain(other, "another run's events are never replayed");
         body.Should().Contain("event: final", "then it switches to the live tail");
+    }
+
+    // -------------------------------------------------------------------
+    // Review fix 1 — owner false-404 + replay truncation on a busy tenant
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task Saas_OwnerRunOutsideRecent200Window_StillPasses_And_ReplaysOlderFrames()
+    {
+        var tenantId = Guid.NewGuid();
+        var corr = NewCorr();
+        var http = BuildContext(query: "?replay=true");
+        var bus = new LlmRunStreamBus();
+
+        // The target run's STARTED (seq 1) is buried under 250 NEWER AGENT.* events
+        // for OTHER runs of the same tenant. The retired recent-200 window scan would
+        // never see seq 1 → the OWNER would get a spurious 404 on their own in-flight
+        // run and replay would silently truncate. The targeted correlationId lookup is
+        // volume-independent, so ownership passes (200, not 404) and replay returns the
+        // older frame regardless of the noise volume.
+        var events = new List<DomainEvent> { RunEvent(tenantId, corr, "AGENT.RUN.STARTED", seq: 1) };
+        for (var i = 0; i < 250; i++)
+        {
+            events.Add(RunEvent(tenantId, NewCorr(), "AGENT.TOOL.CALLED", seq: 100 + i));
+        }
+        var repo = Repo(events.ToArray());
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var task = LlmRunStreamEndpoints.StreamRun(
+            corr, bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+
+        await WaitUntilAsync(() => bus.SubscriberCount(corr) > 0, cts.Token);
+        await bus.PublishAsync(corr,
+            new RunStreamFrame(RunStreamFrameType.Final, corr, 0, new { success = true }));
+
+        await task;
+
+        http.Response.StatusCode.Should().NotBe(StatusCodes.Status404NotFound,
+            "the owner must not get a spurious 404 on their own run just because it is old");
+        http.Response.ContentType.Should().Be("text/event-stream", "the stream opened for the owner");
+        var body = ReadBody(http);
+        body.Should().Contain("event: replay", "replay is not truncated by a recent-N window");
+        body.Should().Contain("AGENT.RUN.STARTED", "the older stored frame is replayed");
+        body.Should().Contain("event: final");
+    }
+
+    // -------------------------------------------------------------------
+    // Review fix 2 — finished runs close promptly, never park 30 minutes
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task FinishedRun_NonReplay_ClosesPromptly_And_NeverSubscribes()
+    {
+        var tenantId = Guid.NewGuid();
+        var corr = NewCorr();
+        var http = BuildContext();
+        var bus = new LlmRunStreamBus();
+
+        // A run that already finished: a terminal AGENT.RUN.SUCCESS is persisted and
+        // there is NO live topic. Tapping it (no replay) must close PROMPTLY with a
+        // terminal event: end — not park until MaxStreamDuration for a live `final`
+        // that will never come — and must never (re)create a bus topic.
+        var repo = Repo(
+            RunEvent(tenantId, corr, "AGENT.RUN.STARTED", seq: 1),
+            RunEvent(tenantId, corr, "AGENT.RUN.SUCCESS", seq: 2));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var sw = Stopwatch.StartNew();
+        await LlmRunStreamEndpoints.StreamRun(
+            corr, bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5),
+            "a finished run closes at once, nowhere near the 30-minute ceiling");
+        var body = ReadBody(http);
+        body.Should().Contain("event: end");
+        body.Should().Contain("\"reason\":\"already_complete\"");
+        bus.TopicCount.Should().Be(0, "a finished run must not (re)create a bus topic");
+        bus.HasTopic(corr).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task FinishedRun_Replay_StreamsStoredFrames_ThenClosesPromptly()
+    {
+        var tenantId = Guid.NewGuid();
+        var corr = NewCorr();
+        var http = BuildContext(query: "?replay=true");
+        var bus = new LlmRunStreamBus();
+
+        // A finished run with ?replay=true: stream the stored frames, then close —
+        // do NOT wait for a live `final`. No live topic is created.
+        var repo = Repo(
+            RunEvent(tenantId, corr, "AGENT.RUN.STARTED", seq: 1),
+            RunEvent(tenantId, corr, "AGENT.RUN.FAILED", seq: 2));
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var sw = Stopwatch.StartNew();
+        await LlmRunStreamEndpoints.StreamRun(
+            corr, bus, Tenant(tenantId), Mode(TammaMode.SaaS), repo,
+            NullLoggerFactory.Instance, TimeProvider.System, http, cts.Token);
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(5));
+        var body = ReadBody(http);
+        body.Should().Contain("event: replay");
+        body.Should().Contain("AGENT.RUN.STARTED");
+        body.Should().Contain("AGENT.RUN.FAILED");
+        body.Should().Contain("event: end");
+        body.Should().Contain("\"reason\":\"already_complete\"");
+        bus.TopicCount.Should().Be(0, "a finished run must not (re)create a bus topic");
     }
 
     // -------------------------------------------------------------------
     // helpers / fakes
     // -------------------------------------------------------------------
+
+    private static string NewCorr() => Guid.NewGuid().ToString();
 
     private static DefaultHttpContext BuildContext(string? query = null)
     {
@@ -216,13 +361,43 @@ public class LlmRunStreamEndpointsTests
         public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
             Guid tenantId, string? typePrefix, int limit, int offset)
         {
+            // Real SQL honours limit/offset — model that so a test that reverts the
+            // ownership/replay path to a recent-N window scan would (correctly) fail.
             var rows = _events
                 .Where(e => e.TenantId == tenantId
                     && (typePrefix is null || e.Type.StartsWith(typePrefix, StringComparison.Ordinal)))
                 .OrderByDescending(e => e.SequenceNumber) // repo contract: most-recent first
+                .Skip(offset)
                 .Take(limit)
                 .ToList();
             return Task.FromResult(((IReadOnlyList<DomainEvent>)rows, rows.Count));
+        }
+
+        // Review-fix methods — behave like the real tenant-scoped SQL: match by
+        // Tags.correlationId across ALL rows (never limited), oldest-first for the list.
+        public Task<bool> ExistsByCorrelationIdAsync(Guid tenantId, string correlationId)
+        {
+            var exists = _events.Any(e => e.TenantId == tenantId
+                && CorrelationIdOf(e) == correlationId);
+            return Task.FromResult(exists);
+        }
+
+        public Task<IReadOnlyList<DomainEvent>> ListByCorrelationIdAsync(Guid tenantId, string correlationId)
+        {
+            var rows = _events
+                .Where(e => e.TenantId == tenantId && CorrelationIdOf(e) == correlationId)
+                .OrderBy(e => e.SequenceNumber)
+                .ToList();
+            return Task.FromResult((IReadOnlyList<DomainEvent>)rows);
+        }
+
+        private static string? CorrelationIdOf(DomainEvent e)
+        {
+            using var doc = JsonDocument.Parse(e.Tags);
+            return doc.RootElement.TryGetProperty("correlationId", out var c)
+                && c.ValueKind == JsonValueKind.String
+                ? c.GetString()
+                : null;
         }
 
         public Task<DomainEvent> AppendAsync(DomainEvent evt) => Task.FromResult(evt);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs
@@ -1,0 +1,205 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Security;
+using Tamma.Api.Services.Streaming;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC6, THE load-bearing invariant) — the buffered
+/// <see cref="ManagedAgent"/> run is IDENTICAL whether 0 or N tap subscribers are
+/// attached, and a streaming failure NEVER faults or alters the buffered run. The
+/// tap can only ever be a decoupled mirror of the engine's source-of-truth call.
+/// </summary>
+[TestFixture]
+public class BufferedNonRegressionTests
+{
+    private const string TestApiKey = "sk-secret-never-in-a-frame-000";
+
+    [Test]
+    public async Task BufferedResult_IsIdentical_With0_vs_N_Subscribers()
+    {
+        var bus = new LlmRunStreamBus();
+
+        // Run with ZERO subscribers.
+        var agent0 = BuildAgent(bus);
+        var result0 = await agent0.RunAsync(Req("corr-nonreg"));
+
+        // Run again with N subscribers attached to the SAME correlationId's bus.
+        var agentN = BuildAgent(bus);
+        using var s1 = bus.Subscribe("corr-nonreg");
+        using var s2 = bus.Subscribe("corr-nonreg");
+        var resultN = await agentN.RunAsync(Req("corr-nonreg"));
+
+        // Everything the engine keys off is identical; only wall-clock DurationMs
+        // differs between the two invocations (it is not a function of subscribers).
+        resultN.Should().BeEquivalentTo(result0, opts => opts.Excluding(r => r.DurationMs));
+
+        // The mapped wire response the engine consumes is also unaffected.
+        var mapper = new LlmCallResponseMapper();
+        var wire0 = mapper.ToResponse(result0);
+        var wireN = mapper.ToResponse(resultN);
+        wireN.Should().BeEquivalentTo(wire0, opts => opts.Excluding(r => r.DurationMs));
+
+        result0.Success.Should().BeTrue();
+        resultN.Success.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PublishThatThrows_IsSwallowed_RunStillSucceeds()
+    {
+        // A misbehaving bus that throws on publish must NEVER fault the run — the
+        // producer-side publish is wrapped log-and-swallow (AC5/AC6).
+        var throwingBus = new ThrowingRunStreamBus();
+        var agent = BuildAgent(throwingBus);
+
+        var act = async () => await agent.RunAsync(Req("corr-throw"));
+
+        var result = await act.Should().NotThrowAsync();
+        result.Which.Success.Should().BeTrue("a streaming failure never alters the buffered run");
+    }
+
+    [Test]
+    public async Task Run_PublishesTerminalFinalFrame_ToSubscribers()
+    {
+        var bus = new LlmRunStreamBus();
+        var agent = BuildAgent(bus);
+        using var sub = bus.Subscribe("corr-final");
+
+        await agent.RunAsync(Req("corr-final"));
+
+        // The run publishes exactly one terminal `final` frame carrying the
+        // key-free turn summary; the channel completes on it.
+        var frames = new List<RunStreamFrame>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var f in sub.Reader.ReadAllAsync(cts.Token))
+        {
+            frames.Add(f);
+        }
+
+        frames.Should().ContainSingle();
+        frames[0].Type.Should().Be(RunStreamFrameType.Final);
+        var json = System.Text.Json.JsonSerializer.Serialize(RunStreamFrameScrubber.Scrub(frames[0]));
+        json.Should().Contain("\"success\":true");
+        json.Should().NotContain(TestApiKey, "the final frame is key-free (AC9)");
+    }
+
+    // -------------------------------------------------------------------
+    // builders / fakes
+    // -------------------------------------------------------------------
+
+    private static ManagedAgent BuildAgent(ILlmRunStreamBus bus)
+    {
+        var gate = new Mock<ISaaSProviderGate>();
+        gate.Setup(g => g.InspectAsync(It.IsAny<ProviderGateContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProviderGateDecision.Allow(ProviderAuthModel.ApiKey));
+
+        var budget = new Mock<IBudgetGuard>();
+        budget.Setup(b => b.IsWithinBudgetAsync(It.IsAny<Guid?>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var resolver = new Mock<IAgentResolverService>();
+        resolver.Setup(r => r.ResolveForRoleAsync("developer", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResolvedAgentConfig
+            {
+                Role = "developer",
+                Handle = "tamma-developer",
+                Provider = "anthropic",
+                Model = "claude-sonnet-4",
+                Temperature = 0.7,
+                MaxTokens = 4096,
+                TokenBudget = 100_000,
+                SystemPrompt = "You are a developer.",
+                AgentId = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+                AgentVersion = 3,
+                Source = "system-public",
+            });
+
+        var credentials = new Mock<IProviderCredentialResolver>();
+        credentials.Setup(c => c.ResolveAsync(It.IsAny<Guid?>(), "anthropic", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProviderCredential(TestApiKey, CredentialSource.Platform, "platform:anthropic/api-key", null));
+
+        var runner = new Mock<IInlineToolLoopRunner>();
+        runner.Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InlineToolLoopResult
+            {
+                Response = new NormalizedLlmResponse
+                {
+                    Success = true,
+                    ResponseText = "done",
+                    HttpStatusCode = 200,
+                    PromptTokens = 100,
+                    CompletionTokens = 50,
+                },
+                InputTokens = 100,
+                OutputTokens = 50,
+                Turns = 1,
+                Exhausted = false,
+            });
+
+        var pricing = new Mock<IProviderPricingService>();
+        pricing.Setup(p => p.Compute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(0.003m);
+
+        return new ManagedAgent(
+            gate.Object, budget.Object, resolver.Object, credentials.Object,
+            runner.Object, pricing.Object, new PassthroughProviderMarkupEngine(),
+            new NoOpUsageEmitter(), new NoOpEventRepository(),
+            NullLogger<ManagedAgent>.Instance,
+            sanitizer: null, trail: null, runStreamBus: bus);
+    }
+
+    private static ManagedAgentRequest Req(string correlationId) => new()
+    {
+        TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222"),
+        Role = "developer",
+        Prompt = "do the thing",
+        CorrelationId = correlationId,
+        Params = new LlmCallParams { MaxTokens = 4096, Temperature = 0.7 },
+    };
+
+    private sealed class ThrowingRunStreamBus : ILlmRunStreamBus
+    {
+        public ValueTask PublishAsync(string correlationId, RunStreamFrame frame, CancellationToken ct = default)
+            => throw new InvalidOperationException("bus is down");
+
+        public IRunStreamSubscription Subscribe(string correlationId)
+            => throw new NotSupportedException();
+
+        public int SubscriberCount(string correlationId) => 0;
+    }
+
+    private sealed class NoOpUsageEmitter : IUsageEmitter
+    {
+        public Task EmitAsync(UsageRecord record, CancellationToken ct = default) => Task.CompletedTask;
+    }
+
+    private sealed class NoOpEventRepository : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) { Appended.Add(evt); return Task.FromResult(evt); }
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit)
+            => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BusToolLoopEventSinkTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BusToolLoopEventSinkTests.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ToolExecution;
+using Tamma.Api.Services.Streaming;
+
+namespace Tamma.Api.Tests.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC3/AC9) — the live <see cref="BusToolLoopEventSink"/> that
+/// replaces the null sink. Locks the TOOL_LOOP.* → frame-vocabulary mapping, the
+/// correlationId routing (threaded from the emitter's <c>workflowInstanceId</c>),
+/// the "unmapped events publish nothing" rule, and the credential-safety
+/// guarantee that only fixed-vocabulary fields ever reach a frame.
+/// </summary>
+[TestFixture]
+public class BusToolLoopEventSinkTests
+{
+    [Test]
+    public void BusToolLoopEventSink_IsAn_IToolLoopEventSink()
+    {
+        // Locks AC3: the live sink is a drop-in for the null sink the DI swap
+        // replaces behind the streaming flag.
+        typeof(BusToolLoopEventSink).Should().BeAssignableTo<IToolLoopEventSink>();
+    }
+
+    [Test]
+    public async Task WriteEventAsync_ToolExecuting_MapsTo_ToolCall_Frame()
+    {
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-1");
+
+        await sink.WriteEventAsync("TOOL_LOOP.TOOL_EXECUTING", new
+        {
+            turnNumber = 3,
+            toolName = "file_read",
+            toolCallId = "call_abc",
+            workflowInstanceId = "run-1",
+        });
+
+        var frame = DrainAvailable(sub.Reader).Should().ContainSingle().Subject;
+        frame.Type.Should().Be(RunStreamFrameType.ToolCall);
+        frame.CorrelationId.Should().Be("run-1", "the correlationId is threaded from workflowInstanceId");
+
+        var json = Scrubbed(frame);
+        json.Should().Contain("\"toolName\":\"file_read\"");
+        json.Should().Contain("\"toolCallId\":\"call_abc\"");
+        json.Should().Contain("\"turn\":3");
+    }
+
+    [Test]
+    public async Task WriteEventAsync_ToolCompleted_MapsTo_ToolResult_Frame()
+    {
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-2");
+
+        await sink.WriteEventAsync("TOOL_LOOP.TOOL_COMPLETED", new
+        {
+            turnNumber = 1,
+            toolName = "shell_execute",
+            toolCallId = "call_xyz",
+            success = false,
+            durationMs = 1234L,
+            workflowInstanceId = "run-2",
+        });
+
+        var frame = DrainAvailable(sub.Reader).Should().ContainSingle().Subject;
+        frame.Type.Should().Be(RunStreamFrameType.ToolResult);
+
+        var json = Scrubbed(frame);
+        json.Should().Contain("\"toolName\":\"shell_execute\"");
+        json.Should().Contain("\"success\":false");
+        json.Should().Contain("\"durationMs\":1234");
+    }
+
+    [Test]
+    public async Task WriteEventAsync_LoopCompleted_MapsTo_Final_Frame()
+    {
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-3");
+
+        await sink.WriteEventAsync("TOOL_LOOP.COMPLETED", new
+        {
+            totalTurns = 5,
+            totalToolCalls = 12,
+            totalDurationMs = 3000L,
+            totalTokens = 150000,
+            exhausted = true,
+            workflowInstanceId = "run-3",
+        });
+
+        var frame = DrainAvailable(sub.Reader).Should().ContainSingle().Subject;
+        frame.Type.Should().Be(RunStreamFrameType.Final);
+
+        var json = Scrubbed(frame);
+        json.Should().Contain("\"exhausted\":true");
+        json.Should().Contain("\"totalTurns\":5");
+        json.Should().Contain("\"totalTokens\":150000");
+    }
+
+    [Test]
+    public async Task WriteEventAsync_TurnEvents_AreIgnored_NoFrame()
+    {
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-4");
+
+        await sink.WriteEventAsync("TOOL_LOOP.TURN_STARTED",
+            new { turnNumber = 0, messageCount = 2, estimatedTokens = 1000, workflowInstanceId = "run-4" });
+        await sink.WriteEventAsync("TOOL_LOOP.TURN_COMPLETED",
+            new { turnNumber = 0, totalTools = 1, totalDurationMs = 10L, cumulativeTokens = 1000, workflowInstanceId = "run-4" });
+
+        DrainAvailable(sub.Reader).Should().BeEmpty("turn-progress events have no run-tap frame");
+    }
+
+    [Test]
+    public async Task WriteEventAsync_MissingCorrelationId_PublishesNothing()
+    {
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-5");
+
+        // No workflowInstanceId => the sink can't route => no publish (the run is
+        // unaffected — pure observability).
+        await sink.WriteEventAsync("TOOL_LOOP.TOOL_EXECUTING",
+            new { turnNumber = 1, toolName = "x", toolCallId = "c" });
+
+        DrainAvailable(sub.Reader).Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task WriteEventAsync_NeverCopiesOffVocabularyFields_Even_IfPresent()
+    {
+        // AC9 — even if a (hypothetical) upstream payload smuggled a secret, the
+        // sink only ever copies the fixed vocabulary; the secret never reaches a
+        // frame.
+        var bus = new LlmRunStreamBus();
+        var sink = new BusToolLoopEventSink(bus);
+        using var sub = bus.Subscribe("run-6");
+
+        await sink.WriteEventAsync("TOOL_LOOP.TOOL_EXECUTING", new
+        {
+            turnNumber = 1,
+            toolName = "file_read",
+            toolCallId = "c1",
+            apiKey = "sk-should-never-appear",
+            rawArgs = "{\"path\":\"/etc/shadow\"}",
+            workflowInstanceId = "run-6",
+        });
+
+        var frame = DrainAvailable(sub.Reader).Should().ContainSingle().Subject;
+        var json = Scrubbed(frame);
+        json.Should().NotContain("sk-should-never-appear");
+        json.Should().NotContain("rawArgs");
+        json.Should().NotContain("/etc/shadow");
+    }
+
+    private static string Scrubbed(RunStreamFrame frame)
+        => JsonSerializer.Serialize(RunStreamFrameScrubber.Scrub(frame));
+
+    private static List<RunStreamFrame> DrainAvailable(ChannelReader<RunStreamFrame> reader)
+    {
+        var list = new List<RunStreamFrame>();
+        while (reader.TryRead(out var f))
+        {
+            list.Add(f);
+        }
+        return list;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs
@@ -1,0 +1,149 @@
+using System.Threading.Channels;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Streaming;
+
+namespace Tamma.Api.Tests.Streaming;
+
+/// <summary>
+/// Story 32-23 (AC5) — the in-process run-stream bus. Locks the decoupling
+/// invariants that let the tap never break the buffered run: publish with zero
+/// subscribers is a no-op that never throws; N subscribers each receive every
+/// frame in order; a slow subscriber drops oldest under back-pressure (never a
+/// producer stall); <c>seq</c> is per-run monotonic and independent per
+/// correlationId; a <c>final</c> frame completes + tears down the topic.
+/// </summary>
+[TestFixture]
+public class LlmRunStreamBusTests
+{
+    [Test]
+    public async Task PublishAsync_ZeroSubscribers_IsNoOp_NeverThrows()
+    {
+        var bus = new LlmRunStreamBus();
+
+        var act = async () => await bus.PublishAsync("run-nobody", Frame(RunStreamFrameType.ToolCall));
+
+        await act.Should().NotThrowAsync();
+        bus.SubscriberCount("run-nobody").Should().Be(0);
+    }
+
+    [Test]
+    public async Task PublishAsync_NSubscribers_EachReceivesEveryFrame_InOrder()
+    {
+        var bus = new LlmRunStreamBus();
+        using var s1 = bus.Subscribe("run-1");
+        using var s2 = bus.Subscribe("run-1");
+
+        bus.SubscriberCount("run-1").Should().Be(2);
+
+        await bus.PublishAsync("run-1", Frame(RunStreamFrameType.ToolCall));
+        await bus.PublishAsync("run-1", Frame(RunStreamFrameType.ToolResult));
+
+        var got1 = DrainAvailable(s1.Reader);
+        var got2 = DrainAvailable(s2.Reader);
+
+        got1.Should().HaveCount(2);
+        got2.Should().HaveCount(2);
+
+        got1[0].Type.Should().Be(RunStreamFrameType.ToolCall);
+        got1[0].Seq.Should().Be(1, "the bus stamps a per-run monotonic seq starting at 1");
+        got1[1].Type.Should().Be(RunStreamFrameType.ToolResult);
+        got1[1].Seq.Should().Be(2);
+
+        // Both subscribers see the identical stamped seq sequence.
+        got2.Select(f => f.Seq).Should().Equal(got1.Select(f => f.Seq));
+    }
+
+    [Test]
+    public async Task PublishAsync_SlowSubscriber_DropsOldest_NoStall()
+    {
+        var bus = new LlmRunStreamBus();
+        using var sub = bus.Subscribe("run-slow");
+
+        const int published = LlmRunStreamBus.Capacity + 50; // overflow the bounded channel
+        for (var i = 0; i < published; i++)
+        {
+            // Never blocks — DropOldest bounded channel. If it stalled, this
+            // loop (2s guard on the whole test via the fixture) would hang.
+            await bus.PublishAsync("run-slow", Frame(RunStreamFrameType.Token));
+        }
+
+        var got = DrainAvailable(sub.Reader);
+
+        got.Should().HaveCount(LlmRunStreamBus.Capacity,
+            "a slow subscriber's channel retains at most Capacity frames — oldest dropped");
+        got[0].Seq.Should().Be(published - LlmRunStreamBus.Capacity + 1,
+            "the retained window is the newest Capacity frames (oldest dropped)");
+        got[^1].Seq.Should().Be(published, "the newest frame is retained");
+    }
+
+    [Test]
+    public async Task Seq_IsPerRunMonotonic_AndIndependentPerCorrelationId()
+    {
+        var bus = new LlmRunStreamBus();
+        using var a = bus.Subscribe("run-a");
+        using var b = bus.Subscribe("run-b");
+
+        await bus.PublishAsync("run-a", Frame(RunStreamFrameType.ToolCall));
+        await bus.PublishAsync("run-b", Frame(RunStreamFrameType.ToolCall));
+        await bus.PublishAsync("run-a", Frame(RunStreamFrameType.ToolResult));
+
+        var ga = DrainAvailable(a.Reader);
+        var gb = DrainAvailable(b.Reader);
+
+        ga.Select(f => f.Seq).Should().Equal(new long[] { 1, 2 }, "run-a's seq is independent of run-b");
+        gb.Select(f => f.Seq).Should().Equal(new long[] { 1 }, "run-b's seq starts fresh at 1");
+    }
+
+    [Test]
+    public async Task PublishAsync_FinalFrame_CompletesAndTearsDownTopic()
+    {
+        var bus = new LlmRunStreamBus();
+        var sub = bus.Subscribe("run-final");
+
+        await bus.PublishAsync("run-final", Frame(RunStreamFrameType.ToolCall));
+        await bus.PublishAsync("run-final", Frame(RunStreamFrameType.Final));
+
+        // The channel is completed on `final`, so ReadAllAsync drains both frames
+        // then ends — no hang.
+        var all = new List<RunStreamFrame>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await foreach (var f in sub.Reader.ReadAllAsync(cts.Token))
+        {
+            all.Add(f);
+        }
+
+        all.Should().HaveCount(2);
+        all[^1].Type.Should().Be(RunStreamFrameType.Final);
+        bus.SubscriberCount("run-final").Should().Be(0, "the topic is torn down on `final`");
+
+        sub.Dispose(); // idempotent after teardown
+    }
+
+    [Test]
+    public void Dispose_DetachesSubscriber()
+    {
+        var bus = new LlmRunStreamBus();
+        var sub = bus.Subscribe("run-detach");
+        bus.SubscriberCount("run-detach").Should().Be(1);
+
+        sub.Dispose();
+
+        bus.SubscriberCount("run-detach").Should().Be(0, "dispose detaches the channel so nothing leaks");
+    }
+
+    private static RunStreamFrame Frame(string type)
+        => new(type, "run", 0, new { x = 1 });
+
+    private static List<RunStreamFrame> DrainAvailable(ChannelReader<RunStreamFrame> reader)
+    {
+        // Publishing is synchronous (TryWrite), so everything published is already
+        // queued — a TryRead loop drains it deterministically.
+        var list = new List<RunStreamFrame>();
+        while (reader.TryRead(out var f))
+        {
+            list.Add(f);
+        }
+        return list;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/LlmRunStreamBusTests.cs
@@ -132,6 +132,41 @@ public class LlmRunStreamBusTests
         bus.SubscriberCount("run-detach").Should().Be(0, "dispose detaches the channel so nothing leaks");
     }
 
+    [Test]
+    public void Detach_RemovesTopic_WhenLastSubscriberLeaves_NoZombieLeak()
+    {
+        // Review fix — a run tapped-then-disconnected (or a finished/aborted run that
+        // never publishes `final`) must NOT leak a topic into the process-global
+        // singleton. Removing the LAST subscriber reclaims the topic.
+        var bus = new LlmRunStreamBus();
+        var sub = bus.Subscribe("run-reclaim");
+        bus.TopicCount.Should().Be(1);
+        bus.HasTopic("run-reclaim").Should().BeTrue();
+
+        sub.Dispose();
+
+        bus.SubscriberCount("run-reclaim").Should().Be(0);
+        bus.HasTopic("run-reclaim").Should().BeFalse("the empty topic is reclaimed on the last detach");
+        bus.TopicCount.Should().Be(0, "no zombie topic lingers after the last subscriber leaves");
+    }
+
+    [Test]
+    public void Detach_KeepsTopic_WhileOtherSubscribersRemain_RemovesOnLast()
+    {
+        var bus = new LlmRunStreamBus();
+        var s1 = bus.Subscribe("run-multi");
+        var s2 = bus.Subscribe("run-multi");
+        bus.TopicCount.Should().Be(1);
+
+        s1.Dispose();
+        bus.HasTopic("run-multi").Should().BeTrue("one subscriber still remains");
+        bus.SubscriberCount("run-multi").Should().Be(1);
+
+        s2.Dispose();
+        bus.HasTopic("run-multi").Should().BeFalse("last subscriber left ⇒ topic reclaimed");
+        bus.TopicCount.Should().Be(0);
+    }
+
     private static RunStreamFrame Frame(string type)
         => new(type, "run", 0, new { x = 1 });
 


### PR DESCRIPTION
## What

Story 32-23 (P1). A read-only SSE endpoint `GET /api/v1/llm/runs/{correlationId}/stream` (policy `AuthenticatedAny` — the human JWT/ApiKey plane) that live-tails an agent run's tool-loop + final frames. Source is an in-process `ILlmRunStreamBus` keyed by `correlationId` (= workflow instance id); producers are a `BusToolLoopEventSink` (bridging the existing `ToolLoopEventEmitter`, flag-gated by `Tamma:Streaming:Enabled`) + `ManagedAgent` (the terminal `final` frame). `?replay=true` catches up from the tenant DCB store then live-tails. Reuses the `AdminTenantEventsSseEndpoint` hardening (headers, 30s keepalive, max-duration, clean `event: end`).

**Scope isolation:** the ownership guard reads the caller's OWN auth-derived tenant schema (foreign/unknown run → 404, oracle-free) BEFORE any header/subscribe; `correlationId` is server-minted + globally unique and the run-start path is `EngineServiceOnly`, so a tenant can't inject or adopt another tenant's key. Single-user taps any local run. **AC7** (a second streaming mode on `/llm/call` itself) deferred to keep 32-5's endpoint byte-for-byte unchanged (max non-regression); the dedicated tap endpoint covers the human streaming use case.

## Review + fixes

Adversarial review confirmed **no cross-tenant leak** (isolation airtight), but caught two correctness/resource bugs — both fixed (TDD, fail-before confirmed):
- **Owner false-404 + replay truncation:** the guard/replay scanned only the 200 most-recent `AGENT.*` events tenant-wide, so on a busy tenant the target run's `RUN.STARTED` aged out → owner got a 404 on their own live run and replay silently truncated (invisible because the test fake ignored `limit`/`offset`). Fixed with targeted, parameterized, tenant-scoped `Exists/ListByCorrelationIdAsync` (volume-independent, never capped; a `TODO(perf)` expression-index note left for a later migration). The test fake now honors `limit`/`offset` so the regression can't return.
- **Zombie-topic leak + 30-min hang:** a topic was reclaimed only on a `final` publish, but `Subscribe` always created one — tapping an already-finished run leaked a topic forever and parked the client for the full 30-min max-duration. Fixed: reclaim the topic when the last subscriber detaches (race-safe KV-exact remove), and early-terminal-close (a finished run closes promptly / replays stored frames, never parks). Plus `{correlationId}` Guid validation (400) closing an SSE-line-injection nit.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` → "No changes" (both). **No migration.**
- Tests: `Sse|Stream|Tap|Run` filter 171 passed — incl. owner-outside-200-window-still-passes (fail-before confirmed), finished-run-closes-promptly, topic-removed-on-detach, non-Guid→400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)