### PR TITLE
feat(integration-byok): per-tenant JIRA + email BYOK credentials (fail-loud, tenant-owned transport)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/IntegrationCredentialEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/IntegrationCredentialEndpoints.cs
@@ -1,6 +1,8 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Tamma.Api.Auth;
 using Tamma.Api.Services.Audit;
 using Tamma.Api.Services.Integrations;
@@ -54,7 +56,7 @@ public static class IntegrationCredentialEndpoints
         {
             return Results.BadRequest(new { error = "invalid_body" });
         }
-        var validation = ValidateJira(body);
+        var validation = await ValidateJiraAsync(body, http).ConfigureAwait(false);
         if (validation is not null) return validation;
 
         if (tenantContext.TenantId is not Guid tid)
@@ -86,7 +88,7 @@ public static class IntegrationCredentialEndpoints
         }
         catch (ArgumentException ex)
         {
-            return Results.BadRequest(new { error = ex.Message });
+            return RejectInvalidRequest(http, JiraIntegration, ex);
         }
         catch (Exception ex) when (IsDuplicate(ex))
         {
@@ -155,7 +157,7 @@ public static class IntegrationCredentialEndpoints
         }
         catch (ArgumentException ex)
         {
-            return Results.BadRequest(new { error = ex.Message });
+            return RejectInvalidRequest(http, EmailIntegration, ex);
         }
         catch (Exception ex) when (IsDuplicate(ex))
         {
@@ -247,16 +249,25 @@ public static class IntegrationCredentialEndpoints
             http.RequestAborted).ConfigureAwait(false);
     }
 
-    private static IResult? ValidateJira(SetJiraCredentialRequest body)
+    /// <summary>
+    /// Write-time validation of a JIRA credential bundle, including the SSRF guard on
+    /// <c>baseUrl</c> (https-only + private/loopback/link-local/metadata rejection +
+    /// optional <c>Jira:AllowedHostSuffixes</c> allowlist) via
+    /// <see cref="JiraBaseUrlGuard"/>. This is the first layer; <see cref="JiraApiClient"/>
+    /// re-validates at use time (defense in depth). Reject at write time so a hostile
+    /// baseUrl never even lands in the cabinet.
+    /// </summary>
+    private static async Task<IResult?> ValidateJiraAsync(SetJiraCredentialRequest body, HttpContext http)
     {
-        if (string.IsNullOrWhiteSpace(body.BaseUrl)
-            || !Uri.TryCreate(body.BaseUrl.Trim(), UriKind.Absolute, out var uri)
-            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        var validation = await JiraBaseUrlGuard
+            .ValidateAsync(body.BaseUrl, AllowedJiraHostSuffixes(http), dnsResolve: null, http.RequestAborted)
+            .ConfigureAwait(false);
+        if (!validation.IsValid)
         {
             return Results.BadRequest(new
             {
-                error = "invalid_base_url",
-                detail = "baseUrl must be an absolute http(s) URL.",
+                error = validation.ErrorCode ?? "invalid_base_url",
+                detail = validation.ErrorDetail ?? "baseUrl must be an absolute https URL.",
             });
         }
         if (string.IsNullOrWhiteSpace(body.Email))
@@ -264,6 +275,14 @@ public static class IntegrationCredentialEndpoints
             return Results.BadRequest(new { error = "invalid_email", detail = "email is required." });
         }
         return ValidateSecret(body.ApiToken, "apiToken");
+    }
+
+    private static IReadOnlyList<string>? AllowedJiraHostSuffixes(HttpContext http)
+    {
+        var raw = http.RequestServices?.GetService<IConfiguration>()?["Jira:AllowedHostSuffixes"];
+        return string.IsNullOrWhiteSpace(raw)
+            ? null
+            : raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     private static (EmailCredential? Bundle, IResult? Error) ValidateEmail(SetEmailCredentialRequest body)
@@ -306,6 +325,31 @@ public static class IntegrationCredentialEndpoints
             SmtpPassword: body.SmtpPassword,
             SmtpUseStartTls: body.SmtpUseStartTls);
         return (bundle, null);
+    }
+
+    /// <summary>
+    /// Map a cabinet <see cref="ArgumentException"/> to a fixed, client-safe 400 —
+    /// the raw exception message may carry internal detail (cabinet naming, backend
+    /// state) and must NOT be echoed to the caller. The real message is logged
+    /// server-side (best-effort; never a secret) for operators.
+    /// </summary>
+    private static IResult RejectInvalidRequest(HttpContext http, string integration, ArgumentException ex)
+    {
+        try
+        {
+            http.RequestServices?.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(IntegrationCredentialEndpoints))
+                .LogWarning(ex, "Rejected {Integration} credential set: invalid request.", integration);
+        }
+        catch
+        {
+            // Logging is best-effort; never let it change the response.
+        }
+        return Results.BadRequest(new
+        {
+            error = "invalid_request",
+            detail = "the credential could not be stored; check the submitted values.",
+        });
     }
 
     private static IResult? ValidateSecret(string? secret, string field)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/IntegrationCredentialEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/IntegrationCredentialEndpoints.cs
@@ -1,0 +1,350 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Audit;
+using Tamma.Api.Services.Integrations;
+using Tamma.Core.Audit;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Integration BYOK — tenant-admin management API for per-tenant JIRA + email
+/// credentials, the integration sibling of Story 32-3's
+/// <c>ProviderCredentialEndpoints</c>.
+///
+/// <list type="bullet">
+///   <item><c>POST   /api/v1/integrations/jira/credential</c> — set the tenant's
+///     JIRA credential bundle (baseUrl + email + apiToken).</item>
+///   <item><c>DELETE /api/v1/integrations/jira/credential</c> — remove it (next
+///     resolve falls back to the single-user system tier / fails loud).</item>
+///   <item><c>POST   /api/v1/integrations/email/credential</c> — set the tenant's
+///     email transport credential bundle (transport + from + SMTP/Resend secret).</item>
+///   <item><c>DELETE /api/v1/integrations/email/credential</c> — remove it.</item>
+/// </list>
+///
+/// <para>RBAC: writes are gated to <c>tenant_owner</c> / <c>tenant_admin</c> by the
+/// <c>PlatformsManage</c> route policy (member → 403). Set is write-only: the
+/// response carries metadata (version) only, NEVER the secret (reveal-safe). Every
+/// mutation calls the resolver's <c>Invalidate</c> and emits the curated
+/// <see cref="SensitiveActionCatalog.IntegrationCredentialChanged"/> audit event.
+/// Integration credentials are tenant-scoped only (no per-user layer, mirroring the
+/// provider BYOK + prompt store).</para>
+/// </summary>
+public static class IntegrationCredentialEndpoints
+{
+    private const string JiraIntegration = "jira";
+    private const string EmailIntegration = "email";
+    private const int MinSecretLength = 4;
+    private const int MaxSecretLength = 8192;
+
+    // ── JIRA ────────────────────────────────────────────────────────────────
+
+    /// <summary><c>POST /api/v1/integrations/jira/credential</c>.</summary>
+    public static async Task<IResult> SetJiraCredential(
+        SetJiraCredentialRequest body,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] IIntegrationCredentialCabinet cabinet,
+        [FromServices] IJiraCredentialResolver resolver,
+        HttpContext http)
+    {
+        if (body is null)
+        {
+            return Results.BadRequest(new { error = "invalid_body" });
+        }
+        var validation = ValidateJira(body);
+        if (validation is not null) return validation;
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.BadRequest(new
+            {
+                error = "no_tenant_context",
+                detail = "registering an integration credential requires tenant context.",
+            });
+        }
+
+        var bundle = new JiraCredential(body.BaseUrl!.Trim(), body.Email!.Trim(), body.ApiToken!);
+        var json = JiraCredentialCodec.Serialize(bundle);
+
+        try
+        {
+            var meta = await cabinet.SetAsync(
+                tid, IntegrationCabinetNames.JiraConfig, JiraIntegration, json,
+                principal.GetUserId() ?? Guid.Empty, http.RequestAborted)
+                .ConfigureAwait(false);
+
+            resolver.Invalidate(tid);
+            await EmitChangeAsync(http, tid, principal.GetUserId(), JiraIntegration, "set",
+                meta.ActiveVersionNumber).ConfigureAwait(false);
+
+            return Results.Created(
+                "/api/v1/integrations/jira/credential",
+                new SetIntegrationCredentialResponse(JiraIntegration, meta.ActiveVersionNumber));
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+        catch (Exception ex) when (IsDuplicate(ex))
+        {
+            return Results.Conflict(new
+            {
+                error = "credential_exists",
+                detail = "a JIRA credential already exists for this tenant; delete it then set again to change it.",
+            });
+        }
+    }
+
+    /// <summary><c>DELETE /api/v1/integrations/jira/credential</c>.</summary>
+    public static Task<IResult> DeleteJiraCredential(
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] IIntegrationCredentialCabinet cabinet,
+        [FromServices] IJiraCredentialResolver resolver,
+        HttpContext http) =>
+        DeleteAsync(
+            JiraIntegration, IntegrationCabinetNames.JiraConfig,
+            principal, tenantContext, cabinet, () => resolver.Invalidate(tenantContext.TenantId), http);
+
+    // ── EMAIL ───────────────────────────────────────────────────────────────
+
+    /// <summary><c>POST /api/v1/integrations/email/credential</c>.</summary>
+    public static async Task<IResult> SetEmailCredential(
+        SetEmailCredentialRequest body,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] IIntegrationCredentialCabinet cabinet,
+        [FromServices] IEmailCredentialResolver resolver,
+        HttpContext http)
+    {
+        if (body is null)
+        {
+            return Results.BadRequest(new { error = "invalid_body" });
+        }
+        var (bundle, validation) = ValidateEmail(body);
+        if (validation is not null) return validation;
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.BadRequest(new
+            {
+                error = "no_tenant_context",
+                detail = "registering an integration credential requires tenant context.",
+            });
+        }
+
+        var json = EmailCredentialCodec.Serialize(bundle!);
+
+        try
+        {
+            var meta = await cabinet.SetAsync(
+                tid, IntegrationCabinetNames.EmailConfig, EmailIntegration, json,
+                principal.GetUserId() ?? Guid.Empty, http.RequestAborted)
+                .ConfigureAwait(false);
+
+            resolver.Invalidate(tid);
+            await EmitChangeAsync(http, tid, principal.GetUserId(), EmailIntegration, "set",
+                meta.ActiveVersionNumber).ConfigureAwait(false);
+
+            return Results.Created(
+                "/api/v1/integrations/email/credential",
+                new SetIntegrationCredentialResponse(EmailIntegration, meta.ActiveVersionNumber));
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = ex.Message });
+        }
+        catch (Exception ex) when (IsDuplicate(ex))
+        {
+            return Results.Conflict(new
+            {
+                error = "credential_exists",
+                detail = "an email credential already exists for this tenant; delete it then set again to change it.",
+            });
+        }
+    }
+
+    /// <summary><c>DELETE /api/v1/integrations/email/credential</c>.</summary>
+    public static Task<IResult> DeleteEmailCredential(
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        [FromServices] IIntegrationCredentialCabinet cabinet,
+        [FromServices] IEmailCredentialResolver resolver,
+        HttpContext http) =>
+        DeleteAsync(
+            EmailIntegration, IntegrationCabinetNames.EmailConfig,
+            principal, tenantContext, cabinet, () => resolver.Invalidate(tenantContext.TenantId), http);
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static async Task<IResult> DeleteAsync(
+        string integration,
+        string cabinetName,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        IIntegrationCredentialCabinet cabinet,
+        Action invalidate,
+        HttpContext http)
+    {
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.NotFound();
+        }
+
+        var removed = await cabinet.RemoveAsync(tid, cabinetName, http.RequestAborted)
+            .ConfigureAwait(false);
+        if (!removed)
+        {
+            return Results.NotFound(new
+            {
+                error = "credential_not_found",
+                detail = $"no {integration} credential is configured for this tenant.",
+            });
+        }
+
+        invalidate();
+        await EmitChangeAsync(http, tid, principal.GetUserId(), integration, "removed", version: null)
+            .ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    /// <summary>
+    /// Emit the curated <see cref="SensitiveActionCatalog.IntegrationCredentialChanged"/>
+    /// BYOK audit event (tenant-scoped) after a successful cabinet mutation. Metadata
+    /// only (integration, operation, version) — the emitter additionally scrubs any
+    /// secret-shaped value. Best-effort off the request scope; a missing registration
+    /// simply skips the emission. Never throws.
+    /// </summary>
+    private static async Task EmitChangeAsync(
+        HttpContext http, Guid tenantId, Guid? actorUserId,
+        string integration, string operation, int? version)
+    {
+        ISensitiveActionEmitter? emitter;
+        try { emitter = http.RequestServices?.GetService<ISensitiveActionEmitter>(); }
+        catch { emitter = null; }
+        if (emitter is null) return;
+
+        var tags = new Dictionary<string, string?>
+        {
+            ["integration"] = integration,
+            ["operation"] = operation,
+            ["mode"] = "byok",
+        };
+        var data = new Dictionary<string, object?>
+        {
+            ["integration"] = integration,
+            ["operation"] = operation,
+            ["mode"] = "byok",
+        };
+        if (version is int v) data["version"] = v;
+
+        await emitter.EmitAsync(
+            SensitiveAction.ForTenant(
+                SensitiveActionCatalog.IntegrationCredentialChanged, tenantId, actorUserId, tags, data),
+            http.RequestAborted).ConfigureAwait(false);
+    }
+
+    private static IResult? ValidateJira(SetJiraCredentialRequest body)
+    {
+        if (string.IsNullOrWhiteSpace(body.BaseUrl)
+            || !Uri.TryCreate(body.BaseUrl.Trim(), UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_base_url",
+                detail = "baseUrl must be an absolute http(s) URL.",
+            });
+        }
+        if (string.IsNullOrWhiteSpace(body.Email))
+        {
+            return Results.BadRequest(new { error = "invalid_email", detail = "email is required." });
+        }
+        return ValidateSecret(body.ApiToken, "apiToken");
+    }
+
+    private static (EmailCredential? Bundle, IResult? Error) ValidateEmail(SetEmailCredentialRequest body)
+    {
+        var transport = (body.Transport ?? string.Empty).Trim().ToLowerInvariant();
+        if (transport != EmailCredential.TransportSmtp && transport != EmailCredential.TransportResend)
+        {
+            return (null, Results.BadRequest(new
+            {
+                error = "invalid_transport",
+                detail = "transport must be 'smtp' or 'resend'.",
+            }));
+        }
+        if (string.IsNullOrWhiteSpace(body.From))
+        {
+            return (null, Results.BadRequest(new { error = "invalid_from", detail = "from is required." }));
+        }
+
+        if (transport == EmailCredential.TransportResend)
+        {
+            var secretError = ValidateSecret(body.ResendApiKey, "resendApiKey");
+            if (secretError is not null) return (null, secretError);
+        }
+        else if (string.IsNullOrWhiteSpace(body.SmtpHost))
+        {
+            return (null, Results.BadRequest(new
+            {
+                error = "invalid_smtp_host",
+                detail = "smtpHost is required for the smtp transport.",
+            }));
+        }
+
+        var bundle = new EmailCredential(
+            transport,
+            body.From!.Trim(),
+            ResendApiKey: body.ResendApiKey,
+            SmtpHost: body.SmtpHost,
+            SmtpPort: body.SmtpPort,
+            SmtpUsername: body.SmtpUsername,
+            SmtpPassword: body.SmtpPassword,
+            SmtpUseStartTls: body.SmtpUseStartTls);
+        return (bundle, null);
+    }
+
+    private static IResult? ValidateSecret(string? secret, string field)
+    {
+        if (string.IsNullOrWhiteSpace(secret))
+        {
+            return Results.BadRequest(new { error = "invalid_secret", detail = $"{field} is required." });
+        }
+        if (secret.Length is < MinSecretLength or > MaxSecretLength)
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_secret",
+                detail = $"{field} must be between {MinSecretLength} and {MaxSecretLength} chars.",
+            });
+        }
+        return null;
+    }
+
+    private static bool IsDuplicate(Exception ex) =>
+        ex is InvalidOperationException
+        || (ex.InnerException is Npgsql.PostgresException pg && pg.SqlState == "23505")
+        || (ex is Microsoft.EntityFrameworkCore.DbUpdateException due
+            && due.InnerException is Npgsql.PostgresException ipg && ipg.SqlState == "23505");
+}
+
+/// <summary>Request body to set a JIRA credential bundle. Fields are write-only; never echoed.</summary>
+public sealed record SetJiraCredentialRequest(string? BaseUrl, string? Email, string? ApiToken);
+
+/// <summary>Request body to set an email transport credential bundle. Write-only.</summary>
+public sealed record SetEmailCredentialRequest(
+    string? Transport,
+    string? From,
+    string? ResendApiKey = null,
+    string? SmtpHost = null,
+    int? SmtpPort = null,
+    string? SmtpUsername = null,
+    string? SmtpPassword = null,
+    bool? SmtpUseStartTls = null);
+
+/// <summary>Reveal-safe response — metadata only (integration + active version). NEVER the secret.</summary>
+public sealed record SetIntegrationCredentialResponse(string Integration, int Version);

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/EmailServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/EmailServiceCollectionExtensions.cs
@@ -41,6 +41,17 @@ public static class EmailServiceCollectionExtensions
         // runs, or by re-registering afterwards.
         services.TryAddSingleton<ISmtpTransport, MailKitSmtpTransport>();
 
+        // Integration BYOK — the per-tenant (SaaS) email transport. A SaaS tenant's
+        // message is delivered via THIS seam over the tenant's OWN authority (their
+        // Resend key / SMTP relay from the resolved bundle), never the platform
+        // singleton IEmailService with a tenant-supplied From (the From-spoofing /
+        // open-relay hole). ITenantEmailTransport is scoped because it emits the
+        // EMAIL.* audit through the scoped IEventRepository; the MailKit tenant SMTP
+        // transport is a stateless singleton.
+        services.TryAddSingleton<ITenantSmtpTransport, MailKitTenantSmtpTransport>();
+        services.TryAddScoped<Tamma.Api.Services.EmailMediation.ITenantEmailTransport,
+            Tamma.Api.Services.EmailMediation.TenantEmailTransport>();
+
         // Named HttpClient for Resend. Safe to register unconditionally — it
         // is only resolved when ResendEmailService is the active provider.
         services.AddHttpClient("resend", client =>

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/IntegrationCredentialServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/IntegrationCredentialServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// Integration BYOK — DI registration for the per-tenant JIRA + email credential
+/// resolvers (the mediation reads them), the credential-bound JIRA HTTP client, and
+/// the cabinet write helper (the write endpoints use it).
+///
+/// <para>The resolvers are singletons (their in-process BYOK cache is process-wide,
+/// like <c>DefaultProviderCredentialResolver</c>). They depend on the singleton
+/// <c>ITenantProviderKeyReader</c> registered by <c>AddProviderCredentialResolution</c>
+/// (call this AFTER it). The cabinet write helper is scoped (it composes the scoped
+/// <c>ISecretStore</c> facade) and is only registered when the secret store is wired
+/// (the write endpoints are inert without it).</para>
+/// </summary>
+public static class IntegrationCredentialServiceCollectionExtensions
+{
+    public static IServiceCollection AddIntegrationCredentialResolution(
+        this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        // Per-request resolvers (tenant BYOK → single-user system config → fail-loud).
+        // Singletons so the short-TTL cache is process-wide; Invalidate() keeps it
+        // coherent after a write.
+        services.TryAddSingleton<IJiraCredentialResolver, JiraCredentialResolver>();
+        services.TryAddSingleton<IEmailCredentialResolver, EmailCredentialResolver>();
+
+        // Credential-bound JIRA HTTP client (the JIRA analog of git's client factory).
+        services.TryAddSingleton<IJiraApiClient, JiraApiClient>();
+
+        // Governed cabinet write helper (set via ISecretStore facade; remove via the
+        // cabinet seam). Only meaningful with the secret store wired.
+        if (services.Any(d => d.ServiceType == typeof(IDbContextFactory<SecretsDbContext>)))
+        {
+            services.TryAddScoped<IIntegrationCredentialCabinet, IntegrationCredentialCabinet>();
+        }
+
+        return services;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -634,6 +634,16 @@ builder.Services.AddScoped<Tamma.Api.Services.Jira.IJiraMediationService,
 builder.Services.AddScoped<Tamma.Api.Services.EmailMediation.IEmailMediationService,
     Tamma.Api.Services.EmailMediation.EmailMediationService>();
 
+// ── Integration BYOK — per-tenant JIRA + email credentials ──
+// The JIRA/email mediation now resolves the acting tenant's OWN credential
+// per-request (BYOK→system→fail-loud, like git/LLM) instead of a shared platform
+// credential + SaaS-deny guard. This wires the resolvers (mediation reads them),
+// the credential-bound JIRA HTTP client, and the cabinet write helper (the
+// /api/v1/integrations/* management endpoints use it). Registered AFTER
+// AddProviderCredentialResolution so the singleton cabinet reader + SecretsDbContext
+// factory signal are already present.
+builder.Services.AddIntegrationCredentialResolution();
+
 // Story 32-5 (T4) — provider-side DI for the server-side tool loop, FORMALIZED
 // in the API process (replacing T3's best-effort GetService factory). The loop
 // (extracted verbatim into InlineToolLoopRunner) now executes HERE, where the
@@ -2349,6 +2359,25 @@ agents.MapPost("/providers/{provider}/credential/rotate", ProviderCredentialEndp
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
 agents.MapDelete("/providers/{provider}/credential", ProviderCredentialEndpoints.DeleteCredential)
     .RequireAuthorization("AgentManage").RequireRateLimiting("ConfigWrite");
+
+// ── Integration BYOK — tenant-admin JIRA + email credential management ──
+// Sibling of the Story 32-3 provider BYOK endpoints. Set/remove the tenant's own
+// JIRA/email credential in the secret cabinet so the mediation resolves it
+// per-request (BYOK→system→fail-loud). PlatformsManage (tenant_owner/tenant_admin →
+// member 403), like the platform-installation picker. Set is reveal-safe — the
+// response carries the version only, NEVER the secret.
+app.MapPost("/api/v1/integrations/jira/credential", IntegrationCredentialEndpoints.SetJiraCredential)
+    .RequireAuthorization("PlatformsManage").RequireRateLimiting("ConfigWrite")
+    .WithName("SetJiraCredential");
+app.MapDelete("/api/v1/integrations/jira/credential", IntegrationCredentialEndpoints.DeleteJiraCredential)
+    .RequireAuthorization("PlatformsManage").RequireRateLimiting("ConfigWrite")
+    .WithName("DeleteJiraCredential");
+app.MapPost("/api/v1/integrations/email/credential", IntegrationCredentialEndpoints.SetEmailCredential)
+    .RequireAuthorization("PlatformsManage").RequireRateLimiting("ConfigWrite")
+    .WithName("SetEmailCredential");
+app.MapDelete("/api/v1/integrations/email/credential", IntegrationCredentialEndpoints.DeleteEmailCredential)
+    .RequireAuthorization("PlatformsManage").RequireRateLimiting("ConfigWrite")
+    .WithName("DeleteEmailCredential");
 
 // ── Story 32-2 — entity-aware registry / resolution surface (/api/agents) ──
 // Distinct from the legacy /api/v1/agents group above (which stays byte-for-byte

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -175,6 +175,18 @@ builder.Services.AddHttpClient("github", client =>
     if (!string.IsNullOrEmpty(token))
         client.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 });
+// Integration BYOK — the credential-bound JIRA client (JiraApiClient) rides this
+// named client. It carries NO base address (each call targets the per-tenant
+// baseUrl) and is hardened against SSRF: redirects are NOT auto-followed (a 3xx to
+// an internal host is refused, not chased), and the connect callback re-checks the
+// resolved address at connect time so a host that passed URL validation but rebinds
+// its DNS to a private/metadata address cannot be reached.
+builder.Services.AddHttpClient(Tamma.Api.Services.Integrations.JiraApiClient.HttpClientName)
+    .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
+    {
+        AllowAutoRedirect = false,
+        ConnectCallback = Tamma.Api.Services.Integrations.JiraBaseUrlGuard.SafeConnectAsync,
+    });
 
 // ────────────────────────────────────────────────────────────────────────────
 // Database + repositories (via extension method)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/ITenantSmtpTransport.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/ITenantSmtpTransport.cs
@@ -1,0 +1,25 @@
+using Tamma.Api.Services.Integrations;
+
+namespace Tamma.Api.Services.Email;
+
+/// <summary>
+/// Per-request SMTP send bound to a TENANT-supplied transport (BYOK). Unlike
+/// <see cref="ISmtpTransport"/> — which reads the process <c>Email:Smtp:*</c>
+/// config and delivers the platform's outbox rows — this seam takes the tenant's
+/// own SMTP host/port/credentials from the resolved
+/// <see cref="EmailCredential"/> bundle and sends via THAT relay. This is the
+/// anti-spoofing control: a SaaS tenant's <c>From</c> only ever rides the tenant's
+/// own sending authority, never the platform relay.
+///
+/// <para>Production is <see cref="MailKitTenantSmtpTransport"/>; tests supply a
+/// fake so the per-tenant routing can be asserted without a real relay. Throws for
+/// ANY transport failure (connect / auth / send) — <see cref="EmailMediation.TenantEmailTransport"/>
+/// catches, emits the <c>EMAIL.SENT.FAILED</c> audit, and never rethrows.</para>
+/// </summary>
+public interface ITenantSmtpTransport
+{
+    /// <summary>Deliver <paramref name="message"/> via the SMTP relay described by
+    /// <paramref name="credential"/> (host/port/username/password), using
+    /// <see cref="EmailCredential.From"/> as the envelope sender.</summary>
+    Task SendAsync(EmailCredential credential, EmailMessage message, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Email/MailKitTenantSmtpTransport.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Email/MailKitTenantSmtpTransport.cs
@@ -1,0 +1,57 @@
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using MimeKit;
+using Tamma.Api.Services.Integrations;
+
+namespace Tamma.Api.Services.Email;
+
+/// <summary>
+/// Production MailKit implementation of <see cref="ITenantSmtpTransport"/>. Connects
+/// to the TENANT'S OWN SMTP relay (host/port/credentials from the resolved
+/// <see cref="EmailCredential"/>) and sends synchronously. Does not log recipient,
+/// subject, or body — only the relay host on failure (surfaced by the exception the
+/// caller catches).
+/// </summary>
+public sealed class MailKitTenantSmtpTransport : ITenantSmtpTransport
+{
+    private const int DefaultSmtpPort = 587;
+
+    public async Task SendAsync(EmailCredential credential, EmailMessage message, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(message);
+
+        var host = credential.SmtpHost
+            ?? throw new InvalidOperationException("Tenant SMTP transport requires smtpHost.");
+        var port = credential.SmtpPort ?? DefaultSmtpPort;
+
+        var mime = new MimeMessage();
+        mime.From.Add(MailboxAddress.Parse(credential.From));
+        mime.To.Add(MailboxAddress.Parse(message.To));
+        mime.Subject = message.Subject;
+        mime.Body = new BodyBuilder
+        {
+            HtmlBody = message.Html,
+            TextBody = message.Text,
+        }.ToMessageBody();
+
+        // Default to opportunistic STARTTLS (matches MailKitSmtpTransport); a tenant
+        // that pins smtpUseStartTls=false still negotiates TLS when the relay offers
+        // it via Auto. We never fall back to a cleartext-only connection silently.
+        var secureOptions = credential.SmtpUseStartTls == false
+            ? SecureSocketOptions.Auto
+            : SecureSocketOptions.StartTlsWhenAvailable;
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(host, port, secureOptions, ct).ConfigureAwait(false);
+
+        if (!string.IsNullOrEmpty(credential.SmtpUsername))
+        {
+            await client.AuthenticateAsync(credential.SmtpUsername, credential.SmtpPassword, ct)
+                .ConfigureAwait(false);
+        }
+
+        await client.SendAsync(mime, ct).ConfigureAwait(false);
+        await client.DisconnectAsync(quit: true, ct).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationResponses.cs
@@ -36,13 +36,14 @@ public static class EmailMediationFailureCodes
     public const string PlatformError = "PLATFORM_ERROR";
 
     /// <summary>
-    /// SaaS fail-closed guard: a tenant-workflow-initiated mediated send was denied
-    /// because the message would go out FROM the platform's configured sender
-    /// identity (<c>Email:From</c>) with no per-tenant sender/domain allowlist. Opt
-    /// back in with <c>Email:AllowMediatedSendInSaaS=true</c> once a per-tenant sender
-    /// policy exists. Single-user mode is never denied (one principal owns the domain).
+    /// Per-tenant BYOK fail-loud: no email transport credential resolved for the
+    /// acting tenant (no tenant cabinet bundle in SaaS, and no single-user
+    /// <c>Email:*</c> config). The transport is NEVER reached — the mediation
+    /// fails loud rather than sending under a shared platform sender identity
+    /// (the confused-deputy). The tenant registers its own credential via
+    /// <c>POST /api/v1/integrations/email/credential</c>.
     /// </summary>
-    public const string MediationDeniedInSaaS = "email_mediation_denied_in_saas";
+    public const string CredentialUnavailable = "EMAIL_CREDENTIAL_UNAVAILABLE";
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
@@ -8,49 +8,59 @@ namespace Tamma.Api.Services.EmailMediation;
 /// <summary>
 /// Story 38 (Phase 1) + integration BYOK — composes the email-mediation sequence
 /// entirely inside <c>Tamma.Api</c>: resolve the acting tenant's email transport
-/// credential per-request (BYOK→system→fail-loud, like git/LLM), thread its
-/// tenant-authorized <c>From</c> identity onto the rendered message, and accept it
-/// into the credentialed, outbox-backed <see cref="IEmailService"/> for delivery.
-/// The transport secret NEVER reaches the engine — it stays in Tamma.Api (cabinet
-/// or single-user config).
+/// credential per-request (BYOK→system→fail-loud, like git/LLM), then deliver via
+/// the resolved credential's OWN transport authority. The transport secret NEVER
+/// reaches the engine — it stays in Tamma.Api (cabinet or single-user config).
 ///
 /// <para><b>Fail-loud tenant resolution (replaces the old SaaS-deny guard).</b>
 /// The credential is resolved via <see cref="IEmailCredentialResolver"/>:
 /// <list type="bullet">
 ///   <item><b>present</b> — the tenant's BYOK bundle (SaaS) or the single-user
 ///     <c>Email:*</c> config (system tier) ⇒ ALLOW, sending FROM the resolved
-///     tenant-authorized identity.</item>
+///     tenant-authorized identity, over that tier's own transport.</item>
 ///   <item><b>absent</b> — no per-tenant credential and no legitimate system tier
 ///     ⇒ <b>fail loud</b> with the typed
 ///     <see cref="EmailMediationFailureCodes.CredentialUnavailable"/> and a WARN
-///     log; the transport is NEVER reached. This closes the confused-deputy: a
+///     log; no transport is ever reached. This closes the confused-deputy: a
 ///     SaaS tenant can no longer send under a shared platform sender identity.</item>
 /// </list></para>
 ///
-/// <para>The DCB audit is owned by <see cref="IEmailService"/> itself
+/// <para><b>Per-tier transport authority (the anti-spoofing invariant).</b> The
+/// transport is chosen by the tier that answered — NOT a single shared singleton:
+/// <list type="bullet">
+///   <item><b>SaaS BYOK (<see cref="IntegrationCredentialSource.Tenant"/>)</b> —
+///     delivered via <see cref="ITenantEmailTransport"/> built from the tenant's
+///     OWN bundle (their Resend key / their SMTP relay). The tenant's <c>From</c> is
+///     therefore backed by the tenant's own sending authority (their DKIM); they can
+///     only ever send as themselves. The platform singleton
+///     <see cref="IEmailService"/> is <b>never</b> used for a SaaS tenant — using it
+///     with a tenant-supplied <c>From</c> would be an open-relay / From-spoofing
+///     hole (the platform's DKIM-signed transport emitting brand-impersonating
+///     mail).</item>
+///   <item><b>single-user system tier (<see cref="IntegrationCredentialSource.System"/>)</b>
+///     — delivered via the platform singleton <see cref="IEmailService"/>, whose
+///     <c>Email:*</c> process config IS the sole principal's own authority.</item>
+/// </list></para>
+///
+/// <para>The DCB audit is owned by the transport itself
 /// (<c>EMAIL.QUEUED/SENT/FAILED</c>); the mediation layer does NOT emit a duplicate
 /// terminal event.</para>
-///
-/// <para><b>Bounded transport threading.</b> The resolved <c>From</c> is threaded
-/// onto the message (the tenant-owned sender identity — the anti-spoofing control);
-/// swapping the singleton outbox transport's own secret (the tenant's Resend key /
-/// SMTP endpoint) per-tenant is a follow-on, because the outbox transport reads
-/// process config and carrying a per-tenant SMTP endpoint would need an outbox
-/// column (NON-migration forbids it). Single-user's transport IS the config the
-/// resolver mirrors, so delivery is fully consistent there.</para>
 /// </summary>
 public sealed class EmailMediationService : IEmailMediationService
 {
     private readonly IEmailService _email;
+    private readonly ITenantEmailTransport _tenantTransport;
     private readonly IEmailCredentialResolver _credentials;
     private readonly ILogger<EmailMediationService> _logger;
 
     public EmailMediationService(
         IEmailService email,
+        ITenantEmailTransport tenantTransport,
         IEmailCredentialResolver credentials,
         ILogger<EmailMediationService> logger)
     {
         _email = email ?? throw new ArgumentNullException(nameof(email));
+        _tenantTransport = tenantTransport ?? throw new ArgumentNullException(nameof(tenantTransport));
         _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -124,7 +134,14 @@ public sealed class EmailMediationService : IEmailMediationService
                 TenantId: tenantId,
                 UserId: null);
 
-            var txnId = await _email.SendAsync(message, ct).ConfigureAwait(false);
+            // Route by the tier that answered — the anti-spoofing invariant. A SaaS
+            // BYOK credential is delivered via the TENANT'S OWN transport (their
+            // Resend key / SMTP relay), never the platform singleton with a
+            // tenant-supplied From. Single-user's system tier uses the platform
+            // singleton, whose Email:* config IS the sole principal's authority.
+            var txnId = resolution.Source == IntegrationCredentialSource.Tenant
+                ? await _tenantTransport.SendAsync(resolution.Credential, message, ct).ConfigureAwait(false)
+                : await _email.SendAsync(message, ct).ConfigureAwait(false);
 
             return new EmailMediationResult
             {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/EmailMediationService.cs
@@ -1,50 +1,57 @@
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.Email;
-using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Integrations;
 using Tamma.Core.Logging;
 
 namespace Tamma.Api.Services.EmailMediation;
 
 /// <summary>
-/// Story 38 (Phase 1) — composes the email-mediation sequence entirely inside
-/// <c>Tamma.Api</c>: accept the engine's rendered message into the credentialed,
-/// outbox-backed <see cref="IEmailService"/> (SMTP / Resend / in-memory, chosen by
-/// <c>AddEmailServices</c> config) under the caller's tenant context. Unlike git/CI
-/// there is no per-tenant BYOK token resolver and no repo guard — email is a single,
-/// server-side, config-provided integration (mirrors the Slack outbox plane).
+/// Story 38 (Phase 1) + integration BYOK — composes the email-mediation sequence
+/// entirely inside <c>Tamma.Api</c>: resolve the acting tenant's email transport
+/// credential per-request (BYOK→system→fail-loud, like git/LLM), thread its
+/// tenant-authorized <c>From</c> identity onto the rendered message, and accept it
+/// into the credentialed, outbox-backed <see cref="IEmailService"/> for delivery.
+/// The transport secret NEVER reaches the engine — it stays in Tamma.Api (cabinet
+/// or single-user config).
 ///
-/// <para>The DCB audit is owned by <see cref="IEmailService"/> itself, which emits
-/// <see cref="EmailEventTypes.Queued"/> on accept and later
-/// <see cref="EmailEventTypes.Sent"/> / <see cref="EmailEventTypes.Failed"/> from the
-/// transport; the mediation layer therefore does NOT emit a duplicate terminal event
-/// (that would double-audit and collide with the subsystem's <c>EMAIL.SENT.*</c>
-/// types). The email credential NEVER reaches the engine — it stays in Tamma.Api
-/// config.</para>
+/// <para><b>Fail-loud tenant resolution (replaces the old SaaS-deny guard).</b>
+/// The credential is resolved via <see cref="IEmailCredentialResolver"/>:
+/// <list type="bullet">
+///   <item><b>present</b> — the tenant's BYOK bundle (SaaS) or the single-user
+///     <c>Email:*</c> config (system tier) ⇒ ALLOW, sending FROM the resolved
+///     tenant-authorized identity.</item>
+///   <item><b>absent</b> — no per-tenant credential and no legitimate system tier
+///     ⇒ <b>fail loud</b> with the typed
+///     <see cref="EmailMediationFailureCodes.CredentialUnavailable"/> and a WARN
+///     log; the transport is NEVER reached. This closes the confused-deputy: a
+///     SaaS tenant can no longer send under a shared platform sender identity.</item>
+/// </list></para>
+///
+/// <para>The DCB audit is owned by <see cref="IEmailService"/> itself
+/// (<c>EMAIL.QUEUED/SENT/FAILED</c>); the mediation layer does NOT emit a duplicate
+/// terminal event.</para>
+///
+/// <para><b>Bounded transport threading.</b> The resolved <c>From</c> is threaded
+/// onto the message (the tenant-owned sender identity — the anti-spoofing control);
+/// swapping the singleton outbox transport's own secret (the tenant's Resend key /
+/// SMTP endpoint) per-tenant is a follow-on, because the outbox transport reads
+/// process config and carrying a per-tenant SMTP endpoint would need an outbox
+/// column (NON-migration forbids it). Single-user's transport IS the config the
+/// resolver mirrors, so delivery is fully consistent there.</para>
 /// </summary>
 public sealed class EmailMediationService : IEmailMediationService
 {
-    /// <summary>
-    /// Config flag (default FALSE) that opts a SaaS deployment back into
-    /// tenant-workflow-initiated mediated email sends. See the SaaS guard in
-    /// <see cref="SendEmailAsync"/> and <see cref="EmailMediationFailureCodes.MediationDeniedInSaaS"/>.
-    /// </summary>
-    internal const string AllowMediatedSendInSaaSKey = "Email:AllowMediatedSendInSaaS";
-
     private readonly IEmailService _email;
-    private readonly ITammaModeProvider _mode;
-    private readonly IConfiguration _config;
+    private readonly IEmailCredentialResolver _credentials;
     private readonly ILogger<EmailMediationService> _logger;
 
     public EmailMediationService(
         IEmailService email,
-        ITammaModeProvider mode,
-        IConfiguration config,
+        IEmailCredentialResolver credentials,
         ILogger<EmailMediationService> logger)
     {
         _email = email ?? throw new ArgumentNullException(nameof(email));
-        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
-        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -52,31 +59,39 @@ public sealed class EmailMediationService : IEmailMediationService
     {
         ArgumentNullException.ThrowIfNull(body);
 
-        // SaaS fail-closed tenant guard (mirrors the JIRA/git mediation guards).
-        // A mediated send composes mail FROM the platform's configured sender identity
-        // (Email:From) — there is no per-tenant From/domain allowlist here. In SaaS a
-        // tenant workflow could therefore emit arbitrary mail under the platform's
-        // reputation/domain (spam/phishing amplification), so deny-by-default. An
-        // operator opts back in with Email:AllowMediatedSendInSaaS=true once a
-        // per-tenant sender policy exists. Single-user mode is always allowed (the sole
-        // principal owns the domain). Fail-soft: return a typed denial inside 200
-        // success:false, never a raw 5xx. Only TENANT-WORKFLOW-initiated sends reach
-        // this service; system emails (welcome/verification/password-reset) call
-        // IEmailService directly and are unaffected.
-        if (_mode.Mode == TammaMode.SaaS
-            && !_config.GetValue(AllowMediatedSendInSaaSKey, false))
+        // ── fail-loud per-tenant credential gate (runs BEFORE the transport) ──
+        // SaaS: the tenant must have registered its own email credential; absent ⇒
+        // fail loud rather than sending under a shared platform sender identity
+        // (the confused-deputy). Single-user resolves the Email:* config tier.
+        EmailCredentialResolution? resolution;
+        try
+        {
+            resolution = await _credentials.ResolveAsync(tenantId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "email-mediation credential resolution threw; failing loud (CREDENTIAL_UNAVAILABLE). correlationId={CorrelationId}, tenantId={TenantId}",
+                LogSanitizer.Clean(body.CorrelationId), tenantId);
+            resolution = null;
+        }
+
+        if (resolution is null)
         {
             _logger.LogWarning(
-                "email-mediation send DENIED in SaaS mode: no per-tenant sender allowlist; " +
-                "set {ConfigKey}=true to opt in. correlationId={CorrelationId}, tenantId={TenantId}",
-                AllowMediatedSendInSaaSKey, LogSanitizer.Clean(body.CorrelationId), tenantId);
+                "email-mediation FAILED-LOUD (no email credential for tenant): send refused — register a per-tenant email credential or configure Email:* (single-user). correlationId={CorrelationId}, tenantId={TenantId}",
+                LogSanitizer.Clean(body.CorrelationId), tenantId);
 
             return new EmailMediationResult
             {
                 Success = false,
-                Outcome = "Denied",
-                FailureCode = EmailMediationFailureCodes.MediationDeniedInSaaS,
-                FailureReason = "mediated email send is not permitted in SaaS mode",
+                Outcome = "Error",
+                FailureCode = EmailMediationFailureCodes.CredentialUnavailable,
+                FailureReason = "no email credential is configured for this tenant; register one via POST /api/v1/integrations/email/credential.",
                 CorrelationId = body.CorrelationId,
             };
         }
@@ -96,15 +111,15 @@ public sealed class EmailMediationService : IEmailMediationService
         try
         {
             // The engine sends a single already-rendered body; use it for BOTH the
-            // plain-text (required) and HTML variants. The tenant scopes the message
-            // + its EMAIL.* audit events; no per-user identity at the engine-service
-            // principal plane.
+            // plain-text (required) and HTML variants. From = the resolved
+            // tenant-authorized sender identity. The tenant scopes the message +
+            // its EMAIL.* audit events.
             var message = new EmailMessage(
                 To: body.To,
                 Subject: body.Subject,
                 Html: body.Body,
                 Text: body.Body,
-                From: null,
+                From: resolution.Credential.From,
                 Template: null,
                 TenantId: tenantId,
                 UserId: null);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/ITenantEmailTransport.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/ITenantEmailTransport.cs
@@ -1,0 +1,38 @@
+using Tamma.Api.Services.Email;
+using Tamma.Api.Services.Integrations;
+
+namespace Tamma.Api.Services.EmailMediation;
+
+/// <summary>
+/// SaaS BYOK email transport — sends a single message via the TENANT'S OWN sending
+/// authority resolved from the per-tenant credential bundle: their Resend API key,
+/// or their SMTP relay (host/port/username/password). This is the anti-spoofing
+/// control at the heart of email BYOK.
+///
+/// <para><b>Why not the platform singleton <see cref="IEmailService"/>?</b> The
+/// platform transport is DKIM-signed for the platform's own domain. If a SaaS
+/// tenant's message were delivered through it with only a tenant-supplied
+/// <c>From</c>, a <c>tenant_admin</c> could set
+/// <c>From: security@&lt;platform-domain&gt;</c> and the platform would emit a
+/// valid, brand-impersonating email — the tenant's stored transport secret never
+/// used, the BYOK gate illusory. Routing SaaS sends through THIS seam means the
+/// <c>From</c> is always backed by the tenant's own transport authority (their DKIM
+/// / their relay), so a tenant can only ever send as themselves. The platform
+/// singleton is reserved for the single-user system tier, whose <c>Email:*</c>
+/// config IS the sole principal's authority.</para>
+///
+/// <para>Emits the same <c>EMAIL.QUEUED / EMAIL.SENT.SUCCESS / EMAIL.SENT.FAILED</c>
+/// DCB audit the platform transport does, so a SaaS tenant's mail keeps a full
+/// audit trail. Never throws for transport failures — those surface via
+/// <c>EMAIL.SENT.FAILED</c> and the returned txn id (mirrors the
+/// <see cref="IEmailService"/> contract).</para>
+/// </summary>
+public interface ITenantEmailTransport
+{
+    /// <summary>
+    /// Send <paramref name="message"/> via the transport described by
+    /// <paramref name="credential"/> (<c>resend</c> or <c>smtp</c>). Returns the
+    /// transaction id correlating the emitted EMAIL.* events.
+    /// </summary>
+    Task<Guid> SendAsync(EmailCredential credential, EmailMessage message, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/TenantEmailTransport.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/EmailMediation/TenantEmailTransport.cs
@@ -1,0 +1,181 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Email;
+using Tamma.Api.Services.Integrations;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.EmailMediation;
+
+/// <summary>
+/// Default <see cref="ITenantEmailTransport"/> — delivers a SaaS tenant's message
+/// through the tenant's OWN transport (their Resend key over HTTP, or their SMTP
+/// relay via <see cref="ITenantSmtpTransport"/>), emitting the EMAIL.* DCB audit.
+/// The tenant transport secret is request-scoped (from the resolved bundle) and is
+/// NEVER logged or echoed.
+/// </summary>
+public sealed class TenantEmailTransport : ITenantEmailTransport
+{
+    private const string ResendClientName = "resend";
+    private static readonly Uri ResendBaseAddress = new("https://api.resend.com/");
+    private const string ResendEndpoint = "emails";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITenantSmtpTransport _smtp;
+    private readonly IEventRepository _events;
+    private readonly ILogger<TenantEmailTransport> _logger;
+
+    public TenantEmailTransport(
+        IHttpClientFactory httpClientFactory,
+        ITenantSmtpTransport smtp,
+        IEventRepository events,
+        ILogger<TenantEmailTransport> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _smtp = smtp ?? throw new ArgumentNullException(nameof(smtp));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Guid> SendAsync(EmailCredential credential, EmailMessage message, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(message);
+
+        var txnId = Guid.NewGuid();
+        var tenantId = message.TenantId;
+        var template = message.Template ?? "unknown";
+
+        await SafeEmitAsync(EmailEventTypes.Queued, txnId, template, tenantId, message.UserId, extraData: null)
+            .ConfigureAwait(false);
+
+        try
+        {
+            if (credential.Transport == EmailCredential.TransportResend)
+            {
+                await SendViaResendAsync(txnId, credential, message, template, tenantId, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                await _smtp.SendAsync(credential, message, ct).ConfigureAwait(false);
+                await SafeEmitAsync(EmailEventTypes.Sent, txnId, template, tenantId, message.UserId,
+                    extraData: new Dictionary<string, object?> { ["provider"] = "smtp" }).ConfigureAwait(false);
+                _logger.LogInformation("Tenant SMTP delivery ok txn={TxnId}", txnId);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // NEVER log recipient / subject / body / host — only txn id + provider.
+            _logger.LogError(ex, "Tenant email delivery failed txn={TxnId} transport={Transport}",
+                txnId, credential.Transport);
+            await SafeEmitAsync(EmailEventTypes.Failed, txnId, template, tenantId, message.UserId,
+                extraData: new Dictionary<string, object?>
+                {
+                    ["provider"] = credential.Transport,
+                    ["error_class"] = ex.GetType().FullName,
+                }).ConfigureAwait(false);
+        }
+
+        return txnId;
+    }
+
+    private async Task SendViaResendAsync(
+        Guid txnId, EmailCredential credential, EmailMessage message, string template,
+        Guid? tenantId, CancellationToken ct)
+    {
+        var client = _httpClientFactory.CreateClient(ResendClientName);
+        var baseAddress = client.BaseAddress ?? ResendBaseAddress;
+
+        var payload = new ResendRequest(
+            From: credential.From,
+            To: new[] { message.To },
+            Subject: message.Subject,
+            Html: message.Html,
+            Text: message.Text);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, new Uri(baseAddress, ResendEndpoint))
+        {
+            Content = JsonContent.Create(payload),
+        };
+        // Per-request auth with the TENANT'S key — never mutate the shared named
+        // client's DefaultRequestHeaders (that would leak one tenant's key onto
+        // another tenant's request on the pooled handler).
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", credential.ResendApiKey);
+
+        using var response = await client.SendAsync(request, ct).ConfigureAwait(false);
+
+        if (response.IsSuccessStatusCode)
+        {
+            await SafeEmitAsync(EmailEventTypes.Sent, txnId, template, tenantId, message.UserId,
+                extraData: new Dictionary<string, object?>
+                {
+                    ["provider"] = "resend",
+                    ["http_status"] = (int)response.StatusCode,
+                }).ConfigureAwait(false);
+            _logger.LogInformation("Tenant Resend delivery ok txn={TxnId} status={Status}",
+                txnId, (int)response.StatusCode);
+            return;
+        }
+
+        _logger.LogError("Tenant Resend delivery failed txn={TxnId} status={Status}",
+            txnId, (int)response.StatusCode);
+        await SafeEmitAsync(EmailEventTypes.Failed, txnId, template, tenantId, message.UserId,
+            extraData: new Dictionary<string, object?>
+            {
+                ["provider"] = "resend",
+                ["error_class"] = "HttpStatusError",
+                ["http_status"] = (int)response.StatusCode,
+            }).ConfigureAwait(false);
+    }
+
+    private async Task SafeEmitAsync(
+        string type, Guid txnId, string template, Guid? tenantId, Guid? userId,
+        IReadOnlyDictionary<string, object?>? extraData)
+    {
+        try
+        {
+            var tags = new Dictionary<string, string?>
+            {
+                ["txn_id"] = txnId.ToString(),
+                ["template"] = template,
+                ["tenant_id"] = tenantId?.ToString(),
+                ["user_id"] = userId?.ToString(),
+                ["mode"] = "byok",
+            };
+            var data = new Dictionary<string, object?>();
+            if (extraData is not null)
+            {
+                foreach (var kv in extraData)
+                    data[kv.Key] = kv.Value;
+            }
+
+            await _events.AppendAsync(new DomainEvent
+            {
+                Type = type,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(tags),
+                Metadata = """{"eventSource":"system"}""",
+                Data = JsonSerializer.Serialize(data),
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Event-store failures must never break the send. Txn id + type only — no PII.
+            _logger.LogWarning(ex, "Tenant email event emission failed txn={TxnId} type={Type}", txnId, type);
+        }
+    }
+
+    private sealed record ResendRequest(
+        [property: JsonPropertyName("from")] string From,
+        [property: JsonPropertyName("to")] string[] To,
+        [property: JsonPropertyName("subject")] string Subject,
+        [property: JsonPropertyName("html")] string Html,
+        [property: JsonPropertyName("text")] string Text);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredential.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredential.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// A resolved email transport credential bundle. The transport secret
+/// (<see cref="ResendApiKey"/> / <see cref="SmtpPassword"/>) is request-scoped and
+/// is NEVER logged, emitted onto a DCB event, or echoed on an HTTP response. The
+/// non-secret <see cref="From"/> is the tenant-authorized sender identity threaded
+/// onto the outgoing message.
+/// </summary>
+/// <param name="Transport">Transport kind: <c>smtp</c> or <c>resend</c>.</param>
+/// <param name="From">The sender identity (RFC-5322 from address).</param>
+/// <param name="ResendApiKey">Resend API key (required when
+/// <see cref="Transport"/> is <c>resend</c>). Secret.</param>
+/// <param name="SmtpHost">SMTP host (required when <see cref="Transport"/> is
+/// <c>smtp</c>).</param>
+/// <param name="SmtpPort">SMTP port (optional; transport default when null).</param>
+/// <param name="SmtpUsername">SMTP username (optional).</param>
+/// <param name="SmtpPassword">SMTP password (optional). Secret.</param>
+/// <param name="SmtpUseStartTls">Whether to negotiate STARTTLS (optional).</param>
+public sealed record EmailCredential(
+    string Transport,
+    string From,
+    string? ResendApiKey = null,
+    string? SmtpHost = null,
+    int? SmtpPort = null,
+    string? SmtpUsername = null,
+    string? SmtpPassword = null,
+    bool? SmtpUseStartTls = null)
+{
+    public const string TransportSmtp = "smtp";
+    public const string TransportResend = "resend";
+}
+
+/// <summary>
+/// A resolved <see cref="EmailCredential"/> plus the tier that answered
+/// (tenant BYOK vs single-user system config).
+/// </summary>
+public sealed record EmailCredentialResolution(
+    EmailCredential Credential, IntegrationCredentialSource Source);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialCodec.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialCodec.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// The single (de)serialization seam for the email credential BUNDLE stored as a
+/// cabinet secret's plaintext. One source of truth so the write endpoint
+/// (serialize) and the resolver (deserialize) cannot drift on the JSON shape.
+/// </summary>
+public static class EmailCredentialCodec
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Serialize a bundle to the cabinet plaintext JSON.</summary>
+    public static string Serialize(EmailCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        return JsonSerializer.Serialize(
+            new Bundle(
+                credential.Transport,
+                credential.From,
+                credential.ResendApiKey,
+                credential.SmtpHost,
+                credential.SmtpPort,
+                credential.SmtpUsername,
+                credential.SmtpPassword,
+                credential.SmtpUseStartTls),
+            Options);
+    }
+
+    /// <summary>
+    /// Parse a stored bundle back into an <see cref="EmailCredential"/>. Returns
+    /// null when the JSON is malformed, the transport is unknown, or the
+    /// transport-required secret / <c>from</c> is missing — the resolver treats
+    /// that as "credential absent" (never a partial credential).
+    /// </summary>
+    public static EmailCredential? TryDeserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        Bundle? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<Bundle>(json, Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (bundle is null
+            || string.IsNullOrWhiteSpace(bundle.Transport)
+            || string.IsNullOrWhiteSpace(bundle.From))
+        {
+            return null;
+        }
+
+        var transport = bundle.Transport.Trim().ToLowerInvariant();
+        var credential = new EmailCredential(
+            transport,
+            bundle.From.Trim(),
+            bundle.ResendApiKey,
+            bundle.SmtpHost,
+            bundle.SmtpPort,
+            bundle.SmtpUsername,
+            bundle.SmtpPassword,
+            bundle.SmtpUseStartTls);
+
+        return IsComplete(credential) ? credential : null;
+    }
+
+    /// <summary>
+    /// A bundle is usable when its transport-required secret is present:
+    /// resend ⇒ <c>resendApiKey</c>; smtp ⇒ <c>smtpHost</c>. An unknown transport
+    /// is rejected.
+    /// </summary>
+    public static bool IsComplete(EmailCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        return credential.Transport switch
+        {
+            EmailCredential.TransportResend => !string.IsNullOrWhiteSpace(credential.ResendApiKey),
+            EmailCredential.TransportSmtp => !string.IsNullOrWhiteSpace(credential.SmtpHost),
+            _ => false,
+        };
+    }
+
+    private sealed record Bundle(
+        string? Transport,
+        string? From,
+        string? ResendApiKey,
+        string? SmtpHost,
+        int? SmtpPort,
+        string? SmtpUsername,
+        string? SmtpPassword,
+        bool? SmtpUseStartTls);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialResolver.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Cabinet-backed <see cref="IEmailCredentialResolver"/> — the email sibling of
+/// git BYOK's <c>GitTokenResolver</c>. Reuses the tenant-scoped cabinet read seam
+/// (<see cref="ITenantProviderKeyReader"/>) and the single-user <c>Email:*</c>
+/// config as the system tier.
+///
+/// <para>Resolution order (tenant→system→fail-loud):</para>
+/// <list type="number">
+///   <item>tenant BYOK bundle from <c>integration/email/config</c> (only when a
+///     tenant is present).</item>
+///   <item>process <c>Email:*</c> config — ONLY in single-user mode.</item>
+///   <item>otherwise null ⇒ the mediation fails loud
+///     (<c>EMAIL_CREDENTIAL_UNAVAILABLE</c>).</item>
+/// </list>
+/// </summary>
+public sealed class EmailCredentialResolver : IEmailCredentialResolver
+{
+    /// <summary>In-process cache TTL for a resolved tenant bundle.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
+
+    private readonly ITenantProviderKeyReader _cabinet;
+    private readonly IConfiguration _configuration;
+    private readonly ITammaModeProvider _mode;
+    private readonly ILogger<EmailCredentialResolver> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _cacheTtl;
+
+    private readonly ConcurrentDictionary<Guid, CacheEntry> _cache = new();
+
+    public EmailCredentialResolver(
+        ITenantProviderKeyReader cabinet,
+        IConfiguration configuration,
+        ITammaModeProvider mode,
+        ILogger<EmailCredentialResolver> logger,
+        TimeProvider? timeProvider = null,
+        TimeSpan? cacheTtl = null)
+    {
+        _cabinet = cabinet ?? throw new ArgumentNullException(nameof(cabinet));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+    }
+
+    /// <inheritdoc />
+    public async Task<EmailCredentialResolution?> ResolveAsync(
+        Guid? tenantId, CancellationToken ct = default)
+    {
+        // ── tenant tier (BYOK) ──
+        if (tenantId is { } tid)
+        {
+            var now = _timeProvider.GetUtcNow();
+            if (_cache.TryGetValue(tid, out var cached) && cached.ExpiresAt > now)
+            {
+                return new EmailCredentialResolution(cached.Credential, IntegrationCredentialSource.Tenant);
+            }
+
+            var byok = await TryReadTenantAsync(tid, ct).ConfigureAwait(false);
+            if (byok is not null)
+            {
+                _cache[tid] = new CacheEntry(byok, now.Add(_cacheTtl));
+                return new EmailCredentialResolution(byok, IntegrationCredentialSource.Tenant);
+            }
+        }
+
+        // ── system tier (single-user config) ──
+        if (_mode.Mode == TammaMode.SingleUser)
+        {
+            var system = TryReadSystemConfig();
+            if (system is not null)
+            {
+                return new EmailCredentialResolution(system, IntegrationCredentialSource.System);
+            }
+        }
+
+        // ── fail-loud tier ──
+        _logger.LogWarning(
+            "Email credential unresolvable for tenant {TenantId} (mode {Mode}): no tenant BYOK bundle" +
+            " and no single-user Email:* config — failing loud (EMAIL_CREDENTIAL_UNAVAILABLE).",
+            tenantId, _mode.Mode);
+        return null;
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(Guid? tenantId)
+    {
+        if (tenantId is { } tid)
+        {
+            _cache.TryRemove(tid, out _);
+        }
+    }
+
+    private async Task<EmailCredential?> TryReadTenantAsync(Guid tenantId, CancellationToken ct)
+    {
+        var row = await _cabinet
+            .TryReadAsync(tenantId, IntegrationCabinetNames.EmailConfig, ct)
+            .ConfigureAwait(false);
+        return row is null ? null : EmailCredentialCodec.TryDeserialize(row.Plaintext);
+    }
+
+    private EmailCredential? TryReadSystemConfig()
+    {
+        var from = _configuration["Email:From"];
+        if (string.IsNullOrWhiteSpace(from))
+        {
+            // The single-user transports (SmtpEmailService / ResendEmailService)
+            // both REQUIRE a from address; without it there is nothing to resolve.
+            return null;
+        }
+
+        var transport = (_configuration["Email:Provider"] ?? EmailCredential.TransportSmtp)
+            .Trim().ToLowerInvariant();
+
+        var credential = transport switch
+        {
+            EmailCredential.TransportResend => new EmailCredential(
+                EmailCredential.TransportResend, from.Trim(),
+                ResendApiKey: _configuration["Email:Resend:ApiKey"]),
+            _ => new EmailCredential(
+                EmailCredential.TransportSmtp, from.Trim(),
+                SmtpHost: _configuration["Email:Smtp:Host"],
+                SmtpPort: _configuration.GetValue<int?>("Email:Smtp:Port"),
+                SmtpUsername: _configuration["Email:Smtp:Username"],
+                SmtpPassword: _configuration["Email:Smtp:Password"],
+                SmtpUseStartTls: _configuration.GetValue<bool?>("Email:Smtp:UseStartTls")),
+        };
+
+        // In single-user mode the outbox transport reads the same Email:* config
+        // this bundle mirrors, so a from-only config (SMTP host supplied later at
+        // the sender) is still a legitimate "present" system credential: enqueue
+        // works without the host. We therefore treat from-present as sufficient
+        // for the SMTP tier, and require the api key only for the resend tier.
+        if (transport == EmailCredential.TransportResend
+            && string.IsNullOrWhiteSpace(credential.ResendApiKey))
+        {
+            return null;
+        }
+
+        return credential;
+    }
+
+    private readonly record struct CacheEntry(EmailCredential Credential, DateTimeOffset ExpiresAt);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/EmailCredentialResolver.cs
@@ -23,7 +23,14 @@ namespace Tamma.Api.Services.Integrations;
 /// </summary>
 public sealed class EmailCredentialResolver : IEmailCredentialResolver
 {
-    /// <summary>In-process cache TTL for a resolved tenant bundle.</summary>
+    /// <summary>
+    /// In-process cache TTL for a resolved tenant bundle. NOTE (same as provider
+    /// BYOK): a positive entry lives up to this TTL and <see cref="Invalidate"/> only
+    /// evicts the LOCAL process cache — in a multi-replica deployment a credential
+    /// revoked/rotated on one replica may keep resolving on another for up to this
+    /// window before its own entry expires. 60s bounds that revocation lag; we do NOT
+    /// over-engineer distributed invalidation here.
+    /// </summary>
     public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
 
     private readonly ITenantProviderKeyReader _cabinet;

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IEmailCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IEmailCredentialResolver.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Per-request BYOK→system resolver for the tenant's email transport credential,
+/// modelled on git BYOK's <c>IGitTokenResolver</c> (tenant→system→fail-loud):
+/// <list type="number">
+///   <item><b>tenant</b> — the tenant's BYOK bundle from the secret cabinet
+///     (<c>integration/email/config</c>, <c>Scope=tenant</c>). Present ⇒ use it.</item>
+///   <item><b>system</b> — the process <c>Email:*</c> config, consulted ONLY in
+///     single-user mode (the sole principal owns the sender domain). NEVER in
+///     SaaS — sending under a shared platform sender identity with no per-tenant
+///     allowlist is the confused-deputy the fail-loud rule blocks.</item>
+///   <item><b>fail-loud</b> — neither resolvable ⇒ <c>null</c> ⇒ the mediation
+///     returns the typed <c>EMAIL_CREDENTIAL_UNAVAILABLE</c> failure (never a
+///     silent platform default).</item>
+/// </list>
+/// </summary>
+public interface IEmailCredentialResolver
+{
+    /// <summary>
+    /// Resolve the email transport credential for <paramref name="tenantId"/>, or
+    /// <c>null</c> when neither the tenant BYOK bundle nor the single-user system
+    /// config yields a complete credential.
+    /// </summary>
+    Task<EmailCredentialResolution?> ResolveAsync(
+        Guid? tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Evict any cached resolution for <paramref name="tenantId"/> so the next
+    /// resolve re-reads the cabinet. Called by the write endpoints after a
+    /// set/remove mutation.
+    /// </summary>
+    void Invalidate(Guid? tenantId);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IIntegrationCredentialCabinet.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IIntegrationCredentialCabinet.cs
@@ -1,0 +1,44 @@
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// The governed write surface for a per-tenant integration credential bundle in
+/// the Epic 29 secret cabinet. Backs the BYOK write endpoints
+/// (<c>IntegrationCredentialEndpoints</c>).
+///
+/// <para><b>Set</b> goes through the merged <see cref="ISecretStore"/> facade
+/// (<c>CreateAsync</c>) — the governed / audited write API that mints v1 active
+/// and emits the <c>SECRET.WRITE</c> cabinet audit. <b>Remove</b> deletes the
+/// secret row + version rows and scrubs the backend bytes through the cabinet's
+/// own seam, because the facade exposes no secret-row deletion and its
+/// <c>RetireVersionAsync</c> refuses the active version — so a working "drop the
+/// credential" (which a later set can cleanly re-create) is not expressible on
+/// the facade. NON-migration: both paths reuse the existing
+/// <c>secrets</c>/<c>secret_versions</c> tables.</para>
+/// </summary>
+public interface IIntegrationCredentialCabinet
+{
+    /// <summary>
+    /// Create the tenant-scoped credential secret <paramref name="cabinetName"/>
+    /// with <paramref name="bundleJson"/> as its first active version. Throws
+    /// <see cref="InvalidOperationException"/> when one already exists (set-once;
+    /// the caller maps that to 409 — remove then re-set to change it).
+    /// </summary>
+    Task<SecretMetadata> SetAsync(
+        Guid tenantId,
+        string cabinetName,
+        string consumerSystem,
+        string bundleJson,
+        Guid ownerUserId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Remove the tenant-scoped credential secret so resolution falls back to the
+    /// system tier / fails loud, and a later set can re-create the same slug.
+    /// Returns <c>true</c> when a row existed and was removed, <c>false</c> when
+    /// nothing matched.
+    /// </summary>
+    Task<bool> RemoveAsync(
+        Guid tenantId, string cabinetName, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IJiraApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IJiraApiClient.cs
@@ -1,0 +1,23 @@
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Credential-bound JIRA HTTP client — the JIRA analog of git BYOK's
+/// <c>IGitHubClientFactory</c>-minted, token-bound client. Every call takes the
+/// RESOLVED per-tenant <see cref="JiraCredential"/> and threads its
+/// baseUrl/email/apiToken straight into the HTTP request, instead of reading a
+/// process-global config. The token never leaves this call; it is never logged
+/// or surfaced on the returned <see cref="IntegrationResult{T}"/>.
+/// </summary>
+public interface IJiraApiClient
+{
+    /// <summary>Fetch a ticket using the supplied per-tenant credential.</summary>
+    Task<IntegrationResult<JiraTicket?>> GetTicketAsync(
+        JiraCredential credential, string ticketId, CancellationToken ct = default);
+
+    /// <summary>Update a ticket (comment/status) using the supplied credential.</summary>
+    Task<IntegrationResult<JiraTicketResult>> UpdateTicketAsync(
+        JiraCredential credential, string ticketId, JiraTicketUpdate update,
+        CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IJiraCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IJiraCredentialResolver.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Per-request BYOK→system resolver for the tenant's JIRA credential bundle,
+/// modelled on git BYOK's <c>IGitTokenResolver</c> (tenant→system→fail-loud):
+/// <list type="number">
+///   <item><b>tenant</b> — the tenant's BYOK bundle from the secret cabinet
+///     (<c>integration/jira/config</c>, <c>Scope=tenant</c>). Present ⇒ use it.</item>
+///   <item><b>system</b> — the process <c>Jira:*</c> config, consulted ONLY in
+///     single-user mode (the sole principal's legitimate creds). NEVER in SaaS —
+///     a shared platform JIRA credential with no per-tenant scoping is the
+///     confused-deputy the fail-loud rule blocks.</item>
+///   <item><b>fail-loud</b> — neither resolvable ⇒ <c>null</c> ⇒ the mediation
+///     returns the typed <c>JIRA_CREDENTIAL_UNAVAILABLE</c> failure (never a
+///     silent platform default).</item>
+/// </list>
+/// </summary>
+public interface IJiraCredentialResolver
+{
+    /// <summary>
+    /// Resolve the JIRA credential for <paramref name="tenantId"/>, or
+    /// <c>null</c> when neither the tenant BYOK bundle nor the single-user system
+    /// config yields a complete credential.
+    /// </summary>
+    Task<JiraCredentialResolution?> ResolveAsync(
+        Guid? tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Evict any cached resolution for <paramref name="tenantId"/> so the next
+    /// resolve re-reads the cabinet. Called by the write endpoints after a
+    /// set/remove mutation (mirrors the provider resolver's cache invalidation).
+    /// </summary>
+    void Invalidate(Guid? tenantId);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCabinetNames.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCabinetNames.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Canonical secret-cabinet slugs for per-tenant integration credentials
+/// (JIRA + email BYOK), kept as one source of truth so the write endpoints
+/// (<c>IntegrationCredentialEndpoints</c>) and the per-request resolvers
+/// (<c>JiraCredentialResolver</c> / <c>EmailCredentialResolver</c>) cannot drift
+/// apart on the slug. Aligns with the provider BYOK convention
+/// (<c>Tamma.Activities.LlmCall.Credentials.ProviderCabinetNames</c>): a stable
+/// lower-kebab path under a feature prefix.
+///
+/// <para>Each integration stores its whole credential BUNDLE as a single
+/// tenant-scoped cabinet secret (a JSON payload) under one slug — NON-migration:
+/// this reuses the existing <c>secrets</c>/<c>secret_versions</c> cabinet with a
+/// new name, no new table/column. The bundle is unique per
+/// <c>(scope, tenantId, name)</c>, so two tenants can both hold
+/// <c>integration/jira/config</c> without collision (the cabinet's tenant-scoped
+/// unique index).</para>
+/// </summary>
+public static class IntegrationCabinetNames
+{
+    /// <summary>
+    /// Tenant-scoped JIRA credential bundle (baseUrl + email + apiToken) —
+    /// <c>integration/jira/config</c>. Matches the Story 29-1 slug grammar
+    /// (lower-kebab with <c>/</c> path separators).
+    /// </summary>
+    public const string JiraConfig = "integration/jira/config";
+
+    /// <summary>
+    /// Tenant-scoped email transport credential bundle (transport + from +
+    /// SMTP/Resend secret) — <c>integration/email/config</c>.
+    /// </summary>
+    public const string EmailConfig = "integration/email/config";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCredentialCabinet.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCredentialCabinet.cs
@@ -1,0 +1,120 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Default <see cref="IIntegrationCredentialCabinet"/>. Set → the merged
+/// <see cref="ISecretStore"/> facade; remove → the cabinet's own
+/// <see cref="SecretsDbContext"/> + <see cref="ISecretStoreBackend"/> seam (the
+/// facade has no row-delete). See the interface doc for the rationale.
+/// </summary>
+public sealed class IntegrationCredentialCabinet : IIntegrationCredentialCabinet
+{
+    private readonly ISecretStore _secretStore;
+    private readonly IDbContextFactory<SecretsDbContext> _secretsFactory;
+    private readonly ISecretStoreBackend _backend;
+    private readonly ILogger<IntegrationCredentialCabinet> _logger;
+
+    public IntegrationCredentialCabinet(
+        ISecretStore secretStore,
+        IDbContextFactory<SecretsDbContext> secretsFactory,
+        ISecretStoreBackend backend,
+        ILogger<IntegrationCredentialCabinet> logger)
+    {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _secretsFactory = secretsFactory ?? throw new ArgumentNullException(nameof(secretsFactory));
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<SecretMetadata> SetAsync(
+        Guid tenantId,
+        string cabinetName,
+        string consumerSystem,
+        string bundleJson,
+        Guid ownerUserId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cabinetName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(bundleJson);
+
+        // The whole bundle is one tenant-scoped ApiKey secret; CreateAsync mints
+        // v1 active and emits SECRET.WRITE. A duplicate throws InvalidOperationException.
+        return await _secretStore.CreateAsync(
+            new CreateSecretRequest(
+                Name: cabinetName,
+                Scope: SecretScope.Tenant,
+                TenantId: tenantId,
+                Purpose: SecretPurpose.ApiKey,
+                ConsumerRefs: new[] { new ConsumerRef(consumerSystem, "config") },
+                OwnerUserId: ownerUserId,
+                RotationSchedule: RotationSchedule.None,
+                InitialPlaintext: bundleJson),
+            ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(
+        Guid tenantId, string cabinetName, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cabinetName);
+
+        await using var ctx = await _secretsFactory
+            .CreateDbContextAsync(ct).ConfigureAwait(false);
+
+        var row = await ctx.Secrets
+            .FirstOrDefaultAsync(
+                s => s.Name == cabinetName
+                     && s.Scope == "tenant"
+                     && s.TenantId == tenantId,
+                ct)
+            .ConfigureAwait(false);
+        if (row is null)
+        {
+            return false;
+        }
+
+        var versions = await ctx.SecretVersions
+            .Where(v => v.SecretId == row.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        // Scrub the ciphertext bytes out of the backend first (best-effort;
+        // idempotent — a KeyNotFound means the bytes were never stored / already
+        // gone). NEVER logs the bytes.
+        foreach (var v in versions)
+        {
+            try
+            {
+                await _backend.DeleteVersionAsync(row.Id, v.VersionNumber, ct).ConfigureAwait(false);
+            }
+            catch (KeyNotFoundException)
+            {
+                // never stored
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Best-effort backend scrub failed removing integration credential {CabinetName}" +
+                    " v{Version} for tenant {TenantId}.", cabinetName, v.VersionNumber, tenantId);
+            }
+        }
+
+        if (versions.Count > 0)
+        {
+            ctx.SecretVersions.RemoveRange(versions);
+        }
+        ctx.Secrets.Remove(row);
+        await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Removed integration credential {CabinetName} for tenant {TenantId}.",
+            cabinetName, tenantId);
+        return true;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCredentialSource.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/IntegrationCredentialSource.cs
@@ -1,0 +1,19 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Which tier of the tenant→system→fail-loud chain resolved an integration
+/// credential (mirrors git BYOK's <c>GitCredentialSources</c>). Recorded on the
+/// resolution so callers / tests can assert the tier that answered.
+/// </summary>
+public enum IntegrationCredentialSource
+{
+    /// <summary>The tenant's own BYOK bundle, read from the tenant-scoped secret
+    /// cabinet. The legitimate SaaS tier.</summary>
+    Tenant,
+
+    /// <summary>The process-level <c>Jira:*</c> / <c>Email:*</c> configuration —
+    /// the single-user "system" tier (the sole principal's legitimate creds).
+    /// Deliberately NOT consulted in SaaS: a shared platform credential with no
+    /// per-tenant scoping is the confused-deputy the fail-loud guard blocks.</summary>
+    System,
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraApiClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Tamma.Core.Interfaces;
 
@@ -15,17 +16,34 @@ namespace Tamma.Api.Services.Integrations;
 /// <c>JiraIntegrationService</c> but with the credential threaded in per call
 /// instead of read from global config, so a per-tenant BYOK bundle drives the
 /// request. Never logs the token; a 404 maps to a typed "not found" failure.
+///
+/// <para><b>SSRF hardening.</b> The tenant-supplied <c>baseUrl</c> is re-validated
+/// at USE time via <see cref="JiraBaseUrlGuard"/> (https-only + private-range
+/// rejection + optional <c>Jira:AllowedHostSuffixes</c> allowlist), the
+/// <c>ticketId</c> is validated as a safe JIRA key/id (no <c>../</c> path
+/// traversal), the request rides the named <c>"jira"</c> client whose handler does
+/// NOT auto-follow redirects (a 3xx is refused, not chased into a private address),
+/// and that handler's connect callback re-checks the resolved address at connect
+/// time (anti-rebinding). Write-time validation on the credential endpoint is the
+/// first layer; this is defense in depth.</para>
 /// </summary>
 public sealed class JiraApiClient : IJiraApiClient
 {
+    /// <summary>The named client Program.cs configures with
+    /// <c>AllowAutoRedirect=false</c> + <see cref="JiraBaseUrlGuard.SafeConnectAsync"/>.</summary>
+    public const string HttpClientName = "jira";
+
     private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<JiraApiClient> _logger;
 
     public JiraApiClient(
         IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
         ILogger<JiraApiClient> logger)
     {
         _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,18 +51,29 @@ public sealed class JiraApiClient : IJiraApiClient
         JiraCredential credential, string ticketId, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(credential);
+
+        var guard = await GuardAsync(credential, ticketId, ct).ConfigureAwait(false);
+        if (guard is not null)
+        {
+            return IntegrationResult<JiraTicket?>.Fail(guard);
+        }
+
         try
         {
-            var httpClient = _httpClientFactory.CreateClient();
-            Authorize(httpClient, credential);
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
 
-            var response = await httpClient
-                .GetAsync($"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}", ct)
-                .ConfigureAwait(false);
+            using var request = new HttpRequestMessage(
+                HttpMethod.Get, $"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}");
+            Authorize(request, credential);
+            using var response = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
 
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
                 return IntegrationResult<JiraTicket?>.Fail("not found");
+            }
+            if (IsRedirect(response))
+            {
+                return IntegrationResult<JiraTicket?>.Fail("refused redirect");
             }
             response.EnsureSuccessStatusCode();
 
@@ -78,10 +107,16 @@ public sealed class JiraApiClient : IJiraApiClient
     {
         ArgumentNullException.ThrowIfNull(credential);
         ArgumentNullException.ThrowIfNull(update);
+
+        var guard = await GuardAsync(credential, ticketId, ct).ConfigureAwait(false);
+        if (guard is not null)
+        {
+            return IntegrationResult<JiraTicketResult>.Fail(guard);
+        }
+
         try
         {
-            var httpClient = _httpClientFactory.CreateClient();
-            Authorize(httpClient, credential);
+            var httpClient = _httpClientFactory.CreateClient(HttpClientName);
 
             if (!string.IsNullOrEmpty(update.Comment))
             {
@@ -104,12 +139,20 @@ public sealed class JiraApiClient : IJiraApiClient
                         },
                     },
                 };
-                var commentResponse = await httpClient
-                    .PostAsJsonAsync($"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}/comment", commentPayload, ct)
-                    .ConfigureAwait(false);
+                using var request = new HttpRequestMessage(
+                    HttpMethod.Post, $"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}/comment")
+                {
+                    Content = JsonContent.Create(commentPayload),
+                };
+                Authorize(request, credential);
+                using var commentResponse = await httpClient.SendAsync(request, ct).ConfigureAwait(false);
                 if (commentResponse.StatusCode == HttpStatusCode.NotFound)
                 {
                     return IntegrationResult<JiraTicketResult>.Fail("not found");
+                }
+                if (IsRedirect(commentResponse))
+                {
+                    return IntegrationResult<JiraTicketResult>.Fail("refused redirect");
                 }
                 commentResponse.EnsureSuccessStatusCode();
             }
@@ -124,10 +167,48 @@ public sealed class JiraApiClient : IJiraApiClient
         }
     }
 
-    private static void Authorize(HttpClient httpClient, JiraCredential credential)
+    /// <summary>
+    /// Use-time SSRF gate. Returns a failure reason string when the ticket id or
+    /// base URL is rejected (so the HTTP call is NEVER made), or null when both
+    /// pass. Runs before every request as defense in depth.
+    /// </summary>
+    private async Task<string?> GuardAsync(JiraCredential credential, string ticketId, CancellationToken ct)
+    {
+        if (!JiraBaseUrlGuard.IsValidTicketId(ticketId))
+        {
+            _logger.LogWarning("JIRA request refused: invalid ticket id shape.");
+            return "invalid ticket id";
+        }
+
+        var validation = await JiraBaseUrlGuard
+            .ValidateAsync(credential.BaseUrl, AllowedHostSuffixes(), dnsResolve: null, ct)
+            .ConfigureAwait(false);
+        if (!validation.IsValid)
+        {
+            _logger.LogWarning("JIRA request refused: baseUrl blocked ({Code}).", validation.ErrorCode);
+            return validation.ErrorDetail ?? "invalid base url";
+        }
+
+        return null;
+    }
+
+    private IReadOnlyList<string>? AllowedHostSuffixes()
+    {
+        var raw = _configuration["Jira:AllowedHostSuffixes"];
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+        return raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static bool IsRedirect(HttpResponseMessage response) =>
+        (int)response.StatusCode is >= 300 and < 400;
+
+    private static void Authorize(HttpRequestMessage request, JiraCredential credential)
     {
         var authBytes = Encoding.UTF8.GetBytes($"{credential.Email}:{credential.ApiToken}");
-        httpClient.DefaultRequestHeaders.Authorization =
+        request.Headers.Authorization =
             new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraApiClient.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Default <see cref="IJiraApiClient"/> — performs the JIRA REST v3 calls with a
+/// per-request <see cref="JiraCredential"/> (basic auth = <c>email:apiToken</c>,
+/// base URL from the credential). Mirrors the HTTP shape of the legacy
+/// <c>JiraIntegrationService</c> but with the credential threaded in per call
+/// instead of read from global config, so a per-tenant BYOK bundle drives the
+/// request. Never logs the token; a 404 maps to a typed "not found" failure.
+/// </summary>
+public sealed class JiraApiClient : IJiraApiClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<JiraApiClient> _logger;
+
+    public JiraApiClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<JiraApiClient> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IntegrationResult<JiraTicket?>> GetTicketAsync(
+        JiraCredential credential, string ticketId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            Authorize(httpClient, credential);
+
+            var response = await httpClient
+                .GetAsync($"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}", ct)
+                .ConfigureAwait(false);
+
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                return IntegrationResult<JiraTicket?>.Fail("not found");
+            }
+            response.EnsureSuccessStatusCode();
+
+            var data = await response.Content.ReadFromJsonAsync<JsonElement>(ct).ConfigureAwait(false);
+            var fields = data.GetProperty("fields");
+
+            var ticket = new JiraTicket
+            {
+                Id = data.GetProperty("id").GetString() ?? string.Empty,
+                Key = data.GetProperty("key").GetString() ?? ticketId,
+                Summary = fields.GetProperty("summary").GetString() ?? string.Empty,
+                Description = fields.TryGetProperty("description", out var desc) && desc.ValueKind != JsonValueKind.Null
+                    ? desc.ToString() : string.Empty,
+                Status = fields.GetProperty("status").GetProperty("name").GetString() ?? string.Empty,
+                Priority = fields.TryGetProperty("priority", out var pri) && pri.ValueKind != JsonValueKind.Null
+                    ? pri.GetProperty("name").GetString() ?? string.Empty : string.Empty,
+            };
+            return IntegrationResult<JiraTicket?>.Ok(ticket);
+        }
+        catch (Exception ex)
+        {
+            // Ticket id is not sensitive; the token is NEVER in the message.
+            _logger.LogError(ex, "JIRA get-ticket failed for {TicketId}", ticketId);
+            return IntegrationResult<JiraTicket?>.Fail(ex.Message);
+        }
+    }
+
+    public async Task<IntegrationResult<JiraTicketResult>> UpdateTicketAsync(
+        JiraCredential credential, string ticketId, JiraTicketUpdate update,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(update);
+        try
+        {
+            var httpClient = _httpClientFactory.CreateClient();
+            Authorize(httpClient, credential);
+
+            if (!string.IsNullOrEmpty(update.Comment))
+            {
+                var commentPayload = new
+                {
+                    body = new
+                    {
+                        type = "doc",
+                        version = 1,
+                        content = new[]
+                        {
+                            new
+                            {
+                                type = "paragraph",
+                                content = new object[]
+                                {
+                                    new { type = "text", text = update.Comment },
+                                },
+                            },
+                        },
+                    },
+                };
+                var commentResponse = await httpClient
+                    .PostAsJsonAsync($"{TrimBase(credential.BaseUrl)}/rest/api/3/issue/{ticketId}/comment", commentPayload, ct)
+                    .ConfigureAwait(false);
+                if (commentResponse.StatusCode == HttpStatusCode.NotFound)
+                {
+                    return IntegrationResult<JiraTicketResult>.Fail("not found");
+                }
+                commentResponse.EnsureSuccessStatusCode();
+            }
+
+            return IntegrationResult<JiraTicketResult>.Ok(
+                new JiraTicketResult { Success = true, TicketKey = ticketId });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "JIRA update-ticket failed for {TicketId}", ticketId);
+            return IntegrationResult<JiraTicketResult>.Fail(ex.Message);
+        }
+    }
+
+    private static void Authorize(HttpClient httpClient, JiraCredential credential)
+    {
+        var authBytes = Encoding.UTF8.GetBytes($"{credential.Email}:{credential.ApiToken}");
+        httpClient.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Basic", Convert.ToBase64String(authBytes));
+    }
+
+    private static string TrimBase(string baseUrl) => baseUrl.TrimEnd('/');
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraBaseUrlGuard.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraBaseUrlGuard.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// SSRF guard for the per-tenant JIRA <c>baseUrl</c> (and the <c>ticketId</c> that
+/// is interpolated into the request path). A tenant supplies its own JIRA base URL;
+/// without validation a <c>tenant_admin</c> could point it at an internal address —
+/// <c>http://169.254.169.254/…</c> (cloud metadata), <c>http://postgres:5432</c>,
+/// <c>http://127.0.0.1</c> — and have the server fetch it from inside the docker
+/// network (SSRF), or smuggle <c>../</c> through the ticket id for path traversal.
+///
+/// <para><b>Defense in depth.</b> This guard is applied at BOTH write time (the
+/// credential endpoint) and use time (<see cref="JiraApiClient"/>). The hard floor
+/// is always enforced:</para>
+/// <list type="bullet">
+///   <item>scheme MUST be <c>https</c> (plain <c>http</c> is rejected);</item>
+///   <item>the host — whether a literal IP or a DNS name that resolves to one —
+///     must NOT fall in a private / loopback / link-local / unique-local / metadata
+///     range (see <see cref="IsBlockedAddress"/>);</item>
+///   <item>an optional allowlist of host suffixes (e.g. <c>.atlassian.net</c>) may
+///     be layered on top — when configured, the host must match one. The
+///     private-range rejection is the hard floor even when the allowlist is empty.</item>
+/// </list>
+///
+/// <para><see cref="SafeConnectAsync"/> is the belt-and-suspenders anti-rebinding
+/// control: wired as the <c>SocketsHttpHandler.ConnectCallback</c> for the JIRA
+/// client, it re-checks the ACTUAL resolved address at connect time, so a host that
+/// passed validation but rebinds its DNS to a private address before the socket
+/// opens still cannot be reached.</para>
+/// </summary>
+public static class JiraBaseUrlGuard
+{
+    /// <summary>A JIRA key (<c>PROJ-42</c>) or numeric id — letters, digits, hyphen
+    /// only. No <c>/</c>, <c>.</c>, whitespace or other path metacharacters, so it
+    /// cannot break out of <c>/rest/api/3/issue/{ticketId}</c> via <c>../</c>.</summary>
+    private static readonly Regex TicketIdPattern = new("^[A-Za-z0-9-]+$", RegexOptions.Compiled);
+
+    private const int MaxTicketIdLength = 255;
+
+    /// <summary>Validate a candidate JIRA <c>baseUrl</c>. When
+    /// <paramref name="dnsResolve"/> is null the system resolver is used; tests inject
+    /// a deterministic one.</summary>
+    public static async Task<JiraBaseUrlValidation> ValidateAsync(
+        string? baseUrl,
+        IReadOnlyList<string>? allowedHostSuffixes = null,
+        Func<string, CancellationToken, Task<IPAddress[]>>? dnsResolve = null,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl)
+            || !Uri.TryCreate(baseUrl.Trim(), UriKind.Absolute, out var uri))
+        {
+            return JiraBaseUrlValidation.Invalid("invalid_base_url", "baseUrl must be an absolute https URL.");
+        }
+
+        // Scheme: https only. Plain http is refused (no cleartext, no SSRF over http).
+        if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return JiraBaseUrlValidation.Invalid("invalid_base_url", "baseUrl must use the https scheme.");
+        }
+
+        var host = uri.DnsSafeHost;
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            return JiraBaseUrlValidation.Invalid("invalid_base_url", "baseUrl has no host.");
+        }
+
+        // Optional allowlist. When configured the host must match a suffix; a matched
+        // host is a trusted SaaS/self-hosted destination and short-circuits (still
+        // protected at connect time by SafeConnectAsync).
+        if (allowedHostSuffixes is { Count: > 0 })
+        {
+            if (!MatchesAllowlist(host, allowedHostSuffixes))
+            {
+                return JiraBaseUrlValidation.Invalid("host_not_allowed",
+                    "baseUrl host is not in the configured JIRA allowlist.");
+            }
+            return JiraBaseUrlValidation.Valid(uri);
+        }
+
+        // Literal IP host — check directly, no DNS.
+        if (IPAddress.TryParse(host, out var literal))
+        {
+            return IsBlockedAddress(literal)
+                ? JiraBaseUrlValidation.Invalid("host_not_allowed",
+                    "baseUrl host resolves to a private, loopback, link-local, or metadata address.")
+                : JiraBaseUrlValidation.Valid(uri);
+        }
+
+        // Named host — resolve and reject if ANY resolved address is blocked (a
+        // partially-private result is treated as hostile). A resolution failure is
+        // NOT treated as a private mapping (the host is simply unresolvable here);
+        // the connect-time SafeConnectAsync remains the hard guard.
+        var resolver = dnsResolve ?? DefaultResolveAsync;
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await resolver(host, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch
+        {
+            // Unresolvable at validation time — allow past the DNS floor; scheme +
+            // connect-time guard still apply.
+            return JiraBaseUrlValidation.Valid(uri);
+        }
+
+        if (addresses.Any(IsBlockedAddress))
+        {
+            return JiraBaseUrlValidation.Invalid("host_not_allowed",
+                "baseUrl host resolves to a private, loopback, link-local, or metadata address.");
+        }
+
+        return JiraBaseUrlValidation.Valid(uri);
+    }
+
+    /// <summary>Whether <paramref name="ticketId"/> is a safe JIRA key/id (no path
+    /// metacharacters — prevents <c>../</c> traversal in the request path).</summary>
+    public static bool IsValidTicketId(string? ticketId) =>
+        !string.IsNullOrWhiteSpace(ticketId)
+        && ticketId.Length <= MaxTicketIdLength
+        && TicketIdPattern.IsMatch(ticketId);
+
+    /// <summary>
+    /// Whether <paramref name="ip"/> is in a range Tamma must never fetch from
+    /// server-side: loopback (127/8, ::1), any-address (0.0.0.0, ::), private
+    /// (10/8, 172.16/12, 192.168/16), link-local + metadata (169.254/16, fe80::/10),
+    /// and IPv6 unique-local (fc00::/7). IPv4-mapped IPv6 is unwrapped first.
+    /// </summary>
+    public static bool IsBlockedAddress(IPAddress ip)
+    {
+        ArgumentNullException.ThrowIfNull(ip);
+        if (ip.IsIPv4MappedToIPv6)
+        {
+            ip = ip.MapToIPv4();
+        }
+
+        if (IPAddress.IsLoopback(ip))
+        {
+            return true; // 127.0.0.0/8 and ::1
+        }
+
+        if (ip.AddressFamily == AddressFamily.InterNetwork)
+        {
+            var b = ip.GetAddressBytes();
+            return b[0] switch
+            {
+                0 => true,                                   // 0.0.0.0/8 (incl. 0.0.0.0)
+                10 => true,                                  // 10.0.0.0/8
+                127 => true,                                 // 127.0.0.0/8 (also loopback above)
+                169 when b[1] == 254 => true,                // 169.254.0.0/16 (link-local + metadata)
+                172 when b[1] >= 16 && b[1] <= 31 => true,   // 172.16.0.0/12
+                192 when b[1] == 168 => true,                // 192.168.0.0/16
+                _ => false,
+            };
+        }
+
+        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            if (ip.Equals(IPAddress.IPv6Any) || ip.IsIPv6LinkLocal)
+            {
+                return true; // :: and fe80::/10
+            }
+            // fc00::/7 unique-local.
+            var b = ip.GetAddressBytes();
+            if ((b[0] & 0xFE) == 0xFC)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <c>SocketsHttpHandler.ConnectCallback</c> for the JIRA client: resolve the
+    /// endpoint host at CONNECT time and open a socket only to a non-blocked address,
+    /// closing the DNS-rebinding TOCTOU window that a validate-then-connect flow
+    /// leaves open.
+    /// </summary>
+    public static async ValueTask<Stream> SafeConnectAsync(
+        SocketsHttpConnectionContext context, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var host = context.DnsEndPoint.Host;
+        var port = context.DnsEndPoint.Port;
+
+        IPAddress[] addresses = IPAddress.TryParse(host, out var literal)
+            ? new[] { literal }
+            : await Dns.GetHostAddressesAsync(host, ct).ConfigureAwait(false);
+
+        var allowed = addresses.Where(a => !IsBlockedAddress(a)).ToArray();
+        if (allowed.Length == 0)
+        {
+            throw new HttpRequestException(
+                "JIRA host resolves only to disallowed (private/loopback/link-local/metadata) addresses.");
+        }
+
+        var socket = new Socket(SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(allowed, port, ct).ConfigureAwait(false);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+
+    private static bool MatchesAllowlist(string host, IReadOnlyList<string> suffixes)
+    {
+        foreach (var raw in suffixes)
+        {
+            var suffix = raw?.Trim();
+            if (string.IsNullOrEmpty(suffix))
+            {
+                continue;
+            }
+            // Exact host match, or a dot-boundary suffix match (".atlassian.net"
+            // matches "acme.atlassian.net" but not "evilatlassian.net").
+            if (string.Equals(host, suffix.TrimStart('.'), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+            var dotted = suffix.StartsWith('.') ? suffix : "." + suffix;
+            if (host.EndsWith(dotted, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Task<IPAddress[]> DefaultResolveAsync(string host, CancellationToken ct) =>
+        Dns.GetHostAddressesAsync(host, ct);
+}
+
+/// <summary>Result of <see cref="JiraBaseUrlGuard.ValidateAsync"/>.</summary>
+public readonly record struct JiraBaseUrlValidation(bool IsValid, Uri? Uri, string? ErrorCode, string? ErrorDetail)
+{
+    public static JiraBaseUrlValidation Valid(Uri uri) => new(true, uri, null, null);
+    public static JiraBaseUrlValidation Invalid(string code, string detail) => new(false, null, code, detail);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredential.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredential.cs
@@ -1,0 +1,24 @@
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// A resolved JIRA credential bundle — the tuple threaded into the JIRA HTTP
+/// client per request (the JIRA analog of git BYOK's resolved token). The
+/// <see cref="ApiToken"/> is request-scoped: it is NEVER logged, emitted onto a
+/// DCB event, or echoed on any HTTP response.
+/// </summary>
+/// <param name="BaseUrl">The JIRA Cloud/Server base URL (e.g.
+/// <c>https://acme.atlassian.net</c>).</param>
+/// <param name="Email">The account email used for JIRA basic auth.</param>
+/// <param name="ApiToken">The JIRA API token (basic-auth password). Secret.</param>
+public sealed record JiraCredential(string BaseUrl, string Email, string ApiToken);
+
+/// <summary>
+/// A resolved <see cref="JiraCredential"/> plus the tier that answered
+/// (tenant BYOK vs single-user system config). Mirrors git BYOK's
+/// <c>GitTokenResolution</c>.
+/// </summary>
+/// <param name="Credential">The resolved bundle (never null here — a null
+/// resolution is represented by the resolver returning <c>null</c>).</param>
+/// <param name="Source">The tier that answered.</param>
+public sealed record JiraCredentialResolution(
+    JiraCredential Credential, IntegrationCredentialSource Source);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialCodec.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialCodec.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// The single (de)serialization seam for the JIRA credential BUNDLE stored as a
+/// cabinet secret's plaintext. Kept as one source of truth so the write endpoint
+/// (serialize) and the resolver (deserialize) cannot drift on the JSON shape.
+/// </summary>
+public static class JiraCredentialCodec
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Serialize a bundle to the cabinet plaintext JSON.</summary>
+    public static string Serialize(JiraCredential credential)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        return JsonSerializer.Serialize(
+            new Bundle(credential.BaseUrl, credential.Email, credential.ApiToken),
+            Options);
+    }
+
+    /// <summary>
+    /// Parse a stored bundle back into a <see cref="JiraCredential"/>. Returns
+    /// null when the JSON is malformed or any required field is missing/blank —
+    /// the resolver treats that as "credential absent" and moves to the next tier
+    /// (never a partial credential).
+    /// </summary>
+    public static JiraCredential? TryDeserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        Bundle? bundle;
+        try
+        {
+            bundle = JsonSerializer.Deserialize<Bundle>(json, Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        if (bundle is null
+            || string.IsNullOrWhiteSpace(bundle.BaseUrl)
+            || string.IsNullOrWhiteSpace(bundle.Email)
+            || string.IsNullOrWhiteSpace(bundle.ApiToken))
+        {
+            return null;
+        }
+
+        return new JiraCredential(bundle.BaseUrl.Trim(), bundle.Email.Trim(), bundle.ApiToken);
+    }
+
+    private sealed record Bundle(string? BaseUrl, string? Email, string? ApiToken);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialResolver.cs
@@ -28,7 +28,14 @@ namespace Tamma.Api.Services.Integrations;
 /// </summary>
 public sealed class JiraCredentialResolver : IJiraCredentialResolver
 {
-    /// <summary>In-process cache TTL for a resolved tenant bundle.</summary>
+    /// <summary>
+    /// In-process cache TTL for a resolved tenant bundle. NOTE (same as provider
+    /// BYOK): a positive entry lives up to this TTL and <see cref="Invalidate"/> only
+    /// evicts the LOCAL process cache — in a multi-replica deployment a credential
+    /// revoked/rotated on one replica may keep resolving on another for up to this
+    /// window before its own entry expires. 60s bounds that revocation lag; we do NOT
+    /// over-engineer distributed invalidation here.
+    /// </summary>
     public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
 
     private readonly ITenantProviderKeyReader _cabinet;

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Integrations/JiraCredentialResolver.cs
@@ -1,0 +1,132 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Services.Integrations;
+
+/// <summary>
+/// Cabinet-backed <see cref="IJiraCredentialResolver"/> — the JIRA sibling of
+/// git BYOK's <c>GitTokenResolver</c>. Reuses the proven tenant-scoped cabinet
+/// read seam (<see cref="ITenantProviderKeyReader"/> → a <c>Scope=tenant</c> row
+/// → active-version plaintext), which honours the "<c>ISecretStore</c> never
+/// surfaces plaintext" boundary by reading through the backend directly.
+///
+/// <para>Resolution order (tenant→system→fail-loud):</para>
+/// <list type="number">
+///   <item>tenant BYOK bundle from <c>integration/jira/config</c> (only when a
+///     tenant is present).</item>
+///   <item>process <c>Jira:*</c> config — ONLY in single-user mode.</item>
+///   <item>otherwise null ⇒ the mediation fails loud
+///     (<c>JIRA_CREDENTIAL_UNAVAILABLE</c>).</item>
+/// </list>
+///
+/// <para>A short-TTL in-process cache (keyed by tenant) mirrors the provider
+/// resolver; the write endpoints call <see cref="Invalidate"/> after a mutation.
+/// The plaintext token lives only on the returned credential — never logged.</para>
+/// </summary>
+public sealed class JiraCredentialResolver : IJiraCredentialResolver
+{
+    /// <summary>In-process cache TTL for a resolved tenant bundle.</summary>
+    public static readonly TimeSpan DefaultCacheTtl = TimeSpan.FromSeconds(60);
+
+    private readonly ITenantProviderKeyReader _cabinet;
+    private readonly IConfiguration _configuration;
+    private readonly ITammaModeProvider _mode;
+    private readonly ILogger<JiraCredentialResolver> _logger;
+    private readonly TimeProvider _timeProvider;
+    private readonly TimeSpan _cacheTtl;
+
+    private readonly ConcurrentDictionary<Guid, CacheEntry> _cache = new();
+
+    public JiraCredentialResolver(
+        ITenantProviderKeyReader cabinet,
+        IConfiguration configuration,
+        ITammaModeProvider mode,
+        ILogger<JiraCredentialResolver> logger,
+        TimeProvider? timeProvider = null,
+        TimeSpan? cacheTtl = null)
+    {
+        _cabinet = cabinet ?? throw new ArgumentNullException(nameof(cabinet));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _cacheTtl = cacheTtl ?? DefaultCacheTtl;
+    }
+
+    /// <inheritdoc />
+    public async Task<JiraCredentialResolution?> ResolveAsync(
+        Guid? tenantId, CancellationToken ct = default)
+    {
+        // ── tenant tier (BYOK) ──
+        if (tenantId is { } tid)
+        {
+            var now = _timeProvider.GetUtcNow();
+            if (_cache.TryGetValue(tid, out var cached) && cached.ExpiresAt > now)
+            {
+                return new JiraCredentialResolution(cached.Credential, IntegrationCredentialSource.Tenant);
+            }
+
+            var byok = await TryReadTenantAsync(tid, ct).ConfigureAwait(false);
+            if (byok is not null)
+            {
+                _cache[tid] = new CacheEntry(byok, now.Add(_cacheTtl));
+                return new JiraCredentialResolution(byok, IntegrationCredentialSource.Tenant);
+            }
+        }
+
+        // ── system tier (single-user config) ──
+        if (_mode.Mode == TammaMode.SingleUser)
+        {
+            var system = TryReadSystemConfig();
+            if (system is not null)
+            {
+                return new JiraCredentialResolution(system, IntegrationCredentialSource.System);
+            }
+        }
+
+        // ── fail-loud tier ──
+        _logger.LogWarning(
+            "JIRA credential unresolvable for tenant {TenantId} (mode {Mode}): no tenant BYOK bundle" +
+            " and no single-user Jira:* config — failing loud (JIRA_CREDENTIAL_UNAVAILABLE).",
+            tenantId, _mode.Mode);
+        return null;
+    }
+
+    /// <inheritdoc />
+    public void Invalidate(Guid? tenantId)
+    {
+        if (tenantId is { } tid)
+        {
+            _cache.TryRemove(tid, out _);
+        }
+    }
+
+    private async Task<JiraCredential?> TryReadTenantAsync(Guid tenantId, CancellationToken ct)
+    {
+        var row = await _cabinet
+            .TryReadAsync(tenantId, IntegrationCabinetNames.JiraConfig, ct)
+            .ConfigureAwait(false);
+        // A malformed/partial stored bundle deserializes to null → treated as
+        // absent (never a partial credential).
+        return row is null ? null : JiraCredentialCodec.TryDeserialize(row.Plaintext);
+    }
+
+    private JiraCredential? TryReadSystemConfig()
+    {
+        var baseUrl = _configuration["Jira:BaseUrl"];
+        var email = _configuration["Jira:Email"];
+        var apiToken = _configuration["Jira:ApiToken"];
+        if (string.IsNullOrWhiteSpace(baseUrl)
+            || string.IsNullOrWhiteSpace(email)
+            || string.IsNullOrWhiteSpace(apiToken))
+        {
+            return null;
+        }
+        return new JiraCredential(baseUrl.Trim(), email.Trim(), apiToken);
+    }
+
+    private readonly record struct CacheEntry(JiraCredential Credential, DateTimeOffset ExpiresAt);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraEventTypes.cs
@@ -31,13 +31,14 @@ public static class JiraFailureCodes
     public const string NotFound = "NOT_FOUND";
 
     /// <summary>
-    /// SaaS fail-closed guard: JIRA uses a single platform-global credential with no
-    /// per-tenant/ticket scoping (there is no tenant↔JIRA-project mapping yet), so in
-    /// SaaS mode the shared-credential path is a confused-deputy — any tenant could
-    /// read/patch ANY ticket id. Denied by default; an operator re-enables it
-    /// knowingly via <c>Jira:AllowSharedCredentialInSaaS=true</c>.
+    /// Per-tenant BYOK fail-loud: no JIRA credential resolved for the acting
+    /// tenant (no tenant cabinet bundle in SaaS, and no single-user <c>Jira:*</c>
+    /// config). The credential-bound JIRA client is
+    /// NEVER called — the mediation fails loud rather than silently using a
+    /// shared platform default. The tenant registers its own credential via
+    /// <c>POST /api/v1/integrations/jira/credential</c>.
     /// </summary>
-    public const string SharedCredentialDeniedInSaaS = "JIRA_SHARED_CREDENTIAL_DENIED_IN_SAAS";
+    public const string CredentialUnavailable = "JIRA_CREDENTIAL_UNAVAILABLE";
 
     /// <summary>Any other expected platform failure (permission, rate-limit, transient).</summary>
     public const string PlatformError = "PLATFORM_ERROR";

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Jira/JiraMediationService.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Integrations;
 using Tamma.Core.Interfaces;
 using Tamma.Core.Logging;
 using Tamma.Data.Entities;
@@ -10,78 +9,63 @@ using Tamma.Data.Repositories;
 namespace Tamma.Api.Services.Jira;
 
 /// <summary>
-/// Story 38 (Phase 1) — composes the JIRA-mediation sequence entirely inside
-/// <c>Tamma.Api</c>: platform call via the existing config-credentialed
-/// <see cref="IJiraIntegrationService"/> (the JIRA base URL / email / API token live
-/// in Tamma.Api config, resolved inside that service) → exactly-one terminal DCB
-/// event scoped by the acting tenant. Unlike git/CI there is no per-tenant BYOK
-/// token resolver: JIRA is a single, server-side, config-provided integration
-/// (mirrors the Slack outbox plane, not the repo-scoped git plane). The JIRA token
-/// NEVER reaches the engine — it stays in Tamma.Api config.
+/// Story 38 (Phase 1) + integration BYOK — composes the JIRA-mediation sequence
+/// entirely inside <c>Tamma.Api</c>: resolve the acting tenant's JIRA credential
+/// per-request (BYOK→system→fail-loud, like git/LLM), thread it into the
+/// credential-bound <see cref="IJiraApiClient"/>, then emit exactly one terminal
+/// DCB event scoped by the tenant. The JIRA token NEVER reaches the engine — it
+/// stays in Tamma.Api (cabinet or single-user config).
 ///
-/// <para><b>Fail-closed tenant guard (SaaS).</b> Because that single credential has
-/// NO per-tenant/ticket authorization — and there is no tenant↔JIRA-project mapping
-/// to derive one from — the shared-credential path is a confused-deputy in SaaS: any
-/// tenant A could GET/PATCH ANY ticket id belonging to tenant B through the global
-/// client. So this service is mode-gated (mirroring <c>GitRepoAuthorizer</c>):
+/// <para><b>Fail-loud tenant resolution (replaces the old SaaS-deny guard).</b>
+/// The credential is resolved via <see cref="IJiraCredentialResolver"/>:
 /// <list type="bullet">
-///   <item><b>single-user</b> — the sole principal owns everything ⇒ ALLOW.</item>
-///   <item><b>SaaS</b> — DENY by default with a typed, key-free soft-fail
-///     (<see cref="JiraFailureCodes.SharedCredentialDeniedInSaaS"/>) and a WARN log;
-///     the underlying <see cref="IJiraIntegrationService"/> is NEVER called. An
-///     operator may re-enable the shared-credential behavior knowingly by setting
-///     <c>Jira:AllowSharedCredentialInSaaS=true</c> (default <c>false</c>).</item>
-/// </list>
-/// This is a conservative guard, not full per-tenant JIRA scoping (blocked until a
-/// tenant↔project mapping exists).</para>
+///   <item><b>present</b> — the tenant's BYOK bundle (SaaS) or the single-user
+///     <c>Jira:*</c> config (system tier) ⇒ ALLOW, using THAT credential.</item>
+///   <item><b>absent</b> — no per-tenant credential and no legitimate system tier
+///     ⇒ <b>fail loud</b> with the typed key-free
+///     <see cref="JiraFailureCodes.CredentialUnavailable"/> and a WARN log; the
+///     JIRA client is NEVER reached. This is the confused-deputy fix: SaaS no
+///     longer silently falls back to a shared platform credential.</item>
+/// </list></para>
 /// </summary>
 public sealed class JiraMediationService : IJiraMediationService
 {
-    private readonly IJiraIntegrationService _jira;
+    private readonly IJiraApiClient _jira;
+    private readonly IJiraCredentialResolver _credentials;
     private readonly IEventRepository _events;
-    private readonly ITammaModeProvider _mode;
-    private readonly bool _allowSharedCredentialInSaaS;
     private readonly ILogger<JiraMediationService> _logger;
 
     public JiraMediationService(
-        IJiraIntegrationService jira,
+        IJiraApiClient jira,
+        IJiraCredentialResolver credentials,
         IEventRepository events,
-        ITammaModeProvider mode,
-        IConfiguration configuration,
         ILogger<JiraMediationService> logger)
     {
         _jira = jira ?? throw new ArgumentNullException(nameof(jira));
+        _credentials = credentials ?? throw new ArgumentNullException(nameof(credentials));
         _events = events ?? throw new ArgumentNullException(nameof(events));
-        _mode = mode ?? throw new ArgumentNullException(nameof(mode));
-        ArgumentNullException.ThrowIfNull(configuration);
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-
-        // Opt-in escape hatch: an operator who has accepted the cross-tenant risk of
-        // a shared JIRA credential in SaaS sets this to true. Default (unset / any
-        // non-"true" value) ⇒ false ⇒ SaaS denies.
-        _allowSharedCredentialInSaaS =
-            bool.TryParse(configuration["Jira:AllowSharedCredentialInSaaS"], out var allow) && allow;
     }
 
     public Task<JiraMediationResult> GetTicketAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct = default)
         => ExecuteGuardedAsync(tenantId, ticketId, JiraEventTypes.TicketReadOperation, JiraEventTypes.TicketReadFailed, correlationId, ct,
-            () => GetTicketCoreAsync(tenantId, ticketId, correlationId, ct));
+            cred => GetTicketCoreAsync(tenantId, ticketId, correlationId, cred, ct));
 
     public Task<JiraMediationResult> UpdateTicketAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct = default)
     {
         ArgumentNullException.ThrowIfNull(body);
         return ExecuteGuardedAsync(tenantId, ticketId, JiraEventTypes.TicketUpdateOperation, JiraEventTypes.TicketUpdatedFailed, body.CorrelationId, ct,
-            () => UpdateTicketCoreAsync(tenantId, ticketId, body, ct));
+            cred => UpdateTicketCoreAsync(tenantId, ticketId, body, cred, ct));
     }
 
     // ===================================================================
     // Read ticket
     // ===================================================================
 
-    private async Task<JiraMediationResult> GetTicketCoreAsync(Guid? tenantId, string ticketId, string correlationId, CancellationToken ct)
+    private async Task<JiraMediationResult> GetTicketCoreAsync(Guid? tenantId, string ticketId, string correlationId, JiraCredential credential, CancellationToken ct)
     {
         var op = JiraEventTypes.TicketReadOperation;
-        var res = await _jira.GetJiraTicketAsync(ticketId).ConfigureAwait(false);
+        var res = await _jira.GetTicketAsync(credential, ticketId, ct).ConfigureAwait(false);
 
         if (!res.Success)
             return await FailAsync(tenantId, ticketId, op, JiraEventTypes.TicketReadFailed, correlationId, res.Error, ct).ConfigureAwait(false);
@@ -116,7 +100,7 @@ public sealed class JiraMediationService : IJiraMediationService
     // Update ticket (status transition + comment)
     // ===================================================================
 
-    private async Task<JiraMediationResult> UpdateTicketCoreAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, CancellationToken ct)
+    private async Task<JiraMediationResult> UpdateTicketCoreAsync(Guid? tenantId, string ticketId, UpdateTicketRequest body, JiraCredential credential, CancellationToken ct)
     {
         var op = JiraEventTypes.TicketUpdateOperation;
         var update = new JiraTicketUpdate
@@ -126,7 +110,7 @@ public sealed class JiraMediationService : IJiraMediationService
             CustomFields = body.CustomFields,
         };
 
-        var res = await _jira.UpdateJiraTicketAsync(ticketId, update).ConfigureAwait(false);
+        var res = await _jira.UpdateTicketAsync(credential, ticketId, update, ct).ConfigureAwait(false);
 
         if (!res.Success)
             return await FailAsync(tenantId, ticketId, op, JiraEventTypes.TicketUpdatedFailed, correlationId: body.CorrelationId, res.Error, ct).ConfigureAwait(false);
@@ -166,27 +150,45 @@ public sealed class JiraMediationService : IJiraMediationService
 
     private async Task<JiraMediationResult> ExecuteGuardedAsync(
         Guid? tenantId, string ticketId, string operation, string failedEventType, string correlationId,
-        CancellationToken ct, Func<Task<JiraMediationResult>> body)
+        CancellationToken ct, Func<JiraCredential, Task<JiraMediationResult>> body)
     {
-        // Fail-closed tenant guard (runs BEFORE the body so the shared-credential
-        // IJiraIntegrationService is never reached on denial). In SaaS the single
-        // platform-global JIRA credential has no per-tenant/ticket scoping ⇒ deny
-        // unless an operator opted in. Single-user owns everything ⇒ allow.
-        if (_mode.Mode == TammaMode.SaaS && !_allowSharedCredentialInSaaS)
+        // Fail-loud per-tenant credential resolution (runs BEFORE the body so the
+        // JIRA client is never reached on an unresolved credential). In SaaS the
+        // tenant must have registered its own BYOK bundle; single-user resolves
+        // the Jira:* config as the system tier. Absent ⇒ typed key-free failure,
+        // NOT a silent shared-credential fallback.
+        JiraCredentialResolution? resolution;
+        try
+        {
+            resolution = await _credentials.ResolveAsync(tenantId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "jira-mediation credential resolution threw for op {Operation}; failing loud (CREDENTIAL_UNAVAILABLE). correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
+                operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(ticketId), tenantId);
+            resolution = null;
+        }
+
+        if (resolution is null)
         {
             _logger.LogWarning(
-                "jira-mediation guard DENIED (shared-credential in SaaS): op {Operation} refused — JIRA has no per-tenant scoping and Jira:AllowSharedCredentialInSaaS is not set. correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
+                "jira-mediation FAILED-LOUD (no JIRA credential for tenant): op {Operation} refused — register a per-tenant JIRA credential or configure Jira:* (single-user). correlationId={CorrelationId}, ticketId={TicketId}, tenantId={TenantId}",
                 operation, LogSanitizer.Clean(correlationId), LogSanitizer.Clean(ticketId), tenantId);
 
             await EmitAsync(failedEventType, operation, tenantId, ticketId, correlationId,
-                JiraFailureCodes.SharedCredentialDeniedInSaaS, new { ticketId }, ct).ConfigureAwait(false);
+                JiraFailureCodes.CredentialUnavailable, new { ticketId }, ct).ConfigureAwait(false);
 
             return new JiraMediationResult
             {
                 Success = false,
                 Outcome = "Error",
-                FailureCode = JiraFailureCodes.SharedCredentialDeniedInSaaS,
-                FailureReason = "JIRA uses a shared platform credential with no per-tenant scoping; refused in SaaS mode. Set Jira:AllowSharedCredentialInSaaS=true to allow knowingly.",
+                FailureCode = JiraFailureCodes.CredentialUnavailable,
+                FailureReason = "no JIRA credential is configured for this tenant; register one via POST /api/v1/integrations/jira/credential.",
                 TicketKey = ticketId,
                 CorrelationId = correlationId,
             };
@@ -194,7 +196,7 @@ public sealed class JiraMediationService : IJiraMediationService
 
         try
         {
-            return await body().ConfigureAwait(false);
+            return await body(resolution.Credential).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {

--- a/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Audit/SensitiveActionCatalog.cs
@@ -78,6 +78,14 @@ public static class SensitiveActionCatalog
     public const string ProviderKeyChanged = "PROVIDER_KEY.CHANGED.SUCCESS";
     public const string ProviderChainChanged = "PROVIDER_CHAIN.CHANGED.SUCCESS";
 
+    /// <summary>A tenant BYOK integration credential (JIRA / email) was set or
+    /// removed — wired by <c>IntegrationCredentialEndpoints</c>. The concrete
+    /// operation (set|removed) + integration (jira|email) travel in the event's
+    /// <c>operation</c>/<c>integration</c> tag/data; the underlying <c>SECRET.*</c>
+    /// cabinet write stays the secret source of truth (this is the curated,
+    /// catalog-facing BYOK event, not a second write).</summary>
+    public const string IntegrationCredentialChanged = "INTEGRATION_CREDENTIAL.CHANGED.SUCCESS";
+
     // ── BILLING (maps existing BillingEvents; budget edits forward-looking) ──
     public const string BillingCustomerCreated = "BILLING.CUSTOMER.CREATED";
     public const string PlanUpdated = "PLAN.UPDATED";
@@ -196,6 +204,7 @@ public static class SensitiveActionCatalog
         // ── BYOK — CC6.1 (provider credential / chain configuration) ──
         Add(ProviderKeyChanged, AuditCategory.Byok, AuditSeverity.Warning, "CC6.1", "provider", true);
         Add(ProviderChainChanged, AuditCategory.Byok, AuditSeverity.Notice, "CC6.1", "provider", false);
+        Add(IntegrationCredentialChanged, AuditCategory.Byok, AuditSeverity.Warning, "CC6.1", "integration", true);
 
         // ── BILLING — A1.1 (commitments affecting availability/spend) ──
         Add(BillingCustomerCreated, AuditCategory.Billing, AuditSeverity.Notice, "A1.1", "tenant", true);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
@@ -1,26 +1,32 @@
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Email;
 using Tamma.Api.Services.EmailMediation;
-using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Integrations;
 
 namespace Tamma.Api.Tests.EmailMediation;
 
 /// <summary>
-/// Story 38 (Phase 1) — <see cref="EmailMediationService"/> composition. Email is not
-/// repo-scoped: it accepts the engine's rendered message into the credentialed,
-/// outbox-backed <see cref="IEmailService"/> (which owns transport + EMAIL.* audit)
-/// under the acting tenant. Fail-soft: a missing recipient or an accept exception
-/// surfaces a typed PLATFORM_ERROR inside a 200 success:false envelope (never a raw
-/// 5xx). The email credential never reaches the engine.
+/// Integration BYOK — <see cref="EmailMediationService"/> composition. The old
+/// SaaS-deny guard is replaced by per-tenant credential resolution: the tenant's
+/// email credential is resolved (BYOK→system→fail-loud), its tenant-authorized
+/// <c>From</c> is threaded onto the message, and the message is accepted into the
+/// outbox-backed <see cref="IEmailService"/>.
+///
+/// <para>Pins: present credential ⇒ Queued with the resolved From on the message;
+/// ABSENT credential ⇒ fail-loud
+/// <see cref="EmailMediationFailureCodes.CredentialUnavailable"/> with the transport
+/// NEVER reached; a missing recipient / accept exception is fail-soft PLATFORM_ERROR.</para>
 /// </summary>
 [TestFixture]
 public class EmailMediationServiceTests
 {
+    private const string ResolvedFrom = "team@tenant.example.com";
+
     private Mock<IEmailService> _email = null!;
+    private FakeResolver _resolver = null!;
     private EmailMediationService _sut = null!;
     private readonly Guid _tenant = Guid.NewGuid();
 
@@ -28,25 +34,13 @@ public class EmailMediationServiceTests
     public void SetUp()
     {
         _email = new Mock<IEmailService>(MockBehavior.Strict);
-        // Default SUT is single-user mode — the existing accept/fail-soft tests
-        // exercise the composition without the SaaS guard tripping.
-        _sut = BuildSut(TammaMode.SingleUser);
-    }
-
-    private EmailMediationService BuildSut(TammaMode mode, bool allowMediatedSendInSaaS = false)
-    {
-        var modeProvider = new Mock<ITammaModeProvider>();
-        modeProvider.SetupGet(m => m.Mode).Returns(mode);
-
-        var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                [EmailMediationService.AllowMediatedSendInSaaSKey] = allowMediatedSendInSaaS ? "true" : "false",
-            })
-            .Build();
-
-        return new EmailMediationService(
-            _email.Object, modeProvider.Object, config, NullLogger<EmailMediationService>.Instance);
+        _resolver = new FakeResolver
+        {
+            Resolution = new EmailCredentialResolution(
+                new EmailCredential(EmailCredential.TransportResend, ResolvedFrom, ResendApiKey: "fake-resend-key"),
+                IntegrationCredentialSource.Tenant),
+        };
+        _sut = new EmailMediationService(_email.Object, _resolver, NullLogger<EmailMediationService>.Instance);
     }
 
     private static SendEmailRequest Body() => new()
@@ -55,7 +49,7 @@ public class EmailMediationServiceTests
     };
 
     [Test]
-    public async Task Send_Success_AcceptsIntoOutbox_ReturnsTxnId_ScopesTenant()
+    public async Task Send_CredentialResolved_ThreadsFrom_AcceptsIntoOutbox_ReturnsTxn()
     {
         var txn = Guid.NewGuid();
         EmailMessage? captured = null;
@@ -69,9 +63,25 @@ public class EmailMediationServiceTests
         result.Outcome.Should().Be("Queued");
         result.TxnId.Should().Be(txn);
         captured.Should().NotBeNull();
-        captured!.TenantId.Should().Be(_tenant, "the acting tenant scopes the message + its EMAIL.* events");
+        captured!.From.Should().Be(ResolvedFrom, "the resolved tenant-authorized sender identity is threaded onto the message");
+        captured.TenantId.Should().Be(_tenant);
         captured.To.Should().Be("dev@example.com");
         captured.Text.Should().Be("All green");
+    }
+
+    [Test]
+    public async Task Send_NoCredential_FailsLoud_NeverCallsTransport()
+    {
+        _resolver.Resolution = null;
+
+        var result = await _sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeFalse();
+        result.Outcome.Should().Be("Error");
+        result.FailureCode.Should().Be(EmailMediationFailureCodes.CredentialUnavailable);
+        result.CorrelationId.Should().Be("corr-e");
+        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a fail-loud send must never reach the outbox/transport");
     }
 
     [Test]
@@ -98,58 +108,11 @@ public class EmailMediationServiceTests
         result.CorrelationId.Should().Be("corr-e");
     }
 
-    // ── SaaS fail-closed tenant guard ──
-    // A tenant workflow mediates mail FROM the platform's configured sender identity
-    // (Email:From). In SaaS that lets a tenant emit arbitrary mail under the
-    // platform's reputation/domain, so mediated sends are denied by default. Only
-    // TENANT-WORKFLOW-initiated sends flow through here; system emails
-    // (welcome/verification/password-reset) call IEmailService directly and are
-    // unaffected.
-
-    [Test]
-    public async Task Send_SingleUserMode_Allowed_AcceptsIntoOutbox()
+    private sealed class FakeResolver : IEmailCredentialResolver
     {
-        var txn = Guid.NewGuid();
-        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(txn);
-        var sut = BuildSut(TammaMode.SingleUser);
-
-        var result = await sut.SendEmailAsync(_tenant, Body());
-
-        result.Success.Should().BeTrue("single-user mode has one principal who owns the sender domain");
-        result.Outcome.Should().Be("Queued");
-        result.TxnId.Should().Be(txn);
-        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Test]
-    public async Task Send_SaaSMode_NoOptIn_TypedDenial_NeverEnqueues()
-    {
-        var sut = BuildSut(TammaMode.SaaS, allowMediatedSendInSaaS: false);
-
-        var result = await sut.SendEmailAsync(_tenant, Body());
-
-        result.Success.Should().BeFalse();
-        result.Outcome.Should().Be("Denied");
-        result.FailureCode.Should().Be(EmailMediationFailureCodes.MediationDeniedInSaaS);
-        result.CorrelationId.Should().Be("corr-e");
-        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never,
-            "a denied mediated send must never reach the outbox/transport");
-    }
-
-    [Test]
-    public async Task Send_SaaSMode_WithOptIn_Allowed_AcceptsIntoOutbox()
-    {
-        var txn = Guid.NewGuid();
-        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(txn);
-        var sut = BuildSut(TammaMode.SaaS, allowMediatedSendInSaaS: true);
-
-        var result = await sut.SendEmailAsync(_tenant, Body());
-
-        result.Success.Should().BeTrue("the explicit Email:AllowMediatedSendInSaaS opt-in re-enables the send");
-        result.Outcome.Should().Be("Queued");
-        result.TxnId.Should().Be(txn);
-        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+        public EmailCredentialResolution? Resolution { get; set; }
+        public Task<EmailCredentialResolution?> ResolveAsync(Guid? tenantId, CancellationToken ct = default)
+            => Task.FromResult(Resolution);
+        public void Invalidate(Guid? tenantId) { }
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/EmailMediationServiceTests.cs
@@ -9,38 +9,47 @@ using Tamma.Api.Services.Integrations;
 namespace Tamma.Api.Tests.EmailMediation;
 
 /// <summary>
-/// Integration BYOK — <see cref="EmailMediationService"/> composition. The old
-/// SaaS-deny guard is replaced by per-tenant credential resolution: the tenant's
-/// email credential is resolved (BYOK→system→fail-loud), its tenant-authorized
-/// <c>From</c> is threaded onto the message, and the message is accepted into the
-/// outbox-backed <see cref="IEmailService"/>.
+/// Integration BYOK — <see cref="EmailMediationService"/> composition, pinning the
+/// <b>anti-spoofing transport-authority invariant</b>: a SaaS tenant's message is
+/// delivered via the TENANT'S OWN transport (<see cref="ITenantEmailTransport"/>)
+/// resolved from its bundle — the platform singleton <see cref="IEmailService"/> is
+/// NEVER used for a SaaS tenant (that would let a tenant_admin send a
+/// platform-DKIM-signed, brand-impersonating email with an arbitrary <c>From</c>).
+/// The single-user system tier still uses the platform singleton, whose
+/// <c>Email:*</c> config IS the sole principal's authority.
 ///
-/// <para>Pins: present credential ⇒ Queued with the resolved From on the message;
-/// ABSENT credential ⇒ fail-loud
-/// <see cref="EmailMediationFailureCodes.CredentialUnavailable"/> with the transport
-/// NEVER reached; a missing recipient / accept exception is fail-soft PLATFORM_ERROR.</para>
+/// <para>Pins: SaaS tenant tier ⇒ tenant transport used with the tenant credential,
+/// platform singleton NOT called; single-user system tier ⇒ platform singleton used,
+/// tenant transport NOT called; ABSENT credential ⇒ fail-loud
+/// <see cref="EmailMediationFailureCodes.CredentialUnavailable"/> with NEITHER
+/// transport reached; a missing recipient / transport exception is fail-soft
+/// PLATFORM_ERROR.</para>
 /// </summary>
 [TestFixture]
 public class EmailMediationServiceTests
 {
     private const string ResolvedFrom = "team@tenant.example.com";
 
-    private Mock<IEmailService> _email = null!;
+    private Mock<IEmailService> _platform = null!;
+    private Mock<ITenantEmailTransport> _tenantTransport = null!;
     private FakeResolver _resolver = null!;
     private EmailMediationService _sut = null!;
     private readonly Guid _tenant = Guid.NewGuid();
 
+    private static readonly EmailCredential ResendBundle =
+        new(EmailCredential.TransportResend, ResolvedFrom, ResendApiKey: "fake-resend-key");
+
     [SetUp]
     public void SetUp()
     {
-        _email = new Mock<IEmailService>(MockBehavior.Strict);
+        _platform = new Mock<IEmailService>(MockBehavior.Strict);
+        _tenantTransport = new Mock<ITenantEmailTransport>(MockBehavior.Strict);
         _resolver = new FakeResolver
         {
-            Resolution = new EmailCredentialResolution(
-                new EmailCredential(EmailCredential.TransportResend, ResolvedFrom, ResendApiKey: "fake-resend-key"),
-                IntegrationCredentialSource.Tenant),
+            Resolution = new EmailCredentialResolution(ResendBundle, IntegrationCredentialSource.Tenant),
         };
-        _sut = new EmailMediationService(_email.Object, _resolver, NullLogger<EmailMediationService>.Instance);
+        _sut = new EmailMediationService(
+            _platform.Object, _tenantTransport.Object, _resolver, NullLogger<EmailMediationService>.Instance);
     }
 
     private static SendEmailRequest Body() => new()
@@ -49,12 +58,14 @@ public class EmailMediationServiceTests
     };
 
     [Test]
-    public async Task Send_CredentialResolved_ThreadsFrom_AcceptsIntoOutbox_ReturnsTxn()
+    public async Task Send_SaasTenantByok_UsesTenantTransport_NeverPlatformSingleton()
     {
         var txn = Guid.NewGuid();
-        EmailMessage? captured = null;
-        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
-            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+        EmailCredential? capturedCred = null;
+        EmailMessage? capturedMsg = null;
+        _tenantTransport
+            .Setup(t => t.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailCredential, EmailMessage, CancellationToken>((c, m, _) => { capturedCred = c; capturedMsg = m; })
             .ReturnsAsync(txn);
 
         var result = await _sut.SendEmailAsync(_tenant, Body());
@@ -62,15 +73,45 @@ public class EmailMediationServiceTests
         result.Success.Should().BeTrue();
         result.Outcome.Should().Be("Queued");
         result.TxnId.Should().Be(txn);
-        captured.Should().NotBeNull();
-        captured!.From.Should().Be(ResolvedFrom, "the resolved tenant-authorized sender identity is threaded onto the message");
-        captured.TenantId.Should().Be(_tenant);
-        captured.To.Should().Be("dev@example.com");
-        captured.Text.Should().Be("All green");
+
+        // Delivered via the tenant's OWN transport, with the tenant's bundle …
+        capturedCred.Should().BeSameAs(ResendBundle, "the SaaS send must ride the tenant's own transport authority");
+        capturedMsg!.From.Should().Be(ResolvedFrom);
+        capturedMsg.TenantId.Should().Be(_tenant);
+        capturedMsg.To.Should().Be("dev@example.com");
+        capturedMsg.Text.Should().Be("All green");
+
+        // … and NEVER the platform DKIM-signed singleton (the From-spoofing hole).
+        _platform.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a SaaS tenant must never be delivered via the platform transport with a tenant-supplied From");
     }
 
     [Test]
-    public async Task Send_NoCredential_FailsLoud_NeverCallsTransport()
+    public async Task Send_SingleUserSystemTier_UsesPlatformSingleton_NeverTenantTransport()
+    {
+        _resolver.Resolution = new EmailCredentialResolution(
+            new EmailCredential(EmailCredential.TransportSmtp, "ops@self-hosted.example", SmtpHost: "smtp.self.example"),
+            IntegrationCredentialSource.System);
+
+        var txn = Guid.NewGuid();
+        EmailMessage? captured = null;
+        _platform.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(txn);
+
+        var result = await _sut.SendEmailAsync(_tenant, Body());
+
+        result.Success.Should().BeTrue();
+        result.TxnId.Should().Be(txn);
+        captured!.From.Should().Be("ops@self-hosted.example");
+
+        _tenantTransport.Verify(
+            t => t.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never, "the single-user system tier uses the platform/config transport, not a per-tenant transport");
+    }
+
+    [Test]
+    public async Task Send_NoCredential_FailsLoud_NeverCallsAnyTransport()
     {
         _resolver.Resolution = null;
 
@@ -80,25 +121,31 @@ public class EmailMediationServiceTests
         result.Outcome.Should().Be("Error");
         result.FailureCode.Should().Be(EmailMediationFailureCodes.CredentialUnavailable);
         result.CorrelationId.Should().Be("corr-e");
-        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never,
-            "a fail-loud send must never reach the outbox/transport");
+        _platform.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        _tenantTransport.Verify(
+            t => t.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never, "a fail-loud send must never reach any transport");
     }
 
     [Test]
-    public async Task Send_MissingRecipient_TypedPlatformError_NeverCallsTransport()
+    public async Task Send_MissingRecipient_TypedPlatformError_NeverCallsAnyTransport()
     {
         var result = await _sut.SendEmailAsync(_tenant, new SendEmailRequest { To = "", Subject = "s", Body = "b", CorrelationId = "c" });
 
         result.Success.Should().BeFalse();
         result.FailureCode.Should().Be(EmailMediationFailureCodes.PlatformError);
-        _email.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        _platform.Verify(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        _tenantTransport.Verify(
+            t => t.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Test]
-    public async Task Send_TransportAcceptThrows_FailSoft_TypedPlatformError_No5xx()
+    public async Task Send_TenantTransportThrows_FailSoft_TypedPlatformError_No5xx()
     {
-        _email.Setup(e => e.SendAsync(It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new InvalidOperationException("smtp accept failed"));
+        _tenantTransport
+            .Setup(t => t.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("tenant transport failed"));
 
         var result = await _sut.SendEmailAsync(_tenant, Body());
 

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/TenantEmailTransportTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/EmailMediation/TenantEmailTransportTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Tamma.Api.Services.Email;
+using Tamma.Api.Services.EmailMediation;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.EmailMediation;
+
+/// <summary>
+/// <see cref="TenantEmailTransport"/> — the SaaS BYOK transport. Pins that a
+/// tenant's message is delivered over the TENANT'S OWN sending authority:
+/// <list type="bullet">
+///   <item>resend ⇒ POST carries <c>Authorization: Bearer &lt;TENANT key&gt;</c> and
+///     <c>from = &lt;TENANT From&gt;</c> (never a platform key) + EMAIL.SENT audit.</item>
+///   <item>smtp ⇒ the per-tenant <see cref="ITenantSmtpTransport"/> is invoked with
+///     the TENANT'S relay credentials + EMAIL.SENT audit.</item>
+///   <item>transport failure ⇒ EMAIL.SENT.FAILED audit + txn still returned, never
+///     throws.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class TenantEmailTransportTests
+{
+    private const string TenantResendKey = "re_tenant_secret_key";
+    private const string TenantFrom = "team@tenant.example.com";
+
+    private InMemoryDbFixture _fx = null!;
+    private ControlPlaneDbContext _db = null!;
+    private EventRepository _events = null!;
+    private TenantContext _tenantContext = null!;
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [SetUp]
+    public void SetUp()
+    {
+        _fx = new InMemoryDbFixture();
+        _tenantContext = new TenantContext();
+        _db = _fx.Cp;
+        _events = new EventRepository(_fx.Factory, _tenantContext, new PlatformEventRepository(_db));
+    }
+
+    [TearDown]
+    public async Task TearDown() => await _fx.DisposeAsync();
+
+    private static EmailMessage Message() => new(
+        To: "dev@example.com", Subject: "Build passed", Html: "<p>green</p>", Text: "green",
+        From: TenantFrom, Template: "ci", TenantId: null);
+
+    private EmailMessage TenantMessage() => Message() with { TenantId = _tenant };
+
+    // ── resend ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Resend_UsesTenantKeyAndFrom_EmitsSent_ReturnsTxn()
+    {
+        HttpRequestMessage? captured = null;
+        string? capturedBody = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                captured = req;
+                capturedBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+            })
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"id":"x"}""") });
+
+        var sut = BuildSut(handler);
+        var cred = new EmailCredential(EmailCredential.TransportResend, TenantFrom, ResendApiKey: TenantResendKey);
+
+        var txn = await sut.SendAsync(cred, TenantMessage());
+
+        txn.Should().NotBe(Guid.Empty);
+        // The tenant's OWN key authorizes the send — not a platform key.
+        captured!.Headers.Authorization!.Scheme.Should().Be("Bearer");
+        captured.Headers.Authorization.Parameter.Should().Be(TenantResendKey);
+        // The From on the wire is the tenant's identity.
+        var payload = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(capturedBody!)!;
+        payload["from"].GetString().Should().Be(TenantFrom);
+
+        var sent = await _events.QueryAsync(_tenant, EmailEventTypes.Sent, null, 10);
+        sent.Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task Resend_Non2xx_EmitsFailed_StillReturnsTxn_NoThrow()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Forbidden));
+
+        var sut = BuildSut(handler);
+        var cred = new EmailCredential(EmailCredential.TransportResend, TenantFrom, ResendApiKey: TenantResendKey);
+
+        var txn = await sut.SendAsync(cred, TenantMessage());
+
+        txn.Should().NotBe(Guid.Empty);
+        (await _events.QueryAsync(_tenant, EmailEventTypes.Failed, null, 10)).Should().ContainSingle();
+        (await _events.QueryAsync(_tenant, EmailEventTypes.Sent, null, 10)).Should().BeEmpty();
+    }
+
+    // ── smtp ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Smtp_InvokesTenantSmtpTransportWithTenantCreds_EmitsSent()
+    {
+        var smtp = new Mock<ITenantSmtpTransport>(MockBehavior.Strict);
+        EmailCredential? capturedCred = null;
+        smtp.Setup(s => s.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailCredential, EmailMessage, CancellationToken>((c, _, _) => capturedCred = c)
+            .Returns(Task.CompletedTask);
+
+        var sut = BuildSut(new Mock<HttpMessageHandler>(), smtp);
+        var cred = new EmailCredential(EmailCredential.TransportSmtp, TenantFrom,
+            SmtpHost: "smtp.tenant.example", SmtpPort: 587, SmtpUsername: "u", SmtpPassword: "p");
+
+        var txn = await sut.SendAsync(cred, TenantMessage());
+
+        txn.Should().NotBe(Guid.Empty);
+        capturedCred.Should().BeSameAs(cred, "the tenant's own SMTP relay credentials must be used");
+        (await _events.QueryAsync(_tenant, EmailEventTypes.Sent, null, 10)).Should().ContainSingle();
+        smtp.VerifyAll();
+    }
+
+    [Test]
+    public async Task Smtp_TransportThrows_EmitsFailed_StillReturnsTxn_NoThrow()
+    {
+        var smtp = new Mock<ITenantSmtpTransport>();
+        smtp.Setup(s => s.SendAsync(It.IsAny<EmailCredential>(), It.IsAny<EmailMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("relay refused"));
+
+        var sut = BuildSut(new Mock<HttpMessageHandler>(), smtp);
+        var cred = new EmailCredential(EmailCredential.TransportSmtp, TenantFrom, SmtpHost: "smtp.tenant.example");
+
+        var txn = await sut.SendAsync(cred, TenantMessage());
+
+        txn.Should().NotBe(Guid.Empty);
+        (await _events.QueryAsync(_tenant, EmailEventTypes.Failed, null, 10)).Should().ContainSingle();
+    }
+
+    private TenantEmailTransport BuildSut(Mock<HttpMessageHandler> handler, Mock<ITenantSmtpTransport>? smtp = null)
+    {
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://api.resend.com/") };
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("resend")).Returns(client);
+        return new TenantEmailTransport(
+            factory.Object,
+            (smtp ?? new Mock<ITenantSmtpTransport>()).Object,
+            _events,
+            NullLogger<TenantEmailTransport>.Instance);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/EmailCredentialResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/EmailCredentialResolverTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// Email BYOK resolver — tenant→system→fail-loud. Pins: tenant Resend/SMTP bundle
+/// wins (SaaS); single-user Email:* config is the system tier; SaaS with no bundle
+/// fails loud (NO config fallback); an incomplete bundle (resend w/o key) is absent.
+/// </summary>
+[TestFixture]
+public class EmailCredentialResolverTests
+{
+    private const string FakeResendKey = "fake-resend-key-value";
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    private FakeCabinetReader _cabinet = null!;
+
+    [SetUp]
+    public void SetUp() => _cabinet = new FakeCabinetReader();
+
+    private EmailCredentialResolver Build(TammaMode mode, IConfiguration? config = null)
+    {
+        var modeProvider = new Mock<ITammaModeProvider>();
+        modeProvider.SetupGet(m => m.Mode).Returns(mode);
+        return new EmailCredentialResolver(
+            _cabinet, config ?? Empty(), modeProvider.Object,
+            NullLogger<EmailCredentialResolver>.Instance);
+    }
+
+    private static IConfiguration Empty() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+
+    private static IConfiguration ResendConfig() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Email:Provider"] = "resend",
+            ["Email:From"] = "noreply@sys.example.com",
+            ["Email:Resend:ApiKey"] = "fake-system-resend-key",
+        }).Build();
+
+    private static IConfiguration SmtpFromOnlyConfig() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Email:From"] = "noreply@sys.example.com",
+        }).Build();
+
+    [Test]
+    public async Task Saas_ResendBundlePresent_ResolvesTenantTier()
+    {
+        var bundle = EmailCredentialCodec.Serialize(new EmailCredential(
+            EmailCredential.TransportResend, "team@tenant.example.com", ResendApiKey: FakeResendKey));
+        _cabinet.Set(Tenant, IntegrationCabinetNames.EmailConfig, bundle);
+        var sut = Build(TammaMode.SaaS);
+
+        var res = await sut.ResolveAsync(Tenant);
+
+        res.Should().NotBeNull();
+        res!.Source.Should().Be(IntegrationCredentialSource.Tenant);
+        res.Credential.Transport.Should().Be(EmailCredential.TransportResend);
+        res.Credential.From.Should().Be("team@tenant.example.com");
+        res.Credential.ResendApiKey.Should().Be(FakeResendKey);
+    }
+
+    [Test]
+    public async Task Saas_NoBundle_FailsLoud_NoConfigFallback()
+    {
+        var sut = Build(TammaMode.SaaS, ResendConfig());
+
+        var res = await sut.ResolveAsync(Tenant);
+
+        res.Should().BeNull("SaaS with no tenant email bundle fails loud, never the shared config");
+    }
+
+    [Test]
+    public async Task Saas_IncompleteBundle_ResendWithoutKey_TreatedAsAbsent()
+    {
+        // Serialize a resend bundle WITHOUT the api key → codec rejects it as incomplete.
+        var bundle = EmailCredentialCodec.Serialize(new EmailCredential(
+            EmailCredential.TransportResend, "team@tenant.example.com", ResendApiKey: null));
+        _cabinet.Set(Tenant, IntegrationCabinetNames.EmailConfig, bundle);
+        var sut = Build(TammaMode.SaaS);
+
+        (await sut.ResolveAsync(Tenant)).Should().BeNull();
+    }
+
+    [Test]
+    public async Task SingleUser_ResendConfig_ResolvesSystemTier()
+    {
+        var sut = Build(TammaMode.SingleUser, ResendConfig());
+
+        var res = await sut.ResolveAsync(tenantId: null);
+
+        res.Should().NotBeNull();
+        res!.Source.Should().Be(IntegrationCredentialSource.System);
+        res.Credential.Transport.Should().Be(EmailCredential.TransportResend);
+        res.Credential.From.Should().Be("noreply@sys.example.com");
+    }
+
+    [Test]
+    public async Task SingleUser_SmtpFromOnlyConfig_ResolvesSystemTier()
+    {
+        // SMTP tier: from-present is sufficient (the outbox host is supplied at the
+        // sender). Default provider = smtp when Email:Provider is unset.
+        var sut = Build(TammaMode.SingleUser, SmtpFromOnlyConfig());
+
+        var res = await sut.ResolveAsync(tenantId: null);
+
+        res.Should().NotBeNull();
+        res!.Source.Should().Be(IntegrationCredentialSource.System);
+        res.Credential.Transport.Should().Be(EmailCredential.TransportSmtp);
+    }
+
+    [Test]
+    public async Task SingleUser_NoFrom_FailsLoud()
+    {
+        var sut = Build(TammaMode.SingleUser, Empty());
+
+        (await sut.ResolveAsync(tenantId: null)).Should().BeNull();
+    }
+
+    private sealed class FakeCabinetReader : ITenantProviderKeyReader
+    {
+        private readonly Dictionary<(Guid, string), string> _rows = new();
+        public void Set(Guid tenantId, string name, string plaintext) => _rows[(tenantId, name)] = plaintext;
+        public Task<TenantProviderKey?> TryReadAsync(Guid tenantId, string cabinetName, CancellationToken ct = default)
+            => Task.FromResult(_rows.TryGetValue((tenantId, cabinetName), out var v)
+                ? new TenantProviderKey(v, 1)
+                : null);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialCabinetTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialCabinetTests.cs
@@ -1,0 +1,153 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Postgres;
+using Tamma.Api.Tests.TestDoubles;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// Integration BYOK cabinet write/read round-trip over the REAL
+/// <see cref="SecretStore"/> facade (set) + <see cref="CabinetTenantProviderKeyReader"/>
+/// (read), on the EF-InMemory <see cref="SecretsDbContext"/> + in-memory backend
+/// (the same fixture the other secret suites use).
+///
+/// <para>Pins: set mints an active v1 whose bundle the reader reads back; a second
+/// tenant's same-named credential does NOT collide (the cabinet's tenant-scoped
+/// unique key); set-twice for one tenant is a duplicate; remove drops it (reader →
+/// null) and a later set can re-create the same slug.</para>
+/// </summary>
+[TestFixture]
+public class IntegrationCredentialCabinetTests
+{
+    private static readonly Guid TenantA = Guid.Parse("aaaaaaaa-1111-1111-1111-111111111111");
+    private static readonly Guid TenantB = Guid.Parse("bbbbbbbb-2222-2222-2222-222222222222");
+    private static readonly Guid Owner = Guid.Parse("cccccccc-3333-3333-3333-333333333333");
+
+    private SecretsDbContextFactoryDouble _factory = null!;
+    private InMemorySecretStoreBackend _backend = null!;
+    private IntegrationCredentialCabinet _cabinet = null!;
+    private CabinetTenantProviderKeyReader _reader = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory = new SecretsDbContextFactoryDouble(Guid.NewGuid().ToString());
+        _backend = new InMemorySecretStoreBackend();
+        var store = new SecretStore(
+            _factory, _backend, new RecordingSecretAccessAuditor(),
+            TimeProvider.System, NullLogger<SecretStore>.Instance);
+        _cabinet = new IntegrationCredentialCabinet(
+            store, _factory, _backend, NullLogger<IntegrationCredentialCabinet>.Instance);
+        _reader = new CabinetTenantProviderKeyReader(
+            _factory, _backend, NullLogger<CabinetTenantProviderKeyReader>.Instance);
+    }
+
+    [TearDown]
+    public void TearDown() => _factory.Dispose();
+
+    private static string Bundle(string token) =>
+        JiraCredentialCodec.Serialize(new JiraCredential("https://jira.example.com", "bot@example.com", token));
+
+    [Test]
+    public async Task Set_ThenReaderReadsBackBundle_AsActiveV1()
+    {
+        var meta = await _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a"), Owner);
+        meta.ActiveVersionNumber.Should().Be(1);
+
+        var row = await _reader.TryReadAsync(TenantA, IntegrationCabinetNames.JiraConfig);
+        row.Should().NotBeNull();
+        var cred = JiraCredentialCodec.TryDeserialize(row!.Plaintext);
+        cred.Should().NotBeNull();
+        cred!.ApiToken.Should().Be("fake-token-a");
+    }
+
+    [Test]
+    public async Task TwoTenants_SameSlug_DoNotCollide()
+    {
+        await _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a"), Owner);
+        await _cabinet.SetAsync(TenantB, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-b"), Owner);
+
+        var a = await _reader.TryReadAsync(TenantA, IntegrationCabinetNames.JiraConfig);
+        var b = await _reader.TryReadAsync(TenantB, IntegrationCabinetNames.JiraConfig);
+
+        JiraCredentialCodec.TryDeserialize(a!.Plaintext)!.ApiToken.Should().Be("fake-token-a");
+        JiraCredentialCodec.TryDeserialize(b!.Plaintext)!.ApiToken.Should().Be("fake-token-b");
+    }
+
+    [Test]
+    public async Task Set_Twice_SameTenant_IsDuplicate()
+    {
+        await _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a"), Owner);
+
+        var act = () => _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a2"), Owner);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Remove_DropsIt_ReaderReturnsNull_AndReSetSucceeds()
+    {
+        await _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a"), Owner);
+
+        var removed = await _cabinet.RemoveAsync(TenantA, IntegrationCabinetNames.JiraConfig);
+        removed.Should().BeTrue();
+
+        (await _reader.TryReadAsync(TenantA, IntegrationCabinetNames.JiraConfig)).Should().BeNull();
+
+        // A later set can cleanly re-create the same slug.
+        var meta = await _cabinet.SetAsync(TenantA, IntegrationCabinetNames.JiraConfig, "jira", Bundle("fake-token-a3"), Owner);
+        meta.ActiveVersionNumber.Should().Be(1);
+        JiraCredentialCodec.TryDeserialize(
+            (await _reader.TryReadAsync(TenantA, IntegrationCabinetNames.JiraConfig))!.Plaintext)!
+            .ApiToken.Should().Be("fake-token-a3");
+    }
+
+    [Test]
+    public async Task Remove_Missing_ReturnsFalse()
+    {
+        (await _cabinet.RemoveAsync(TenantA, IntegrationCabinetNames.JiraConfig)).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// EF-InMemory <see cref="SecretsDbContext"/> factory over one backing db name
+    /// (mirrors the other secret suites — no testcontainer).
+    /// </summary>
+    private sealed class SecretsDbContextFactoryDouble
+        : IDbContextFactory<SecretsDbContext>, IDisposable
+    {
+        private readonly string _dbName;
+        private SecretsDbContext? _trackingHandle;
+
+        public SecretsDbContextFactoryDouble(string dbName)
+        {
+            _dbName = dbName;
+            _trackingHandle = CreateDbContext();
+            _trackingHandle.Database.EnsureCreated();
+        }
+
+        public SecretsDbContext CreateDbContext()
+        {
+            var options = new DbContextOptionsBuilder<SecretsDbContext>()
+                .UseInMemoryDatabase(_dbName)
+                .ConfigureWarnings(w => w.Ignore(
+                    Microsoft.EntityFrameworkCore.Diagnostics
+                        .InMemoryEventId.TransactionIgnoredWarning))
+                .Options;
+            return new SecretsDbContext(options);
+        }
+
+        public Task<SecretsDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(CreateDbContext());
+
+        public void Dispose()
+        {
+            _trackingHandle?.Dispose();
+            _trackingHandle = null;
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialEndpointsTests.cs
@@ -79,6 +79,40 @@ public class IntegrationCredentialEndpointsTests
         _cabinet.SetName.Should().BeNull();
     }
 
+    [TestCase("http://acme.atlassian.net")]   // http scheme
+    [TestCase("https://169.254.169.254")]     // cloud metadata
+    [TestCase("https://127.0.0.1")]           // loopback
+    [TestCase("https://10.0.0.1")]            // private
+    [TestCase("https://192.168.1.1")]         // private
+    public async Task SetJira_SsrfOrHttpBaseUrl_BadRequest_NotStored(string baseUrl)
+    {
+        var body = new SetJiraCredentialRequest(baseUrl, "bot@example.com", JiraToken);
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+        _cabinet.SetName.Should().BeNull("a hostile baseUrl must never reach the cabinet");
+    }
+
+    [Test]
+    public async Task SetJira_CabinetArgumentException_FixedClientSafeError_NotRawMessage()
+    {
+        _cabinet.ThrowArgument = "internal cabinet detail leak";
+        var body = new SetJiraCredentialRequest("https://acme.atlassian.net", "bot@example.com", JiraToken);
+
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+
+        result.GetType().Name.Should().Contain("BadRequest");
+        // The raw exception message must NOT be echoed to the client.
+        JsonSerializer.Serialize(GetValue(result)).Should().NotContain("internal cabinet detail leak");
+    }
+
+    private static object? GetValue(IResult result)
+    {
+        var prop = result.GetType().GetProperty("Value");
+        return prop?.GetValue(result);
+    }
+
     [Test]
     public async Task SetJira_MissingToken_BadRequest()
     {
@@ -202,10 +236,15 @@ public class IntegrationCredentialEndpointsTests
         public string? SetJson { get; private set; }
         public string? RemovedName { get; private set; }
         public bool ThrowDuplicate { get; set; }
+        public string? ThrowArgument { get; set; }
         public bool RemoveResult { get; set; }
 
         public Task<SecretMetadata> SetAsync(Guid tenantId, string cabinetName, string consumerSystem, string bundleJson, Guid ownerUserId, CancellationToken ct = default)
         {
+            if (ThrowArgument is not null)
+            {
+                throw new ArgumentException(ThrowArgument);
+            }
             if (ThrowDuplicate)
             {
                 throw new InvalidOperationException("already exists");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialEndpointsTests.cs
@@ -1,0 +1,246 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Services.Secrets;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// Integration BYOK write endpoints — driven directly against the static handlers
+/// with cabinet/resolver fakes (mirrors <c>ProviderCredentialEndpointsTests</c>).
+/// Pins: valid set → Created + reveal-SAFE (no secret in the response) + the bundle
+/// JSON handed to the cabinet DOES carry the secret; input validation; no-tenant
+/// handling; duplicate → 409; delete existing → NoContent + invalidate; delete
+/// missing → 404. (Member-role 403 is enforced by the PlatformsManage route policy
+/// and pinned by <c>IntegrationCredentialRbacTests</c>.)
+/// </summary>
+[TestFixture]
+public class IntegrationCredentialEndpointsTests
+{
+    private const string JiraToken = "fake-jira-api-token";
+    private const string ResendKey = "fake-resend-key-value";
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    private FakeCabinet _cabinet = null!;
+    private FakeJiraResolver _jiraResolver = null!;
+    private FakeEmailResolver _emailResolver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _cabinet = new FakeCabinet();
+        _jiraResolver = new FakeJiraResolver();
+        _emailResolver = new FakeEmailResolver();
+    }
+
+    private static ClaimsPrincipal Principal() =>
+        new(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()) }, "test"));
+
+    private static HttpContext Http() => new DefaultHttpContext();
+    private static ITenantContext TenantCtx(Guid? id) => new StubTenant(id);
+
+    // ── JIRA set ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SetJira_Valid_Created_RevealSafe_StoresBundleWithSecret_Invalidates()
+    {
+        var body = new SetJiraCredentialRequest("https://jira.example.com", "bot@example.com", JiraToken);
+
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Created<SetIntegrationCredentialResponse>>();
+        var value = ((Microsoft.AspNetCore.Http.HttpResults.Created<SetIntegrationCredentialResponse>)result).Value!;
+        value.Integration.Should().Be("jira");
+        value.Version.Should().Be(1);
+        // Reveal-safe: the token must NEVER round-trip in the response.
+        JsonSerializer.Serialize(value).Should().NotContain(JiraToken);
+
+        _cabinet.SetName.Should().Be(IntegrationCabinetNames.JiraConfig);
+        _cabinet.SetTenant.Should().Be(Tenant);
+        _cabinet.SetConsumer.Should().Be("jira");
+        // The bundle handed to the cabinet DOES carry the secret (it's what gets stored).
+        _cabinet.SetJson.Should().Contain(JiraToken);
+        _jiraResolver.Invalidated.Should().ContainSingle().Which.Should().Be(Tenant);
+    }
+
+    [Test]
+    public async Task SetJira_InvalidBaseUrl_BadRequest()
+    {
+        var body = new SetJiraCredentialRequest("not-a-url", "bot@example.com", JiraToken);
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+        _cabinet.SetName.Should().BeNull();
+    }
+
+    [Test]
+    public async Task SetJira_MissingToken_BadRequest()
+    {
+        var body = new SetJiraCredentialRequest("https://jira.example.com", "bot@example.com", "  ");
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+    }
+
+    [Test]
+    public async Task SetJira_NoTenantContext_BadRequest()
+    {
+        var body = new SetJiraCredentialRequest("https://jira.example.com", "bot@example.com", JiraToken);
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(null), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+        _cabinet.SetName.Should().BeNull();
+    }
+
+    [Test]
+    public async Task SetJira_Duplicate_Conflict()
+    {
+        _cabinet.ThrowDuplicate = true;
+        var body = new SetJiraCredentialRequest("https://jira.example.com", "bot@example.com", JiraToken);
+        var result = await IntegrationCredentialEndpoints.SetJiraCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("Conflict");
+    }
+
+    // ── JIRA delete ───────────────────────────────────────────────────────
+
+    [Test]
+    public async Task DeleteJira_Existing_NoContent_Invalidates()
+    {
+        _cabinet.RemoveResult = true;
+        var result = await IntegrationCredentialEndpoints.DeleteJiraCredential(
+            Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("NoContent");
+        _cabinet.RemovedName.Should().Be(IntegrationCabinetNames.JiraConfig);
+        _jiraResolver.Invalidated.Should().Contain(Tenant);
+    }
+
+    [Test]
+    public async Task DeleteJira_Missing_NotFound()
+    {
+        _cabinet.RemoveResult = false;
+        var result = await IntegrationCredentialEndpoints.DeleteJiraCredential(
+            Principal(), TenantCtx(Tenant), _cabinet, _jiraResolver, Http());
+        result.GetType().Name.Should().Contain("NotFound");
+        _jiraResolver.Invalidated.Should().BeEmpty();
+    }
+
+    // ── EMAIL set ─────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task SetEmail_Resend_Valid_Created_RevealSafe_StoresSecret()
+    {
+        var body = new SetEmailCredentialRequest("resend", "team@tenant.example.com", ResendApiKey: ResendKey);
+        var result = await IntegrationCredentialEndpoints.SetEmailCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _emailResolver, Http());
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Created<SetIntegrationCredentialResponse>>();
+        var value = ((Microsoft.AspNetCore.Http.HttpResults.Created<SetIntegrationCredentialResponse>)result).Value!;
+        value.Integration.Should().Be("email");
+        JsonSerializer.Serialize(value).Should().NotContain(ResendKey);
+        _cabinet.SetName.Should().Be(IntegrationCabinetNames.EmailConfig);
+        _cabinet.SetJson.Should().Contain(ResendKey);
+        _emailResolver.Invalidated.Should().Contain(Tenant);
+    }
+
+    [Test]
+    public async Task SetEmail_Smtp_Valid_Created()
+    {
+        var body = new SetEmailCredentialRequest("smtp", "team@tenant.example.com", SmtpHost: "smtp.example.com", SmtpPort: 587);
+        var result = await IntegrationCredentialEndpoints.SetEmailCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _emailResolver, Http());
+        result.GetType().Name.Should().Contain("Created");
+    }
+
+    [Test]
+    public async Task SetEmail_UnknownTransport_BadRequest()
+    {
+        var body = new SetEmailCredentialRequest("carrier-pigeon", "team@tenant.example.com");
+        var result = await IntegrationCredentialEndpoints.SetEmailCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _emailResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+    }
+
+    [Test]
+    public async Task SetEmail_ResendWithoutKey_BadRequest()
+    {
+        var body = new SetEmailCredentialRequest("resend", "team@tenant.example.com", ResendApiKey: null);
+        var result = await IntegrationCredentialEndpoints.SetEmailCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _emailResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+    }
+
+    [Test]
+    public async Task SetEmail_SmtpWithoutHost_BadRequest()
+    {
+        var body = new SetEmailCredentialRequest("smtp", "team@tenant.example.com", SmtpHost: null);
+        var result = await IntegrationCredentialEndpoints.SetEmailCredential(
+            body, Principal(), TenantCtx(Tenant), _cabinet, _emailResolver, Http());
+        result.GetType().Name.Should().Contain("BadRequest");
+    }
+
+    // ── fakes ─────────────────────────────────────────────────────────────
+
+    private sealed class StubTenant(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class FakeCabinet : IIntegrationCredentialCabinet
+    {
+        public string? SetName { get; private set; }
+        public Guid? SetTenant { get; private set; }
+        public string? SetConsumer { get; private set; }
+        public string? SetJson { get; private set; }
+        public string? RemovedName { get; private set; }
+        public bool ThrowDuplicate { get; set; }
+        public bool RemoveResult { get; set; }
+
+        public Task<SecretMetadata> SetAsync(Guid tenantId, string cabinetName, string consumerSystem, string bundleJson, Guid ownerUserId, CancellationToken ct = default)
+        {
+            if (ThrowDuplicate)
+            {
+                throw new InvalidOperationException("already exists");
+            }
+            SetName = cabinetName;
+            SetTenant = tenantId;
+            SetConsumer = consumerSystem;
+            SetJson = bundleJson;
+            return Task.FromResult(new SecretMetadata(
+                Guid.NewGuid(), cabinetName, SecretScope.Tenant, tenantId, SecretPurpose.ApiKey,
+                Array.Empty<ConsumerRef>(), ownerUserId, RotationSchedule.None,
+                LastRotatedAt: null, NextRotationDueAt: null, ActiveVersionNumber: 1,
+                CreatedAt: DateTimeOffset.UtcNow, UpdatedAt: DateTimeOffset.UtcNow));
+        }
+
+        public Task<bool> RemoveAsync(Guid tenantId, string cabinetName, CancellationToken ct = default)
+        {
+            RemovedName = cabinetName;
+            return Task.FromResult(RemoveResult);
+        }
+    }
+
+    private sealed class FakeJiraResolver : IJiraCredentialResolver
+    {
+        public List<Guid?> Invalidated { get; } = new();
+        public Task<JiraCredentialResolution?> ResolveAsync(Guid? tenantId, CancellationToken ct = default)
+            => Task.FromResult<JiraCredentialResolution?>(null);
+        public void Invalidate(Guid? tenantId) => Invalidated.Add(tenantId);
+    }
+
+    private sealed class FakeEmailResolver : IEmailCredentialResolver
+    {
+        public List<Guid?> Invalidated { get; } = new();
+        public Task<EmailCredentialResolution?> ResolveAsync(Guid? tenantId, CancellationToken ct = default)
+            => Task.FromResult<EmailCredentialResolution?>(null);
+        public void Invalidate(Guid? tenantId) => Invalidated.Add(tenantId);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialRbacTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/IntegrationCredentialRbacTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// Integration BYOK write endpoints (<c>POST/DELETE /api/v1/integrations/*/credential</c>)
+/// are gated by the <c>PlatformsManage</c> route policy → the <c>platforms:manage</c>
+/// permission. This pins the RBAC contract the routes rely on: member → 403,
+/// tenant_admin / tenant_owner → allowed (200/2xx). (Enforcement is the route
+/// policy; this asserts the underlying authorization decision, like the provider
+/// BYOK endpoints rely on <c>PermissionsMatrixTests</c> for <c>agents:manage</c>.)
+/// </summary>
+[TestFixture]
+public class IntegrationCredentialRbacTests
+{
+    private const string Permission = "platforms:manage";
+
+    [Test]
+    public void Member_IsDenied()
+    {
+        Permissions.HasPermission("member", Permission).Should().BeFalse(
+            "a member-role SaaS caller must hit 403 on the integration BYOK write endpoints");
+    }
+
+    [TestCase("admin")]
+    [TestCase("owner")]
+    public void AdminAndOwner_AreAllowed(string role)
+    {
+        Permissions.HasPermission(role, Permission).Should().BeTrue(
+            "tenant_admin and tenant_owner may set/remove the tenant's integration credential");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraApiClientSsrfTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraApiClientSsrfTests.cs
@@ -1,0 +1,121 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// <see cref="JiraApiClient"/> use-time SSRF hardening. Pins that a hostile
+/// per-tenant <c>baseUrl</c> (private/loopback/metadata) or a path-traversal
+/// <c>ticketId</c> is refused BEFORE any HTTP call is made, that a redirect is not
+/// followed, and that a legitimate allowlisted host still works.
+/// </summary>
+[TestFixture]
+public class JiraApiClientSsrfTests
+{
+    // Allowlist atlassian so the legitimate-host tests need no DNS.
+    private static IConfiguration Config() => new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Jira:AllowedHostSuffixes"] = ".atlassian.net",
+        })
+        .Build();
+
+    private static (JiraApiClient client, Mock<HttpMessageHandler> handler) Build(
+        HttpStatusCode status = HttpStatusCode.OK, string? body = null)
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body ?? "{}", System.Text.Encoding.UTF8, "application/json"),
+            });
+
+        var http = new HttpClient(handler.Object);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(JiraApiClient.HttpClientName)).Returns(http);
+
+        return (new JiraApiClient(factory.Object, Config(), NullLogger<JiraApiClient>.Instance), handler);
+    }
+
+    private static void VerifyNoHttpCall(Mock<HttpMessageHandler> handler) =>
+        handler.Protected().Verify("SendAsync", Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+
+    [TestCase("http://169.254.169.254")]
+    [TestCase("https://169.254.169.254")]
+    [TestCase("https://127.0.0.1")]
+    [TestCase("https://10.0.0.1")]
+    [TestCase("http://acme.atlassian.net")]   // http scheme rejected even when host allowlisted
+    public async Task GetTicket_HostileBaseUrl_RefusedWithoutHttpCall(string baseUrl)
+    {
+        var (client, handler) = Build();
+        var cred = new JiraCredential(baseUrl, "bot@example.com", "token");
+
+        var result = await client.GetTicketAsync(cred, "PROJ-1");
+
+        result.Success.Should().BeFalse();
+        VerifyNoHttpCall(handler);
+    }
+
+    [TestCase("../../../etc/passwd")]
+    [TestCase("PROJ/1/../../admin")]
+    [TestCase("..")]
+    public async Task GetTicket_PathTraversalTicketId_RefusedWithoutHttpCall(string ticketId)
+    {
+        var (client, handler) = Build();
+        var cred = new JiraCredential("https://acme.atlassian.net", "bot@example.com", "token");
+
+        var result = await client.GetTicketAsync(cred, ticketId);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("invalid ticket id");
+        VerifyNoHttpCall(handler);
+    }
+
+    [Test]
+    public async Task GetTicket_RedirectResponse_RefusedNotFollowed()
+    {
+        var (client, _) = Build(HttpStatusCode.Redirect);
+        var cred = new JiraCredential("https://acme.atlassian.net", "bot@example.com", "token");
+
+        var result = await client.GetTicketAsync(cred, "PROJ-1");
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("refused redirect");
+    }
+
+    [Test]
+    public async Task GetTicket_AllowlistedHost_ValidResponse_Succeeds()
+    {
+        const string body = """
+        {"id":"1001","key":"PROJ-1","fields":{"summary":"do it","status":{"name":"To Do"}}}
+        """;
+        var (client, _) = Build(HttpStatusCode.OK, body);
+        var cred = new JiraCredential("https://acme.atlassian.net", "bot@example.com", "token");
+
+        var result = await client.GetTicketAsync(cred, "PROJ-1");
+
+        result.Success.Should().BeTrue();
+        result.Data!.Key.Should().Be("PROJ-1");
+    }
+
+    [Test]
+    public async Task UpdateTicket_HostileBaseUrl_RefusedWithoutHttpCall()
+    {
+        var (client, handler) = Build();
+        var cred = new JiraCredential("https://192.168.1.10", "bot@example.com", "token");
+
+        var result = await client.UpdateTicketAsync(cred, "PROJ-1", new JiraTicketUpdate { Comment = "hi" });
+
+        result.Success.Should().BeFalse();
+        VerifyNoHttpCall(handler);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraBaseUrlGuardTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraBaseUrlGuardTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// SSRF guard for the per-tenant JIRA <c>baseUrl</c> + <c>ticketId</c>. Pins the
+/// hard floor: https-only, private/loopback/link-local/metadata addresses rejected
+/// (literal AND DNS-resolved), an optional host allowlist, and a path-safe ticket id.
+/// </summary>
+[TestFixture]
+public class JiraBaseUrlGuardTests
+{
+    private static Func<string, CancellationToken, Task<IPAddress[]>> Dns(params string[] ips) =>
+        (_, _) => Task.FromResult(ips.Select(IPAddress.Parse).ToArray());
+
+    private static Func<string, CancellationToken, Task<IPAddress[]>> DnsThrows() =>
+        (_, _) => Task.FromException<IPAddress[]>(new InvalidOperationException("nxdomain"));
+
+    // ── scheme ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Http_Scheme_Rejected()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("http://acme.atlassian.net", dnsResolve: Dns("93.184.215.14"));
+        r.IsValid.Should().BeFalse();
+        r.ErrorCode.Should().Be("invalid_base_url");
+    }
+
+    [Test]
+    public async Task NotAUrl_Rejected()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("not-a-url");
+        r.IsValid.Should().BeFalse();
+    }
+
+    // ── literal private / metadata IPs (no DNS) ───────────────────────────────
+
+    [TestCase("https://169.254.169.254/latest/meta-data")]  // cloud metadata
+    [TestCase("https://127.0.0.1")]                          // loopback
+    [TestCase("https://10.0.0.5")]                           // 10/8
+    [TestCase("https://172.16.4.4")]                         // 172.16/12
+    [TestCase("https://192.168.1.1")]                        // 192.168/16
+    [TestCase("https://0.0.0.0")]                            // any
+    [TestCase("https://[::1]")]                              // IPv6 loopback
+    [TestCase("https://[fe80::1]")]                          // IPv6 link-local
+    [TestCase("https://[fc00::1]")]                          // IPv6 unique-local
+    public async Task LiteralPrivateOrMetadataHost_Rejected(string url)
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync(url);
+        r.IsValid.Should().BeFalse();
+        r.ErrorCode.Should().Be("host_not_allowed");
+    }
+
+    [Test]
+    public async Task LiteralPublicIp_Allowed()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://93.184.215.14");
+        r.IsValid.Should().BeTrue();
+    }
+
+    // ── named host resolved via DNS ───────────────────────────────────────────
+
+    [Test]
+    public async Task NamedHost_ResolvingToPrivate_Rejected()
+    {
+        // Attacker points a public-looking name at an internal address.
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://evil.example.com", dnsResolve: Dns("10.1.2.3"));
+        r.IsValid.Should().BeFalse();
+        r.ErrorCode.Should().Be("host_not_allowed");
+    }
+
+    [Test]
+    public async Task NamedHost_ResolvingToAnyPrivateAmongPublic_Rejected()
+    {
+        // A partially-private result (DNS-rebinding style) is treated as hostile.
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://mixed.example.com",
+            dnsResolve: Dns("93.184.215.14", "169.254.169.254"));
+        r.IsValid.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task NamedHost_ResolvingToPublic_Allowed()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://acme.atlassian.net", dnsResolve: Dns("104.192.142.1"));
+        r.IsValid.Should().BeTrue();
+        r.Uri!.Host.Should().Be("acme.atlassian.net");
+    }
+
+    [Test]
+    public async Task NamedHost_Unresolvable_PassesDnsFloor()
+    {
+        // Not resolvable here — the scheme + connect-time guard still apply.
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://jira.example.com", dnsResolve: DnsThrows());
+        r.IsValid.Should().BeTrue();
+    }
+
+    // ── allowlist ─────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Allowlist_Match_Allowed_WithoutDns()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://acme.atlassian.net",
+            allowedHostSuffixes: new[] { ".atlassian.net" }, dnsResolve: DnsThrows());
+        r.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Allowlist_NoMatch_Rejected()
+    {
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://acme.example.com",
+            allowedHostSuffixes: new[] { ".atlassian.net" }, dnsResolve: Dns("93.184.215.14"));
+        r.IsValid.Should().BeFalse();
+        r.ErrorCode.Should().Be("host_not_allowed");
+    }
+
+    [Test]
+    public async Task Allowlist_SuffixSpoofing_Rejected()
+    {
+        // "evilatlassian.net" must NOT match the ".atlassian.net" suffix.
+        var r = await JiraBaseUrlGuard.ValidateAsync("https://evilatlassian.net",
+            allowedHostSuffixes: new[] { ".atlassian.net" }, dnsResolve: Dns("93.184.215.14"));
+        r.IsValid.Should().BeFalse();
+    }
+
+    // ── ticket id ─────────────────────────────────────────────────────────────
+
+    [TestCase("PROJ-42", true)]
+    [TestCase("ABC-1", true)]
+    [TestCase("10042", true)]
+    [TestCase("../../etc/passwd", false)]
+    [TestCase("PROJ/42", false)]
+    [TestCase("..", false)]
+    [TestCase("PROJ 42", false)]
+    [TestCase("", false)]
+    [TestCase("PROJ%2F..", false)]
+    public void TicketId_Validation(string ticketId, bool expected)
+    {
+        JiraBaseUrlGuard.IsValidTicketId(ticketId).Should().Be(expected);
+    }
+
+    // ── blocked-address unit (also drives the ConnectCallback) ────────────────
+
+    [TestCase("169.254.169.254", true)]
+    [TestCase("127.0.0.1", true)]
+    [TestCase("10.255.255.255", true)]
+    [TestCase("172.31.0.1", true)]
+    [TestCase("172.32.0.1", false)]   // just outside 172.16/12
+    [TestCase("192.168.0.1", true)]
+    [TestCase("8.8.8.8", false)]
+    [TestCase("::1", true)]
+    [TestCase("::ffff:10.0.0.1", true)] // IPv4-mapped private
+    public void IsBlockedAddress(string ip, bool blocked)
+    {
+        JiraBaseUrlGuard.IsBlockedAddress(IPAddress.Parse(ip)).Should().Be(blocked);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraCredentialResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Integrations/JiraCredentialResolverTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Api.Tests.Integrations;
+
+/// <summary>
+/// JIRA BYOK resolver — tenant→system→fail-loud, mirroring git BYOK's
+/// GitTokenResolver. Pins: tenant cabinet bundle wins (SaaS); single-user config
+/// is the system tier; SaaS with no bundle fails loud (NO config fallback); a
+/// malformed stored bundle is treated as absent; Invalidate re-reads.
+/// </summary>
+[TestFixture]
+public class JiraCredentialResolverTests
+{
+    // Obvious fakes — never a real token/secret literal.
+    private const string FakeToken = "fake-jira-api-token-value";
+    private const string BaseUrl = "https://jira.example.com";
+    private const string Email = "bot@example.com";
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    private FakeCabinetReader _cabinet = null!;
+
+    [SetUp]
+    public void SetUp() => _cabinet = new FakeCabinetReader();
+
+    private JiraCredentialResolver Build(TammaMode mode, IConfiguration? config = null)
+    {
+        var modeProvider = new Mock<ITammaModeProvider>();
+        modeProvider.SetupGet(m => m.Mode).Returns(mode);
+        return new JiraCredentialResolver(
+            _cabinet, config ?? Empty(), modeProvider.Object,
+            NullLogger<JiraCredentialResolver>.Instance);
+    }
+
+    private static IConfiguration Empty() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>()).Build();
+
+    private static IConfiguration JiraConfig() =>
+        new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Jira:BaseUrl"] = "https://sys.example.com",
+            ["Jira:Email"] = "sys@example.com",
+            ["Jira:ApiToken"] = "fake-system-jira-token",
+        }).Build();
+
+    private static string Bundle(string baseUrl = BaseUrl, string email = Email, string token = FakeToken) =>
+        JiraCredentialCodec.Serialize(new JiraCredential(baseUrl, email, token));
+
+    [Test]
+    public async Task Saas_TenantBundlePresent_ResolvesTenantTier()
+    {
+        _cabinet.Set(Tenant, IntegrationCabinetNames.JiraConfig, Bundle());
+        var sut = Build(TammaMode.SaaS);
+
+        var res = await sut.ResolveAsync(Tenant);
+
+        res.Should().NotBeNull();
+        res!.Source.Should().Be(IntegrationCredentialSource.Tenant);
+        res.Credential.BaseUrl.Should().Be(BaseUrl);
+        res.Credential.Email.Should().Be(Email);
+        res.Credential.ApiToken.Should().Be(FakeToken);
+    }
+
+    [Test]
+    public async Task Saas_NoBundle_FailsLoud_NoConfigFallback()
+    {
+        // Config is present but SaaS must NOT fall back to it (confused-deputy).
+        var sut = Build(TammaMode.SaaS, JiraConfig());
+
+        var res = await sut.ResolveAsync(Tenant);
+
+        res.Should().BeNull("SaaS with no tenant BYOK bundle fails loud, never the shared config");
+    }
+
+    [Test]
+    public async Task SingleUser_ConfigPresent_ResolvesSystemTier()
+    {
+        var sut = Build(TammaMode.SingleUser, JiraConfig());
+
+        var res = await sut.ResolveAsync(tenantId: null);
+
+        res.Should().NotBeNull();
+        res!.Source.Should().Be(IntegrationCredentialSource.System);
+        res.Credential.BaseUrl.Should().Be("https://sys.example.com");
+    }
+
+    [Test]
+    public async Task SingleUser_NoConfig_FailsLoud()
+    {
+        var sut = Build(TammaMode.SingleUser, Empty());
+
+        var res = await sut.ResolveAsync(tenantId: null);
+
+        res.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Saas_MalformedBundle_TreatedAsAbsent_FailsLoud()
+    {
+        _cabinet.Set(Tenant, IntegrationCabinetNames.JiraConfig, "{ not valid json ");
+        var sut = Build(TammaMode.SaaS);
+
+        var res = await sut.ResolveAsync(Tenant);
+
+        res.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Invalidate_ReReadsCabinet()
+    {
+        _cabinet.Set(Tenant, IntegrationCabinetNames.JiraConfig, Bundle(token: "fake-old-token"));
+        var sut = Build(TammaMode.SaaS);
+
+        (await sut.ResolveAsync(Tenant))!.Credential.ApiToken.Should().Be("fake-old-token");
+
+        _cabinet.Set(Tenant, IntegrationCabinetNames.JiraConfig, Bundle(token: "fake-new-token"));
+        // Cached — still old until invalidated.
+        (await sut.ResolveAsync(Tenant))!.Credential.ApiToken.Should().Be("fake-old-token");
+
+        sut.Invalidate(Tenant);
+        (await sut.ResolveAsync(Tenant))!.Credential.ApiToken.Should().Be("fake-new-token");
+    }
+
+    /// <summary>Minimal mutable fake for the tenant-scoped cabinet read seam.</summary>
+    private sealed class FakeCabinetReader : ITenantProviderKeyReader
+    {
+        private readonly Dictionary<(Guid, string), string> _rows = new();
+
+        public void Set(Guid tenantId, string name, string plaintext) => _rows[(tenantId, name)] = plaintext;
+
+        public Task<TenantProviderKey?> TryReadAsync(Guid tenantId, string cabinetName, CancellationToken ct = default)
+            => Task.FromResult(_rows.TryGetValue((tenantId, cabinetName), out var v)
+                ? new TenantProviderKey(v, 1)
+                : null);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Jira/JiraMediationServiceTests.cs
@@ -1,12 +1,11 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using FluentAssertions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using NUnit.Framework;
+using Tamma.Api.Services.Integrations;
 using Tamma.Api.Services.Jira;
-using Tamma.Api.Services.PromptStore;
 using Tamma.Core.Interfaces;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
@@ -14,23 +13,25 @@ using Tamma.Data.Repositories;
 namespace Tamma.Api.Tests.Jira;
 
 /// <summary>
-/// Story 38 (Phase 1) — <see cref="JiraMediationService"/> composition. JIRA has no
-/// per-tenant token resolver: it runs the config-credentialed
-/// <see cref="IJiraIntegrationService"/> under the acting tenant, then emits exactly
-/// one terminal DCB event. Failures ride inside a typed key-free result (200
-/// success:false at the endpoint); an unexpected exception becomes PLATFORM_ERROR.
+/// Integration BYOK — <see cref="JiraMediationService"/> composition. The old
+/// SaaS-deny guard is replaced by per-tenant credential resolution: the tenant's
+/// JIRA credential is resolved (BYOK→system→fail-loud) and threaded into the
+/// credential-bound <see cref="IJiraApiClient"/>; a terminal DCB event is emitted.
 ///
-/// <para>Because that single credential has no per-tenant/ticket scoping, a
-/// fail-closed mode guard applies: single-user ⇒ allow; SaaS ⇒ deny (typed
-/// <see cref="JiraFailureCodes.SharedCredentialDeniedInSaaS"/>, underlying client
-/// never called) unless <c>Jira:AllowSharedCredentialInSaaS=true</c> opts in.</para>
+/// <para>Pins: present credential ⇒ the client is called with it and one terminal
+/// event is emitted; ABSENT credential ⇒ fail-loud
+/// <see cref="JiraFailureCodes.CredentialUnavailable"/> with the client NEVER
+/// reached; client failures map to the typed key-free taxonomy; an exception
+/// becomes PLATFORM_ERROR.</para>
 /// </summary>
 [TestFixture]
 public class JiraMediationServiceTests
 {
     private const string TicketId = "PROJ-42";
+    private static readonly JiraCredential Cred = new("https://jira.example.com", "bot@example.com", "fake-jira-token");
 
-    private Mock<IJiraIntegrationService> _jira = null!;
+    private Mock<IJiraApiClient> _jira = null!;
+    private FakeResolver _resolver = null!;
     private RecordingEventRepository _events = null!;
     private JiraMediationService _sut = null!;
     private readonly Guid _tenant = Guid.NewGuid();
@@ -38,32 +39,16 @@ public class JiraMediationServiceTests
     [SetUp]
     public void SetUp()
     {
-        _jira = new Mock<IJiraIntegrationService>(MockBehavior.Strict);
+        _jira = new Mock<IJiraApiClient>(MockBehavior.Strict);
+        _resolver = new FakeResolver { Resolution = new JiraCredentialResolution(Cred, IntegrationCredentialSource.Tenant) };
         _events = new RecordingEventRepository();
-        // Default SUT runs in single-user mode (the sole principal owns everything),
-        // so the shared JIRA credential is always allowed — matches the pre-guard
-        // behavior the composition tests below assert.
-        _sut = Build(TammaMode.SingleUser);
-    }
-
-    private JiraMediationService Build(TammaMode mode, bool allowSharedInSaaS = false)
-    {
-        var modeProvider = new Mock<ITammaModeProvider>();
-        modeProvider.SetupGet(m => m.Mode).Returns(mode);
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Jira:AllowSharedCredentialInSaaS"] = allowSharedInSaaS ? "true" : "false",
-            })
-            .Build();
-        return new JiraMediationService(
-            _jira.Object, _events, modeProvider.Object, configuration, NullLogger<JiraMediationService>.Instance);
+        _sut = new JiraMediationService(_jira.Object, _resolver, _events, NullLogger<JiraMediationService>.Instance);
     }
 
     [Test]
-    public async Task GetTicket_Success_MapsTicket_OneEvent()
+    public async Task GetTicket_CredentialResolved_CallsClientWithIt_OneEvent()
     {
-        _jira.Setup(j => j.GetJiraTicketAsync(TicketId))
+        _jira.Setup(j => j.GetTicketAsync(Cred, TicketId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(IntegrationResult<JiraTicket?>.Ok(new JiraTicket { Id = "1", Key = TicketId, Summary = "s", Status = "In Progress" }));
 
         var result = await _sut.GetTicketAsync(_tenant, TicketId, "corr-j");
@@ -71,14 +56,14 @@ public class JiraMediationServiceTests
         result.Success.Should().BeTrue();
         result.Outcome.Should().Be("Read");
         result.Ticket!.Key.Should().Be(TicketId);
-        result.Ticket.Status.Should().Be("In Progress");
+        _jira.Verify(j => j.GetTicketAsync(Cred, TicketId, It.IsAny<CancellationToken>()), Times.Once);
         _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadSuccess);
     }
 
     [Test]
-    public async Task UpdateTicket_Success_ReturnsKey_OneEvent()
+    public async Task UpdateTicket_CredentialResolved_ReturnsKey_OneEvent()
     {
-        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
+        _jira.Setup(j => j.UpdateTicketAsync(Cred, TicketId, It.IsAny<JiraTicketUpdate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(IntegrationResult<JiraTicketResult>.Ok(new JiraTicketResult { Success = true, TicketKey = TicketId }));
 
         var body = new UpdateTicketRequest { Status = "Done", Comment = "merged", CorrelationId = "corr-u" };
@@ -91,9 +76,25 @@ public class JiraMediationServiceTests
     }
 
     [Test]
-    public async Task UpdateTicket_NotConfigured_TypedNotConfigured_OneFailedEvent()
+    public async Task NoCredential_FailsLoud_NeverCallsClient_OneFailedEvent()
     {
-        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
+        // The strict mock has NO setup ⇒ any call would throw. Resolver returns null.
+        _resolver.Resolution = null;
+
+        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-x" };
+        var result = await _sut.UpdateTicketAsync(_tenant, TicketId, body);
+
+        result.Success.Should().BeFalse();
+        result.FailureCode.Should().Be(JiraFailureCodes.CredentialUnavailable);
+        result.TicketKey.Should().Be(TicketId);
+        _jira.Verify(j => j.UpdateTicketAsync(It.IsAny<JiraCredential>(), It.IsAny<string>(), It.IsAny<JiraTicketUpdate>(), It.IsAny<CancellationToken>()), Times.Never);
+        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedFailed);
+    }
+
+    [Test]
+    public async Task UpdateTicket_NotConfiguredFromClient_TypedNotConfigured()
+    {
+        _jira.Setup(j => j.UpdateTicketAsync(Cred, TicketId, It.IsAny<JiraTicketUpdate>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(IntegrationResult<JiraTicketResult>.Fail("JIRA not configured"));
 
         var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-u" };
@@ -105,9 +106,10 @@ public class JiraMediationServiceTests
     }
 
     [Test]
-    public async Task GetTicket_ServiceThrows_TypedPlatformError_OneFailedEvent()
+    public async Task GetTicket_ClientThrows_TypedPlatformError_OneFailedEvent()
     {
-        _jira.Setup(j => j.GetJiraTicketAsync(TicketId)).ThrowsAsync(new InvalidOperationException("boom"));
+        _jira.Setup(j => j.GetTicketAsync(Cred, TicketId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
 
         var result = await _sut.GetTicketAsync(_tenant, TicketId, "corr-j");
 
@@ -116,58 +118,12 @@ public class JiraMediationServiceTests
         _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadFailed);
     }
 
-    // ── fail-closed tenant guard (SaaS shared-credential) ───────────────────
-
-    [Test]
-    public async Task SingleUser_SharedCredential_Allows_CallsJira()
+    private sealed class FakeResolver : IJiraCredentialResolver
     {
-        // (a) single-user: the sole principal owns everything ⇒ the guard allows the
-        // op and the underlying JIRA client is reached.
-        _jira.Setup(j => j.GetJiraTicketAsync(TicketId))
-            .ReturnsAsync(IntegrationResult<JiraTicket?>.Ok(new JiraTicket { Id = "1", Key = TicketId, Summary = "s", Status = "Open" }));
-        var sut = Build(TammaMode.SingleUser);
-
-        var result = await sut.GetTicketAsync(_tenant, TicketId, "corr-su");
-
-        result.Success.Should().BeTrue();
-        _jira.Verify(j => j.GetJiraTicketAsync(TicketId), Times.Once);
-        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketReadSuccess);
-    }
-
-    [Test]
-    public async Task Saas_NoOptIn_Denies_TypedResult_NeverCallsJira()
-    {
-        // (b) SaaS without the opt-in: the shared-credential path is a confused-deputy,
-        // so the guard denies with the typed key-free failure and the strict-mock JIRA
-        // client is NEVER invoked (no Setup ⇒ any call would throw).
-        var sut = Build(TammaMode.SaaS, allowSharedInSaaS: false);
-
-        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-saas" };
-        var result = await sut.UpdateTicketAsync(_tenant, TicketId, body);
-
-        result.Success.Should().BeFalse();
-        result.FailureCode.Should().Be(JiraFailureCodes.SharedCredentialDeniedInSaaS);
-        result.TicketKey.Should().Be(TicketId);
-        _jira.Verify(j => j.UpdateJiraTicketAsync(It.IsAny<string>(), It.IsAny<JiraTicketUpdate>()), Times.Never);
-        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedFailed);
-    }
-
-    [Test]
-    public async Task Saas_WithOptIn_Allows_CallsJira()
-    {
-        // (c) SaaS WITH Jira:AllowSharedCredentialInSaaS=true: the operator knowingly
-        // re-enabled the shared credential ⇒ the op runs and reaches the JIRA client.
-        _jira.Setup(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()))
-            .ReturnsAsync(IntegrationResult<JiraTicketResult>.Ok(new JiraTicketResult { Success = true, TicketKey = TicketId }));
-        var sut = Build(TammaMode.SaaS, allowSharedInSaaS: true);
-
-        var body = new UpdateTicketRequest { Status = "Done", CorrelationId = "corr-optin" };
-        var result = await sut.UpdateTicketAsync(_tenant, TicketId, body);
-
-        result.Success.Should().BeTrue();
-        result.Outcome.Should().Be("Updated");
-        _jira.Verify(j => j.UpdateJiraTicketAsync(TicketId, It.IsAny<JiraTicketUpdate>()), Times.Once);
-        _events.Appended.Should().ContainSingle().Which.Type.Should().Be(JiraEventTypes.TicketUpdatedSuccess);
+        public JiraCredentialResolution? Resolution { get; set; }
+        public Task<JiraCredentialResolution?> ResolveAsync(Guid? tenantId, CancellationToken ct = default)
+            => Task.FromResult(Resolution);
+        public void Invalidate(Guid? tenantId) { }
     }
 
     private sealed class RecordingEventRepository : IEventRepository


### PR DESCRIPTION
## What

Per-tenant BYOK for the JIRA + email integrations, replacing the interim SaaS-deny guards (#416/#417) with resolve-per-tenant-or-fail-loud. Reuses the Epic-29 secret cabinet (no migration).

- **Resolvers** (`JiraCredentialResolver`/`EmailCredentialResolver`): tenant cabinet → `Jira:*`/`Email:*` config **only in single-user** → else `null` → fail-loud. SaaS never falls back to a shared platform credential.
- **Write endpoints** `POST/DELETE /api/v1/integrations/{jira,email}/credential` — `PlatformsManage` RBAC (member → 403), `ISecretStore` facade writes, reveal-safe (version only), curated `INTEGRATION_CREDENTIAL.CHANGED` audit event.
- **Mediation** reworked: JIRA threads the tenant's baseUrl+token into a credential-bound client; email sends via the tenant's **own** transport.

## Review + fixes (all applied)

Adversarial security review verified the confused-deputy fix, cross-tenant isolation, RBAC, reveal-safety, and the engine boundary (TAMMA001) as solid. Fixed 2 real holes:
- **Critical — email open-relay/`From`-spoofing:** the rework delivered via the *platform* transport with only a per-tenant `From` (no domain check) → a tenant_admin could send brand-impersonating DKIM-signed mail. Fixed (Approach A): a SaaS tenant now sends via **their own** transport (Resend key with per-request auth, or SMTP via MailKit) from the cabinet bundle — the platform singleton is unreachable for a SaaS tenant (proven `Times.Never`); From-only with no transport secret → fail-loud.
- **Important — JIRA `baseUrl` SSRF:** was any absolute http(s) URL. Now `JiraBaseUrlGuard` (write + use time): https-only, rejects private/loopback/link-local/metadata ranges (literal + DNS-resolved), no-follow redirects + connect-time re-check (DNS-rebind TOCTOU), optional host allowlist; `ticketId` sanitized `^[A-Za-z0-9-]+$` (no path traversal).
- Hardening: fixed client-safe error string (no internal-message echo); documented the 60s resolver-cache revocation window (matches provider BYOK).

## Verification

- Build: 0 errors, no TAMMA001 (all in `Tamma.Api`, engine untouched). Both `has-pending-model-changes` → "No changes" (transport rides the cabinet JSON bundle — no new column). Tests: 541 passed (incl. the spoofing + SSRF regression tests).

Note: email transport for SaaS SMTP tenants uses a synchronous MailKit send with the tenant's relay creds (the shared outbox can't carry a per-tenant SMTP endpoint without a column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)