### PR TITLE
feat(epic-4-6): DCB event coverage for approval requests/decisions & escalations

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/PlanApprovalEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/PlanApprovalEvents.cs
@@ -1,0 +1,74 @@
+using Tamma.Activities.ADL.Models;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// Story 4-6 — central catalogue of the <c>PLAN_APPROVAL.*</c> DCB event types emitted by
+/// the human plan-approval gate (<see cref="WaitForPlanApprovalActivity"/>). The gate is the
+/// AI-plan checkpoint of the autonomous loop: a generated plan suspends on a bookmark until a
+/// human chooses <i>approve / reject / edit</i>. Every transition of that gate is an auditable
+/// approval event (the architecture lists "approvals/escalations" as a first-class captured
+/// event family).
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="EmitMergeApprovalEventActivity"/> uses. No activity holds a DB / repository
+/// dependency of its own (none is registered in the Elsa engine — a directly-injected
+/// <c>IEventRepository</c> would be inert and silently drop every gate event).</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention and
+/// mirrors <see cref="MergeApprovalEvents"/> (the merge-approval gate). The request event is
+/// <c>PLAN_APPROVAL.REQUESTED</c> (emitted at suspend) and the decision lands as a
+/// <c>PLAN_APPROVAL.DECISION.*</c> event on resume.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>PLAN_APPROVAL.REQUESTED</c> — the gate suspended on its bookmark,
+///     awaiting a human plan decision.</description></item>
+///   <item><description><c>PLAN_APPROVAL.DECISION.APPROVED</c> — a human approved the
+///     plan.</description></item>
+///   <item><description><c>PLAN_APPROVAL.DECISION.REJECTED</c> — a human rejected the plan
+///     (or the resume payload carried an unknown / empty decision — fail-closed, never a
+///     silent approve). LOUD (error-status).</description></item>
+///   <item><description><c>PLAN_APPROVAL.DECISION.EDIT_REQUESTED</c> — a human requested
+///     edits; the cycle loops back to plan generation.</description></item>
+/// </list>
+/// </summary>
+public static class PlanApprovalEvents
+{
+    public const string Requested = "PLAN_APPROVAL.REQUESTED";
+    public const string DecisionApproved = "PLAN_APPROVAL.DECISION.APPROVED";
+    public const string DecisionRejected = "PLAN_APPROVAL.DECISION.REJECTED";
+    public const string DecisionEditRequested = "PLAN_APPROVAL.DECISION.EDIT_REQUESTED";
+
+    /// <summary>
+    /// Map a resolved <see cref="ApprovalDecision"/> onto its <c>PLAN_APPROVAL.DECISION.*</c>
+    /// event type. Approve → APPROVED, Edit → EDIT_REQUESTED; anything else (Reject / Test /
+    /// unknown) → REJECTED (fail-closed: an ambiguous decision must never proceed with the
+    /// plan). Mirrors the gate's own outcome mapping.
+    /// </summary>
+    public static string DecisionEventType(ApprovalDecision decision) => decision switch
+    {
+        ApprovalDecision.Approve => DecisionApproved,
+        ApprovalDecision.Edit => DecisionEditRequested,
+        _ => DecisionRejected,
+    };
+
+    /// <summary>
+    /// Status convention: a rejection is a LOUD (error-status) audit row — the plan was
+    /// declined and the cycle ends — mirroring <see cref="MergeApprovalEvents"/> /
+    /// <c>DeployEvents</c> where a rejected decision is never recorded as a false success.
+    /// Requested / approved / edit-requested are normal (success-status) rows.
+    /// </summary>
+    public static string StatusForEvent(string type)
+        => type == DecisionRejected ? "error" : "success";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (plan-approval events
+    /// in single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="MergeApprovalEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPlanApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPlanApprovalActivity.cs
@@ -6,6 +6,7 @@ using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.ADL.Models;
+using Tamma.Activities.Core;
 
 namespace Tamma.Activities.ADL;
 
@@ -20,6 +21,13 @@ namespace Tamma.Activities.ADL;
 ///   - Approved: plan accepted
 ///   - Rejected: plan rejected, cycle should end
 ///   - EditRequested: plan needs revision, loop back to plan generation
+///
+/// <para>Events (Story 4-6): emits <c>PLAN_APPROVAL.REQUESTED</c> at the RAISE point
+/// (when the gate suspends on its bookmark) and a <c>PLAN_APPROVAL.DECISION.*</c> event on
+/// resume, via <c>TammaEventEmitter.Emit</c> into the durable engine event drain — the same
+/// path <see cref="EmitMergeApprovalEventActivity"/> uses. This keeps the plan-approval gate
+/// auditable on the DCB stream (request + decision) consistent with the merge / deploy
+/// approval gates.</para>
 /// </summary>
 [Activity(
     "Tamma.ADL",
@@ -38,6 +46,10 @@ public class WaitForPlanApprovalActivity : Activity
     [Input(Description = "Generated plan JSON to present for approval", UIHint = "json-editor")]
     public Input<string> PlanJson { get; set; } = default!;
 
+    /// <summary>Tenant id (Story 4-6 — empty / single-user → platform-scope approval event).</summary>
+    [Input(Description = "Tenant id (empty / single-user → platform-scope approval event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     [Output(Description = "Approval result with decision and feedback")]
     public Output<string?> ApprovalResultJson { get; set; } = default!;
 
@@ -55,11 +67,19 @@ public class WaitForPlanApprovalActivity : Activity
     protected override void Execute(ActivityExecutionContext context)
     {
         var issueNumber = IssueNumber.Get(context);
+        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.Get(context));
         var bookmarkName = $"adl-plan-approval-{issueNumber}";
 
         _logger?.LogInformation(
             "Creating plan approval bookmark {BookmarkName} for issue #{IssueNumber}",
             bookmarkName, issueNumber);
+
+        // Story 4-6 — emit PLAN_APPROVAL.REQUESTED at the RAISE point so the approval request
+        // is on the DCB audit stream the moment the gate suspends (mirrors the merge / deploy
+        // approval-request events). The decision is emitted on resume below.
+        TammaEventEmitter.Emit(context, this, _logger,
+            BuildTammaEvent(PlanApprovalEvents.Requested, issueNumber, tenantId,
+                decision: null, approvedBy: null, feedback: null));
 
         context.CreateBookmark(
             new CreateBookmarkArgs
@@ -94,6 +114,19 @@ public class WaitForPlanApprovalActivity : Activity
             "Plan approval received for issue #{IssueNumber}: {Decision}",
             IssueNumber.Get(context), result.Decision);
 
+        // Story 4-6 — emit the human decision as a PLAN_APPROVAL.DECISION.* DCB event on the
+        // resuming edge so the approver / feedback context is captured durably (a rejection is
+        // a LOUD error-status row, never a silent approve).
+        var issueNumber = IssueNumber.Get(context);
+        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.Get(context));
+        TammaEventEmitter.Emit(context, this, _logger,
+            BuildTammaEvent(
+                PlanApprovalEvents.DecisionEventType(result.Decision),
+                issueNumber, tenantId,
+                decision: result.Decision.ToString().ToLowerInvariant(),
+                approvedBy: result.ApprovedBy,
+                feedback: feedback));
+
         var outcome = result.Decision switch
         {
             ApprovalDecision.Approve => "Approved",
@@ -112,4 +145,46 @@ public class WaitForPlanApprovalActivity : Activity
         "edit" => ApprovalDecision.Edit,
         _ => ApprovalDecision.Reject
     };
+
+    /// <summary>
+    /// Map the plan-approval gate inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>issueId</c>/<c>issueNumber</c>/<c>tenantId</c>/
+    /// <c>decision</c>/<c>approver</c>); <c>Data</c> carries the decision payload. Status is
+    /// driven off the event type (a rejection is a LOUD error row). Pure (no Elsa context) —
+    /// exposed for unit testing the mapping. Mirrors
+    /// <see cref="EmitMergeApprovalEventActivity.BuildTammaEvent"/>.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        int issueNumber,
+        Guid? tenantId,
+        string? decision,
+        string? approvedBy,
+        string? feedback)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = issueNumber.ToString(),
+            ["issueNumber"] = issueNumber.ToString(),
+        };
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+        if (!string.IsNullOrWhiteSpace(decision)) tags["decision"] = decision;
+        if (!string.IsNullOrWhiteSpace(approvedBy)) tags["approver"] = approvedBy;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["decision"] = decision ?? "",
+            ["approver"] = approvedBy ?? "",
+            ["feedback"] = feedback ?? "",
+        };
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = PlanApprovalEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/CodeReviewEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/CodeReviewEvents.cs
@@ -38,8 +38,17 @@ namespace Tamma.Activities.Review;
 ///     (carries the iteration number).</description></item>
 ///   <item><description><c>CODE_REVIEW.MERGED.SUCCESS</c> / <c>.FAILED</c> — the PR was
 ///     merged (carries the merge sha + strategy) or merge failed irrecoverably.</description></item>
-///   <item><description><c>CODE_REVIEW.ESCALATED</c> — the review was escalated to a senior
-///     (carries the reason).</description></item>
+///   <item><description><c>CODE_REVIEW.ESCALATED</c> — Story 4-6: the review was escalated
+///     to a senior. Emitted at the RAISE point (when <see cref="EscalateReviewActivity"/>
+///     suspends awaiting the senior) so an escalation is auditable the moment it is
+///     triggered — regardless of whether the senior later resolves, rejects, or the SLA
+///     expires. Mirrors <c>BLOCKER.ESCALATED</c> (emitted before the blocker escalation
+///     wait). Carries the reason.</description></item>
+///   <item><description><c>CODE_REVIEW.ESCALATION_RESOLVED</c> — Story 4-6: the senior
+///     resolved the escalation (approved / fixed) and the run proceeds to merge. The
+///     resolution companion to <c>CODE_REVIEW.ESCALATED</c> (a rejection is recorded as
+///     <c>CODE_REVIEW.FAILED</c>; an SLA expiry as the timed-out <c>CODE_REVIEW.FAILED</c>
+///     terminal).</description></item>
 ///   <item><description><c>CODE_REVIEW.FAILED</c> — terminal: the review ended without a
 ///     merge (validation failure, senior rejection). LOUD (error-status) — never a silent
 ///     false success.</description></item>
@@ -54,7 +63,13 @@ public static class CodeReviewEvents
     public const string IterationStarted = "CODE_REVIEW.ITERATION.STARTED";
     public const string MergedSuccess = "CODE_REVIEW.MERGED.SUCCESS";
     public const string MergedFailed = "CODE_REVIEW.MERGED.FAILED";
+
+    /// <summary>Story 4-6 — an escalation was RAISED (senior notified, workflow suspended).</summary>
     public const string Escalated = "CODE_REVIEW.ESCALATED";
+
+    /// <summary>Story 4-6 — an escalation was RESOLVED by the senior (proceeding to merge).</summary>
+    public const string EscalationResolved = "CODE_REVIEW.ESCALATION_RESOLVED";
+
     public const string Failed = "CODE_REVIEW.FAILED";
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
@@ -5,6 +5,7 @@ using Elsa.Workflows.Activities.Flowchart.Attributes;
 using Elsa.Workflows.Attributes;
 using Elsa.Workflows.Models;
 using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.Review.Models;
 using Microsoft.Extensions.Configuration;
@@ -61,6 +62,14 @@ public class EscalateReviewActivity : Activity
     [Input(Description = "Junior developer ID")]
     public Input<string> JuniorId { get; set; } = default!;
 
+    /// <summary>Story id under review (Story 4-6 — DCB escalation-raised event tag).</summary>
+    [Input(Description = "Story id under review (escalation-event tag)")]
+    public Input<string?> StoryId { get; set; } = new((string?)null);
+
+    /// <summary>Tenant id (Story 4-6 — empty / single-user → platform-scope escalation event).</summary>
+    [Input(Description = "Tenant id (empty / single-user → platform-scope escalation event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
     /// <summary>Escalation reason</summary>
     [Input(Description = "Reason for escalation")]
     public Input<EscalationReason> Reason { get; set; } = default!;
@@ -95,6 +104,8 @@ public class EscalateReviewActivity : Activity
         var sessionId = SessionId.Get(context);
         var prNumber = PRNumber.Get(context);
         var juniorId = JuniorId.Get(context);
+        var storyId = StoryId.Get(context);
+        var tenantId = TenantId.Get(context);
         var reason = Reason.Get(context);
         var iterations = IterationsAttempted.Get(context);
         var message = EscalationMessage.Get(context);
@@ -163,6 +174,27 @@ public class EscalateReviewActivity : Activity
                 "Error during escalation notification for session {SessionId}", sessionId);
             // Continue to create the bookmark even if notifications fail
         }
+
+        // Story 4-6 — emit CODE_REVIEW.ESCALATED at the RAISE point (before the suspending
+        // wait) so the escalation is on the DCB audit stream the moment it is triggered,
+        // regardless of the eventual outcome (resolved / rejected / SLA-expired). Mirrors
+        // BLOCKER.ESCALATED (emitted before the blocker escalation wait). The MentorshipEvent
+        // row logged above feeds the mentorship state machine; this DCB event feeds the
+        // platform audit / time-travel stream. Emitted here (outside the notification
+        // try/catch) so a failed Slack notification never suppresses the audit row.
+        var escalatedEvt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.Escalated,
+            sessionId: sessionId.ToString(),
+            storyId: storyId,
+            juniorId: juniorId,
+            tenantId: CodeReviewEvents.ParseTenantId(tenantId),
+            prNumber: prNumber,
+            prUrl: null,
+            iteration: iterations,
+            mergeSha: null,
+            reason: reason.ToString(),
+            detail: message);
+        TammaEventEmitter.Emit(context, this, _logger, escalatedEvt);
 
         var bookmarkName = $"escalate-{sessionId}-{prNumber}";
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
@@ -446,6 +446,10 @@ public class CodeReviewWorkflow : WorkflowBase
             SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            // Story 4-6 — thread the DCB escalation-event tags so the raise-time
+            // CODE_REVIEW.ESCALATED event carries storyId + tenantId.
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            TenantId = Expr<string?>(ctx => tenantId.Get(ctx)),
             Reason = new(EscalationReason.MaxIterationsReached),
             IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
             EscalationMessage = new("Maximum fix iterations reached during code review."),
@@ -460,6 +464,10 @@ public class CodeReviewWorkflow : WorkflowBase
             SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            // Story 4-6 — thread the DCB escalation-event tags so the raise-time
+            // CODE_REVIEW.ESCALATED event carries storyId + tenantId.
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            TenantId = Expr<string?>(ctx => tenantId.Get(ctx)),
             Reason = new(EscalationReason.ReviewTimeout),
             IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
             EscalationMessage = new("Review or fix submission timed out."),
@@ -474,6 +482,10 @@ public class CodeReviewWorkflow : WorkflowBase
             SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            // Story 4-6 — thread the DCB escalation-event tags so the raise-time
+            // CODE_REVIEW.ESCALATED event carries storyId + tenantId.
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            TenantId = Expr<string?>(ctx => tenantId.Get(ctx)),
             Reason = new(EscalationReason.Other),
             IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
             EscalationMessage = new("Automated fix guidance could not be generated."),
@@ -487,6 +499,10 @@ public class CodeReviewWorkflow : WorkflowBase
             SessionId = Expr<Guid>(ctx => sessionIdGuid.Get(ctx)),
             PRNumber = Expr<int>(ctx => prNumber.Get(ctx)),
             JuniorId = Expr<string>(ctx => juniorId.Get(ctx)),
+            // Story 4-6 — thread the DCB escalation-event tags so the raise-time
+            // CODE_REVIEW.ESCALATED event carries storyId + tenantId.
+            StoryId = Expr<string?>(ctx => storyId.Get(ctx)),
+            TenantId = Expr<string?>(ctx => tenantId.Get(ctx)),
             Reason = new(EscalationReason.MergeConflict),
             IterationsAttempted = Expr<int>(ctx => iteration.Get(ctx)),
             EscalationMessage = new("CI not green or merge failed after retry; senior review required."),
@@ -504,9 +520,13 @@ public class CodeReviewWorkflow : WorkflowBase
         };
         captureEscalated.SetDisplayText("Capture Escalation Resolution");
 
-        var emitEscalated = EmitEvent("EmitEscalated", "Emit Escalated",
-            CodeReviewEvents.Escalated, sessionId, storyId, juniorId, tenantId,
-            prNumber, prUrl, iteration, mergeShaVar, new("Escalated to senior developer."));
+        // Story 4-6 — the RESOLVE companion to the raise-time CODE_REVIEW.ESCALATED (emitted
+        // by EscalateReviewActivity at suspend). This fires on the Resolved→merge edge, so the
+        // senior's resolution is a distinct audit row (a rejection instead lands on
+        // CODE_REVIEW.FAILED; an SLA expiry on the timed-out terminal).
+        var emitEscalated = EmitEvent("EmitEscalated", "Emit Escalation Resolved",
+            CodeReviewEvents.EscalationResolved, sessionId, storyId, juniorId, tenantId,
+            prNumber, prUrl, iteration, mergeShaVar, new("Escalation resolved by senior developer."));
 
         // ---- Merge re-escalation loop bound (#IMPORTANT) -------------------------------
         // The merge-failure escalation resolving routes back to MergeAndComplete; count the

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/PlanApprovalEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/PlanApprovalEventTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.ADL;
+using Tamma.Activities.ADL.Models;
+
+namespace Tamma.Activities.Tests.ADL;
+
+/// <summary>
+/// Story 4-6 (Event Capture — Approvals &amp; Escalations) — unit coverage for the
+/// plan-approval gate's DCB event catalogue + mapping:
+///   - the <c>PLAN_APPROVAL.*</c> type catalogue + status convention (a rejection is a
+///     LOUD error row, never a silent approve);
+///   - <see cref="PlanApprovalEvents.DecisionEventType"/> maps a resolved decision onto its
+///     event type (fail-closed: unknown → REJECTED);
+///   - <see cref="WaitForPlanApprovalActivity.BuildTammaEvent"/> maps the gate inputs onto
+///     the durable drain event shape with the right tags, status, and decision payload —
+///     the same event that is pushed into <c>tamma:events</c> at suspend (REQUESTED) and on
+///     resume (DECISION.*).
+/// </summary>
+[TestFixture]
+public class PlanApprovalEventTests
+{
+    // ================================================================
+    // PlanApprovalEvents — type catalogue + status convention
+    // ================================================================
+
+    [Test]
+    public void EventTypes_FollowAggregateActionStatusConvention()
+    {
+        PlanApprovalEvents.Requested.Should().Be("PLAN_APPROVAL.REQUESTED");
+        PlanApprovalEvents.DecisionApproved.Should().Be("PLAN_APPROVAL.DECISION.APPROVED");
+        PlanApprovalEvents.DecisionRejected.Should().Be("PLAN_APPROVAL.DECISION.REJECTED");
+        PlanApprovalEvents.DecisionEditRequested.Should().Be("PLAN_APPROVAL.DECISION.EDIT_REQUESTED");
+    }
+
+    [Test]
+    public void StatusForEvent_RejectionIsError_RestAreSuccess()
+    {
+        PlanApprovalEvents.StatusForEvent(PlanApprovalEvents.DecisionRejected).Should().Be("error",
+            "a rejected plan is a loud audit row, not a false success");
+        PlanApprovalEvents.StatusForEvent(PlanApprovalEvents.Requested).Should().Be("success");
+        PlanApprovalEvents.StatusForEvent(PlanApprovalEvents.DecisionApproved).Should().Be("success");
+        PlanApprovalEvents.StatusForEvent(PlanApprovalEvents.DecisionEditRequested).Should().Be("success");
+    }
+
+    [TestCase(ApprovalDecision.Approve, "PLAN_APPROVAL.DECISION.APPROVED")]
+    [TestCase(ApprovalDecision.Edit, "PLAN_APPROVAL.DECISION.EDIT_REQUESTED")]
+    [TestCase(ApprovalDecision.Reject, "PLAN_APPROVAL.DECISION.REJECTED")]
+    [TestCase(ApprovalDecision.Test, "PLAN_APPROVAL.DECISION.REJECTED")] // fail-closed
+    public void DecisionEventType_MapsDecisionToType_FailClosed(ApprovalDecision decision, string expected)
+    {
+        PlanApprovalEvents.DecisionEventType(decision).Should().Be(expected);
+    }
+
+    [Test]
+    public void ParseTenantId_HandlesEmptyAndValid()
+    {
+        PlanApprovalEvents.ParseTenantId(null).Should().BeNull();
+        PlanApprovalEvents.ParseTenantId("").Should().BeNull();
+        PlanApprovalEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        PlanApprovalEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+
+    // ================================================================
+    // WaitForPlanApprovalActivity.BuildTammaEvent — DCB mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_Requested_AtSuspend_SetsSuccessAndIssueTags_NoDecisionYet()
+    {
+        // The event pushed into tamma:events at the RAISE point (gate suspend).
+        var evt = WaitForPlanApprovalActivity.BuildTammaEvent(
+            PlanApprovalEvents.Requested, issueNumber: 21, tenantId: null,
+            decision: null, approvedBy: null, feedback: null);
+
+        evt.EventType.Should().Be("PLAN_APPROVAL.REQUESTED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["issueId"].Should().Be("21");
+        evt.Tags["issueNumber"].Should().Be("21");
+        evt.Tags.Should().NotContainKey("decision");
+        evt.Tags.Should().NotContainKey("approver");
+        evt.Tags.Should().NotContainKey("tenantId");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Approved_AtResume_SetsSuccessDecisionTagsAndData()
+    {
+        // The event pushed into tamma:events on RESUME (human decision).
+        var evt = WaitForPlanApprovalActivity.BuildTammaEvent(
+            PlanApprovalEvents.DecisionApproved, issueNumber: 21, tenantId: null,
+            decision: "approve", approvedBy: "alice", feedback: "looks good");
+
+        evt.EventType.Should().Be("PLAN_APPROVAL.DECISION.APPROVED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["decision"].Should().Be("approve");
+        evt.Tags["approver"].Should().Be("alice");
+        evt.Data["decision"].Should().Be("approve");
+        evt.Data["approver"].Should().Be("alice");
+        evt.Data["feedback"].Should().Be("looks good");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Rejected_AtResume_IsErrorStatus()
+    {
+        var evt = WaitForPlanApprovalActivity.BuildTammaEvent(
+            PlanApprovalEvents.DecisionRejected, issueNumber: 7, tenantId: null,
+            decision: "reject", approvedBy: "bob", feedback: "wrong approach");
+
+        evt.EventType.Should().Be("PLAN_APPROVAL.DECISION.REJECTED");
+        evt.Status.Should().Be("error",
+            "a rejected plan is a loud audit row, not a false success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_WithTenant_SetsTenantIdTag()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = WaitForPlanApprovalActivity.BuildTammaEvent(
+            PlanApprovalEvents.DecisionEditRequested, issueNumber: 3, tenantId: tenant,
+            decision: "edit", approvedBy: "carol", feedback: "add tests");
+
+        evt.EventType.Should().Be("PLAN_APPROVAL.DECISION.EDIT_REQUESTED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+    }
+
+    [Test]
+    public void JsonConstructor_DoesNotThrow()
+    {
+        Action act = () => _ = new WaitForPlanApprovalActivity();
+        act.Should().NotThrow();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/CodeReviewEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Review/CodeReviewEventTests.cs
@@ -33,6 +33,8 @@ public class CodeReviewEventTests
         CodeReviewEvents.MergedSuccess.Should().Be("CODE_REVIEW.MERGED.SUCCESS");
         CodeReviewEvents.MergedFailed.Should().Be("CODE_REVIEW.MERGED.FAILED");
         CodeReviewEvents.Escalated.Should().Be("CODE_REVIEW.ESCALATED");
+        // Story 4-6 — escalation resolution companion to the raise-time ESCALATED.
+        CodeReviewEvents.EscalationResolved.Should().Be("CODE_REVIEW.ESCALATION_RESOLVED");
         CodeReviewEvents.Failed.Should().Be("CODE_REVIEW.FAILED");
     }
 
@@ -51,6 +53,52 @@ public class CodeReviewEventTests
         // An escalation is an expected, auditable hand-off — success-status (the rejection
         // that may follow is recorded as CODE_REVIEW.FAILED).
         CodeReviewEvents.StatusForEvent(CodeReviewEvents.Escalated).Should().Be("success");
+        // Story 4-6 — an escalation RESOLVED by the senior is a normal (success) audit row.
+        CodeReviewEvents.StatusForEvent(CodeReviewEvents.EscalationResolved).Should().Be("success");
+    }
+
+    // ================================================================
+    // Story 4-6 — escalation RAISE / RESOLVE DCB event mapping
+    // ================================================================
+
+    [Test]
+    public void BuildTammaEvent_EscalationRaised_HasSuccessStatusTagsAndReasonData()
+    {
+        // The event EscalateReviewActivity pushes into tamma:events at the RAISE point
+        // (before the suspending senior-wait). Success-status: the raise is an auditable
+        // hand-off, not a failure.
+        var tenant = Guid.NewGuid();
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.Escalated,
+            sessionId: "sess-9", storyId: "story-9", juniorId: "junior-9", tenantId: tenant,
+            prNumber: 42, prUrl: null, iteration: 3,
+            mergeSha: null, reason: "MaxIterationsReached",
+            detail: "Maximum fix iterations reached during code review.");
+
+        evt.EventType.Should().Be("CODE_REVIEW.ESCALATED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-9");
+        evt.Tags["storyId"].Should().Be("story-9");
+        evt.Tags["juniorId"].Should().Be("junior-9");
+        evt.Tags["prId"].Should().Be("42");
+        evt.Tags["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Data["reason"].Should().Be("MaxIterationsReached");
+    }
+
+    [Test]
+    public void BuildTammaEvent_EscalationResolved_IsSuccess_DistinctFromEscalated()
+    {
+        // The RESOLVE companion emitted on the Resolved→merge edge.
+        var evt = EmitCodeReviewEventActivity.BuildTammaEvent(
+            CodeReviewEvents.EscalationResolved,
+            sessionId: "sess-9", storyId: "story-9", juniorId: "junior-9", tenantId: null,
+            prNumber: 42, prUrl: null, iteration: 3,
+            mergeSha: null, reason: null,
+            detail: "Escalation resolved by senior developer.");
+
+        evt.EventType.Should().Be("CODE_REVIEW.ESCALATION_RESOLVED");
+        evt.EventType.Should().NotBe(CodeReviewEvents.Escalated);
+        evt.Status.Should().Be("success");
     }
 
     [Test]


### PR DESCRIPTION
## What

Story 4-6 (Event Capture — Approvals & Escalations) — a coverage pass ensuring every approval/escalation point emits a proper DCB audit event. Audited all 5 wired flows; 3 were already complete (merge-approval, deploy-approval, blocker-escalation). Filled 2 gaps:

1. **Code-review escalation raise:** `EscalateReviewActivity` now emits `CODE_REVIEW.ESCALATED` at the RAISE point (before the suspending wait) for all entry points/outcomes — previously a rejected/SLA-expired escalation got no raise-time audit row. The resolve edge is retyped to a distinct `CODE_REVIEW.ESCALATION_RESOLVED` (no duplicate). Emitted outside the Slack try/catch so a failed notification can't suppress the audit row.
2. **Plan-approval gate:** `WaitForPlanApprovalActivity` now emits `PLAN_APPROVAL.REQUESTED` at suspend + `PLAN_APPROVAL.DECISION.{APPROVED,REJECTED,EDIT_REQUESTED}` on resume (rejection is a loud `error` row). New `PlanApprovalEvents` catalog.

All via the existing `TammaEventEmitter`; tags include `tenantId` (omitted → platform scope for single-user).

## Verification

- Build: 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes" (JSONB appends only, no schema). **No `Program.cs` touch.**
- Tests: Activities 216 + 219 + Workflows/Review 626 + Api 36 — all green (new `PlanApprovalEventTests` + extended `CodeReviewEventTests`).

Note: `WaitForPlanApprovalActivity` isn't yet wired into a workflow (unit-tested, correct-by-construction for when it is). `MentorshipWorkflow`'s `EscalateToSeniorActivity` use is outside the 4-6 scope (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)