### PR TITLE
feat(epic-30-3): real RegisterSecrets saga step via ISecretStore facade

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ProvisioningServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ProvisioningServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Tamma.Api.Services.PlatformTasks;
+using Tamma.Api.Services.Secrets;
 using Tamma.Api.Services.Provisioning;
 using Tamma.Api.Services.Provisioning.Cranl;
 using Tamma.Api.Services.Provisioning.V2;
@@ -97,6 +98,19 @@ public static class ProvisioningServiceCollectionExtensions
         // Both need ControlPlaneDbContext + the registry, so Scoped.
         // The workflow itself is also Scoped because it persists
         // tenant-row state via the same DbContext.
+        //
+        // ── Story 30-3: RegisterSecrets saga-step collaborator ─────────────
+        // Registers per-tenant provisioning secrets (Step 6) via the Epic 29
+        // ISecretStore facade. ISecretStore is resolved OPTIONALLY here: it is
+        // only wired on the Postgres cabinet path (AddTammaPostgresSecrets). On
+        // a dev/in-memory host it is absent, and the registrar then fails loud
+        // ONLY if a DedicatedCompute tenant actually needs it (the dormant
+        // Cranl path); every non-dedicated topology is a clean guarded no-op
+        // regardless. Factory registration keeps the optional resolve explicit.
+        services.TryAddScoped<IProvisioningSecretRegistrar>(sp =>
+            new ProvisioningSecretRegistrar(
+                sp.GetService<ISecretStore>(),
+                sp.GetRequiredService<ILogger<ProvisioningSecretRegistrar>>()));
         services.TryAddScoped<ProvisionTenantV2Workflow>();
         services.TryAddScoped<ProvisionTenantV2Dispatcher>();
         // Register the handler under both IPlatformTaskHandler (so

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/IProvisioningSecretRegistrar.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/IProvisioningSecretRegistrar.cs
@@ -1,0 +1,68 @@
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Services.Provisioning.V2;
+
+/// <summary>
+/// Story 30-3 — the RegisterSecrets saga step (Step 6 of
+/// <see cref="ProvisionTenantV2Workflow"/>). Registers the per-tenant
+/// secrets a freshly-provisioned tenant genuinely needs into the Epic 29
+/// <see cref="ISecretStore"/> cabinet, and knows how to retire them on
+/// rollback.
+///
+/// <para><b>What it registers (and deliberately does NOT)</b>:</para>
+/// <list type="bullet">
+///   <item><description><b>Registered</b> — the per-tenant HMAC /
+///     <c>TAMMA_SHARED_SECRET</c> shadow (<c>tenant:cranl/app-env-hmac</c>),
+///     and ONLY for <see cref="ProvisioningTopology.DedicatedCompute"/>
+///     (a per-tenant engine that signs its control-plane calls). See
+///     <see cref="ProvisioningSecretRegistrar"/>.</description></item>
+///   <item><description><b>NOT registered</b> — the
+///     <c>tenant:db/cranl-connection</c> secret named in the story brief
+///     (AC9). It is VESTIGIAL post-Epic-30 Phase B: DB routing no longer
+///     flows through a stored per-tenant <c>DATABASE_URL</c> — every
+///     tenant routes via the unified pool's encrypted connection-string
+///     envelope (<c>CranlTenantProviderV2.TryBuildEndpoints</c> returns
+///     <c>DatabaseUrl = string.Empty</c> and reads only the engine host).
+///     Registering it would create a secret no consumer reads. See the
+///     code comment in <see cref="ProvisioningSecretRegistrar"/>.</description></item>
+/// </list>
+///
+/// <para><b>Guarded no-op</b>: for non-dedicated topologies
+/// (<see cref="ProvisioningTopology.DatabaseOnly"/> /
+/// <see cref="ProvisioningTopology.Managed"/>) there is no per-tenant
+/// engine, so nothing is registered and
+/// <see cref="RegisterInitialSecretsAsync"/> returns an empty list — a
+/// DELIBERATE guarded no-op, not a stub.</para>
+///
+/// <para><b>Dormancy</b>: the dedicated-compute path is exercised only by
+/// the opt-in Cranl backend with a dedicated per-tenant engine, which is
+/// dormant in the default deployment (Cranl opt-in;
+/// <c>PlatformTaskWorker:RunOnStartup=false</c>). This surface is
+/// therefore unit-testable but not exercised end-to-end today.</para>
+/// </summary>
+public interface IProvisioningSecretRegistrar
+{
+    /// <summary>
+    /// Register the per-tenant secrets the saga needs for
+    /// <paramref name="topology"/>. Returns the refs that were registered
+    /// (empty for the guarded no-op paths) so the caller can retire them
+    /// on rollback via <see cref="RetireInitialSecretsAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// FAIL LOUD: throws when a secret genuinely needs to be registered but
+    /// the cabinet is unavailable or the underlying create fails — the saga
+    /// must NOT proceed with a missing per-tenant secret. The
+    /// "nothing to register" path is NOT a failure; it returns empty.
+    /// </remarks>
+    Task<IReadOnlyList<SecretRef>> RegisterInitialSecretsAsync(
+        Guid tenantId, ProvisioningTopology topology, CancellationToken ct = default);
+
+    /// <summary>
+    /// Compensation for <see cref="RegisterInitialSecretsAsync"/>: retire
+    /// each ref it registered. Idempotent and non-throwing — safe to run on
+    /// rollback even when a secret was never created (e.g. registration
+    /// threw before the create landed) or was already scrubbed.
+    /// </summary>
+    Task RetireInitialSecretsAsync(
+        IReadOnlyList<SecretRef> registered, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Workflow.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisionTenantV2Workflow.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Secrets;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -37,11 +38,16 @@ namespace Tamma.Api.Services.Provisioning.V2;
 ///     +  endpoints in workflow state (not yet persisted to columns
 ///     because <c>provider_resource_ids</c> + <c>provider_key</c> land
 ///     in 30-3). Compensation: clear the in-memory captures.</description></item>
-///   <item><description>RegisterSecrets — placeholder hook that 30-2 leaves
-///     intentionally unimplemented. The cabinet integration (Epic 29
-///     <c>ISecretStore.CreateAsync</c>) is wired by 30-3 once each
-///     provider declares which secrets it surfaces. Compensation: noop
-///     today; <c>RetireVersionAsync</c> per registered secret in 30-3.</description></item>
+///   <item><description>RegisterSecrets — Story 30-3: register the
+///     per-tenant secrets the saga needs via the Epic 29
+///     <see cref="ISecretStore"/> facade
+///     (<see cref="IProvisioningSecretRegistrar"/>). For
+///     <see cref="ProvisioningTopology.DedicatedCompute"/> that is the
+///     per-tenant HMAC / <c>TAMMA_SHARED_SECRET</c> shadow; for every
+///     other topology it is a DELIBERATE guarded no-op (nothing to
+///     register). Fails loud on a genuine registration failure.
+///     Compensation: <c>RetireVersionAsync</c> per registered secret
+///     (idempotent — safe even if nothing was created).</description></item>
 ///   <item><description>InitialProbe — SINGLE-SHOT
 ///     <see cref="ITenantInfrastructureProvider.GetStatusAsync"/>: Ready →
 ///     Activate; Failed → compensate; still-provisioning within budget →
@@ -91,6 +97,7 @@ public class ProvisionTenantV2Workflow
 
     private readonly ControlPlaneDbContext _db;
     private readonly TenantProviderRegistry _registry;
+    private readonly IProvisioningSecretRegistrar _secretRegistrar;
     private readonly IPlatformEventPublisher _events;
     private readonly TimeProvider _clock;
     private readonly ILogger<ProvisionTenantV2Workflow> _logger;
@@ -98,12 +105,14 @@ public class ProvisionTenantV2Workflow
     public ProvisionTenantV2Workflow(
         ControlPlaneDbContext db,
         TenantProviderRegistry registry,
+        IProvisioningSecretRegistrar secretRegistrar,
         IPlatformEventPublisher events,
         TimeProvider clock,
         ILogger<ProvisionTenantV2Workflow> logger)
     {
         _db = db;
         _registry = registry;
+        _secretRegistrar = secretRegistrar;
         _events = events;
         _clock = clock;
         _logger = logger;
@@ -395,20 +404,68 @@ public class ProvisionTenantV2Workflow
                 return Task.CompletedTask;
             }));
 
-            // ── Step 6: RegisterSecrets ──────────────────────────────
-            // Hook is intentionally a no-op in 30-2. 30-3 lands the
-            // per-provider secret declaration + the
-            // ISecretStore.CreateAsync call. Tracked as a follow-up;
-            // documented in the return summary so the gap is visible.
+            // ── Step 6: RegisterSecrets (Story 30-3) ─────────────────
+            // Register the per-tenant secrets the saga genuinely needs via
+            // the Epic 29 ISecretStore facade. For DedicatedCompute that is
+            // the per-tenant HMAC / TAMMA_SHARED_SECRET shadow
+            // (tenant:cranl/app-env-hmac); for every other topology the
+            // registrar registers NOTHING and returns an empty list — a
+            // DELIBERATE guarded no-op (there is no per-tenant engine env to
+            // sign), NOT a stub.
             await EmitStepEventAsync(payload.TenantId, "register_secrets",
                 "STEP_STARTED", null, ct).ConfigureAwait(false);
+
+            IReadOnlyList<SecretRef> registeredSecrets;
+            try
+            {
+                registeredSecrets = await _secretRegistrar
+                    .RegisterInitialSecretsAsync(payload.TenantId, payload.Topology, ct)
+                    .ConfigureAwait(false)
+                    ?? Array.Empty<SecretRef>();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // FAIL LOUD: a genuine registration failure must NOT let the
+                // saga proceed with a missing per-tenant secret (the engine
+                // would later fail every signed call). Surface the structured
+                // short-code + run compensation (tears down the provisioned
+                // resources reserved so far).
+                _logger.LogError(ex,
+                    "v2_provisioning.register_secrets_failed tenantId={TenantId}",
+                    payload.TenantId);
+                await EmitStepEventAsync(payload.TenantId, "register_secrets",
+                    "STEP_FAILED",
+                    new Dictionary<string, object?>
+                    {
+                        ["failureReason"] = ProvisioningFailureReasons.SecretRegistrationFailed,
+                        ["errorType"] = ex.GetType().Name,
+                    }, ct).ConfigureAwait(false);
+                await RunCompensationsAsync(compensations, payload.TenantId, ct).ConfigureAwait(false);
+                return ProvisionTenantV2Outcome.Failed(await StampFailureAsync(
+                    tenant,
+                    ProvisioningFailureReasons.SecretRegistrationFailed,
+                    $"secret_registration_threw_{ex.GetType().Name}",
+                    ct).ConfigureAwait(false));
+            }
+
+            // Compensation: retire every secret we registered. Registered
+            // BEFORE the STEP_COMPLETED event so a LATER step's failure rolls
+            // the secrets back. Idempotent — RetireInitialSecretsAsync tolerates
+            // an empty list (guarded no-op ⇒ pure no-op) and a secret that was
+            // never created.
+            compensations.Add(("register_secrets", async ictok =>
+            {
+                await _secretRegistrar
+                    .RetireInitialSecretsAsync(registeredSecrets, ictok)
+                    .ConfigureAwait(false);
+            }));
+
             await EmitStepEventAsync(payload.TenantId, "register_secrets",
                 "STEP_COMPLETED",
                 new Dictionary<string, object?>
                 {
-                    ["status"] = "deferred_to_30_3",
+                    ["secretsRegistered"] = registeredSecrets.Count,
                 }, ct).ConfigureAwait(false);
-            compensations.Add(("register_secrets", _ => Task.CompletedTask));
 
             // ── Step 7: InitialProbe (SINGLE-SHOT + defer) ───────────
             // Phase-B I1: exactly ONE GetStatusAsync per invocation. We do

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisioningFailureReasons.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisioningFailureReasons.cs
@@ -96,4 +96,13 @@ public static class ProvisioningFailureReasons
     /// (e.g. already <c>ready</c>, or in <c>deprovisioning</c>). Dispatch
     /// refuses without making a provider call.</summary>
     public const string IllegalTenantState = "illegal_tenant_state";
+
+    /// <summary>Story 30-3 — the RegisterSecrets step (Step 6) could not
+    /// register a per-tenant secret it genuinely needed (cabinet
+    /// unavailable, duplicate-mint race, or a fail-closed backend rejecting
+    /// the write). The workflow fails loud + compensates rather than
+    /// activating a tenant whose engine is missing its
+    /// <c>TAMMA_SHARED_SECRET</c> shadow — a silent miss would surface later
+    /// as an un-diagnosable HMAC mismatch on every signed engine call.</summary>
+    public const string SecretRegistrationFailed = "secret_registration_failed";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisioningSecretRegistrar.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Provisioning/V2/ProvisioningSecretRegistrar.cs
@@ -1,0 +1,207 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Services.Provisioning.V2;
+
+/// <summary>
+/// Story 30-3 — real, facade-based implementation of
+/// <see cref="IProvisioningSecretRegistrar"/> (the RegisterSecrets saga
+/// step) built on the Epic 29 <see cref="ISecretStore"/> cabinet.
+///
+/// <para><b>Secret registered</b>: <c>tenant:cranl/app-env-hmac</c> — a
+/// per-tenant HMAC that shadows the platform-wide
+/// <c>TAMMA_SHARED_SECRET</c>. Splitting the shared secret per tenant
+/// isolates a tenant compromise to that tenant's engine. A fresh
+/// cryptographically-random value is minted per tenant (NOT a copy of the
+/// platform <c>Tamma:TenantSharedSecret</c>).</para>
+///
+/// <para><b>Secret deliberately NOT registered</b>:
+/// <c>tenant:db/cranl-connection</c> (named in story brief AC9). Post
+/// Epic-30 Phase B (commit <c>c44261f7</c>) the stored per-tenant
+/// <c>DATABASE_URL</c> model was removed — DB routing flows through the
+/// unified pool's AES-GCM connection-string envelope, and
+/// <c>CranlTenantProviderV2.TryBuildEndpoints</c> returns
+/// <c>DatabaseUrl = string.Empty</c> (reading only the engine host). No
+/// consumer reads a <c>tenant:db/cranl-connection</c> secret, so it would
+/// be a vestigial write. It is intentionally omitted.</para>
+///
+/// <para><b>Consumed today?</b> No. The Cranl env-var push
+/// (<c>CranlProvisioningWorkflow.BuildEnvironment</c>) still sources
+/// <c>TAMMA_SHARED_SECRET</c> from the PLATFORM-scoped
+/// <c>hmac/shared-engine</c> secret, not this per-tenant shadow. This
+/// registrar lays down the per-tenant row so a future switch (and Epic 29
+/// per-tenant rotation) has something to rotate; wiring the env push to
+/// read it is a follow-up. Combined with the dormant dedicated-compute
+/// Cranl path, this step is unit-testable but not exercised end-to-end in
+/// the default deployment.</para>
+/// </summary>
+public sealed class ProvisioningSecretRegistrar : IProvisioningSecretRegistrar
+{
+    /// <summary>Cabinet slug for the per-tenant HMAC / TAMMA_SHARED_SECRET
+    /// shadow. Scope is <see cref="SecretScope.Tenant"/>; the
+    /// <c>tenant:</c> prefix in the brief is the SCOPE, not part of the
+    /// slug (which must match the cabinet name regex).</summary>
+    public const string HmacSecretName = "cranl/app-env-hmac";
+
+    /// <summary>Byte length of the generated per-tenant HMAC before
+    /// base64url encoding. 32 bytes = 256 bits of entropy.</summary>
+    private const int HmacByteLength = 32;
+
+    /// <summary>Deterministic system-actor owner for provisioning-minted
+    /// secrets. The cabinet requires a non-empty owner GUID; provisioning
+    /// runs with no authenticated user, so we use a stable well-known id
+    /// (Epic 30 suffix) — mirrors <c>StopgapSecretMigrator</c>'s
+    /// deterministic-actor convention (Epic 29 suffix).</summary>
+    private static readonly Guid SystemProvisioningActor =
+        Guid.Parse("00000000-0000-0000-0000-000000000030");
+
+    // ISecretStore is OPTIONAL: it is only wired on the Postgres cabinet
+    // path (AddTammaPostgresSecrets). On a dev/in-memory host it is absent,
+    // and that is fine for every non-dedicated topology (a clean guarded
+    // no-op). It becomes REQUIRED only when a DedicatedCompute tenant must
+    // register the HMAC — that path fails loud (see RegisterInitialSecretsAsync).
+    private readonly ISecretStore? _secretStore;
+    private readonly ILogger<ProvisioningSecretRegistrar> _logger;
+
+    public ProvisioningSecretRegistrar(
+        ISecretStore? secretStore,
+        ILogger<ProvisioningSecretRegistrar> logger)
+    {
+        _secretStore = secretStore;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<SecretRef>> RegisterInitialSecretsAsync(
+        Guid tenantId, ProvisioningTopology topology, CancellationToken ct = default)
+    {
+        // ── GUARDED NO-OP ────────────────────────────────────────────────
+        // Only a dedicated per-tenant engine needs a per-tenant
+        // TAMMA_SHARED_SECRET. DatabaseOnly / Managed tenants run on shared
+        // platform compute — no engine env to sign — so there is nothing to
+        // register. Return an empty list: a DELIBERATE, documented no-op that
+        // completes the step cleanly (NOT a stub, NOT a deferral).
+        if (topology != ProvisioningTopology.DedicatedCompute)
+        {
+            _logger.LogDebug(
+                "RegisterSecrets no-op for tenant {TenantId}: topology {Topology} has no " +
+                "per-tenant engine (no TAMMA_SHARED_SECRET shadow required).",
+                tenantId, topology);
+            return Array.Empty<SecretRef>();
+        }
+
+        // ── FAIL LOUD ────────────────────────────────────────────────────
+        // Dedicated compute genuinely needs the HMAC. If the cabinet is not
+        // configured we refuse — silently provisioning a per-tenant engine
+        // with no shared secret would surface later as an un-diagnosable HMAC
+        // mismatch on every signed engine call.
+        if (_secretStore is null)
+        {
+            throw new InvalidOperationException(
+                "Dedicated-compute provisioning requires the secret cabinet " +
+                "(ISecretStore / AddTammaPostgresSecrets), which is not configured. " +
+                "Refusing to register the per-tenant TAMMA_SHARED_SECRET shadow.");
+        }
+
+        var hmacRef = SecretRef.ForTenant(tenantId, HmacSecretName);
+
+        // Idempotency: a resumed/retried provision (or a re-attempt after a
+        // rolled-back one) must not double-create. CreateAsync throws on a
+        // duplicate (scope, tenant, name), and the facade has no delete for a
+        // sole-active-version secret, so an existing row is treated as
+        // already-registered and reused.
+        var existing = await _secretStore.GetAsync(hmacRef, ct).ConfigureAwait(false);
+        if (existing is not null)
+        {
+            _logger.LogDebug(
+                "Per-tenant HMAC shadow already present for tenant {TenantId}; reusing " +
+                "(idempotent register).", tenantId);
+            return new[] { hmacRef };
+        }
+
+        var hmacValue = GenerateHmacSecret();
+
+        // CreateAsync mints v1 + activates it (ActiveVersionNumber = 1) and
+        // emits SECRET.WRITE. Any failure (duplicate race, fail-closed backend)
+        // surfaces to the caller unchanged → the saga step fails loud.
+        await _secretStore.CreateAsync(
+            new CreateSecretRequest(
+                Name: HmacSecretName,
+                Scope: SecretScope.Tenant,
+                TenantId: tenantId,
+                Purpose: SecretPurpose.HmacSharedSecret,
+                ConsumerRefs: new[] { new ConsumerRef("cranl", "env=TAMMA_SHARED_SECRET") },
+                OwnerUserId: SystemProvisioningActor,
+                RotationSchedule: RotationSchedule.None,
+                InitialPlaintext: hmacValue),
+            ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Registered per-tenant HMAC shadow ({SecretName}) for tenant {TenantId}.",
+            HmacSecretName, tenantId);
+
+        return new[] { hmacRef };
+    }
+
+    /// <inheritdoc />
+    public async Task RetireInitialSecretsAsync(
+        IReadOnlyList<SecretRef> registered, CancellationToken ct = default)
+    {
+        // Nothing could have been registered without a cabinet, and an empty
+        // list (guarded no-op path) is a pure no-op. Both branches make
+        // compensation safe to run on any rollback.
+        if (_secretStore is null || registered is null || registered.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var reference in registered)
+        {
+            try
+            {
+                var meta = await _secretStore.GetAsync(reference, ct).ConfigureAwait(false);
+                if (meta is null || meta.ActiveVersionNumber <= 0)
+                {
+                    // Never created (register threw before CreateAsync landed)
+                    // or already scrubbed — nothing to retire. Idempotent.
+                    continue;
+                }
+
+                await _secretStore
+                    .RetireVersionAsync(reference, meta.ActiveVersionNumber, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (KeyNotFoundException)
+            {
+                // Secret / version already gone — idempotent no-op.
+            }
+            catch (InvalidOperationException ex)
+            {
+                // The facade refuses to retire a secret's SOLE active version
+                // (RetireVersionAsync guards the active pointer, and
+                // ISecretStore exposes no row-delete). A freshly-registered v1
+                // therefore cannot be fully revoked here. This is acceptable:
+                // RegisterInitialSecretsAsync is idempotent (it reuses an
+                // existing row), so a re-provision does NOT double-create, and
+                // the Story 30-9 reconciliation sweep reclaims the orphaned row.
+                // A compensation must never throw — log and continue.
+                _logger.LogWarning(ex,
+                    "Compensation could not fully retire provisioning secret {SecretKey} " +
+                    "(facade has no delete for a sole active version); leaving it for the " +
+                    "reconciliation sweep. Re-provision stays safe (register is idempotent).",
+                    reference.ToStorageKey());
+            }
+        }
+    }
+
+    /// <summary>Mint a fresh, URL-safe per-tenant HMAC value.</summary>
+    private static string GenerateHmacSecret()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(HmacByteLength);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/FakeSecretStore.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/FakeSecretStore.cs
@@ -1,0 +1,138 @@
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Tests.Provisioning.V2;
+
+/// <summary>
+/// Story 30-3 test double for <see cref="ISecretStore"/>. Implements only
+/// the three methods <see cref="Tamma.Api.Services.Provisioning.V2.ProvisioningSecretRegistrar"/>
+/// exercises (Create / Get / RetireVersion) and faithfully reproduces the
+/// real <c>SecretStore</c> facade's contract so the registrar tests reflect
+/// production behaviour:
+///
+/// <list type="bullet">
+///   <item><description><see cref="CreateAsync"/> throws
+///     <see cref="InvalidOperationException"/> on a duplicate
+///     <c>(scope, tenant, name)</c>; mints <c>ActiveVersionNumber = 1</c>
+///     when an initial plaintext is supplied.</description></item>
+///   <item><description><see cref="RetireVersionAsync"/> throws
+///     <see cref="KeyNotFoundException"/> when the secret is absent and
+///     <see cref="InvalidOperationException"/> when asked to retire the
+///     current active version (the facade's "no delete for the sole active
+///     version" guard).</description></item>
+/// </list>
+///
+/// Every mutating call is recorded for assertions. Read-only helpers not
+/// used by the registrar throw <see cref="NotSupportedException"/> so an
+/// accidental new dependency is caught loudly.
+/// </summary>
+public sealed class FakeSecretStore : ISecretStore
+{
+    private readonly Dictionary<string, SecretMetadata> _store = new(StringComparer.Ordinal);
+
+    public List<CreateSecretRequest> CreateCalls { get; } = new();
+    public List<(SecretRef Reference, int VersionNumber)> RetireVersionCalls { get; } = new();
+
+    /// <summary>Override to script a create failure (fail-loud tests).</summary>
+    public Func<CreateSecretRequest, Task<SecretMetadata>>? OnCreate { get; set; }
+
+    public Task<SecretMetadata> CreateAsync(
+        CreateSecretRequest request, CancellationToken ct = default)
+    {
+        CreateCalls.Add(request);
+        if (OnCreate is not null)
+        {
+            return OnCreate(request);
+        }
+
+        var key = new SecretRef(request.Scope, request.TenantId, request.Name).ToStorageKey();
+        if (_store.ContainsKey(key))
+        {
+            throw new InvalidOperationException(
+                $"A secret named '{request.Name}' already exists in scope {request.Scope}.");
+        }
+
+        var meta = SecretMetadataFactory.Create(
+            request.Name,
+            request.Scope,
+            request.TenantId,
+            request.Purpose,
+            request.ConsumerRefs,
+            request.OwnerUserId,
+            request.RotationSchedule,
+            DateTimeOffset.UtcNow);
+
+        if (!string.IsNullOrEmpty(request.InitialPlaintext))
+        {
+            meta = meta with { ActiveVersionNumber = 1 };
+        }
+
+        _store[key] = meta;
+        return Task.FromResult(meta);
+    }
+
+    public Task<SecretMetadata?> GetAsync(
+        SecretRef reference, CancellationToken ct = default)
+    {
+        _store.TryGetValue(reference.ToStorageKey(), out var meta);
+        return Task.FromResult<SecretMetadata?>(meta);
+    }
+
+    public Task<SecretMetadata> RetireVersionAsync(
+        SecretRef reference, int versionNumber, CancellationToken ct = default)
+    {
+        RetireVersionCalls.Add((reference, versionNumber));
+
+        var key = reference.ToStorageKey();
+        if (!_store.TryGetValue(key, out var meta))
+        {
+            throw new KeyNotFoundException($"No secret matches {key}.");
+        }
+
+        // Faithful to the real facade: the sole active version cannot be
+        // retired (there is no successor to fall back to; ISecretStore has no
+        // row-delete). Register's idempotency + the reconciliation sweep cover
+        // this in production.
+        if (meta.ActiveVersionNumber == versionNumber)
+        {
+            throw new InvalidOperationException(
+                "Cannot retire the active version. Rotate first so the successor " +
+                "is in place before the current version is taken away.");
+        }
+
+        return Task.FromResult(meta);
+    }
+
+    /// <summary>Test helper — seed an already-registered secret (simulates a
+    /// resumed / re-attempted provision that already minted the row).</summary>
+    public void SeedActiveSecret(SecretRef reference)
+    {
+        var meta = SecretMetadataFactory.Create(
+            reference.Name,
+            reference.Scope,
+            reference.TenantId,
+            SecretPurpose.HmacSharedSecret,
+            Array.Empty<ConsumerRef>(),
+            Guid.Parse("00000000-0000-0000-0000-000000000030"),
+            RotationSchedule.None,
+            DateTimeOffset.UtcNow) with
+        { ActiveVersionNumber = 1 };
+        _store[reference.ToStorageKey()] = meta;
+    }
+
+    // ── Unused by the registrar ──────────────────────────────────────────
+    public Task<IReadOnlyList<SecretMetadata>> ListAsync(
+        SecretListFilter filter, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task<SecretMetadata> RotateAsync(
+        SecretRef reference, RotateSecretRequest request, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task<SecretVersion?> GetVersionAsync(
+        SecretRef reference, int versionNumber, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+
+    public Task<IReadOnlyList<SecretVersion>> ListVersionsAsync(
+        SecretRef reference, CancellationToken ct = default) =>
+        throw new NotSupportedException();
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2SingleWorkerInterleaveTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2SingleWorkerInterleaveTests.cs
@@ -76,9 +76,15 @@ public sealed class ProvisionTenantV2SingleWorkerInterleaveTests
             new ITenantInfrastructureProvider[] { new NullTenantProvider(), fake }));
         // Small probe interval so the deferred saga's VisibleAt window is short;
         // large enough that tick-2 runs before it re-opens.
+        // Story 30-3 — real registrar backed by a throwaway fake cabinet
+        // (Step 6 registers the HMAC harmlessly; this suite asserts single-worker
+        // interleave, not secret registration).
+        services.AddScoped<IProvisioningSecretRegistrar>(_ => new ProvisioningSecretRegistrar(
+            new FakeSecretStore(), NullLogger<ProvisioningSecretRegistrar>.Instance));
         services.AddScoped(sp => new ProvisionTenantV2Workflow(
             sp.GetRequiredService<ControlPlaneDbContext>(),
             sp.GetRequiredService<TenantProviderRegistry>(),
+            sp.GetRequiredService<IProvisioningSecretRegistrar>(),
             sp.GetRequiredService<IPlatformEventPublisher>(),
             sp.GetRequiredService<TimeProvider>(),
             NullLogger<ProvisionTenantV2Workflow>.Instance)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2TaskHandlerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2TaskHandlerTests.cs
@@ -82,6 +82,12 @@ public sealed class ProvisionTenantV2TaskHandlerTests
         var workflow = new ProvisionTenantV2Workflow(
             _db,
             registry,
+            // Story 30-3 — a real registrar backed by a throwaway fake cabinet
+            // so the DedicatedCompute paths reach Ready (Step 6 registers the
+            // HMAC into the fake harmlessly). This handler suite asserts queue
+            // routing, not secret registration.
+            new ProvisioningSecretRegistrar(
+                new FakeSecretStore(), NullLogger<ProvisioningSecretRegistrar>.Instance),
             Mock.Of<IPlatformEventPublisher>(),
             TimeProvider.System,
             NullLogger<ProvisionTenantV2Workflow>.Instance)
@@ -292,6 +298,7 @@ public sealed class ProvisionTenantV2TaskHandlerTests
         var workflowMock = new Mock<ProvisionTenantV2Workflow>(
             _db,
             registry,
+            Mock.Of<IProvisioningSecretRegistrar>(),
             Mock.Of<IPlatformEventPublisher>(),
             TimeProvider.System,
             NullLogger<ProvisionTenantV2Workflow>.Instance);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2WorkflowTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisionTenantV2WorkflowTests.cs
@@ -6,6 +6,7 @@ using Moq;
 using NUnit.Framework;
 using Tamma.Api.Services.Provisioning;
 using Tamma.Api.Services.Provisioning.V2;
+using Tamma.Api.Services.Secrets;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -72,14 +73,24 @@ public sealed class ProvisionTenantV2WorkflowTests
         return tenant;
     }
 
+    /// <summary>The fake cabinet the last <see cref="Build"/> wired into the
+    /// workflow's Story 30-3 secret registrar. Tests inspect / script it
+    /// (e.g. <c>_secretStore.CreateCalls</c>, <c>_secretStore.OnCreate</c>).</summary>
+    private FakeSecretStore _secretStore = null!;
+
     private ProvisionTenantV2Workflow Build(
         TenantProviderRegistry registry,
-        IPlatformEventPublisher? events = null)
+        IPlatformEventPublisher? events = null,
+        IProvisioningSecretRegistrar? registrar = null)
     {
         var publisher = events ?? Mock.Of<IPlatformEventPublisher>();
+        _secretStore = new FakeSecretStore();
+        var secretRegistrar = registrar ?? new ProvisioningSecretRegistrar(
+            _secretStore, NullLogger<ProvisioningSecretRegistrar>.Instance);
         return new ProvisionTenantV2Workflow(
             _db,
             registry,
+            secretRegistrar,
             publisher,
             TimeProvider.System,
             NullLogger<ProvisionTenantV2Workflow>.Instance)
@@ -499,5 +510,97 @@ public sealed class ProvisionTenantV2WorkflowTests
         result.Status.FailureReason.Should().Be("cranl_app_deploy_failed",
             "probe surfaces the provider's failure short-code");
         fake.DeprovisionCalls.Should().HaveCount(1, "compensation runs once");
+    }
+
+    // ── Step 6: RegisterSecrets (Story 30-3) ────────────────────────
+
+    [Test]
+    public async Task ExecuteAsync_DedicatedCompute_RegistersHmacSecretAtStep6()
+    {
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueReady();
+
+        var workflow = Build(RegistryWith(fake));
+
+        var result = await workflow.ExecuteAsync(
+            PayloadFor(tenant.Id, "cranl", ProvisioningTopology.DedicatedCompute),
+            CancellationToken.None);
+
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Completed);
+        _secretStore.CreateCalls.Should().ContainSingle(
+            "dedicated compute registers the per-tenant TAMMA_SHARED_SECRET shadow");
+        _secretStore.CreateCalls[0].Name.Should().Be("cranl/app-env-hmac");
+        _secretStore.CreateCalls[0].Scope.Should().Be(SecretScope.Tenant);
+        _secretStore.CreateCalls[0].TenantId.Should().Be(tenant.Id);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_NonDedicatedTopology_RegistersNoSecrets_GuardedNoOp()
+    {
+        var tenant = await SeedAsync();
+        // Default fake caps support DatabaseOnly | DedicatedCompute.
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueReady();
+
+        var workflow = Build(RegistryWith(fake));
+
+        var result = await workflow.ExecuteAsync(
+            PayloadFor(tenant.Id, "cranl", ProvisioningTopology.DatabaseOnly),
+            CancellationToken.None);
+
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Completed,
+            "the guarded no-op completes the step cleanly and reaches Ready");
+        _secretStore.CreateCalls.Should().BeEmpty(
+            "a database-only tenant has no per-tenant engine, so nothing is registered");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_SecretRegistrationThrows_FailsStepLoudAndCompensates()
+    {
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        fake.EnqueueReady();
+
+        var workflow = Build(RegistryWith(fake));
+        // Script a cabinet failure at Step 6 (e.g. fail-closed backend).
+        _secretStore.OnCreate = _ => throw new InvalidOperationException("fail_closed_backend");
+
+        var result = await workflow.ExecuteAsync(
+            PayloadFor(tenant.Id, "cranl", ProvisioningTopology.DedicatedCompute),
+            CancellationToken.None);
+
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Failed);
+        result.Status.FailureReason.Should().Be(
+            ProvisioningFailureReasons.SecretRegistrationFailed,
+            "a genuine registration failure fails the saga step loud, not silently");
+        fake.ProvisionCalls.Should().HaveCount(1, "Step 4 ran before Step 6 failed");
+        fake.DeprovisionCalls.Should().HaveCount(1,
+            "compensation tears down the ExecuteProvision resources");
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DedicatedCompute_LaterStepFails_CompensationRetiresHmacSecret()
+    {
+        var tenant = await SeedAsync();
+        var fake = new FakeTenantInfrastructureProvider("cranl");
+        // Registers the HMAC at Step 6, then the probe (Step 7) observes Failed.
+        fake.EnqueueProviderFailure("cranl_app_deploy_failed", "deploy returned 500");
+
+        var workflow = Build(RegistryWith(fake));
+
+        var result = await workflow.ExecuteAsync(
+            PayloadFor(tenant.Id, "cranl", ProvisioningTopology.DedicatedCompute),
+            CancellationToken.None);
+
+        result.Kind.Should().Be(ProvisionTenantV2OutcomeKind.Failed);
+        _secretStore.CreateCalls.Should().ContainSingle("the HMAC was registered at Step 6");
+
+        var hmacRef = SecretRef.ForTenant(
+            tenant.Id, ProvisioningSecretRegistrar.HmacSecretName);
+        _secretStore.RetireVersionCalls.Should().ContainSingle()
+            .Which.Should().Be((hmacRef, 1),
+                "register_secrets compensation retires the secret it registered");
+        fake.DeprovisionCalls.Should().HaveCount(1, "execute_provision compensation also runs");
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisioningSecretRegistrarTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Provisioning/V2/ProvisioningSecretRegistrarTests.cs
@@ -1,0 +1,234 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Services.Provisioning.V2;
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Tests.Provisioning.V2;
+
+/// <summary>
+/// Story 30-3 — unit tests for <see cref="ProvisioningSecretRegistrar"/>
+/// (the RegisterSecrets saga-step helper). Drives the registrar directly
+/// against a <see cref="FakeSecretStore"/> facade seam:
+///
+/// <list type="bullet">
+///   <item><description>DedicatedCompute → registers the per-tenant HMAC
+///     shadow (tenant:cranl/app-env-hmac).</description></item>
+///   <item><description>Non-dedicated topologies → guarded no-op (nothing
+///     registered).</description></item>
+///   <item><description>DedicatedCompute with no cabinet → fails loud.</description></item>
+///   <item><description>Register is idempotent (reuses an existing row).</description></item>
+///   <item><description>Retire is idempotent + non-throwing.</description></item>
+/// </list>
+/// </summary>
+[TestFixture]
+public sealed class ProvisioningSecretRegistrarTests
+{
+    private static ProvisioningSecretRegistrar Build(ISecretStore? store) =>
+        new(store, NullLogger<ProvisioningSecretRegistrar>.Instance);
+
+    private static SecretRef HmacRefFor(Guid tenantId) =>
+        SecretRef.ForTenant(tenantId, ProvisioningSecretRegistrar.HmacSecretName);
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_DedicatedCompute_RegistersHmacShadow()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+        var tenantId = Guid.NewGuid();
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            tenantId, ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        registered.Should().ContainSingle().Which.Should().Be(HmacRefFor(tenantId));
+
+        store.CreateCalls.Should().ContainSingle();
+        var req = store.CreateCalls[0];
+        req.Name.Should().Be("cranl/app-env-hmac");
+        req.Scope.Should().Be(SecretScope.Tenant);
+        req.TenantId.Should().Be(tenantId);
+        req.Purpose.Should().Be(SecretPurpose.HmacSharedSecret);
+        req.InitialPlaintext.Should().NotBeNullOrWhiteSpace(
+            "the per-tenant HMAC value is minted, not left null");
+        req.OwnerUserId.Should().NotBe(Guid.Empty,
+            "the cabinet requires a non-empty owner GUID");
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_MintsFreshRandomValuePerTenant()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+
+        await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+        await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        store.CreateCalls.Should().HaveCount(2);
+        store.CreateCalls[0].InitialPlaintext.Should()
+            .NotBe(store.CreateCalls[1].InitialPlaintext,
+                "each tenant gets its own random HMAC — not a shared value");
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_DatabaseOnly_RegistersNothing_GuardedNoOp()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DatabaseOnly, CancellationToken.None);
+
+        registered.Should().BeEmpty();
+        store.CreateCalls.Should().BeEmpty("non-dedicated topologies have no per-tenant engine");
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_Managed_RegistersNothing_GuardedNoOp()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.Managed, CancellationToken.None);
+
+        registered.Should().BeEmpty();
+        store.CreateCalls.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_NoCabinet_NonDedicated_IsCleanNoOp()
+    {
+        // No ISecretStore wired (dev/in-memory host). A non-dedicated tenant
+        // needs no secret, so the guard short-circuits BEFORE the null check —
+        // clean no-op, no throw.
+        var registrar = Build(store: null);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DatabaseOnly, CancellationToken.None);
+
+        registered.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_NoCabinet_DedicatedCompute_FailsLoud()
+    {
+        var registrar = Build(store: null);
+
+        var act = async () => await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*secret cabinet*",
+                "dedicated compute cannot proceed with no place to store the HMAC");
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_AlreadyRegistered_IsIdempotent()
+    {
+        var store = new FakeSecretStore();
+        var tenantId = Guid.NewGuid();
+        store.SeedActiveSecret(HmacRefFor(tenantId)); // prior (rolled-back) attempt minted it
+        var registrar = Build(store);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            tenantId, ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        registered.Should().ContainSingle().Which.Should().Be(HmacRefFor(tenantId));
+        store.CreateCalls.Should().BeEmpty(
+            "an existing row is reused — a resumed provision must not double-create");
+    }
+
+    [Test]
+    public async Task RegisterInitialSecretsAsync_CabinetCreateThrows_Propagates()
+    {
+        var store = new FakeSecretStore
+        {
+            OnCreate = _ => throw new InvalidOperationException("fail-closed backend"),
+        };
+        var registrar = Build(store);
+
+        var act = async () => await registrar.RegisterInitialSecretsAsync(
+            Guid.NewGuid(), ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*fail-closed*",
+                "a genuine create failure surfaces to the caller (the saga fails loud)");
+    }
+
+    [Test]
+    public async Task RetireInitialSecretsAsync_AttemptsToRetireRegisteredSecret()
+    {
+        var store = new FakeSecretStore();
+        var tenantId = Guid.NewGuid();
+        var registrar = Build(store);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            tenantId, ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        // Compensation must not throw even though the facade refuses to retire
+        // the sole active version (documented limitation).
+        var act = async () => await registrar.RetireInitialSecretsAsync(
+            registered, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        store.RetireVersionCalls.Should().ContainSingle()
+            .Which.Should().Be((HmacRefFor(tenantId), 1),
+                "compensation retires the active version of each registered secret");
+    }
+
+    [Test]
+    public async Task RetireInitialSecretsAsync_SecretNeverCreated_IsIdempotentNoOp()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+        var refs = new[] { HmacRefFor(Guid.NewGuid()) };
+
+        var act = async () => await registrar.RetireInitialSecretsAsync(
+            refs, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        store.RetireVersionCalls.Should().BeEmpty(
+            "GetAsync returns null for a never-created secret → nothing to retire");
+    }
+
+    [Test]
+    public async Task RetireInitialSecretsAsync_EmptyList_NoOp()
+    {
+        var store = new FakeSecretStore();
+        var registrar = Build(store);
+
+        var act = async () => await registrar.RetireInitialSecretsAsync(
+            Array.Empty<SecretRef>(), CancellationToken.None);
+        await act.Should().NotThrowAsync();
+        store.RetireVersionCalls.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task RetireInitialSecretsAsync_NoCabinet_NoThrow()
+    {
+        var registrar = Build(store: null);
+
+        var act = async () => await registrar.RetireInitialSecretsAsync(
+            new[] { HmacRefFor(Guid.NewGuid()) }, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Test]
+    public async Task RetireInitialSecretsAsync_RunTwice_IsIdempotent()
+    {
+        var store = new FakeSecretStore();
+        var tenantId = Guid.NewGuid();
+        var registrar = Build(store);
+
+        var registered = await registrar.RegisterInitialSecretsAsync(
+            tenantId, ProvisioningTopology.DedicatedCompute, CancellationToken.None);
+
+        await registrar.RetireInitialSecretsAsync(registered, CancellationToken.None);
+        var act = async () => await registrar.RetireInitialSecretsAsync(
+            registered, CancellationToken.None);
+
+        await act.Should().NotThrowAsync("re-running compensation is safe");
+    }
+}


### PR DESCRIPTION
## What

Turns Step 6 (`RegisterSecrets`) of `ProvisionTenantV2Workflow` from a `deferred_to_30_3` no-op into a real facade-based per-tenant secret registration, now that the `ISecretStore` facade (#441) is merged.

- **Registers** `tenant:cranl/app-env-hmac` — a fresh per-tenant 256-bit HMAC / `TAMMA_SHARED_SECRET` shadow (not a copy of the platform secret) via `ISecretStore.CreateAsync`, **only for `DedicatedCompute`** topologies.
- **Deliberately omits** the AC9 `tenant:db/cranl-connection` secret — vestigial after Phase B removed the stored-`DATABASE_URL` model (DB routing goes through the unified pool's encrypted envelope). Documented with a code comment.
- **Step 6 rewired:** real `STEP_COMPLETED` (with `secretsRegistered` count); compensation retires the registered secret(s) idempotently; a **guarded no-op** for non-dedicated topologies (deliberate, not a stub); **fail-loud** (`secret_registration_failed` + `STEP_FAILED` + compensation) on a genuine registration failure.
- Idempotent register (re-provision reuses an existing row, never double-creates).

## Scope / honesty

Dormant path — Cranl is opt-in and `PlatformTaskWorker:RunOnStartup=false`, so this is **unit-testable only**, not exercised in the default deployment. Documented limitation: the facade has no row-delete and `RetireVersionAsync` refuses a sole active version, so compensating a freshly-minted v1 can only *attempt* the retire (the row lingers for the 30-9 reconciliation sweep; safe because register is idempotent).

## Verification

- Build: 0 errors, no TAMMA001 (all in `Tamma.Api`, engine untouched). Both `has-pending-model-changes` → "No changes" (secrets on the standalone `SecretsDbContext`, no schema change). Tests: 844 passed (17 new — dedicated-compute registers; non-dedicated no-op; fresh-random-per-tenant; idempotent; fail-loud; idempotent compensation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)