### PR TITLE
fix: reserve PIPELINE.SUCCESS reason for stage failures + consolidate tolerant resume-bool reads

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerResumeInput.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/BlockerResumeInput.cs
@@ -28,7 +28,5 @@ internal static class BlockerResumeInput
     /// string comparison. A <c>null</c> / missing value is <c>false</c>.
     /// </summary>
     internal static bool AsBool(object? value)
-        => value is bool b
-            ? b
-            : string.Equals(value?.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+        => ResumeInput.AsBool(value);
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/ResumeInput.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ResumeInput.cs
@@ -1,0 +1,42 @@
+namespace Tamma.Activities;
+
+/// <summary>
+/// Tolerant read-back coercion for a control-flow boolean arriving on a workflow
+/// resume input (<c>context.WorkflowInput</c> for a bookmark resume) OR on a
+/// dispatched-workflow <c>Result</c> dictionary.
+///
+/// <para>The in-process workflow runtime keeps such a value as a boxed CLR type
+/// (a boxed <see cref="bool"/> for a flag). A SERIALIZING dispatcher (distributed /
+/// MassTransit / ProtoActor) instead delivers the same value as a
+/// <see cref="string"/> or a <see cref="System.Text.Json.JsonElement"/> after a
+/// round-trip. A bare <c>value is true</c> pattern-match — or a
+/// <c>switch { bool b =&gt; b, string s =&gt; ..., _ =&gt; false }</c> that maps a
+/// <see cref="System.Text.Json.JsonElement"/> to the <c>_ =&gt; false</c> arm — only
+/// matches the boxed-bool / string paths; under serialization it silently evaluates
+/// <c>false</c> and the resume advances the WRONG branch while still returning HTTP
+/// 200 (a silent mis-branch).</para>
+///
+/// <para>This is the promoted, shared home of the tolerant read first introduced for
+/// the blocker resume callbacks (<see cref="Blocker.BlockerResumeInput"/>), reused
+/// across <c>Tamma.Activities</c> and <c>Tamma.ElsaServer</c>. It mirrors the
+/// merge/deploy house convention of reading resumed values via <c>.ToString()</c>
+/// then comparing.</para>
+/// </summary>
+public static class ResumeInput
+{
+    /// <summary>
+    /// Coerce a resumed value to <see cref="bool"/> tolerant of the in-process
+    /// boxed-<see cref="bool"/> path AND a serializing runtime that delivers the value
+    /// as a <see cref="string"/> (<c>"true"</c>/<c>"false"</c>) or a
+    /// <see cref="System.Text.Json.JsonElement"/>. <c>true</c> iff a real boxed
+    /// <see cref="bool"/> <c>true</c>, or the value's string form is <c>"true"</c>
+    /// (case-insensitive) — <see cref="System.Text.Json.JsonElement.ToString"/> yields
+    /// <c>"True"</c>/<c>"False"</c> for a JSON boolean, so a JsonElement flows through
+    /// the string comparison. A <c>null</c> / missing value is <c>false</c>
+    /// (fail-closed).
+    /// </summary>
+    public static bool AsBool(object? value)
+        => value is bool b
+            ? b
+            : string.Equals(value?.ToString(), "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs
@@ -130,7 +130,7 @@ public class WaitForCIResultsActivity : Activity
                 {
                     RunId = runId,
                     Status = input.GetValueOrDefault("Status")?.ToString() ?? "Unknown",
-                    BuildPassed = input.TryGetValue("BuildPassed", out var bp) && bp is true,
+                    BuildPassed = input.TryGetValue("BuildPassed", out var bp) && ResumeInput.AsBool(bp),
                     TotalTests = input.TryGetValue("TotalTests", out var tt) && tt is int totalTests ? totalTests : 0,
                     PassedTests = input.TryGetValue("PassedTests", out var pt) && pt is int passedTests ? passedTests : 0,
                     FailedTests = input.TryGetValue("FailedTests", out var ft) && ft is int failedTests ? failedTests : 0,

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
@@ -6,6 +6,7 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
 using System.Text.Json;
+using Tamma.Activities;
 using Tamma.Activities.Assessment;
 using Tamma.Activities.Assessment.Models;
 using Tamma.Api.Services.Agents;
@@ -691,16 +692,12 @@ public class AssessmentWorkflow : WorkflowBase
     /// Returns <c>false</c> if the dictionary is null, the key is absent, or the
     /// value is falsy — fail-closed by design.
     /// </summary>
-    private static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
     {
         if (result == null) return false;
         if (!result.TryGetValue("success", out var s)) return false;
-        return s switch
-        {
-            bool b    => b,
-            string str => bool.TryParse(str, out var r) && r,
-            _         => false,
-        };
+        // Tolerant read (#15 sibling) — boxed bool / string / JsonElement, fail-closed.
+        return ResumeInput.AsBool(s);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
@@ -138,6 +138,12 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         // "deferred"). CreateReleaseActivity sets these on its outcome.
         var releaseStatus = builder.WithVariable<string>("ReleaseStatus", "");
         var releaseUrl = builder.WithVariable<string>("ReleaseUrl", "");
+        // #21 audit fidelity — CreateRelease's ErrorCode is captured in its OWN
+        // variable, kept SEPARATE from the shared `stageError` that seeds a
+        // PIPELINE.SUCCESS `reason`. A release-step failure is surfaced via
+        // releaseStatus="failed" + the loud RELEASE.CREATED.FAILED event, never as the
+        // success event's reason (which stays reserved for genuine stage failures).
+        var releaseError = builder.WithVariable<string>("ReleaseError", "");
 
         var decisionVar = builder.WithVariable<string>("Decision", "");
         var feedbackVar = builder.WithVariable<string>("Feedback", "");
@@ -370,7 +376,11 @@ public class DeploymentPipelineWorkflow : WorkflowBase
             TenantId = new Input<string?>(ctx => tenantId.Get(ctx)),
             ReleaseUrl = new Output<string?>(releaseUrl),
             ReleaseTag = new Output<string?>(releaseTag),
-            ErrorCode = new Output<string?>(stageError),
+            // #21 — route the release-step error into its OWN variable, NOT the shared
+            // `stageError`. That keeps a PIPELINE.SUCCESS event's `reason` reserved for
+            // genuine STAGE failures; the release failure stays observable via
+            // releaseStatus="failed" + the loud RELEASE.CREATED.FAILED DCB event.
+            ErrorCode = new Output<string?>(releaseError),
         };
         createRelease.SetDisplayText("Create Release");
 
@@ -821,35 +831,69 @@ public class DeploymentPipelineWorkflow : WorkflowBase
                 // Rollback emits report the rollback's own status (started rows have
                 // no rollbackStatus yet → "started"); stage emits report stageResult.
                 var status = SelectEmitStatus(isRollback, stageResult.Get(ctx), rollbackStatus.Get(ctx));
-                var data = new Dictionary<string, object?>
-                {
-                    ["status"] = status,
-                    ["completedStages"] = completedStages.Get(ctx),
-                };
-                var err = stageError.Get(ctx);
-                if (!string.IsNullOrEmpty(err)) data["reason"] = err;
-                var rb = rollbackStatus.Get(ctx);
-                if (!string.IsNullOrEmpty(rb)) data["rollbackStatus"] = rb;
-                if (approver != null) data["approver"] = approver.Get(ctx);
-                if (feedback != null) data["feedback"] = feedback.Get(ctx);
-                if (releaseTag != null) data["releaseTag"] = releaseTag.Get(ctx);
-                if (releaseStatus != null)
-                {
-                    // Epic 38 follow-up #21 — the REAL release status (created|failed)
-                    // set by CreateReleaseActivity, replacing the prior "deferred".
-                    var rs = releaseStatus.Get(ctx);
-                    if (!string.IsNullOrEmpty(rs)) data["releaseStatus"] = rs;
-                }
-                if (releaseUrl != null)
-                {
-                    var ru = releaseUrl.Get(ctx);
-                    if (!string.IsNullOrEmpty(ru)) data["releaseUrl"] = ru;
-                }
+                // `reason` is sourced ONLY from the shared stage-error variable: a
+                // release-step failure is surfaced via releaseStatus="failed" (+ the
+                // loud RELEASE.CREATED.FAILED event), NOT here — so a PIPELINE.SUCCESS
+                // event's reason stays reserved for genuine stage failures (#21).
+                var data = BuildDeployEventData(
+                    status,
+                    completedStages.Get(ctx),
+                    reason: stageError.Get(ctx),
+                    rollbackStatus: rollbackStatus.Get(ctx),
+                    approver: approver != null ? approver.Get(ctx) : null,
+                    feedback: feedback != null ? feedback.Get(ctx) : null,
+                    releaseTag: releaseTag != null ? releaseTag.Get(ctx) : null,
+                    releaseStatus: releaseStatus != null ? releaseStatus.Get(ctx) : null,
+                    releaseUrl: releaseUrl != null ? releaseUrl.Get(ctx) : null);
                 return JsonSerializer.Serialize(data);
             }),
         };
         emit.SetDisplayText(label);
         return emit;
+    }
+
+    /// <summary>
+    /// Build the audit-data dictionary an <see cref="EmitDeploymentEventActivity"/>
+    /// node serialises into its <c>DataJson</c> payload. Pure (no Elsa context) —
+    /// exposed for unit testing.
+    ///
+    /// <para><b>#21 audit fidelity:</b> <paramref name="reason"/> is sourced ONLY from
+    /// the shared stage-error variable — a genuine STAGE/deploy failure. A release-step
+    /// failure is surfaced via <paramref name="releaseStatus"/><c>="failed"</c> (+ the
+    /// loud <c>RELEASE.CREATED.FAILED</c> event) and NEVER as <paramref name="reason"/>,
+    /// so a <c>PIPELINE.SUCCESS</c> event (<c>status:"success"</c>) can never carry a
+    /// misleading release-step error as its reason.</para>
+    ///
+    /// <para>Presence rules mirror the emit node exactly: <paramref name="reason"/> /
+    /// <paramref name="rollbackStatus"/> / <paramref name="releaseStatus"/> /
+    /// <paramref name="releaseUrl"/> are omitted when null-or-empty; the optional
+    /// <paramref name="approver"/> / <paramref name="feedback"/> / <paramref name="releaseTag"/>
+    /// are included whenever supplied (non-null), even if empty.</para>
+    /// </summary>
+    public static Dictionary<string, object?> BuildDeployEventData(
+        string status,
+        string completedStages,
+        string? reason,
+        string? rollbackStatus,
+        string? approver = null,
+        string? feedback = null,
+        string? releaseTag = null,
+        string? releaseStatus = null,
+        string? releaseUrl = null)
+    {
+        var data = new Dictionary<string, object?>
+        {
+            ["status"] = status,
+            ["completedStages"] = completedStages,
+        };
+        if (!string.IsNullOrEmpty(reason)) data["reason"] = reason;
+        if (!string.IsNullOrEmpty(rollbackStatus)) data["rollbackStatus"] = rollbackStatus;
+        if (approver != null) data["approver"] = approver;
+        if (feedback != null) data["feedback"] = feedback;
+        if (releaseTag != null) data["releaseTag"] = releaseTag;
+        if (!string.IsNullOrEmpty(releaseStatus)) data["releaseStatus"] = releaseStatus;
+        if (!string.IsNullOrEmpty(releaseUrl)) data["releaseUrl"] = releaseUrl;
+        return data;
     }
 
     private static FlowConnection Connect(IActivity source, IActivity target)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
@@ -7,6 +7,7 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities;
 using Tamma.Activities.ADL;
 using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
 using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
@@ -195,12 +196,8 @@ public class MergeApprovalWorkflow : WorkflowBase
             var result = subResult.Get(ctx);
             if (result != null && result.TryGetValue("success", out var s))
             {
-                return (object)(s switch
-                {
-                    bool b => b,
-                    string str => bool.TryParse(str, out var r) && r,
-                    _ => false,
-                });
+                // Tolerant read (#15 sibling) — boxed bool / string / JsonElement, fail-closed.
+                return (object)ResumeInput.AsBool(s);
             }
             // No readable success flag → treat as a failed merge (never a silent
             // success). The cycle's CRITICAL-1 switch routes escalated → reportError.

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
@@ -8,6 +8,7 @@ using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities;
 using Tamma.Activities.ADL;
 using Tamma.Activities.ADL.Models;
 using Tamma.Activities.CodeIndex;
@@ -258,12 +259,8 @@ public class ReviewFixWorkflow : WorkflowBase
                 var result = llmResultVar.Get(ctx);
                 if (result != null && result.TryGetValue("success", out var s))
                 {
-                    return (object)(s switch
-                    {
-                        bool b => b,
-                        string str => bool.TryParse(str, out var r) && r,
-                        _ => false,
-                    });
+                    // Tolerant read (#15 sibling) — boxed bool / string / JsonElement, fail-closed.
+                    return (object)ResumeInput.AsBool(s);
                 }
                 // No readable success flag → treat as a failed generation (never a
                 // silent success).

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWorkflow.cs
@@ -7,6 +7,7 @@ using Elsa.Workflows.Memory;
 using Elsa.Workflows.Models;
 using Elsa.Workflows.Management.Activities.SetOutput;
 using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities;
 using Tamma.Activities.CodeIndex;
 using Tamma.Activities.TDD;
 using Tamma.Activities.TDD.Models;
@@ -651,14 +652,11 @@ public class TddWorkflow : WorkflowBase
     // We tolerate missing keys / shape drift by falling back to safe defaults.
     // ================================================================
 
-    private static bool ExtractPassed(IDictionary<string, object>? result)
+    internal static bool ExtractPassed(IDictionary<string, object>? result)
     {
         if (result == null) return false;
-        if (result.TryGetValue("passed", out var p))
-        {
-            if (p is bool b) return b;
-            if (p is string s && bool.TryParse(s, out var parsed)) return parsed;
-        }
+        // Tolerant read (#15 sibling) — boxed bool / string / JsonElement, fail-closed.
+        if (result.TryGetValue("passed", out var p)) return ResumeInput.AsBool(p);
         return false;
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ResumeInputTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ResumeInputTests.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities;
+
+namespace Tamma.Activities.Tests;
+
+/// <summary>
+/// Hardening 2026-07-03 (follow-up to #15) — the promoted shared tolerant resume-bool
+/// reader <see cref="ResumeInput.AsBool"/>. Every remaining boxed-bool resume/dispatch
+/// read (WaitForCIResults, MergeApproval, Assessment, Tdd, ReviewFix, and the blocker
+/// callbacks) now delegates here, so a SERIALIZING runtime that round-trips the flag to
+/// a <see cref="string"/> or <see cref="JsonElement"/> no longer silently mis-branches
+/// to <c>false</c>. Boxed-<c>bool</c> and string behaviour is unchanged; JsonElement is
+/// newly tolerated.
+/// </summary>
+[TestFixture]
+public class ResumeInputTests
+{
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    [Test]
+    public void AsBool_BoxedBool_ReadsThrough()
+    {
+        ResumeInput.AsBool(true).Should().BeTrue();
+        ResumeInput.AsBool(false).Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_String_IsTolerant()
+    {
+        ResumeInput.AsBool("true").Should().BeTrue();
+        ResumeInput.AsBool("True").Should().BeTrue();
+        ResumeInput.AsBool("TRUE").Should().BeTrue();
+        ResumeInput.AsBool("false").Should().BeFalse();
+        ResumeInput.AsBool("nonsense").Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_JsonElement_IsTolerant()
+    {
+        // The exact case the switch-expression footgun dropped to `false`.
+        ResumeInput.AsBool(JsonBool(true)).Should().BeTrue();
+        ResumeInput.AsBool(JsonDocument.Parse("true").RootElement).Should().BeTrue();
+        ResumeInput.AsBool(JsonBool(false)).Should().BeFalse();
+    }
+
+    [Test]
+    public void AsBool_NullOrMissing_IsFalse()
+    {
+        ResumeInput.AsBool(null).Should().BeFalse();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DeploymentPipelineWorkflowTests.cs
@@ -1,6 +1,7 @@
 using Elsa.Workflows.Activities;
 using Elsa.Workflows.Activities.Flowchart.Activities;
 using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
 using Elsa.Workflows.Runtime.Activities;
 using FluentAssertions;
 using NUnit.Framework;
@@ -462,8 +463,67 @@ public class DeploymentPipelineWorkflowTests
     }
 
     // ================================================================
+    // Epic 38 follow-up #21 (audit fidelity) — a PIPELINE.SUCCESS event must not
+    // carry a release-step error as its `reason`.
+    // ================================================================
+
+    [Test]
+    public void ReleaseError_IsDecoupledFromStageError_SoPipelineSuccessReasonStaysClean()
+    {
+        // The release-step error (CreateRelease.ErrorCode) must be captured in its OWN
+        // variable, NOT the shared StageError that seeds a PIPELINE.SUCCESS `reason`.
+        // Routing it into StageError makes a successful pipeline emit a misleading
+        // release error as `reason` (status still "success").
+        var release = _flowchart.Activities
+            .OfType<CreateReleaseActivity>()
+            .Single(a => a.Id == "CreateRelease");
+
+        var boundVariable = ReadOutputVariableName(release.ErrorCode);
+        boundVariable.Should().Be("ReleaseError");
+        boundVariable.Should().NotBe("StageError",
+            "the release-step error must not pollute the shared StageError → PIPELINE.SUCCESS reason");
+    }
+
+    [Test]
+    public void PipelineSuccessAuditData_WithFailedRelease_CarriesFailedStatusButNoReason()
+    {
+        // A run where prod succeeded (the shared stage-error is empty) but CreateRelease
+        // returned Error: the emitted PIPELINE.SUCCESS payload is status=success +
+        // releaseStatus=failed, and its `reason` is ABSENT (reserved for stage failures).
+        var data = DeploymentPipelineWorkflow.BuildDeployEventData(
+            status: "success",
+            completedStages: "[\"qa\",\"uat\",\"production\"]",
+            reason: "",              // stageError is "" on the success path
+            rollbackStatus: "",
+            releaseStatus: "failed",
+            releaseUrl: "");
+
+        data["status"].Should().Be("success");
+        data["releaseStatus"].Should().Be("failed");
+        data.Should().NotContainKey("reason",
+            "a PIPELINE.SUCCESS event must not carry a release-step error as its reason");
+    }
+
+    [Test]
+    public void PipelineFailedAuditData_StillCarriesStageErrorAsReason()
+    {
+        // A genuine stage failure still populates `reason` on PIPELINE.FAILED, as before.
+        var data = DeploymentPipelineWorkflow.BuildDeployEventData(
+            status: "failed",
+            completedStages: "[\"qa\"]",
+            reason: "deploy reported status='failed'",
+            rollbackStatus: "");
+
+        data["status"].Should().Be("failed");
+        data["reason"].Should().Be("deploy reported status='failed'");
+    }
+
+    // ================================================================
     // Helpers (mirrors MergeApprovalWorkflowTests)
     // ================================================================
+
+    private static string? ReadOutputVariableName(Elsa.Workflows.Models.Output? output)
+        => (output?.MemoryBlockReference() as Variable)?.Name;
 
     private bool HasEdge(string sourceId, string? port, string targetId)
         => _flowchart.Connections.Any(c =>

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumeReadTolerantSiblingsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumeReadTolerantSiblingsTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Hardening 2026-07-03 (follow-up to #15) — per-site coverage that the dispatched-result
+/// boolean reads flagged by the adversarial review now tolerate a serialized
+/// <see cref="JsonElement"/> flag (the switch-expression <c>_ =&gt; false</c> arm used to
+/// drop it to <c>false</c>, silently mis-branching a merge/assessment/tdd/review success).
+///
+/// <para>These exercise the two reads that already expose a pure boundary —
+/// <see cref="AssessmentWorkflow.ReadSuccessFlag"/> and <see cref="TddWorkflow.ExtractPassed"/>.
+/// The JsonElement-true case fails before the read-back fix and passes after; boxed-bool
+/// and string behaviour is unchanged (the coercion is fail-closed on unknown shapes). The
+/// remaining inline sibling sites (MergeApproval / ReviewFix <c>ExtractGenerateSuccess</c>,
+/// WaitForCIResults <c>BuildPassed</c>) delegate to the same shared
+/// <see cref="Tamma.Activities.ResumeInput.AsBool"/> covered by ResumeInputTests.</para>
+/// </summary>
+[TestFixture]
+public class ResumeReadTolerantSiblingsTests
+{
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    private static Dictionary<string, object> Result(string key, object value)
+        => new() { [key] = value };
+
+    // ---------------------------------------------------------------------
+    // AssessmentWorkflow.ReadSuccessFlag — dispatched `success` flag
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void ReadSuccessFlag_BoxedBool_ReadsThrough()
+    {
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", true)).Should().BeTrue();
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", false)).Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadSuccessFlag_String_IsTolerant()
+    {
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", "true")).Should().BeTrue();
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", "false")).Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadSuccessFlag_JsonElement_IsTolerant()
+    {
+        // Fails before the read-back fix (the `_ => false` arm dropped the JsonElement).
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", JsonBool(true))).Should().BeTrue();
+        AssessmentWorkflow.ReadSuccessFlag(Result("success", JsonBool(false))).Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadSuccessFlag_MissingOrNull_IsFalse()
+    {
+        AssessmentWorkflow.ReadSuccessFlag(Result("other", true)).Should().BeFalse();
+        AssessmentWorkflow.ReadSuccessFlag(null).Should().BeFalse();
+    }
+
+    // ---------------------------------------------------------------------
+    // TddWorkflow.ExtractPassed — dispatched testing-pipeline `passed` flag
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void ExtractPassed_BoxedBool_ReadsThrough()
+    {
+        TddWorkflow.ExtractPassed(Result("passed", true)).Should().BeTrue();
+        TddWorkflow.ExtractPassed(Result("passed", false)).Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtractPassed_String_IsTolerant()
+    {
+        TddWorkflow.ExtractPassed(Result("passed", "true")).Should().BeTrue();
+        TddWorkflow.ExtractPassed(Result("passed", "false")).Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtractPassed_JsonElement_IsTolerant()
+    {
+        // Fails before the read-back fix (the boxed-bool/string `if`s dropped the JsonElement).
+        TddWorkflow.ExtractPassed(Result("passed", JsonBool(true))).Should().BeTrue();
+        TddWorkflow.ExtractPassed(Result("passed", JsonBool(false))).Should().BeFalse();
+    }
+
+    [Test]
+    public void ExtractPassed_MissingOrNull_IsFalse()
+    {
+        TddWorkflow.ExtractPassed(Result("other", true)).Should().BeFalse();
+        TddWorkflow.ExtractPassed(null).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## What

Two review-surfaced polish fixes from the follow-on wave (both non-migration).

**(a) Audit fidelity — `PIPELINE.SUCCESS.reason` no longer carries a release-step error.** `DeploymentPipelineWorkflow` wired `CreateRelease.ErrorCode` into the shared `stageError` var (which `emitPipelineSuccess` copies into `data["reason"]`), so a successful deploy whose release step failed could emit a `PIPELINE.SUCCESS` row carrying the release error as its `reason`. Added a dedicated `ReleaseError` variable; `reason` now sources solely from `stageError` (genuine stage failures). The release failure stays observable via `releaseStatus="failed"` + the `RELEASE.CREATED.FAILED` event (both unchanged). Success/terminal topology untouched.

**(b) Consolidated the boxed-bool resume-read footgun.** The #15 review found `is true` / switch-bool reads silently drop a serialized `JsonElement` flag to `false` (harmless under the in-process runtime, a silent mis-branch if it ever serializes). Promoted the tolerant reader to a shared `Tamma.Activities.ResumeInput.AsBool` (`BlockerResumeInput.AsBool` now delegates — no duplication) and applied it to the remaining sibling sites the reviewer named: `WaitForCIResultsActivity` + `Assessment`/`Tdd`/`MergeApproval`/`ReviewFix` workflows.

## Verification (TDD, RED→GREEN)

- (a): `ReleaseError_IsDecoupledFromStageError` (RED before), `PipelineSuccess_WithFailedRelease_CarriesFailedStatusButNoReason`, `PipelineFailed_StillCarriesStageErrorAsReason`.
- (b): `ResumeInputTests` + `ResumeReadTolerantSiblingsTests` — bool/`"true"`/`JsonElement(true)` → positive; false/`"false"`/`JsonElement(false)`/missing → negative (the JsonElement cases fail-before/pass-after).
- Build: 0 errors, 0 TAMMA001. Both `has-pending-model-changes` → "No changes". Api.Tests Deployment/Pipeline/Release 23; **Activities.Tests full suite 2232 passed, 0 failed**.

Note: `AsBool` matches `"true"` exactly (no whitespace-trim) to stay consistent with the #15 house reader — a padded `" true "` now reads `false` (strictly more fail-closed; not a realistic payload on these JSON/dictionary resume paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)