### PR TITLE
feat(epic-34-3/35-2): authoritative billing_mode owner (TenantProviderBilling) + reader reconciliation

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Analytics/ComputeTenantDimensionalRollupActivity.cs
@@ -150,6 +150,7 @@ public sealed class ComputeTenantDimensionalRollupActivity : TammaAsyncActivity
             {
                 d.ProviderKey, d.AgentType, d.ProjectId, d.CorrelationId,
                 d.InputTokens, d.OutputTokens, d.TokensUsed, d.Cost,
+                d.BillingMode,
             })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
@@ -232,8 +233,9 @@ public sealed class ComputeTenantDimensionalRollupActivity : TammaAsyncActivity
 
         // 2) ProviderDiagnostic rows — provider (ProviderKey), agent (AgentType),
         //    repo (ProjectId). Diagnostics carry no workflow-definition; NULL.
-        //    BillingMode column is a Story 35-2 forward dep (absent today) —
-        //    resolves to the Platform default until 35-2 lands.
+        //    BillingMode (Story 34-3 column, populated by the 35-2 tagger on the
+        //    LLM-call path) is now the real per-call posture — a byok diagnostic
+        //    buckets under CostBasis.Byok, no longer the always-Platform stopgap.
         foreach (var d in diagnostics)
         {
             if (string.IsNullOrWhiteSpace(d.ProviderKey)) continue;
@@ -243,7 +245,7 @@ public sealed class ComputeTenantDimensionalRollupActivity : TammaAsyncActivity
                 NullIfEmpty(d.AgentType),
                 WorkflowDefinitionId: null,
                 NullIfEmpty(d.ProjectId),
-                ResolveCostBasis(billingModeTag: null, diagnosticBillingMode: null));
+                ResolveCostBasis(billingModeTag: null, diagnosticBillingMode: d.BillingMode));
 
             var m = GetOrAdd(measures, key);
             // The dominant writer (LlmProxyService.RecordDiagnosticAsync) sets only

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingModeServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/BillingModeServiceCollectionExtensions.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Story 35-2 — mode-aware billing-mode-tagger DI. Registers
+/// <see cref="IBillingModeTagger"/> as the real <see cref="BillingModeTagger"/>
+/// in SaaS (reads the 34-3 owner + reconciles 32-3's credential source) and the
+/// no-op <see cref="NullBillingModeTagger"/> in single-user (no billing
+/// dimension) — the same Null-seam pattern Story 35-1 uses for
+/// <c>NullBillingProvider</c>, so request handlers never branch on mode.
+///
+/// <para>Mode is read once from <see cref="ITammaModeProvider"/> at composition
+/// time (process-stable). The owner reader
+/// (<see cref="ITenantProviderBillingResolver"/>) is registered by
+/// <c>AddUsagePricingEngine</c>; a <see cref="ServiceCollectionDescriptorExtensions.TryAddScoped{TService,TImplementation}"/>
+/// here keeps it available even if that extension has not run yet.</para>
+/// </summary>
+public static class BillingModeServiceCollectionExtensions
+{
+    public static IServiceCollection AddBillingModeTagging(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // The 34-3 owner reader (Reader A also uses it). Idempotent.
+        services.TryAddScoped<ITenantProviderBillingResolver, TenantProviderBillingResolver>();
+
+        var mode = ResolveMode(services, configuration);
+        if (mode == TammaMode.SaaS)
+        {
+            services.TryAddScoped<IBillingModeTagger, BillingModeTagger>();
+        }
+        else
+        {
+            services.TryAddScoped<IBillingModeTagger, NullBillingModeTagger>();
+        }
+
+        return services;
+    }
+
+    private static TammaMode ResolveMode(
+        IServiceCollection services, IConfiguration configuration)
+    {
+        var registered = services
+            .FirstOrDefault(d => d.ServiceType == typeof(ITammaModeProvider))?
+            .ImplementationInstance as ITammaModeProvider;
+        return registered?.Mode ?? TammaModeProvider.Resolve(configuration);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/PricingServiceCollectionExtensions.cs
@@ -35,10 +35,17 @@ public static class PricingServiceCollectionExtensions
     /// Story 34-5 — the cost->price markup engine + its policy/mode resolvers.
     /// The engine is a pure singleton (depends only on the singleton
     /// <c>IProviderPricingService</c>); the resolvers are scoped (they read the
-    /// scoped <c>ControlPlaneDbContext</c>). The
-    /// <see cref="ITenantProviderPricingModeResolver"/> default reads the
-    /// per-tenant <c>BillingCustomer.BillingMode</c> until Story 34-3 swaps a
-    /// per-<c>(tenant, provider)</c> implementation behind the same seam.
+    /// scoped <c>ControlPlaneDbContext</c>).
+    ///
+    /// <para><b>34-3 wired:</b> the <see cref="ITenantProviderPricingModeResolver"/>
+    /// now reads the AUTHORITATIVE per-<c>(tenant, provider)</c>
+    /// <c>TenantProviderBilling</c> owner via
+    /// <see cref="TenantProviderBillingPricingModeResolver"/> (backed by
+    /// <see cref="ITenantProviderBillingResolver"/>). This is the "one-line swap
+    /// behind the seam" the interim
+    /// <see cref="BillingCustomerPricingModeResolver"/> (per-TENANT
+    /// <c>BillingCustomer.BillingMode</c>) anticipated — the engine + estimate
+    /// endpoint are unchanged.</para>
     /// </summary>
     public static IServiceCollection AddUsagePricingEngine(this IServiceCollection services)
     {
@@ -48,7 +55,11 @@ public static class PricingServiceCollectionExtensions
 
         services.TryAddSingleton<IUsagePricingEngine, UsagePricingEngine>();
         services.TryAddScoped<IMarginPolicyResolver, MarginPolicyResolver>();
-        services.TryAddScoped<ITenantProviderPricingModeResolver, BillingCustomerPricingModeResolver>();
+
+        // Story 34-3 — the authoritative per-(tenant, provider) owner reader …
+        services.TryAddScoped<ITenantProviderBillingResolver, TenantProviderBillingResolver>();
+        // … and the pricing-mode seam repointed onto it (Reader A repoint).
+        services.TryAddScoped<ITenantProviderPricingModeResolver, TenantProviderBillingPricingModeResolver>();
 
         return services;
     }

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1073,9 +1073,15 @@ builder.Services.AddScoped<
 builder.Services.AddPlanCatalog();
 
 // Story 34-5 — the canonical cost->price markup engine (pure IUsagePricingEngine)
-// + the DB-backed IMarginPolicyResolver + the (interim) per-tenant pricing-mode
-// resolver. CP-resident; platform-owned margin policies in both modes.
+// + the DB-backed IMarginPolicyResolver + the pricing-mode resolver. Story 34-3
+// repointed the pricing-mode resolver onto the authoritative per-(tenant, provider)
+// TenantProviderBilling owner. CP-resident; platform-owned margin policies in both modes.
 builder.Services.AddUsagePricingEngine();
+
+// Story 35-2 — the billing-mode tagger: reads the 34-3 owner + reconciles 32-3's
+// runtime credential source, producing the canonical billing_mode tag stamped on
+// LLM.CALL.* usage events + ProviderDiagnostic.BillingMode. Null seam in single-user.
+builder.Services.AddBillingModeTagging(builder.Configuration);
 
 // Story 34-6 — entitlement & quota resolution: the single read seam turning a
 // tenant's pinned plan assignment into a closed ResolvedEntitlements map, plus
@@ -2850,6 +2856,7 @@ using (var scope = app.Services.CreateScope())
                     mentorship_events, mentorship_sessions,
                     password_reset_tokens,
                     tenant_plan_assignments,
+                    tenant_provider_billing,
                     plan_features, plan_entitlements, plan_prices, plans,
                     margin_policies,
                     provider_model_prices, providers,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeEvents.cs
@@ -1,0 +1,25 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-2 — DCB event-type constants for the billing-mode tag propagation
+/// (<c>AGGREGATE.ACTION.STATUS</c> convention). The usage events carry the
+/// <c>billing_mode</c> tag so Story 35-3's metering can split billable
+/// (platform) from non-billable (byok) token usage off the event stream with no
+/// join. <see cref="BillingModeMismatch"/> makes an owner-vs-runtime divergence
+/// auditable (34-3 mode ≠ 32-3 credential source; 32-3 wins for the tag).
+/// </summary>
+public static class BillingModeEvents
+{
+    /// <summary>A successful proxied LLM call. Tags: tenantId, billing_mode, provider, model.</summary>
+    public const string LlmCallSuccess = "LLM.CALL.SUCCESS";
+
+    /// <summary>A failed / over-budget / upstream-error LLM call. Same billing_mode tag.</summary>
+    public const string LlmCallFailed = "LLM.CALL.FAILED";
+
+    /// <summary>
+    /// The 34-3 declared mode disagreed with the 32-3 runtime credential source
+    /// on a call. Tags: tenantId, provider, mode34, source32. 32-3 wins for the
+    /// stamped tag (it is the credential actually used on the wire).
+    /// </summary>
+    public const string BillingModeMismatch = "BILLING.MODE.MISMATCH";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-2 — the SaaS billing-mode tagger. Reads Story 34-3's authoritative
+/// <c>TenantProviderBilling</c> mode (via
+/// <see cref="ITenantProviderBillingResolver"/>) and reconciles it against Story
+/// 32-3's resolved credential source. On disagreement the 32-3 source wins for
+/// the stamped tag (it is the credential actually used on the wire), a WARN is
+/// logged and a <c>BILLING.MODE.MISMATCH</c> DCB event is appended.
+///
+/// <para>Holds NO key plaintext and writes NO mode — it only computes the
+/// <c>byok</c>/<c>platform</c> token.</para>
+/// </summary>
+public sealed class BillingModeTagger : IBillingModeTagger
+{
+    private readonly ITenantProviderBillingResolver _owner;
+    private readonly IEventRepository _events;
+    private readonly ILogger<BillingModeTagger> _logger;
+
+    public BillingModeTagger(
+        ITenantProviderBillingResolver owner,
+        IEventRepository events,
+        ILogger<BillingModeTagger> logger)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ResolveTagAsync(
+        Guid? tenantId,
+        string providerKey,
+        string? credentialSource = null,
+        CancellationToken ct = default)
+    {
+        // 1) The DECLARED mode from the 34-3 owner (default: platform).
+        var declared = await _owner.ResolveModeAsync(tenantId, providerKey, ct).ConfigureAwait(false);
+        var token = declared.ToToken();
+
+        // 2) Reconcile with 32-3's RUNTIME credential source when present.
+        var source = Normalize(credentialSource);
+        if (source is not null)
+        {
+            if (!BillingModeTokens.IsValid(source))
+            {
+                // 32-3 handed us a token outside the closed domain — fail loud
+                // (never silently tag), AC11.
+                _logger.LogError(
+                    "billing_mode reconcile: 32-3 credentialSource '{Source}' is neither "
+                    + "'byok' nor 'platform' (tenant {TenantId} provider {Provider}).",
+                    source, tenantId, providerKey);
+                throw new TammaError(
+                    "BILLING_MODE_INVALID_SOURCE",
+                    $"Credential source '{source}' is not a valid billing mode.",
+                    new Dictionary<string, object?>
+                    {
+                        ["tenantId"] = tenantId,
+                        ["provider"] = providerKey,
+                        ["source"] = source,
+                    },
+                    retryable: false,
+                    severity: TammaErrorSeverity.High);
+            }
+
+            if (!string.Equals(source, token, StringComparison.Ordinal))
+            {
+                // 34-3 mode ≠ 32-3 source. 32-3 wins (it is the wire credential).
+                _logger.LogWarning(
+                    "billing_mode mismatch: declared(34-3)={Declared} source(32-3)={Source} "
+                    + "for tenant {TenantId} provider {Provider} — 32-3 source wins.",
+                    token, source, tenantId, providerKey);
+                await EmitMismatchAsync(tenantId, providerKey, token, source, ct).ConfigureAwait(false);
+                token = source;
+            }
+        }
+
+        // 3) Final validation — the stamped token MUST be exactly byok|platform.
+        if (!BillingModeTokens.IsValid(token))
+        {
+            _logger.LogError(
+                "billing_mode resolved to an out-of-domain token '{Token}' "
+                + "(tenant {TenantId} provider {Provider}).",
+                token, tenantId, providerKey);
+            throw new TammaError(
+                "BILLING_MODE_INVALID_TOKEN",
+                $"Resolved billing_mode '{token}' is not a valid token.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId,
+                    ["provider"] = providerKey,
+                    ["token"] = token,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        _logger.LogInformation(
+            "billing_mode resolved: tenantId={TenantId} provider={Provider} billingMode={BillingMode}",
+            tenantId, providerKey, token);
+        return token;
+    }
+
+    private async Task EmitMismatchAsync(
+        Guid? tenantId, string provider, string mode34, string source32, CancellationToken ct)
+    {
+        try
+        {
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = BillingModeEvents.BillingModeMismatch,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(new
+                {
+                    tenantId = tenantId?.ToString(),
+                    provider,
+                    mode34,
+                    source32,
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = JsonSerializer.Serialize(new { observedAt = DateTime.UtcNow }),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The mismatch audit event is best-effort — never fail the call over
+            // an audit-append error, but log it loudly.
+            _logger.LogError(
+                ex, "Failed to append BILLING.MODE.MISMATCH for tenant {TenantId} provider {Provider}.",
+                tenantId, provider);
+        }
+    }
+
+    private static string? Normalize(string? credentialSource)
+    {
+        if (string.IsNullOrWhiteSpace(credentialSource))
+        {
+            return null;
+        }
+        return credentialSource.Trim().ToLowerInvariant();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
@@ -42,6 +42,11 @@ public sealed class BillingModeTagger : IBillingModeTagger
         string? credentialSource = null,
         CancellationToken ct = default)
     {
+        // Fix 2 — canonicalize the provider to the family key the owner row is stored
+        // under BEFORE resolution + logging, so the owner lookup and every reader agree
+        // on one key (the vendor handle "anthropic-claude" resolves the "anthropic" row).
+        providerKey = BillingProviderKey.Canonicalize(providerKey);
+
         // 1) The DECLARED mode from the 34-3 owner (default: platform).
         var declared = await _owner.ResolveModeAsync(tenantId, providerKey, ct).ConfigureAwait(false);
         var token = declared.ToToken();

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTokens.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTokens.cs
@@ -1,0 +1,20 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-2 — the canonical <c>billing_mode</c> wire tokens. These are the
+/// EXACT tokens <see cref="MetricBillingModeExtensions.ToToken"/> emits, Story
+/// 32-3's <c>CredentialSource.ToTag()</c> emits, and the analytics
+/// <c>ResolveCostBasis</c> reader keys off — so a value stamped on a usage
+/// event / diagnostic resolves identically on every reader (AC11).
+/// </summary>
+public static class BillingModeTokens
+{
+    public const string Byok = MetricBillingModeExtensions.ByokToken;         // "byok"
+    public const string Platform = MetricBillingModeExtensions.PlatformToken; // "platform"
+
+    /// <summary>True iff <paramref name="token"/> is exactly <c>byok</c> or <c>platform</c>.</summary>
+    public static bool IsValid(string? token) =>
+        token is Byok or Platform;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingProviderKey.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingProviderKey.cs
@@ -1,0 +1,49 @@
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Fix 2 — the SINGLE canonical provider-key normalization for billing-mode
+/// resolution. The LLM proxy resolves under the vendor handle
+/// <c>"anthropic-claude"</c>, but the authoritative owner row
+/// (<c>TenantProviderBilling</c>) is keyed by the provider FAMILY
+/// (<c>"anthropic"</c>). Without a shared canonical form the two never match, so
+/// a declared BYOK row is silently ignored and the tenant is billed platform
+/// markup on their own key.
+///
+/// <para>Canonical form = the provider family via the shared
+/// <see cref="ProviderRateLookup.Aliases"/> map (<c>anthropic-claude</c>/<c>claude</c>
+/// → <c>anthropic</c>, <c>gemini</c> → <c>google</c>, ...) THEN force-lowercased.
+/// Reusing <see cref="ProviderRateLookup"/> keeps ONE alias source (no drift with
+/// the pricing lookup); the extra lowercase makes the key deterministic regardless
+/// of caller casing — closing the case-sensitive-index vs case-insensitive-read gap.</para>
+///
+/// <para>Applied on BOTH sides of the lookup:
+/// <list type="bullet">
+///   <item><b>Read path</b> — <c>TenantProviderBillingResolver</c> and
+///     <c>BillingModeTagger</c> canonicalize the incoming provider before matching
+///     the owner row.</item>
+///   <item><b>Write path (future, documented)</b> — a BYOK write endpoint MUST
+///     canonicalize with this helper before persisting
+///     <c>TenantProviderBilling.ProviderKey</c>, so the stored key is always the
+///     lowercase canonical family and the read match is exact.</item>
+/// </list></para>
+/// </summary>
+public static class BillingProviderKey
+{
+    /// <summary>
+    /// Normalize a (possibly vendor-handle / mixed-case) provider key to its
+    /// canonical lowercase family key. Empty/whitespace → <see cref="string.Empty"/>.
+    /// Unknown keys pass through the alias map untouched, then are lowercased.
+    /// </summary>
+    public static string Canonicalize(string? provider)
+    {
+        var trimmed = (provider ?? string.Empty).Trim();
+        if (trimmed.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        return ProviderRateLookup.Canonicalize(trimmed).ToLowerInvariant();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingModeTagger.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/IBillingModeTagger.cs
@@ -1,0 +1,41 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-2 — computes the canonical <c>billing_mode</c> token
+/// (<c>"byok"</c> | <c>"platform"</c>) for an LLM call by READING Story 34-3's
+/// authoritative mode owner (<c>TenantProviderBilling</c> via
+/// <see cref="Pricing.ITenantProviderBillingResolver"/>) and RECONCILING it with
+/// Story 32-3's resolved credential source when that is supplied.
+///
+/// <para>This seam OWNS no mode — it never writes <c>TenantProviderBilling</c>
+/// and never reads or returns a key plaintext. It is a pure producer of the tag
+/// that the usage DCB event + the <c>ProviderDiagnostic.BillingMode</c> column
+/// carry, so Story 35-3 can meter ONLY platform-provided usage.</para>
+/// </summary>
+public interface IBillingModeTagger
+{
+    /// <summary>
+    /// Resolve the <c>billing_mode</c> token for a call.
+    ///
+    /// <list type="number">
+    ///   <item><description>Read the 34-3 DECLARED mode for
+    ///     <c>(tenantId, providerKey)</c>.</description></item>
+    ///   <item><description>If <paramref name="credentialSource"/> (Story 32-3's
+    ///     <c>ProviderCredential.Source</c>, <c>"byok"</c>/<c>"platform"</c>) is
+    ///     supplied and DISAGREES: log WARN, prefer the 32-3 source (it is the
+    ///     credential actually used on the wire), and emit ONE
+    ///     <c>BILLING.MODE.MISMATCH</c> DCB event.</description></item>
+    ///   <item><description>Validate the resulting token is exactly
+    ///     <c>byok</c> or <c>platform</c> — anything else is a logged ERROR, not
+    ///     a silent tag (AC11).</description></item>
+    /// </list>
+    ///
+    /// Single-user mode resolves to <c>platform</c> semantics with no billable
+    /// implication (the <c>NullBillingModeTagger</c> seam).
+    /// </summary>
+    Task<string> ResolveTagAsync(
+        Guid? tenantId,
+        string providerKey,
+        string? credentialSource = null,
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingModeTagger.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/NullBillingModeTagger.cs
@@ -1,0 +1,20 @@
+namespace Tamma.Api.Services.Billing;
+
+/// <summary>
+/// Story 35-2 — the single-user no-op tagger. In single-user mode there is no
+/// billing dimension (the sole user owns all usage), so the tagger always yields
+/// <c>platform</c> semantics with no billable-mode implication and never emits a
+/// mismatch event. Registered by <c>AddBillingModeTagging</c> in single-user
+/// mode (the same Null-seam pattern Story 35-1 uses for <c>NullBillingProvider</c>)
+/// so request handlers never branch on mode.
+/// </summary>
+public sealed class NullBillingModeTagger : IBillingModeTagger
+{
+    /// <inheritdoc />
+    public Task<string> ResolveTagAsync(
+        Guid? tenantId,
+        string providerKey,
+        string? credentialSource = null,
+        CancellationToken ct = default)
+        => Task.FromResult(BillingModeTokens.Platform);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingResolver.cs
@@ -1,0 +1,36 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — the canonical read seam over the AUTHORITATIVE billing-mode
+/// owner (<c>TenantProviderBilling</c>). Returns the DECLARED per-<c>(tenant,
+/// provider)</c> billing posture as the shared <see cref="MetricBillingMode"/>
+/// token. Every reader that needs "what mode did the tenant choose for this
+/// provider?" resolves through here so the four legacy enums never drift again:
+///
+/// <list type="bullet">
+///   <item><description>Reader A — the pricing-mode resolver
+///     (<see cref="ITenantProviderPricingModeResolver"/>) maps this to
+///     <see cref="PricingMode"/> for the cost→price engine.</description></item>
+///   <item><description>The 35-2 billing-mode tagger reads this DECLARED mode and
+///     reconciles it against Story 32-3's RUNTIME credential source.</description></item>
+/// </list>
+///
+/// <para><b>Default is absence.</b> A null tenant (single-user) or a
+/// <c>(tenant, provider)</c> with no <c>active</c> owner row resolves to
+/// <see cref="MetricBillingMode.PlatformProvided"/> — the current reality. This
+/// is the LEGITIMATE default (35-2 AC8), NOT a fail-loud case. Resolution fails
+/// loud ONLY when an <c>active</c> row exists but carries an unparseable mode
+/// (which the DB CHECK constraint already prevents) — never a silent mistag.</para>
+/// </summary>
+public interface ITenantProviderBillingResolver
+{
+    /// <summary>
+    /// The declared <see cref="MetricBillingMode"/> for
+    /// <paramref name="tenantId"/> on <paramref name="provider"/>. Null tenant or
+    /// no active row ⇒ <see cref="MetricBillingMode.PlatformProvided"/>.
+    /// </summary>
+    Task<MetricBillingMode> ResolveModeAsync(
+        Guid? tenantId, string provider, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingPricingModeResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingPricingModeResolver.cs
@@ -1,0 +1,37 @@
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — the per-<c>(tenant, provider)</c> implementation of
+/// <see cref="ITenantProviderPricingModeResolver"/> that Story 34-5 anticipated.
+/// It is the "one-line swap behind the seam": it reads the AUTHORITATIVE
+/// <c>TenantProviderBilling</c> owner (via
+/// <see cref="ITenantProviderBillingResolver"/>) instead of the interim
+/// per-TENANT <c>BillingCustomer.BillingMode</c> column, then maps the shared
+/// <see cref="MetricBillingMode"/> token to the engine's <see cref="PricingMode"/>
+/// vocabulary member-for-member.
+///
+/// <para>The pricing engine + the estimate endpoint keep consuming
+/// <see cref="ITenantProviderPricingModeResolver"/> unchanged — only the wiring
+/// behind the seam moved from per-tenant to per-<c>(tenant, provider)</c>.</para>
+/// </summary>
+public sealed class TenantProviderBillingPricingModeResolver : ITenantProviderPricingModeResolver
+{
+    private readonly ITenantProviderBillingResolver _owner;
+
+    public TenantProviderBillingPricingModeResolver(ITenantProviderBillingResolver owner)
+    {
+        _owner = owner ?? throw new ArgumentNullException(nameof(owner));
+    }
+
+    /// <inheritdoc />
+    public async Task<PricingMode> ResolveModeAsync(
+        Guid? tenantId, string provider, CancellationToken ct = default)
+    {
+        var mode = await _owner.ResolveModeAsync(tenantId, provider, ct).ConfigureAwait(false);
+        return mode == MetricBillingMode.Byok
+            ? PricingMode.Byok
+            : PricingMode.PlatformProvided;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
@@ -1,0 +1,91 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — reads the AUTHORITATIVE per-<c>(tenant, provider)</c> billing
+/// mode from the <c>TenantProviderBilling</c> owner table. This replaces the
+/// interim per-TENANT <c>BillingCustomer.BillingMode</c> read
+/// (<see cref="BillingCustomerPricingModeResolver"/>) with the true per-provider
+/// source of truth — the "one-line swap behind the seam" the interim resolver's
+/// doc anticipated.
+///
+/// <para><b>Resolution:</b> a null tenant (single-user) ⇒
+/// <see cref="MetricBillingMode.PlatformProvided"/>. Otherwise the single
+/// <c>active</c> row for <c>(tenant, provider)</c> decides; no row ⇒
+/// <see cref="MetricBillingMode.PlatformProvided"/> (BYOK is opt-in and only ever
+/// an explicit row). An <c>active</c> row whose <c>Mode</c> is neither
+/// <c>"platform"</c> nor <c>"byok"</c> is a corrupt owner record — the DB CHECK
+/// prevents it, but if one is ever read the resolver FAILS LOUD rather than
+/// silently defaulting to platform (never a silent mistag).</para>
+/// </summary>
+public sealed class TenantProviderBillingResolver : ITenantProviderBillingResolver
+{
+    private readonly ControlPlaneDbContext _db;
+    private readonly ILogger<TenantProviderBillingResolver> _logger;
+
+    public TenantProviderBillingResolver(
+        ControlPlaneDbContext db,
+        ILogger<TenantProviderBillingResolver> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<MetricBillingMode> ResolveModeAsync(
+        Guid? tenantId, string provider, CancellationToken ct = default)
+    {
+        // Single-user / null tenant — always platform-provided (35-2 AC8).
+        if (tenantId is not Guid tid)
+        {
+            return MetricBillingMode.PlatformProvided;
+        }
+
+        var normalized = (provider ?? string.Empty).Trim().ToLowerInvariant();
+
+        var mode = await _db.TenantProviderBillings
+            .AsNoTracking()
+            .Where(r => r.TenantId == tid
+                        && r.Status == "active"
+                        && r.ProviderKey.ToLower() == normalized)
+            .Select(r => r.Mode)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        // No active owner row → the safe default. Existing all-platform tenants
+        // are unaffected (the status quo is preserved, never flipped to an error).
+        if (mode is null)
+        {
+            return MetricBillingMode.PlatformProvided;
+        }
+
+        // A row exists — honour its DECLARED intent. A value outside the closed
+        // domain is a corrupt record (CHECK-prevented); fail loud, never mistag.
+        if (!MetricBillingModeExtensions.TryParseToken(mode, out var parsed))
+        {
+            _logger.LogError(
+                "TenantProviderBilling row for tenant {TenantId} provider {Provider} "
+                + "has an unparseable Mode '{Mode}' — refusing to silently default.",
+                tid, normalized, mode);
+            throw new TammaError(
+                "BILLING_MODE_CORRUPT",
+                $"TenantProviderBilling.Mode '{mode}' is not a valid billing mode "
+                + $"for tenant '{tid}' provider '{normalized}'.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tid,
+                    ["provider"] = normalized,
+                    ["mode"] = mode,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        return parsed;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Billing;
 using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data;
@@ -46,7 +47,12 @@ public sealed class TenantProviderBillingResolver : ITenantProviderBillingResolv
             return MetricBillingMode.PlatformProvided;
         }
 
-        var normalized = (provider ?? string.Empty).Trim().ToLowerInvariant();
+        // Fix 2 — canonicalize the (possibly vendor-handle / mixed-case) provider to
+        // the lowercase family key the owner row is stored under, so a call keyed
+        // "anthropic-claude" matches an owner row keyed "anthropic". r.ProviderKey is
+        // ALSO lowercased for the compare so a legacy mixed-case stored key still
+        // matches; the write path is documented to persist the canonical key.
+        var normalized = BillingProviderKey.Canonicalize(provider);
 
         var mode = await _db.TenantProviderBillings
             .AsNoTracking()

--- a/apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs
@@ -67,6 +67,15 @@ public sealed class LlmProxyService : ILlmProxyService
         // credential resolver, so the tag is derived from 34-3's mode alone
         // (AC5) — no competing key path introduced here.
         var model = string.IsNullOrWhiteSpace(request.Model) ? DefaultModel : request.Model!;
+
+        // Fix 1 — ONE per-call correlation id shared by BOTH sinks this call writes:
+        // the ProviderDiagnostic row AND the LLM.CALL.SUCCESS usage event. The
+        // dimensional rollup (ComputeTenantDimensionalRollupActivity) folds both into
+        // the same bucket; its dedup skips the event only when a diagnostic shares its
+        // correlationId, so the diagnostic stays authoritative and the call is counted
+        // ONCE (without this shared id the rollup double-counts cost/tokens/billed 2x).
+        var callId = Guid.NewGuid();
+
         var billingMode = await _billingModeTagger
             .ResolveTagAsync(tenantId, ProviderKey, credentialSource: null, ct);
 
@@ -80,7 +89,7 @@ public sealed class LlmProxyService : ILlmProxyService
                     "LLM chat rejected: tenant {TenantId} over budget (spent={Spent}, limit={Limit})",
                     t, budget.Spent, budget.Limit);
                 await EmitUsageEventAsync(
-                    tenantId, model, billingMode, success: false, reason: "budget_exceeded",
+                    tenantId, model, billingMode, callId, success: false, reason: "budget_exceeded",
                     tokensUsed: 0, cost: 0m, durationMs: 0, ct);
                 return Error("budget_exceeded", "tenant budget exceeded");
             }
@@ -104,11 +113,11 @@ public sealed class LlmProxyService : ILlmProxyService
                     (int)response.StatusCode, Truncate(errorBody, 500));
 
                 await RecordDiagnosticAsync(
-                    tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
+                    tenantId, model, billingMode, callId, sw.Elapsed.TotalMilliseconds,
                     tokensUsed: 0, cost: 0m, success: false,
                     errorMessage: $"http_{(int)response.StatusCode}", ct);
                 await EmitUsageEventAsync(
-                    tenantId, model, billingMode, success: false,
+                    tenantId, model, billingMode, callId, success: false,
                     reason: $"http_{(int)response.StatusCode}",
                     tokensUsed: 0, cost: 0m, durationMs: sw.Elapsed.TotalMilliseconds, ct);
 
@@ -120,11 +129,11 @@ public sealed class LlmProxyService : ILlmProxyService
             var cost = EstimateCost(model, parsed.PromptTokens, parsed.CompletionTokens);
 
             await RecordDiagnosticAsync(
-                tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
+                tenantId, model, billingMode, callId, sw.Elapsed.TotalMilliseconds,
                 tokensUsed: parsed.TotalTokens, cost: cost, success: true,
                 errorMessage: null, ct);
             await EmitUsageEventAsync(
-                tenantId, model, billingMode, success: true, reason: null,
+                tenantId, model, billingMode, callId, success: true, reason: null,
                 tokensUsed: parsed.TotalTokens, cost: cost,
                 durationMs: sw.Elapsed.TotalMilliseconds, ct,
                 inputTokens: parsed.PromptTokens, outputTokens: parsed.CompletionTokens);
@@ -145,11 +154,11 @@ public sealed class LlmProxyService : ILlmProxyService
             _logger.LogError(ex, "LLM proxy upstream call failed");
 
             await RecordDiagnosticAsync(
-                tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
+                tenantId, model, billingMode, callId, sw.Elapsed.TotalMilliseconds,
                 tokensUsed: 0, cost: 0m, success: false,
                 errorMessage: ex.GetType().Name, ct);
             await EmitUsageEventAsync(
-                tenantId, model, billingMode, success: false, reason: ex.GetType().Name,
+                tenantId, model, billingMode, callId, success: false, reason: ex.GetType().Name,
                 tokensUsed: 0, cost: 0m, durationMs: sw.Elapsed.TotalMilliseconds, ct);
 
             return Error("upstream_error", "upstream request failed");
@@ -244,6 +253,7 @@ public sealed class LlmProxyService : ILlmProxyService
         Guid? tenantId,
         string model,
         string billingMode,
+        Guid callId,
         double durationMs,
         int tokensUsed,
         decimal cost,
@@ -260,6 +270,9 @@ public sealed class LlmProxyService : ILlmProxyService
             // Story 34-3 / 35-2 — stamp the per-call billing posture the tagger
             // resolved so the markup engine + analytics never re-bill a BYOK call.
             BillingMode = billingMode,
+            // Fix 1 — the per-call correlation id shared with the LLM.CALL.SUCCESS
+            // usage event, so the dimensional rollup dedup counts this call ONCE.
+            CorrelationId = callId,
             TenantId = tenantId,
             Model = model,
             RequestType = "chat",
@@ -283,6 +296,7 @@ public sealed class LlmProxyService : ILlmProxyService
         Guid? tenantId,
         string model,
         string billingMode,
+        Guid callId,
         bool success,
         string? reason,
         int tokensUsed,
@@ -311,6 +325,11 @@ public sealed class LlmProxyService : ILlmProxyService
                     provider = ProviderKey,
                     model,
                     reason,
+                    // Fix 1 — the shared per-call id the paired ProviderDiagnostic also
+                    // carries. The dimensional rollup folds the diagnostic (authoritative
+                    // for cost/tokens) and SKIPS this event when their correlationId
+                    // matches, so a proxied call is counted ONCE (not 2x).
+                    correlationId = callId.ToString(),
                 }),
                 Metadata = JsonSerializer.Serialize(new
                 {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/SaaS/LlmProxyService.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Diagnostics;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Services.SaaS;
 
@@ -33,15 +35,21 @@ public sealed class LlmProxyService : ILlmProxyService
 
     private readonly IHttpClientFactory _httpFactory;
     private readonly IDiagnosticsService _diagnostics;
+    private readonly IBillingModeTagger _billingModeTagger;
+    private readonly IEventRepository _events;
     private readonly ILogger<LlmProxyService> _logger;
 
     public LlmProxyService(
         IHttpClientFactory httpFactory,
         IDiagnosticsService diagnostics,
+        IBillingModeTagger billingModeTagger,
+        IEventRepository events,
         ILogger<LlmProxyService> logger)
     {
         _httpFactory = httpFactory;
         _diagnostics = diagnostics;
+        _billingModeTagger = billingModeTagger;
+        _events = events;
         _logger = logger;
     }
 
@@ -54,6 +62,14 @@ public sealed class LlmProxyService : ILlmProxyService
             return Error("invalid_request", "messages[] must contain at least one entry");
         }
 
+        // Story 35-2 — resolve the canonical billing_mode token ONCE for this call
+        // (owner-declared mode via the tagger). This proxy does not consume 32-3's
+        // credential resolver, so the tag is derived from 34-3's mode alone
+        // (AC5) — no competing key path introduced here.
+        var model = string.IsNullOrWhiteSpace(request.Model) ? DefaultModel : request.Model!;
+        var billingMode = await _billingModeTagger
+            .ResolveTagAsync(tenantId, ProviderKey, credentialSource: null, ct);
+
         // Per-tenant budget enforcement. Anonymous/service calls skip the check.
         if (tenantId is Guid t)
         {
@@ -63,11 +79,13 @@ public sealed class LlmProxyService : ILlmProxyService
                 _logger.LogWarning(
                     "LLM chat rejected: tenant {TenantId} over budget (spent={Spent}, limit={Limit})",
                     t, budget.Spent, budget.Limit);
+                await EmitUsageEventAsync(
+                    tenantId, model, billingMode, success: false, reason: "budget_exceeded",
+                    tokensUsed: 0, cost: 0m, durationMs: 0, ct);
                 return Error("budget_exceeded", "tenant budget exceeded");
             }
         }
 
-        var model = string.IsNullOrWhiteSpace(request.Model) ? DefaultModel : request.Model!;
         var client = _httpFactory.CreateClient(HttpClientName);
         var payload = BuildAnthropicPayload(model, request);
 
@@ -86,9 +104,13 @@ public sealed class LlmProxyService : ILlmProxyService
                     (int)response.StatusCode, Truncate(errorBody, 500));
 
                 await RecordDiagnosticAsync(
-                    tenantId, model, sw.Elapsed.TotalMilliseconds,
+                    tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
                     tokensUsed: 0, cost: 0m, success: false,
                     errorMessage: $"http_{(int)response.StatusCode}", ct);
+                await EmitUsageEventAsync(
+                    tenantId, model, billingMode, success: false,
+                    reason: $"http_{(int)response.StatusCode}",
+                    tokensUsed: 0, cost: 0m, durationMs: sw.Elapsed.TotalMilliseconds, ct);
 
                 return Error("upstream_error", $"upstream returned HTTP {(int)response.StatusCode}");
             }
@@ -98,9 +120,14 @@ public sealed class LlmProxyService : ILlmProxyService
             var cost = EstimateCost(model, parsed.PromptTokens, parsed.CompletionTokens);
 
             await RecordDiagnosticAsync(
-                tenantId, model, sw.Elapsed.TotalMilliseconds,
+                tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
                 tokensUsed: parsed.TotalTokens, cost: cost, success: true,
                 errorMessage: null, ct);
+            await EmitUsageEventAsync(
+                tenantId, model, billingMode, success: true, reason: null,
+                tokensUsed: parsed.TotalTokens, cost: cost,
+                durationMs: sw.Elapsed.TotalMilliseconds, ct,
+                inputTokens: parsed.PromptTokens, outputTokens: parsed.CompletionTokens);
 
             return new ChatResponse(
                 Success: true,
@@ -118,9 +145,12 @@ public sealed class LlmProxyService : ILlmProxyService
             _logger.LogError(ex, "LLM proxy upstream call failed");
 
             await RecordDiagnosticAsync(
-                tenantId, model, sw.Elapsed.TotalMilliseconds,
+                tenantId, model, billingMode, sw.Elapsed.TotalMilliseconds,
                 tokensUsed: 0, cost: 0m, success: false,
                 errorMessage: ex.GetType().Name, ct);
+            await EmitUsageEventAsync(
+                tenantId, model, billingMode, success: false, reason: ex.GetType().Name,
+                tokensUsed: 0, cost: 0m, durationMs: sw.Elapsed.TotalMilliseconds, ct);
 
             return Error("upstream_error", "upstream request failed");
         }
@@ -213,6 +243,7 @@ public sealed class LlmProxyService : ILlmProxyService
     private Task RecordDiagnosticAsync(
         Guid? tenantId,
         string model,
+        string billingMode,
         double durationMs,
         int tokensUsed,
         decimal cost,
@@ -226,6 +257,9 @@ public sealed class LlmProxyService : ILlmProxyService
             RequestDurationMs = durationMs,
             TokensUsed = tokensUsed,
             Cost = cost,
+            // Story 34-3 / 35-2 — stamp the per-call billing posture the tagger
+            // resolved so the markup engine + analytics never re-bill a BYOK call.
+            BillingMode = billingMode,
             TenantId = tenantId,
             Model = model,
             RequestType = "chat",
@@ -234,6 +268,72 @@ public sealed class LlmProxyService : ILlmProxyService
             CreatedAt = DateTime.UtcNow
         };
         return _diagnostics.RecordEventAsync(diag, ct);
+    }
+
+    /// <summary>
+    /// Story 35-2 — append the usage DCB event (<c>LLM.CALL.SUCCESS</c> /
+    /// <c>LLM.CALL.FAILED</c>) tagged with <c>billing_mode</c> so Story 35-3's
+    /// metering can split billable (platform) from non-billable (byok) usage off
+    /// the event stream. Only emitted for a tenant-scoped call — single-user /
+    /// anonymous calls (<c>tenantId == null</c>) carry no billing dimension
+    /// (AC8) and the tenant-scoped event store has no null-tenant target.
+    /// Best-effort: an audit-append failure never fails the LLM call.
+    /// </summary>
+    private async Task EmitUsageEventAsync(
+        Guid? tenantId,
+        string model,
+        string billingMode,
+        bool success,
+        string? reason,
+        int tokensUsed,
+        decimal cost,
+        double durationMs,
+        CancellationToken ct,
+        int inputTokens = 0,
+        int outputTokens = 0)
+    {
+        if (tenantId is not Guid tid)
+        {
+            return; // single-user / anonymous — no billable-mode implication.
+        }
+
+        try
+        {
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = success ? BillingModeEvents.LlmCallSuccess : BillingModeEvents.LlmCallFailed,
+                TenantId = tid,
+                Tags = JsonSerializer.Serialize(new
+                {
+                    tenantId = tid.ToString(),
+                    billing_mode = billingMode,
+                    provider = ProviderKey,
+                    model,
+                    reason,
+                }),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = JsonSerializer.Serialize(new
+                {
+                    inputTokens,
+                    outputTokens,
+                    totalTokens = tokensUsed,
+                    costUsd = cost,
+                    durationMs,
+                }),
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex, "Failed to append {EventType} usage event for tenant {TenantId}.",
+                success ? BillingModeEvents.LlmCallSuccess : BillingModeEvents.LlmCallFailed, tid);
+        }
     }
 
     private static async Task<string> SafeReadString(HttpResponseMessage response)

--- a/apps/tamma-elsa/src/Tamma.Core/Enums/MetricBillingMode.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Enums/MetricBillingMode.cs
@@ -1,0 +1,84 @@
+namespace Tamma.Core.Enums;
+
+/// <summary>
+/// Story 34-3 / 35-2 — the single canonical BYOK-vs-platform BILLING POSTURE
+/// token, shared by the authoritative owner (<c>TenantProviderBilling</c>),
+/// the pricing engine (34-5, via <see cref="PricingMode"/>), the per-call cost
+/// record (<c>ProviderDiagnostic.BillingMode</c>), the usage DCB tag
+/// (<c>billing_mode</c>) and analytics (36-1, via <see cref="CostBasis"/>).
+///
+/// <para>Before this story the posture was fragmented across four divergent
+/// enums (<see cref="Tamma.Core.Billing.BillingMode"/>,
+/// <see cref="PricingMode"/>, <see cref="CostBasis"/> and
+/// <c>CredentialSource</c>) with three readers that never agreed.
+/// <see cref="MetricBillingMode"/> is the shared vocabulary those readers
+/// reconcile to — it mirrors the <c>EntitlementMetricKey</c> single-source rule
+/// (Story 34-1) so the posture never drifts between layers.</para>
+///
+/// <para><b>Wire token.</b> The persisted / tagged form is the lowercase
+/// <see cref="MetricBillingModeExtensions.ToToken"/> value (<c>"platform"</c> /
+/// <c>"byok"</c>) — the SAME token <c>CredentialSource.ToTag()</c> (Story 32-3)
+/// emits and the analytics <c>ResolveCostBasis</c> reader keys off, so a value
+/// written here resolves identically on every reader.</para>
+/// </summary>
+public enum MetricBillingMode
+{
+    /// <summary>
+    /// Platform-provided — Tamma supplies the provider credential and bills the
+    /// tenant for metered token usage with the platform markup applied. The
+    /// SAFE DEFAULT: a null tenant (single-user) or a tenant with no explicit
+    /// owner row resolves here (ordinal 0), so the status quo is preserved.
+    /// </summary>
+    PlatformProvided = 0,
+
+    /// <summary>
+    /// Bring-your-own-key — the tenant supplies their own provider credential.
+    /// Only ever the result of an explicit owner row; the token component of the
+    /// sell price is 0 (no platform markup).
+    /// </summary>
+    Byok = 1,
+}
+
+/// <summary>
+/// Token conversions for <see cref="MetricBillingMode"/>. The lowercase tokens
+/// (<c>"platform"</c> / <c>"byok"</c>) are the canonical persisted/tagged form —
+/// matching <c>CredentialSource.ToTag()</c> (32-3) and the analytics
+/// <c>billing_mode</c> discriminator (36-1).
+/// </summary>
+public static class MetricBillingModeExtensions
+{
+    /// <summary>The lowercase wire token for <see cref="MetricBillingMode.PlatformProvided"/>.</summary>
+    public const string PlatformToken = "platform";
+
+    /// <summary>The lowercase wire token for <see cref="MetricBillingMode.Byok"/>.</summary>
+    public const string ByokToken = "byok";
+
+    /// <summary>Project to the canonical lowercase wire token.</summary>
+    public static string ToToken(this MetricBillingMode mode) =>
+        mode == MetricBillingMode.Byok ? ByokToken : PlatformToken;
+
+    /// <summary>
+    /// Parse a wire token back to the enum. Accepts the lowercase tokens
+    /// (<c>"byok"</c> / <c>"platform"</c>, case-insensitive) AND the member
+    /// names (<c>"Byok"</c> / <c>"PlatformProvided"</c>) so a
+    /// <c>BillingCustomer.BillingMode</c> member-name value round-trips too.
+    /// Returns <c>false</c> for anything else — the caller decides whether an
+    /// unknown token is a silent default or a fail-loud ERROR (35-2 AC11).
+    /// </summary>
+    public static bool TryParseToken(string? token, out MetricBillingMode mode)
+    {
+        switch (token?.Trim().ToLowerInvariant())
+        {
+            case ByokToken:
+                mode = MetricBillingMode.Byok;
+                return true;
+            case PlatformToken:
+            case "platformprovided":
+                mode = MetricBillingMode.PlatformProvided;
+                return true;
+            default:
+                mode = MetricBillingMode.PlatformProvided;
+                return false;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/ControlPlaneDbContext.cs
@@ -724,6 +724,15 @@ public class ControlPlaneDbContext : DbContext
     /// </summary>
     public DbSet<MarginPolicy> MarginPolicies => Set<MarginPolicy>();
 
+    /// <summary>
+    /// Story 34-3 — the authoritative per-<c>(tenant, provider)</c> billing-mode
+    /// owner (BYOK vs platform-provided). CP-resident (keyed by tenant). Single
+    /// source of truth the pricing-mode resolver + the 35-2 billing-mode tagger
+    /// read; the 32-3 runtime credential resolver reports what actually resolved
+    /// and is reconciled against this declared intent.
+    /// </summary>
+    public DbSet<TenantProviderBilling> TenantProviderBillings => Set<TenantProviderBilling>();
+
     // Story 28-1 PR D: the 11 + 4 mentorship tenant-resident entities
     // (AgentConfig, PromptOverride, ProviderHealth, ProviderDiagnostic,
     // SanitizationRule, WorkflowDefinition, WorkflowInstance, DomainEvent,
@@ -844,6 +853,12 @@ public class ControlPlaneDbContext : DbContext
         // enforces at most one active assignment per tenant; FKs to tenants
         // (Cascade) + plans (Restrict).
         TammaModelConfiguration.ConfigureTenantPlanAssignments(modelBuilder);
+
+        // Story 34-3 — the authoritative per-(tenant, provider) billing-mode
+        // owner. CP-resident (keyed by tenant, alongside the billing tables).
+        // One active row per (tenant, provider) via a partial unique index;
+        // CHECKs pin mode/status + the byok↔secret XOR. FK to tenants (Cascade).
+        TammaModelConfiguration.ConfigureTenantProviderBilling(modelBuilder);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/ProviderDiagnostic.cs
@@ -21,6 +21,18 @@ public class ProviderDiagnostic
     public int OutputTokens { get; set; }
 
     public decimal Cost { get; set; }
+
+    /// <summary>
+    /// Story 34-3 / 35-2 — the BYOK-vs-platform billing posture that governed
+    /// this call, as the lowercase <c>MetricBillingMode</c> token
+    /// (<c>"byok"</c> | <c>"platform"</c>, default <c>"platform"</c>). Written on
+    /// the LLM-call usage path from the 35-2 billing-mode tagger (which reads the
+    /// 34-3 owner and reconciles 32-3's credential source). The markup engine
+    /// (34-5) and the analytics dimensional rollup (36-2, <c>ResolveCostBasis</c>)
+    /// key off this column so a BYOK call is never token-marked-up / re-billed.
+    /// </summary>
+    public string BillingMode { get; set; } = "platform";
+
     public Guid? TenantId { get; set; }
     public string? Model { get; set; }
     public string? RequestType { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
@@ -8,7 +8,10 @@ namespace Tamma.Data.Entities;
 /// <c>ITenantProviderPricingModeResolver</c>) and the 35-2 billing-mode tagger
 /// both READ this row; Story 32-3's runtime credential resolver reports what
 /// key physically resolved and is reconciled against this DECLARED intent
-/// (disagreement ⇒ <c>BILLING.MODE.MISMATCH</c>, 32-3 wins).
+/// (disagreement ⇒ <c>BILLING.MODE.MISMATCH</c>, 32-3 wins). NOTE: that reconcile
+/// branch is latent today — <c>LlmProxyService</c> calls the tagger with
+/// <c>credentialSource: null</c>, so only the DECLARED (34-3) mode is used. Wiring
+/// the 32-3 credential source into the proxy is a tracked follow-up.
 ///
 /// <para><b>Default is absence.</b> There is no back-fill row: a
 /// <c>(tenant, provider)</c> with no <c>active</c> row — and every single-user
@@ -17,8 +20,13 @@ namespace Tamma.Data.Entities;
 /// <c>active</c> row with <see cref="Mode"/> = <c>"byok"</c>.</para>
 ///
 /// <para><b>ProviderKey overload:</b> <see cref="ProviderKey"/> here is the
-/// provider identifier (<c>"anthropic"</c>) — the same value as
-/// <c>ProviderDiagnostic.ProviderKey</c> — NOT the Cranl tenancy backend label.</para>
+/// CANONICAL provider FAMILY key (<c>"anthropic"</c>) — NOT the Cranl tenancy
+/// backend label. It is NOT necessarily byte-identical to
+/// <c>ProviderDiagnostic.ProviderKey</c>, which carries the vendor HANDLE
+/// (<c>"anthropic-claude"</c>): the read path canonicalizes the handle to the
+/// family key via <c>BillingProviderKey.Canonicalize</c> before matching this row,
+/// and a BYOK write endpoint MUST persist the canonical (lowercase family) key here
+/// so the match is exact.</para>
 /// </summary>
 public class TenantProviderBilling
 {

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
@@ -1,0 +1,58 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 34-3 — the AUTHORITATIVE per-<c>(tenant, provider)</c> billing-mode
+/// owner. This control-plane row is the single source of truth for whether a
+/// tenant runs a provider under <c>byok</c> (their own key) or <c>platform</c>
+/// (Tamma's key). Reader A (the pricing-mode resolver behind
+/// <c>ITenantProviderPricingModeResolver</c>) and the 35-2 billing-mode tagger
+/// both READ this row; Story 32-3's runtime credential resolver reports what
+/// key physically resolved and is reconciled against this DECLARED intent
+/// (disagreement ⇒ <c>BILLING.MODE.MISMATCH</c>, 32-3 wins).
+///
+/// <para><b>Default is absence.</b> There is no back-fill row: a
+/// <c>(tenant, provider)</c> with no <c>active</c> row — and every single-user
+/// null-tenant call — resolves to <see cref="Tamma.Core.Enums.MetricBillingMode.PlatformProvided"/>
+/// (the current reality). BYOK is opt-in and only ever the result of an explicit
+/// <c>active</c> row with <see cref="Mode"/> = <c>"byok"</c>.</para>
+///
+/// <para><b>ProviderKey overload:</b> <see cref="ProviderKey"/> here is the
+/// provider identifier (<c>"anthropic"</c>) — the same value as
+/// <c>ProviderDiagnostic.ProviderKey</c> — NOT the Cranl tenancy backend label.</para>
+/// </summary>
+public class TenantProviderBilling
+{
+    /// <summary>UUIDv7 primary key.</summary>
+    public Guid Id { get; set; }
+
+    /// <summary>FK → <see cref="Tenant"/>. Never null (BYOK is a SaaS/tenant concept).</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>Provider identifier, e.g. <c>"anthropic"</c> / <c>"openai"</c>.</summary>
+    public string ProviderKey { get; set; } = null!;
+
+    /// <summary>
+    /// The declared billing posture — the lowercase
+    /// <see cref="Tamma.Core.Enums.MetricBillingMode"/> token (<c>"platform"</c>
+    /// | <c>"byok"</c>). CHECK-constrained to those two values.
+    /// </summary>
+    public string Mode { get; set; } = "platform";
+
+    /// <summary>
+    /// Cabinet secret name backing a <c>byok</c> row (e.g.
+    /// <c>provider/anthropic/api-key</c>); null for a <c>platform</c> row. A
+    /// CHECK enforces the XOR (byok ⇒ non-null, platform ⇒ null).
+    /// </summary>
+    public string? SecretName { get; set; }
+
+    /// <summary><c>"active"</c> | <c>"disabled"</c>. One active row per (tenant, provider).</summary>
+    public string Status { get; set; } = "active";
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public Guid? CreatedBy { get; set; }
+    public Guid? UpdatedBy { get; set; }
+
+    /// <summary>Navigation to the owning tenant (CP-resident).</summary>
+    public Tenant? Tenant { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260703191700_AddTenantProviderBilling.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260703191700_AddTenantProviderBilling.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.ControlPlane
 {
     [DbContext(typeof(ControlPlaneDbContext))]
-    partial class ControlPlaneDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703191700_AddTenantProviderBilling")]
+    partial class AddTenantProviderBilling
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260703191700_AddTenantProviderBilling.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/ControlPlane/20260703191700_AddTenantProviderBilling.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.ControlPlane
+{
+    /// <inheritdoc />
+    public partial class AddTenantProviderBilling : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "tenant_provider_billing",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProviderKey = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Mode = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false, defaultValue: "platform"),
+                    SecretName = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    Status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false, defaultValue: "active"),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_tenant_provider_billing", x => x.Id);
+                    table.CheckConstraint("ck_tpb_mode", "\"Mode\" IN ('platform','byok')");
+                    table.CheckConstraint("ck_tpb_secret_xor", "(\"Mode\" = 'byok' AND \"SecretName\" IS NOT NULL) OR (\"Mode\" = 'platform' AND \"SecretName\" IS NULL)");
+                    table.CheckConstraint("ck_tpb_status", "\"Status\" IN ('active','disabled')");
+                    table.ForeignKey(
+                        name: "FK_tenant_provider_billing_tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_tpb_active_provider",
+                table: "tenant_provider_billing",
+                columns: new[] { "TenantId", "ProviderKey" },
+                unique: true,
+                filter: "\"Status\" = 'active'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "tenant_provider_billing");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260703191715_AddProviderDiagnosticBillingMode.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260703191715_AddProviderDiagnosticBillingMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703191715_AddProviderDiagnosticBillingMode")]
+    partial class AddProviderDiagnosticBillingMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260703191715_AddProviderDiagnosticBillingMode.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260703191715_AddProviderDiagnosticBillingMode.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddProviderDiagnosticBillingMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "BillingMode",
+                table: "provider_diagnostics",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: false,
+                defaultValue: "platform");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BillingMode",
+                table: "provider_diagnostics");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1024,6 +1024,52 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 34-3 — the authoritative per-<c>(tenant, provider)</c> billing-mode
+    /// owner (<c>tenant_provider_billing</c>). CP-resident. The partial unique
+    /// index enforces at most one <c>active</c> row per <c>(TenantId, ProviderKey)</c>;
+    /// CHECKs pin <c>mode</c>/<c>status</c> to their closed domains and enforce the
+    /// byok↔secret XOR (a byok row MUST carry a secret name; a platform row MUST
+    /// NOT). FK to tenants cascades on tenant purge. Configured in the shared
+    /// single source so the model graph and the additive migration stay aligned
+    /// (same convention as <see cref="ConfigureTenantPlanAssignments"/>).
+    /// </summary>
+    public static void ConfigureTenantProviderBilling(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<TenantProviderBilling>(entity =>
+        {
+            entity.ToTable("tenant_provider_billing", t =>
+            {
+                t.HasCheckConstraint("ck_tpb_mode", "\"Mode\" IN ('platform','byok')");
+                t.HasCheckConstraint("ck_tpb_status", "\"Status\" IN ('active','disabled')");
+                // A byok row MUST carry a secret name; a platform row MUST NOT.
+                t.HasCheckConstraint(
+                    "ck_tpb_secret_xor",
+                    "(\"Mode\" = 'byok' AND \"SecretName\" IS NOT NULL) "
+                    + "OR (\"Mode\" = 'platform' AND \"SecretName\" IS NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.ProviderKey).IsRequired().HasMaxLength(100);
+            entity.Property(e => e.Mode).IsRequired().HasMaxLength(16).HasDefaultValue("platform");
+            entity.Property(e => e.SecretName).HasMaxLength(255);
+            entity.Property(e => e.Status).IsRequired().HasMaxLength(16).HasDefaultValue("active");
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            // AC1 / AC12 — one ACTIVE row per (tenant, provider). Partial index.
+            entity.HasIndex(e => new { e.TenantId, e.ProviderKey })
+                .IsUnique()
+                .HasFilter("\"Status\" = 'active'")
+                .HasDatabaseName("ux_tpb_active_provider");
+
+            entity.HasOne(e => e.Tenant)
+                .WithMany()
+                .HasForeignKey(e => e.TenantId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    /// <summary>
     /// Story 35-1 — billing foundation entities. The tenant→Stripe customer
     /// mapping (<c>billing_customers</c>, unique <c>TenantId</c>) and the
     /// slug→Stripe-ids catalog (<c>billing_plan_prices</c>, unique
@@ -1591,6 +1637,8 @@ internal static class TammaModelConfiguration
             entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
             entity.Property(e => e.ProviderKey).IsRequired().HasMaxLength(100);
             entity.Property(e => e.Cost).HasPrecision(18, 6);
+            // Story 34-3 / 35-2 — per-call billing posture ("byok" | "platform").
+            entity.Property(e => e.BillingMode).IsRequired().HasMaxLength(16).HasDefaultValue("platform");
             entity.Property(e => e.Success).HasDefaultValue(true);
             entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ComputeTenantDimensionalRollupTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/ComputeTenantDimensionalRollupTests.cs
@@ -123,6 +123,38 @@ public class ComputeTenantDimensionalRollupTests
         rows.Single(r => r.CostBasis == CostBasis.Platform).CostUsd.Should().Be(2.00m);
     }
 
+    // ── Story 34-3 / 35-2 (Reader C producer) — the ProviderDiagnostic.BillingMode
+    //    column is now READ (was the always-Platform phantom): a byok diagnostic
+    //    buckets under CostBasis.Byok, a platform diagnostic under Platform. ──
+    [Test]
+    public async Task ComputeAsync_ResolvesCostBasis_FromDiagnosticBillingMode()
+    {
+        var tenantId = Guid.NewGuid();
+        var db = _tenantFactory.Register(tenantId);
+        db.ProviderDiagnostics.AddRange(
+            new ProviderDiagnostic
+            {
+                Id = Guid.NewGuid(), ProviderKey = "anthropic", Model = "claude",
+                BillingMode = "byok", Cost = 1.00m, TokensUsed = 20, CreatedAt = Hour.AddMinutes(5),
+            },
+            new ProviderDiagnostic
+            {
+                Id = Guid.NewGuid(), ProviderKey = "openai", Model = "gpt",
+                BillingMode = "platform", Cost = 2.00m, TokensUsed = 40, CreatedAt = Hour.AddMinutes(6),
+            });
+        await db.SaveChangesAsync();
+
+        await RunAsync(tenantId, new FixedMarginPricing(0m));
+
+        var verify = await _tenantFactory.CreateAsync(tenantId);
+        var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+        rows.Single(r => r.Provider == "anthropic").CostBasis
+            .Should().Be(CostBasis.Byok, "the diagnostic's BillingMode column is now read (not always Platform)");
+        rows.Single(r => r.Provider == "openai").CostBasis
+            .Should().Be(CostBasis.Platform);
+    }
+
     [Test]
     public async Task ComputeAsync_DefaultsToPlatform_WhenNoBillingMode()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingModeTaggerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Billing/BillingModeTaggerTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Billing;
+
+/// <summary>
+/// Story 35-2 — <see cref="BillingModeTagger"/> computes the canonical
+/// <c>billing_mode</c> token by reading Story 34-3's owner and reconciling Story
+/// 32-3's runtime credential source. On disagreement 32-3 WINS (it is the wire
+/// credential) + WARN + one <c>BILLING.MODE.MISMATCH</c> event; an out-of-domain
+/// token fails loud (AC11). The single-user <see cref="NullBillingModeTagger"/>
+/// yields platform with no billable implication.
+/// </summary>
+[TestFixture]
+public class BillingModeTaggerTests
+{
+    private sealed class StubOwner : ITenantProviderBillingResolver
+    {
+        private readonly MetricBillingMode _mode;
+        public StubOwner(MetricBillingMode mode) => _mode = mode;
+        public Task<MetricBillingMode> ResolveModeAsync(
+            Guid? tenantId, string provider, CancellationToken ct = default)
+            => Task.FromResult(_mode);
+    }
+
+    private static (BillingModeTagger tagger, List<DomainEvent> events) NewTagger(MetricBillingMode ownerMode)
+    {
+        var captured = new List<DomainEvent>();
+        var repo = new Mock<IEventRepository>();
+        repo.Setup(r => r.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d)
+            .Callback((DomainEvent d) => captured.Add(d));
+        var tagger = new BillingModeTagger(
+            new StubOwner(ownerMode), repo.Object, NullLogger<BillingModeTagger>.Instance);
+        return (tagger, captured);
+    }
+
+    [Test]
+    public async Task Resolve_OwnerByok_NoSource_TagsByok()
+    {
+        var (tagger, events) = NewTagger(MetricBillingMode.Byok);
+        var tag = await tagger.ResolveTagAsync(Guid.NewGuid(), "anthropic");
+        tag.Should().Be(BillingModeTokens.Byok);
+        events.Should().BeEmpty("no 32-3 source ⇒ nothing to reconcile ⇒ no mismatch event");
+    }
+
+    [Test]
+    public async Task Resolve_OwnerPlatform_NoSource_TagsPlatform()
+    {
+        var (tagger, _) = NewTagger(MetricBillingMode.PlatformProvided);
+        (await tagger.ResolveTagAsync(Guid.NewGuid(), "anthropic")).Should().Be(BillingModeTokens.Platform);
+    }
+
+    [Test]
+    public async Task Resolve_SourceAgrees_TagMatches_NoMismatchEvent()
+    {
+        var (tagger, events) = NewTagger(MetricBillingMode.Byok);
+        var tag = await tagger.ResolveTagAsync(Guid.NewGuid(), "anthropic", credentialSource: "byok");
+        tag.Should().Be(BillingModeTokens.Byok);
+        events.Should().BeEmpty("agreement ⇒ no BILLING.MODE.MISMATCH");
+    }
+
+    [Test]
+    public async Task Resolve_SourceDisagrees_32_3Wins_WarnAndMismatchEvent()
+    {
+        // Owner DECLARES byok, but 32-3 reports the wire credential was platform.
+        var (tagger, events) = NewTagger(MetricBillingMode.Byok);
+        var tenantId = Guid.NewGuid();
+
+        var tag = await tagger.ResolveTagAsync(tenantId, "anthropic", credentialSource: "platform");
+
+        tag.Should().Be(BillingModeTokens.Platform, "32-3 (the credential actually used) wins for the tag");
+        events.Should().HaveCount(1, "exactly one mismatch audit event");
+        var evt = events.Single();
+        evt.Type.Should().Be(BillingModeEvents.BillingModeMismatch);
+        evt.TenantId.Should().Be(tenantId);
+        evt.Tags.Should().Contain("\"mode34\":\"byok\"");
+        evt.Tags.Should().Contain("\"source32\":\"platform\"");
+    }
+
+    [Test]
+    public async Task Resolve_InvalidSourceToken_FailsLoud()
+    {
+        var (tagger, _) = NewTagger(MetricBillingMode.Byok);
+        var act = async () => await tagger.ResolveTagAsync(Guid.NewGuid(), "anthropic", credentialSource: "garbage");
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("BILLING_MODE_INVALID_SOURCE");
+    }
+
+    [Test]
+    public async Task NullTagger_AlwaysPlatform_NoEvents()
+    {
+        var tagger = new NullBillingModeTagger();
+        (await tagger.ResolveTagAsync(null, "anthropic", credentialSource: "byok"))
+            .Should().Be(BillingModeTokens.Platform, "single-user has no billable-mode implication (AC8)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Epic28/ControlPlaneDbContextModelTests.cs
@@ -156,6 +156,10 @@ public class ControlPlaneDbContextModelTests
             // (keyed by tenant, alongside the plans catalog). One active row per
             // tenant (partial unique index).
             "tenant_plan_assignments",
+            // Story 34-3 — the authoritative per-(tenant, provider) billing-mode
+            // owner (BYOK vs platform-provided). CP-resident (keyed by tenant). One
+            // active row per (tenant, provider) via a partial unique index.
+            "tenant_provider_billing",
         }, because: "Story 28-1 PR D (Decision #4) — enumerate every "
             + "CP-resident table; the 11 + 4 mentorship tenant-resident "
             + "entities have moved to TenantDbContext. Story 31-2 adds "
@@ -172,6 +176,7 @@ public class ControlPlaneDbContextModelTests
             + "Story 34-11 adds providers + provider_model_prices. "
             + "Story 34-5 adds margin_policies. "
             + "Story 34-4 adds tenant_plan_assignments. "
+            + "Story 34-3 adds tenant_provider_billing. "
             + "Story 38-3 adds slack_outbox. "
             + "Story 37-2 adds audit_chain_checkpoints.");
     }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingPricingModeResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingPricingModeResolverTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core.Enums;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 (Reader A repoint) — <see cref="TenantProviderBillingPricingModeResolver"/>
+/// reads the authoritative <c>TenantProviderBilling</c> owner (via
+/// <see cref="ITenantProviderBillingResolver"/>) behind the unchanged
+/// <see cref="ITenantProviderPricingModeResolver"/> seam and maps the shared
+/// <see cref="MetricBillingMode"/> token to the engine's <see cref="PricingMode"/>.
+/// </summary>
+[TestFixture]
+public class TenantProviderBillingPricingModeResolverTests
+{
+    private sealed class StubOwner : ITenantProviderBillingResolver
+    {
+        private readonly MetricBillingMode _mode;
+        public StubOwner(MetricBillingMode mode) => _mode = mode;
+        public Guid? SeenTenant { get; private set; }
+        public string? SeenProvider { get; private set; }
+
+        public Task<MetricBillingMode> ResolveModeAsync(
+            Guid? tenantId, string provider, CancellationToken ct = default)
+        {
+            SeenTenant = tenantId;
+            SeenProvider = provider;
+            return Task.FromResult(_mode);
+        }
+    }
+
+    [Test]
+    public async Task ResolveMode_Byok_MapsToByokPricingMode()
+    {
+        var resolver = new TenantProviderBillingPricingModeResolver(
+            new StubOwner(MetricBillingMode.Byok));
+        (await resolver.ResolveModeAsync(Guid.NewGuid(), "anthropic")).Should().Be(PricingMode.Byok);
+    }
+
+    [Test]
+    public async Task ResolveMode_Platform_MapsToPlatformProvidedPricingMode()
+    {
+        var resolver = new TenantProviderBillingPricingModeResolver(
+            new StubOwner(MetricBillingMode.PlatformProvided));
+        (await resolver.ResolveModeAsync(Guid.NewGuid(), "anthropic"))
+            .Should().Be(PricingMode.PlatformProvided);
+    }
+
+    [Test]
+    public async Task ResolveMode_DelegatesTheTenantAndProviderToTheOwner()
+    {
+        var owner = new StubOwner(MetricBillingMode.Byok);
+        var resolver = new TenantProviderBillingPricingModeResolver(owner);
+        var tenantId = Guid.NewGuid();
+
+        await resolver.ResolveModeAsync(tenantId, "openai");
+
+        owner.SeenTenant.Should().Be(tenantId);
+        owner.SeenProvider.Should().Be("openai");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Pricing;
+using Tamma.Core;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 — <see cref="TenantProviderBillingResolver"/> reads the
+/// AUTHORITATIVE per-<c>(tenant, provider)</c> mode from the
+/// <c>TenantProviderBilling</c> owner. Default is absence (no row / null tenant
+/// ⇒ platform); an active byok row flips to byok; a corrupt mode fails loud.
+/// InMemory provider — resolution logic is provider-agnostic (the SQL
+/// invariants are pinned by the Postgres model tests).
+/// </summary>
+[TestFixture]
+public class TenantProviderBillingResolverTests
+{
+    private static ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static TenantProviderBillingResolver NewResolver(ControlPlaneDbContext db) =>
+        new(db, NullLogger<TenantProviderBillingResolver>.Instance);
+
+    private static TenantProviderBilling Row(
+        Guid tenantId, string provider, string mode, string status = "active") => new()
+    {
+        Id = Guid.NewGuid(),
+        TenantId = tenantId,
+        ProviderKey = provider,
+        Mode = mode,
+        SecretName = mode == "byok" ? $"provider/{provider}/api-key" : null,
+        Status = status,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+    };
+
+    [Test]
+    public async Task ResolveMode_NullTenant_IsPlatformProvided()
+    {
+        await using var db = NewContext();
+        var mode = await NewResolver(db).ResolveModeAsync(null, "anthropic");
+        mode.Should().Be(MetricBillingMode.PlatformProvided, "single-user null tenant is always platform (AC8)");
+    }
+
+    [Test]
+    public async Task ResolveMode_NoRow_IsPlatformProvided()
+    {
+        await using var db = NewContext();
+        var mode = await NewResolver(db).ResolveModeAsync(Guid.NewGuid(), "anthropic");
+        mode.Should().Be(MetricBillingMode.PlatformProvided, "absence of an owner row is the safe default");
+    }
+
+    [Test]
+    public async Task ResolveMode_ActiveByokRow_IsByok_PerProvider()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = NewContext();
+        db.TenantProviderBillings.AddRange(
+            Row(tenantId, "anthropic", "byok"),
+            Row(tenantId, "openai", "platform"));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+        (await resolver.ResolveModeAsync(tenantId, "anthropic")).Should().Be(MetricBillingMode.Byok);
+        // Per-(tenant, provider): openai stays platform even though anthropic is byok.
+        (await resolver.ResolveModeAsync(tenantId, "openai")).Should().Be(MetricBillingMode.PlatformProvided);
+    }
+
+    [Test]
+    public async Task ResolveMode_IsCaseInsensitiveOnProvider()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = NewContext();
+        db.TenantProviderBillings.Add(Row(tenantId, "anthropic", "byok"));
+        await db.SaveChangesAsync();
+
+        (await NewResolver(db).ResolveModeAsync(tenantId, "ANTHROPIC")).Should().Be(MetricBillingMode.Byok);
+    }
+
+    [Test]
+    public async Task ResolveMode_IgnoresDisabledRow_FallsBackToPlatform()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = NewContext();
+        db.TenantProviderBillings.Add(Row(tenantId, "anthropic", "byok", status: "disabled"));
+        await db.SaveChangesAsync();
+
+        (await NewResolver(db).ResolveModeAsync(tenantId, "anthropic"))
+            .Should().Be(MetricBillingMode.PlatformProvided, "only an ACTIVE row counts");
+    }
+
+    [Test]
+    public async Task ResolveMode_TenantIsolated()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        await using var db = NewContext();
+        db.TenantProviderBillings.Add(Row(tenantA, "anthropic", "byok"));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+        (await resolver.ResolveModeAsync(tenantA, "anthropic")).Should().Be(MetricBillingMode.Byok);
+        (await resolver.ResolveModeAsync(tenantB, "anthropic"))
+            .Should().Be(MetricBillingMode.PlatformProvided, "tenant B never sees tenant A's mode");
+    }
+
+    [Test]
+    public async Task ResolveMode_CorruptRowMode_FailsLoud()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = NewContext();
+        // The DB CHECK prevents this, but a corrupt row must never silently mistag.
+        db.TenantProviderBillings.Add(Row(tenantId, "anthropic", "garbage"));
+        await db.SaveChangesAsync();
+
+        var act = async () => await NewResolver(db).ResolveModeAsync(tenantId, "anthropic");
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("BILLING_MODE_CORRUPT");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
@@ -85,6 +85,29 @@ public class TenantProviderBillingResolverTests
         (await NewResolver(db).ResolveModeAsync(tenantId, "ANTHROPIC")).Should().Be(MetricBillingMode.Byok);
     }
 
+    // ── Fix 2 — the call site uses the vendor handle "anthropic-claude"; the owner
+    //    row is stored under the canonical family key "anthropic". Canonical
+    //    normalization must make them MATCH (else a declared BYOK row is silently
+    //    ignored and the tenant is billed platform markup on their own key). ──
+    [Test]
+    public async Task ResolveMode_CanonicalizesVendorHandle_MatchesOwnerRow()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var db = NewContext();
+        // Owner row stored under the CANONICAL provider key.
+        db.TenantProviderBillings.Add(Row(tenantId, "anthropic", "byok"));
+        await db.SaveChangesAsync();
+
+        var resolver = NewResolver(db);
+        // The proxy resolves under the vendor handle "anthropic-claude".
+        (await resolver.ResolveModeAsync(tenantId, "anthropic-claude"))
+            .Should().Be(MetricBillingMode.Byok,
+                "'anthropic-claude' canonicalizes to 'anthropic' — the declared BYOK row must match");
+        // Mixed case + vendor handle still canonicalizes.
+        (await resolver.ResolveModeAsync(tenantId, "Anthropic-Claude"))
+            .Should().Be(MetricBillingMode.Byok);
+    }
+
     [Test]
     public async Task ResolveMode_IgnoresDisabledRow_FallsBackToPlatform()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyDoubleCountRegressionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyDoubleCountRegressionTests.cs
@@ -1,0 +1,189 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Tamma.Activities.Analytics;
+using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Diagnostics;
+using Tamma.Api.Services.Diagnostics.Models;
+using Tamma.Api.Services.SaaS;
+using Tamma.Core.Entities;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.SaaS;
+
+/// <summary>
+/// Fix 1 (CRITICAL) regression — <see cref="LlmProxyService"/> writes BOTH a
+/// <see cref="ProviderDiagnostic"/> row AND an <c>LLM.CALL.SUCCESS</c> DCB event
+/// for the SAME proxied call. The dimensional rollup folds both into one bucket,
+/// so without a shared correlation id it double-counts cost/tokens/platform-billed
+/// (2x). This end-to-end test captures exactly what the proxy writes, feeds the
+/// pair into <see cref="ComputeTenantDimensionalRollupActivity.ComputeAsync"/>,
+/// and asserts a SINGLE count. It FAILS before the fix (2x) and PASSES after (1x).
+/// </summary>
+[TestFixture]
+public class LlmProxyDoubleCountRegressionTests
+{
+    private static readonly DateTime Hour = new(2026, 04, 18, 12, 00, 00, DateTimeKind.Utc);
+
+    [Test]
+    public async Task ProxyDiagnosticAndUsageEvent_ForOneCall_AreCountedOnce_InDimensionalRollup()
+    {
+        // ── Arrange: capture the diagnostic + usage event the proxy writes ──
+        var tenantId = Guid.NewGuid();
+        ProviderDiagnostic? diag = null;
+        DomainEvent? evt = null;
+
+        var diagnostics = new Mock<IDiagnosticsService>();
+        diagnostics
+            .Setup(d => d.GetBudgetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BudgetStatus(
+                AccountId: Guid.Empty,
+                PeriodStart: DateTime.UtcNow.AddDays(-1),
+                PeriodEnd: DateTime.UtcNow.AddDays(1),
+                Spent: 0m, Limit: 1_000_000m, Remaining: 1_000_000m,
+                PercentUsed: 0, AlertThreshold: 0.8, ShouldAlert: false, IsOverBudget: false));
+        diagnostics
+            .Setup(d => d.RecordEventAsync(It.IsAny<ProviderDiagnostic>(), It.IsAny<CancellationToken>()))
+            .Callback((ProviderDiagnostic p, CancellationToken _) => diag = p)
+            .ReturnsAsync(Guid.NewGuid());
+
+        var events = new Mock<IEventRepository>();
+        events
+            .Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d)
+            .Callback((DomainEvent d) => evt = d);
+
+        var tagger = new Mock<IBillingModeTagger>();
+        tagger
+            .Setup(t => t.ResolveTagAsync(
+                It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BillingModeTokens.Platform);
+
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"model":"claude-sonnet-4.5","content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1000,"output_tokens":1000}}""",
+                    Encoding.UTF8, "application/json"),
+            });
+        var httpFactory = new Mock<IHttpClientFactory>();
+        httpFactory
+            .Setup(f => f.CreateClient("anthropic"))
+            .Returns(new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.anthropic.com") });
+
+        var service = new LlmProxyService(
+            httpFactory.Object, diagnostics.Object, tagger.Object, events.Object,
+            new Mock<ILogger<LlmProxyService>>().Object);
+
+        var resp = await service.ChatAsync(
+            new ChatRequest("claude-sonnet-4.5", new[] { new ChatMessage("user", "hi") }, 2048, null),
+            tenantId);
+
+        resp.Success.Should().BeTrue();
+        diag.Should().NotBeNull();
+        evt.Should().NotBeNull();
+        var expectedCost = resp.CostUsd; // 1000/1000*0.003 + 1000/1000*0.015 = 0.018
+        expectedCost.Should().BeGreaterThan(0m);
+
+        // ── Seed the captured pair into one tenant hour bucket and roll up ──
+        var opened = new List<IDisposable>();
+        try
+        {
+            var factory = new InMemoryTenantFactory(opened);
+            var db = factory.Register(tenantId);
+            diag!.CreatedAt = Hour.AddMinutes(5);
+            evt!.CreatedAt = Hour.AddMinutes(5);
+            evt.SequenceNumber = 1;
+            db.ProviderDiagnostics.Add(diag);
+            db.DomainEvents.Add(evt);
+            await db.SaveChangesAsync();
+
+            var publisher = new Mock<IPlatformEventPublisher>();
+            publisher
+                .Setup(p => p.AppendAndPublishAsync(It.IsAny<PlatformEvent>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((PlatformEvent e, CancellationToken _) => e);
+
+            await ComputeTenantDimensionalRollupActivity.ComputeAsync(
+                factory, publisher.Object, tenantId, Hour, new NullAnalyticsPricingConfig(),
+                resetCheckpoint: false, logger: null, CancellationToken.None);
+
+            // ── Assert: cost / tokens / platform-billed counted EXACTLY ONCE ──
+            var verify = await factory.CreateAsync(tenantId);
+            var rows = await verify.AnalyticsUsageHourly.ToListAsync();
+
+            rows.Sum(r => r.CostUsd).Should().Be(expectedCost,
+                "the diagnostic and its paired LLM.CALL.SUCCESS event describe ONE call — the shared "
+                + "correlationId must dedup them to a single count (this summed to 2x before the fix)");
+            rows.Sum(r => r.PlatformBilledUsd).Should().Be(expectedCost,
+                "billed once at zero margin (null pricing config)");
+            rows.Sum(r => r.TokensIn).Should().Be(2000L, "the 2000-token call is counted once");
+            rows.Sum(r => r.TokensOut).Should().Be(0L, "the diagnostic total attributes to TokensIn; no event double-add");
+        }
+        finally
+        {
+            foreach (var d in opened) d.Dispose();
+        }
+    }
+
+    /// <summary>Routes a tenant id to its own named InMemory database.</summary>
+    private sealed class InMemoryTenantFactory : ITenantDbContextFactory
+    {
+        private readonly Dictionary<Guid, string> _names = new();
+        private readonly List<IDisposable> _opened;
+        public InMemoryTenantFactory(List<IDisposable> opened) => _opened = opened;
+
+        public TenantDbContext Register(Guid tenantId)
+        {
+            var name = $"llmproxy-dim-{tenantId:N}";
+            _names[tenantId] = name;
+            return Open(name);
+        }
+
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            if (!_names.TryGetValue(tenantId, out var name))
+                throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+            return new ValueTask<TenantDbContext>(Open(name));
+        }
+
+        private TenantDbContext Open(string name)
+        {
+            var options = new DbContextOptionsBuilder<TenantDbContext>()
+                .UseInMemoryDatabase(name)
+                .ConfigureWarnings(w => w.Ignore(
+                    Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+            var ctx = new InMemoryFriendlyTenantDbContext(options);
+            _opened.Add(ctx);
+            return ctx;
+        }
+    }
+
+    /// <summary>InMemory-friendly <see cref="TenantDbContext"/> (drops the mentorship
+    /// aggregate's jsonb/rowversion columns the InMemory provider rejects).</summary>
+    private sealed class InMemoryFriendlyTenantDbContext : TenantDbContext
+    {
+        public InMemoryFriendlyTenantDbContext(DbContextOptions<TenantDbContext> options) : base(options) { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Ignore<JuniorDeveloper>();
+            modelBuilder.Ignore<Story>();
+            modelBuilder.Ignore<MentorshipSession>();
+            modelBuilder.Ignore<MentorshipEvent>();
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyServiceTests.cs
@@ -155,6 +155,46 @@ public class LlmProxyServiceTests
             Times.Once);
     }
 
+    // ─── Fix 1 — the diagnostic and the usage event share ONE per-call
+    //     correlation id so the dimensional rollup dedup counts the call ONCE. ──
+    [Test]
+    public async Task ChatAsync_StampsSharedCorrelationId_OnDiagnosticAndUsageEvent()
+    {
+        var tenantId = Guid.NewGuid();
+        ProviderDiagnostic? capturedDiag = null;
+        DomainEvent? capturedEvent = null;
+
+        _diagnostics
+            .Setup(d => d.RecordEventAsync(It.IsAny<ProviderDiagnostic>(), It.IsAny<CancellationToken>()))
+            .Callback((ProviderDiagnostic p, CancellationToken _) => capturedDiag = p)
+            .ReturnsAsync(Guid.NewGuid());
+        _events
+            .Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d)
+            .Callback((DomainEvent d) => capturedEvent = d);
+
+        SetupHttp(HttpStatusCode.OK, """
+            { "model": "claude-sonnet-4.5", "content": [ { "type": "text", "text": "ok" } ],
+              "usage": { "input_tokens": 5, "output_tokens": 7 } }
+            """);
+
+        var service = CreateService();
+        await service.ChatAsync(
+            new ChatRequest("claude-sonnet-4.5", new[] { new ChatMessage("user", "hi") }, 32, null),
+            tenantId);
+
+        capturedDiag.Should().NotBeNull();
+        capturedEvent.Should().NotBeNull();
+        capturedDiag!.CorrelationId.Should().NotBeNull(
+            "the diagnostic must carry the per-call correlation id so the rollup dedup can fire");
+
+        using var doc = JsonDocument.Parse(capturedEvent!.Tags!);
+        var eventCorr = doc.RootElement.GetProperty("correlationId").GetString();
+        eventCorr.Should().Be(capturedDiag.CorrelationId!.Value.ToString(),
+            "the event's correlationId tag must equal the diagnostic's CorrelationId — both describe ONE call, "
+            + "so the dimensional rollup folds them once (no 2x double-count)");
+    }
+
     [Test]
     public async Task ChatAsync_NullTenant_EmitsNoUsageEvent()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/SaaS/LlmProxyServiceTests.cs
@@ -7,10 +7,12 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using NUnit.Framework;
+using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Diagnostics;
 using Tamma.Api.Services.Diagnostics.Models;
 using Tamma.Api.Services.SaaS;
 using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Tests.SaaS;
 
@@ -24,6 +26,8 @@ public class LlmProxyServiceTests
 {
     private Mock<IHttpClientFactory> _httpFactory = null!;
     private Mock<IDiagnosticsService> _diagnostics = null!;
+    private Mock<IBillingModeTagger> _billingModeTagger = null!;
+    private Mock<IEventRepository> _events = null!;
     private Mock<ILogger<LlmProxyService>> _logger = null!;
     private Mock<HttpMessageHandler> _handler = null!;
 
@@ -32,12 +36,23 @@ public class LlmProxyServiceTests
     {
         _httpFactory = new Mock<IHttpClientFactory>();
         _diagnostics = new Mock<IDiagnosticsService>();
+        _billingModeTagger = new Mock<IBillingModeTagger>();
+        _events = new Mock<IEventRepository>();
         _logger = new Mock<ILogger<LlmProxyService>>();
         _handler = new Mock<HttpMessageHandler>();
 
         // Default: no budget (unlimited).
         _diagnostics.Setup(d => d.GetBudgetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Budget(spent: 0m, limit: 1_000_000m, over: false));
+
+        // Story 35-2 — default the tagger to "platform" (owner-declared default).
+        _billingModeTagger
+            .Setup(t => t.ResolveTagAsync(
+                It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BillingModeTokens.Platform);
+        _events
+            .Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d);
     }
 
     private LlmProxyService CreateService()
@@ -48,7 +63,9 @@ public class LlmProxyServiceTests
         };
         _httpFactory.Setup(f => f.CreateClient("anthropic")).Returns(client);
 
-        return new LlmProxyService(_httpFactory.Object, _diagnostics.Object, _logger.Object);
+        return new LlmProxyService(
+            _httpFactory.Object, _diagnostics.Object, _billingModeTagger.Object,
+            _events.Object, _logger.Object);
     }
 
     // ─── Happy path ────────────────────────────────────────────────────────
@@ -95,6 +112,64 @@ public class LlmProxyServiceTests
                 p.Model == "claude-sonnet-4.5"),
             It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // ─── Story 35-2 — billing_mode stamped on diagnostic + usage event ───────
+
+    [Test]
+    public async Task ChatAsync_Byok_StampsDiagnosticBillingMode_AndEmitsTaggedUsageEvent()
+    {
+        var tenantId = Guid.NewGuid();
+        // Owner-declared byok resolves through the tagger.
+        _billingModeTagger
+            .Setup(t => t.ResolveTagAsync(
+                tenantId, It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(BillingModeTokens.Byok);
+
+        SetupHttp(HttpStatusCode.OK, """
+            {
+              "model": "claude-sonnet-4.5",
+              "content": [ { "type": "text", "text": "ok" } ],
+              "usage": { "input_tokens": 5, "output_tokens": 7 }
+            }
+            """);
+
+        var service = CreateService();
+        var resp = await service.ChatAsync(
+            new ChatRequest("claude-sonnet-4.5", new[] { new ChatMessage("user", "hi") }, 32, null),
+            tenantId);
+
+        resp.Success.Should().BeTrue();
+
+        // The diagnostic carries the resolved billing posture.
+        _diagnostics.Verify(d => d.RecordEventAsync(
+            It.Is<ProviderDiagnostic>(p => p.BillingMode == "byok"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        // A tenant-scoped LLM.CALL.SUCCESS usage event carries the billing_mode tag.
+        _events.Verify(e => e.AppendAsync(
+            It.Is<DomainEvent>(ev =>
+                ev.Type == BillingModeEvents.LlmCallSuccess &&
+                ev.TenantId == tenantId &&
+                ev.Tags != null && ev.Tags.Contains("\"billing_mode\":\"byok\""))),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task ChatAsync_NullTenant_EmitsNoUsageEvent()
+    {
+        // Single-user / anonymous — no billable-mode implication (AC8).
+        SetupHttp(HttpStatusCode.OK, """
+            { "model": "claude-sonnet-4.5", "content": [ { "type": "text", "text": "ok" } ],
+              "usage": { "input_tokens": 1, "output_tokens": 1 } }
+            """);
+
+        var service = CreateService();
+        await service.ChatAsync(
+            new ChatRequest("claude-sonnet-4.5", new[] { new ChatMessage("user", "hi") }, 32, null),
+            tenantId: null);
+
+        _events.Verify(e => e.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/MetricBillingModeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Enums/MetricBillingModeTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Enums;
+
+namespace Tamma.Core.Tests.Enums;
+
+/// <summary>
+/// Story 34-3 / 35-2 — the shared <see cref="MetricBillingMode"/> canonical
+/// token round-trips to the lowercase wire form (<c>"platform"</c>/<c>"byok"</c>)
+/// used by every reader (owner column, diagnostic column, DCB tag,
+/// <c>CredentialSource.ToTag()</c>, analytics <c>ResolveCostBasis</c>).
+/// </summary>
+[TestFixture]
+public class MetricBillingModeTests
+{
+    [Test]
+    public void ToToken_ProducesLowercaseWireTokens()
+    {
+        MetricBillingMode.PlatformProvided.ToToken().Should().Be("platform");
+        MetricBillingMode.Byok.ToToken().Should().Be("byok");
+    }
+
+    [Test]
+    public void PlatformProvided_IsTheZeroOrdinalDefault()
+    {
+        // The safe default (single-user / rows-absent) resolves to platform.
+        ((int)MetricBillingMode.PlatformProvided).Should().Be(0);
+    }
+
+    [TestCase("byok", MetricBillingMode.Byok)]
+    [TestCase("BYOK", MetricBillingMode.Byok)]
+    [TestCase("platform", MetricBillingMode.PlatformProvided)]
+    [TestCase("PlatformProvided", MetricBillingMode.PlatformProvided)]
+    [TestCase(" Byok ", MetricBillingMode.Byok)]
+    public void TryParseToken_AcceptsTokensAndMemberNames(string token, MetricBillingMode expected)
+    {
+        MetricBillingModeExtensions.TryParseToken(token, out var mode).Should().BeTrue();
+        mode.Should().Be(expected);
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    [TestCase("nonsense")]
+    public void TryParseToken_RejectsOutOfDomain_WithPlatformOutParam(string? token)
+    {
+        MetricBillingModeExtensions.TryParseToken(token, out var mode).Should().BeFalse();
+        // Out-param is the safe default; the CALLER decides fail-loud vs default.
+        mode.Should().Be(MetricBillingMode.PlatformProvided);
+    }
+}


### PR DESCRIPTION
## What (issue #19 — full owner build)

Makes one layer authoritative for `billing_mode` (BYOK vs platform-provided billing posture) and reconciles the fragmented readers, implementing the core of drafted Stories 34-3 + 35-2.

- **Owner:** `TenantProviderBilling` (CP table, one active row per `(tenant, provider)`, `MetricBillingMode{PlatformProvided|Byok}`, CHECK constraints + byok↔secret XOR + partial unique index `WHERE status='active'`). Absence of a row ⇒ `PlatformProvided` (opt-in BYOK).
- **Reader A** (pricing mode) repointed behind the unchanged `ITenantProviderPricingModeResolver` seam to read the owner per-`(tenant,provider)`.
- **Reader C** (analytics `CostBasis`) — was a **phantom** (nothing wrote the tag; `ProviderDiagnostic` had no column → always `Platform`). Now `LlmProxyService` populates a new tenant-resident `ProviderDiagnostic.BillingMode` column + a `billing_mode` DCB tag on `LLM.CALL.*`, so analytics reflects reality.
- **Reader B** (32-3 runtime credential source) unchanged — stays the tiebreaker; owner-vs-runtime disagreement emits `BILLING.MODE.MISMATCH` (WARN), 32-3 wins.
- Single-user null-tenant ⇒ `PlatformProvided`, no event, no error (status quo preserved; fail-loud only on a corrupt owner row).

Two migrations: CP `AddTenantProviderBilling`, Tenant `AddProviderDiagnosticBillingMode` (default `'platform'`).

## Review + fixes (all applied)

Adversarial review verified both migrations clean, the CP three-place wiring complete, and the "154 failing tests" as **pre-existing Testcontainer parallel-fixture flake** (`ProviderPricingParityTests`+`DbProviderPricingServiceTests` — 154/154 pass in isolation; the diff doesn't touch their SUT). Fixed 2 findings:
- **Critical — 2× analytics double-count:** the new `LLM.CALL.SUCCESS` event + the existing `ProviderDiagnostic` row were both folded into one rollup bucket with no shared dedup key → every proxied call counted twice. Fixed by threading one per-call `correlationId` to both sinks so the rollup's existing dedup fires (single count; fail-before 2× → pass-after 1×).
- **Important — provider-key mismatch:** owner keyed `anthropic`, proxy tagged `anthropic-claude` → a future BYOK row would never match. Fixed with a canonical key reusing the existing `ProviderRateLookup.Aliases` + lowercase (read path + documented for the write path).

## Deferred (with reason)

The 34-3 **BYOK toggle endpoints** (the write side that populates owner rows — `POST/DELETE …/byok`, `IsSaaSEligible` gate, `PRICING.BYOK.*` events, RBAC) + 35-2 AC14 docker round-trip. This PR is the authoritative owner + reader reconciliation + tag propagation; the entity carries the fields (`CreatedBy/SecretName`) ready for the write layer. Latent note tracked: the "32-3 wins pricing" reconcile branch is dead until a 32-3 credential source is wired into the proxy.

## Verification

- Build: 0 errors, no TAMMA001. `has-pending-model-changes` ControlPlane + Tenant both "No changes". Billing/Analytics/Pricing/LlmProxy tests green (the two flaky Testcontainer classes pass in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)