### PR TITLE
feat(epic-34-9): pricing & plan management dashboard UI (admin catalog/margins + tenant pricing page)

### DIFF
--- a/packages/dashboard-user/src/App.tsx
+++ b/packages/dashboard-user/src/App.tsx
@@ -27,6 +27,8 @@ import { TenantAlertChannels } from './pages/alerts/TenantAlertChannels';
 import { PlatformPicker } from './pages/onboarding/PlatformPicker';
 import { PlatformInstallForm } from './pages/onboarding/PlatformInstallForm';
 import { ConnectedPlatforms } from './pages/settings/ConnectedPlatforms';
+// Story 34-9 — tenant Plan & Pricing page.
+import { PlanPricingPage } from './pages/settings/PlanPricingPage';
 
 import type { JSX } from "react";
 
@@ -47,6 +49,9 @@ export function App(): JSX.Element {
           >
             <Route path="/" element={<DashboardHome />} />
             <Route path="/alerts" element={<TenantAlertFeed />} />
+            {/* Story 34-9 — Plan & Pricing. Rendered for all members; the page
+                itself gates mutations (member = read-only) so members can VIEW. */}
+            <Route path="/settings/billing" element={<PlanPricingPage />} />
             <Route
               path="/settings/alerts"
               element={

--- a/packages/dashboard-user/src/api/pricing.test.ts
+++ b/packages/dashboard-user/src/api/pricing.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Story 34-9 — tenant pricing client contract tests. Asserts the URL/method/body
+ * matrix, the estimate query-string assembly, and — critically — that the client
+ * derives the tenant from the session (never a URL param) and exposes NO
+ * cost/margin field on the estimate response type.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { tenantPricingApi, metricKeyLabel, METRIC_KEYS } from './pricing';
+
+function jsonResponse<T>(body: T, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function lastUrl(spy: ReturnType<typeof vi.fn>): string {
+  return (spy.mock.calls[0]?.[0] as string) ?? '';
+}
+
+describe('tenantPricingApi — URL/method/body matrix', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('getEntitlements GETs /api/pricing/entitlements (no tenant id in path)', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(jsonResponse({ limits: [] }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await tenantPricingApi.getEntitlements();
+
+    const url = lastUrl(spy);
+    expect(url).toBe('/api/pricing/entitlements');
+    // No caller-supplied tenant id anywhere in the URL.
+    expect(url).not.toMatch(/tenant/i);
+  });
+
+  it('listPublicPlans GETs /api/pricing/plans', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(jsonResponse({ plans: [] }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await tenantPricingApi.listPublicPlans();
+    expect(lastUrl(spy)).toBe('/api/pricing/plans');
+  });
+
+  it('getPublicPlan encodes the slug', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(jsonResponse({ slug: 'pro' }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await tenantPricingApi.getPublicPlan('pro');
+    expect(lastUrl(spy)).toBe('/api/pricing/plans/pro');
+  });
+
+  it('estimate builds the query string with provider/model/tokens', async () => {
+    const spy = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          provider: 'anthropic',
+          model: 'claude-3-5-sonnet',
+          inputTokens: 100,
+          outputTokens: 200,
+          pricingMode: 'platform_provided',
+          sellPriceUsd: 0.01,
+          invoice: { sellPriceUsd: 0.01 },
+        }),
+      );
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await tenantPricingApi.estimate({
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 100,
+      outputTokens: 200,
+    });
+
+    const url = lastUrl(spy);
+    expect(url).toContain('/api/pricing/estimate?');
+    expect(url).toContain('provider=anthropic');
+    expect(url).toContain('model=claude-3-5-sonnet');
+    expect(url).toContain('inputTokens=100');
+    expect(url).toContain('outputTokens=200');
+  });
+
+  it('estimate response carries only the sell price — no cost/margin field', async () => {
+    const payload = {
+      provider: 'anthropic',
+      model: 'x',
+      inputTokens: 1,
+      outputTokens: 1,
+      pricingMode: 'byok',
+      sellPriceUsd: 0,
+      invoice: { sellPriceUsd: 0 },
+    };
+    const spy = vi.fn().mockResolvedValueOnce(jsonResponse(payload));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    const result = await tenantPricingApi.estimate({
+      provider: 'anthropic',
+      model: 'x',
+      inputTokens: 1,
+      outputTokens: 1,
+    });
+
+    expect(result).not.toHaveProperty('costBasisUsd');
+    expect(result).not.toHaveProperty('marginUsd');
+    expect(result.sellPriceUsd).toBe(0);
+  });
+
+  it('subscribe POSTs { planSlug } to /api/pricing/subscribe', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(jsonResponse({ tenantId: 't', status: 'ok' }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await tenantPricingApi.subscribe({ planSlug: 'pro' });
+
+    const [url, init] = spy.mock.calls[0] ?? [];
+    expect(url as string).toBe('/api/pricing/subscribe');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.planSlug).toBe('pro');
+  });
+});
+
+describe('metricKeyLabel', () => {
+  it('maps numeric ordinal → snake_case and passes strings through', () => {
+    expect(metricKeyLabel(0)).toBe('agents');
+    expect(metricKeyLabel(METRIC_KEYS.length - 1)).toBe('benchmark_retention_days');
+    expect(metricKeyLabel('seats')).toBe('seats');
+  });
+});

--- a/packages/dashboard-user/src/api/pricing.ts
+++ b/packages/dashboard-user/src/api/pricing.ts
@@ -1,0 +1,150 @@
+/**
+ * Story 34-9 — tenant-facing pricing API client (built on the shared ApiClient
+ * so the refresh-on-401 dance is inherited, exactly like `api/alerts.ts`).
+ *
+ * SECURITY (AC6/AC7 — mirrors the 34-5 estimate-leak rule): the tenant surface
+ * NEVER exposes platform-internal economics. `GET /api/pricing/estimate` returns
+ * ONLY the sell price the caller would be charged — there is no cost-basis or
+ * margin field in `EstimateResponse` (the server strips them). Do not add one.
+ *
+ * The tenant is ALWAYS resolved server-side from the authenticated session; this
+ * client never sends a caller-supplied tenant id, so a member can't spoof
+ * another tenant. Routes consumed (all shipped, gated MemberAccess reads /
+ * SettingsManage mutations):
+ *   GET  /api/pricing/entitlements        (34-6 resolved entitlements + headroom)
+ *   GET  /api/pricing/plans               (34-2 public catalog)
+ *   GET  /api/pricing/plans/{slug}        (34-2 single public plan)
+ *   GET  /api/pricing/estimate?…          (34-5 sell-price-only estimate)
+ *   POST /api/pricing/subscribe           (34-4 self-service plan change)
+ */
+
+import { apiClient } from './client';
+
+export type PricingMode = 'platform_provided' | 'byok';
+
+// Canonical EntitlementMetricKey labels (enum-declaration order). The tenant
+// entitlements endpoint returns snake_case strings; a PlanSnapshot READ returns
+// the numeric ordinal (no string-enum converter) — normalize both via label().
+export const METRIC_KEYS = [
+  'agents',
+  'workflow_runs',
+  'llm_tokens',
+  'seats',
+  'repos',
+  'rag_storage_mb',
+  'benchmark_retention_days',
+] as const;
+
+export function metricKeyLabel(metricKey: number | string): string {
+  if (typeof metricKey === 'string') return metricKey;
+  return METRIC_KEYS[metricKey] ?? `metric_${metricKey}`;
+}
+
+// ── Resolved entitlements (ResolvedEntitlementsDto / ResolvedEntitlementDto) ──
+
+export interface ResolvedEntitlementLine {
+  metricKey: string;
+  limitValue: number | null; // null ⇒ unlimited
+  period: string;
+  overageMode: string;
+  currentUsage: number | null; // null ⇒ usage unavailable
+  remaining: number | null; // null ⇒ unlimited
+  isOver: boolean;
+  overagePercent: number | null;
+}
+
+export interface ResolvedEntitlementsResponse {
+  tenantId: string;
+  planId: string;
+  planVersion: number;
+  isCustom: boolean;
+  limits: ResolvedEntitlementLine[];
+}
+
+// ── Public plan snapshot (PlanSnapshot.cs — entitlement metricKey is numeric) ──
+
+export interface PlanEntitlementView {
+  metricKey: number | string;
+  limitValue: number | null;
+  period: string;
+  overageMode: string;
+}
+
+export interface PlanPriceView {
+  pricingMode: string;
+  recurringUsd: number;
+  seatUsd: number;
+  meteredComponent: string;
+}
+
+export interface PlanSnapshotDto {
+  planId: string;
+  slug: string;
+  displayName: string;
+  version: number;
+  status: string;
+  isCustom: boolean;
+  billingInterval: string;
+  supersedesPlanId: string | null;
+  features: { featureKey: string; boolValue: boolean | null; stringValue: string | null }[];
+  entitlements: PlanEntitlementView[];
+  prices: PlanPriceView[];
+}
+
+// ── Estimate (PricingEndpoints.GetEstimate — SELL PRICE ONLY) ──
+
+export interface EstimateResponse {
+  provider: string;
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  pricingMode: string;
+  sellPriceUsd: number;
+  invoice: { sellPriceUsd: number };
+  // NOTE: intentionally NO costBasisUsd / marginUsd — the tenant never sees them.
+}
+
+export interface EstimateParams {
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+// ── Subscribe (AdminTenantsEndpoints plan-assignment response) ──
+
+export interface SubscribeResponse {
+  tenantId: string;
+  planId?: string;
+  planSlug?: string;
+  planName?: string;
+  version?: number;
+  status?: string;
+  message?: string;
+  /** Optional flagged-violation list surfaced as a non-blocking warning (34-4). */
+  violations?: string[];
+}
+
+export const tenantPricingApi = {
+  getEntitlements: (): Promise<ResolvedEntitlementsResponse> =>
+    apiClient.get<ResolvedEntitlementsResponse>('/api/pricing/entitlements'),
+
+  listPublicPlans: (): Promise<{ plans: PlanSnapshotDto[] }> =>
+    apiClient.get<{ plans: PlanSnapshotDto[] }>('/api/pricing/plans'),
+
+  getPublicPlan: (slug: string): Promise<PlanSnapshotDto> =>
+    apiClient.get<PlanSnapshotDto>(`/api/pricing/plans/${encodeURIComponent(slug)}`),
+
+  estimate: (params: EstimateParams): Promise<EstimateResponse> => {
+    const qs = new URLSearchParams({
+      provider: params.provider,
+      model: params.model,
+      inputTokens: String(params.inputTokens),
+      outputTokens: String(params.outputTokens),
+    });
+    return apiClient.get<EstimateResponse>(`/api/pricing/estimate?${qs.toString()}`);
+  },
+
+  subscribe: (body: { planSlug: string }): Promise<SubscribeResponse> =>
+    apiClient.post<SubscribeResponse>('/api/pricing/subscribe', body),
+};

--- a/packages/dashboard-user/src/components/pricing/CostEstimateWidget.test.tsx
+++ b/packages/dashboard-user/src/components/pricing/CostEstimateWidget.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { CostEstimateWidget } from './CostEstimateWidget';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: { estimate: vi.fn() },
+}));
+
+vi.mock('../../api/pricing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/pricing')>();
+  return { ...actual, tenantPricingApi: mockApi };
+});
+
+describe('CostEstimateWidget', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders the sell price + pricing mode and NEVER a cost/margin figure', async () => {
+    mockApi.estimate.mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 1000,
+      pricingMode: 'platform_provided',
+      sellPriceUsd: 0.0123,
+      invoice: { sellPriceUsd: 0.01 },
+    });
+
+    render(<CostEstimateWidget />);
+    fireEvent.click(screen.getByRole('button', { name: 'Estimate' }));
+
+    await waitFor(() => expect(screen.getByText('$0.012300')).toBeInTheDocument());
+    expect(screen.getByText('platform_provided')).toBeInTheDocument();
+    // Security: the tenant surface must never render platform cost/margin.
+    expect(screen.queryByText(/margin/i)).toBeNull();
+    expect(screen.queryByText(/cost basis/i)).toBeNull();
+    expect(screen.queryByText(/costBasis/i)).toBeNull();
+  });
+
+  it('shows zero markup for BYOK mode', async () => {
+    mockApi.estimate.mockResolvedValueOnce({
+      provider: 'anthropic',
+      model: 'x',
+      inputTokens: 1,
+      outputTokens: 1,
+      pricingMode: 'byok',
+      sellPriceUsd: 0,
+      invoice: { sellPriceUsd: 0 },
+    });
+
+    render(<CostEstimateWidget />);
+    fireEvent.click(screen.getByRole('button', { name: 'Estimate' }));
+
+    await waitFor(() => expect(screen.getByText('byok')).toBeInTheDocument());
+    expect(screen.getByText('$0.000000')).toBeInTheDocument();
+  });
+
+  it('surfaces an unknown-model server error inline (never a silent $0)', async () => {
+    const { ApiError } = await import('../../api/client');
+    mockApi.estimate.mockRejectedValueOnce(
+      new ApiError(400, 'API error', {
+        error: 'PRICING.UNKNOWN_MODEL',
+        message: 'No price sheet for provider/model.',
+      }),
+    );
+
+    render(<CostEstimateWidget />);
+    fireEvent.click(screen.getByRole('button', { name: 'Estimate' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/No price sheet for provider\/model/i)).toBeInTheDocument(),
+    );
+    // No result row rendered on error (the "Pricing mode" label only appears on success).
+    expect(screen.queryByText('Pricing mode')).toBeNull();
+  });
+});

--- a/packages/dashboard-user/src/components/pricing/CostEstimateWidget.tsx
+++ b/packages/dashboard-user/src/components/pricing/CostEstimateWidget.tsx
@@ -1,0 +1,132 @@
+/**
+ * Story 34-9 (AC9) — the tenant cost-estimate widget.
+ *
+ * Form (provider, model, input/output tokens) → `GET /api/pricing/estimate`
+ * (34-5) which returns ONLY the sell price + pricing mode. There is NO cost /
+ * margin in the response or in this UI — the platform economics are never shown
+ * to a tenant (AC6/AC7). An unknown provider/model surfaces the server's
+ * `PRICING.UNKNOWN_MODEL` error inline (never a silent $0).
+ */
+
+import { useState, type JSX } from 'react';
+import { tenantPricingApi, type EstimateResponse } from '../../api/pricing';
+import { ApiError } from '../../api/client';
+
+export function CostEstimateWidget(): JSX.Element {
+  const [provider, setProvider] = useState('anthropic');
+  const [model, setModel] = useState('claude-3-5-sonnet');
+  const [inputTokens, setInputTokens] = useState('1000');
+  const [outputTokens, setOutputTokens] = useState('1000');
+  const [result, setResult] = useState<EstimateResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const run = async (): Promise<void> => {
+    setError(null);
+    setResult(null);
+    setLoading(true);
+    try {
+      const estimate = await tenantPricingApi.estimate({
+        provider: provider.trim(),
+        model: model.trim(),
+        inputTokens: Number(inputTokens) || 0,
+        outputTokens: Number(outputTokens) || 0,
+      });
+      setResult(estimate);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { error?: string; message?: string } | null;
+        setError(body?.message ?? body?.error ?? `Estimate failed (${err.status}).`);
+      } else {
+        setError(err instanceof Error ? err.message : 'Estimate failed.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-md p-4 space-y-3">
+      <h3 className="text-sm font-semibold text-gray-900">Cost estimate</h3>
+      <p className="text-xs text-gray-500">
+        Estimate the price of a usage line under your current plan. Shows the sell price you would
+        be charged.
+      </p>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 items-end">
+        <label className="flex flex-col text-xs text-gray-600">
+          Provider
+          <input
+            aria-label="Provider"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-gray-600">
+          Model
+          <input
+            aria-label="Model"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-gray-600">
+          Input tokens
+          <input
+            aria-label="Input tokens"
+            value={inputTokens}
+            inputMode="numeric"
+            onChange={(e) => setInputTokens(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-gray-600">
+          Output tokens
+          <input
+            aria-label="Output tokens"
+            value={outputTokens}
+            inputMode="numeric"
+            onChange={(e) => setOutputTokens(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm"
+          />
+        </label>
+      </div>
+
+      <button
+        type="button"
+        disabled={loading}
+        onClick={() => void run()}
+        className="px-3 py-1.5 text-sm bg-gray-900 text-white rounded hover:bg-gray-800 disabled:opacity-50"
+      >
+        {loading ? 'Estimating…' : 'Estimate'}
+      </button>
+
+      {error !== null && (
+        <div role="alert" className="p-2 text-sm text-red-700 bg-red-50 rounded">
+          {error}
+        </div>
+      )}
+
+      {result !== null && (
+        <div className="border-t border-gray-100 pt-3 text-sm space-y-1">
+          <div className="flex justify-between">
+            <span className="text-gray-500">Pricing mode</span>
+            <span className="font-medium text-gray-900">{result.pricingMode}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">Sell price</span>
+            <span className="font-semibold text-gray-900">${result.sellPriceUsd.toFixed(6)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">Invoice amount</span>
+            <span className="font-medium text-gray-900">
+              ${result.invoice.sellPriceUsd.toFixed(2)}
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-user/src/components/pricing/EntitlementBar.test.tsx
+++ b/packages/dashboard-user/src/components/pricing/EntitlementBar.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { EntitlementBar } from './EntitlementBar';
+import type { ResolvedEntitlementLine } from '../../api/pricing';
+
+function line(overrides: Partial<ResolvedEntitlementLine>): ResolvedEntitlementLine {
+  return {
+    metricKey: 'seats',
+    limitValue: 10,
+    period: 'monthly',
+    overageMode: 'block',
+    currentUsage: 3,
+    remaining: 7,
+    isOver: false,
+    overagePercent: 30,
+    ...overrides,
+  };
+}
+
+describe('EntitlementBar', () => {
+  it('renders usage vs limit with a bar for a limited metric', () => {
+    render(<EntitlementBar line={line({})} />);
+    expect(screen.getByText('Seats')).toBeInTheDocument();
+    expect(screen.getByText('3 / 10')).toBeInTheDocument();
+    // Bar element present.
+    expect(screen.getByTestId('entitlement-seats').querySelector('.bg-blue-500')).toBeTruthy();
+  });
+
+  it('renders "Unlimited" and NO bar for a null limit', () => {
+    render(<EntitlementBar line={line({ metricKey: 'llm_tokens', limitValue: null, remaining: null })} />);
+    expect(screen.getByText('Unlimited')).toBeInTheDocument();
+    // No progress bar rendered for unlimited.
+    const container = screen.getByTestId('entitlement-llm_tokens');
+    expect(container.querySelector('.bg-blue-500')).toBeNull();
+    expect(container.querySelector('.bg-red-500')).toBeNull();
+  });
+
+  it('renders over-limit styling when isOver', () => {
+    render(<EntitlementBar line={line({ currentUsage: 12, remaining: -2, isOver: true })} />);
+    expect(screen.getByText(/over limit/i)).toBeInTheDocument();
+    expect(screen.getByTestId('entitlement-seats').querySelector('.bg-red-500')).toBeTruthy();
+  });
+});

--- a/packages/dashboard-user/src/components/pricing/EntitlementBar.tsx
+++ b/packages/dashboard-user/src/components/pricing/EntitlementBar.tsx
@@ -1,0 +1,54 @@
+/**
+ * Story 34-9 (AC6) — one entitlement metric: its limit, current usage, and a
+ * headroom bar. Consumes the `CheckHeadroom`-derived `currentUsage` / `remaining`
+ * / `isOver` fields from `GET /api/pricing/entitlements` verbatim — it does NOT
+ * recompute any quota math (34-6 owns headroom; AC13). An unlimited entitlement
+ * (`limitValue == null`) renders as "Unlimited" with no bar.
+ */
+
+import type { JSX } from 'react';
+import { metricKeyLabel, type ResolvedEntitlementLine } from '../../api/pricing';
+
+function prettyMetric(key: string): string {
+  return metricKeyLabel(key)
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export function EntitlementBar({ line }: { line: ResolvedEntitlementLine }): JSX.Element {
+  const label = prettyMetric(line.metricKey);
+  const unlimited = line.limitValue === null;
+  const usage = line.currentUsage ?? 0;
+
+  // Bar percentage is display-only (clamped) — the authoritative over/remaining
+  // values come from the server's headroom calc.
+  const pct =
+    unlimited || line.limitValue === 0
+      ? 0
+      : Math.min(100, Math.round((usage / (line.limitValue as number)) * 100));
+
+  return (
+    <div className="space-y-1" data-testid={`entitlement-${line.metricKey}`}>
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium text-gray-800">{label}</span>
+        {unlimited ? (
+          <span className="text-xs font-medium text-emerald-700">Unlimited</span>
+        ) : (
+          <span className={`text-xs ${line.isOver ? 'text-red-700 font-semibold' : 'text-gray-500'}`}>
+            {line.currentUsage ?? '—'} / {line.limitValue}
+            {line.isOver ? ' (over limit)' : ''}
+          </span>
+        )}
+      </div>
+      {!unlimited && (
+        <div className="h-2 w-full rounded bg-gray-100 overflow-hidden" aria-hidden="true">
+          <div
+            className={`h-full rounded ${line.isOver ? 'bg-red-500' : 'bg-blue-500'}`}
+            style={{ width: `${line.isOver ? 100 : pct}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-user/src/components/pricing/UpgradePlanModal.test.tsx
+++ b/packages/dashboard-user/src/components/pricing/UpgradePlanModal.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { UpgradePlanModal, computeDelta } from './UpgradePlanModal';
+import type { PlanSnapshotDto, ResolvedEntitlementLine } from '../../api/pricing';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: { subscribe: vi.fn() },
+}));
+
+vi.mock('../../api/pricing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/pricing')>();
+  return { ...actual, tenantPricingApi: mockApi };
+});
+
+function ent(overrides: Partial<ResolvedEntitlementLine>): ResolvedEntitlementLine {
+  return {
+    metricKey: 'seats',
+    limitValue: 5,
+    period: 'monthly',
+    overageMode: 'block',
+    currentUsage: 4,
+    remaining: 1,
+    isOver: false,
+    overagePercent: 80,
+    ...overrides,
+  };
+}
+
+// metricKey uses the NUMERIC ordinal on a PlanSnapshot (no string-enum converter):
+// seats = 3, llm_tokens = 2.
+function plan(entitlements: PlanSnapshotDto['entitlements']): PlanSnapshotDto {
+  return {
+    planId: 'p2',
+    slug: 'pro',
+    displayName: 'Pro',
+    version: 1,
+    status: 'active',
+    isCustom: false,
+    billingInterval: 'monthly',
+    supersedesPlanId: null,
+    features: [],
+    entitlements,
+    prices: [],
+  };
+}
+
+describe('computeDelta', () => {
+  it('reports gains and losses vs the current resolved set', () => {
+    const current = [ent({ metricKey: 'seats', limitValue: 5 }), ent({ metricKey: 'llm_tokens', limitValue: null, currentUsage: 0 })];
+    const target = plan([
+      { metricKey: 3, limitValue: 10, period: 'monthly', overageMode: 'block' }, // seats 5→10 gain
+      { metricKey: 2, limitValue: 1000000, period: 'monthly', overageMode: 'meter' }, // llm ∞→1M loss
+    ]);
+
+    const delta = computeDelta(current, target);
+    const seats = delta.find((d) => d.metric === 'Seats');
+    const llm = delta.find((d) => d.metric === 'Llm Tokens');
+    expect(seats?.kind).toBe('gain');
+    expect(llm?.kind).toBe('loss');
+    expect(seats?.violation).toBe(false);
+  });
+
+  it('flags a downgrade that puts current usage over the new limit', () => {
+    const current = [ent({ metricKey: 'seats', limitValue: 5, currentUsage: 4 })];
+    const target = plan([{ metricKey: 3, limitValue: 2, period: 'monthly', overageMode: 'block' }]);
+
+    const delta = computeDelta(current, target);
+    const seats = delta.find((d) => d.metric === 'Seats');
+    expect(seats?.kind).toBe('loss');
+    expect(seats?.violation).toBe(true);
+  });
+});
+
+describe('UpgradePlanModal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const current = [ent({ metricKey: 'seats', limitValue: 5, currentUsage: 4 })];
+  const plans = [plan([{ metricKey: 3, limitValue: 10, period: 'monthly', overageMode: 'block' }])];
+
+  it('shows the delta and subscribes on confirm', async () => {
+    mockApi.subscribe.mockResolvedValueOnce({ tenantId: 't', status: 'active' });
+    const onSubscribed = vi.fn();
+
+    render(
+      <UpgradePlanModal
+        plans={plans}
+        currentEntitlements={current}
+        currentPlanId="p1"
+        canMutate
+        onClose={vi.fn()}
+        onSubscribed={onSubscribed}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Choose a plan'), { target: { value: 'pro' } });
+    expect(screen.getByText('Entitlement changes')).toBeInTheDocument();
+    expect(screen.getByText('Seats')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm change' }));
+    await waitFor(() => expect(mockApi.subscribe).toHaveBeenCalledWith({ planSlug: 'pro' }));
+    await waitFor(() => expect(onSubscribed).toHaveBeenCalled());
+  });
+
+  it('surfaces the flagged-violation list from the response as a non-blocking warning', async () => {
+    mockApi.subscribe.mockResolvedValueOnce({
+      tenantId: 't',
+      status: 'active',
+      violations: ['seats over limit'],
+    });
+
+    render(
+      <UpgradePlanModal
+        plans={plans}
+        currentEntitlements={current}
+        currentPlanId="p1"
+        canMutate
+        onClose={vi.fn()}
+        onSubscribed={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Choose a plan'), { target: { value: 'pro' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm change' }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Subscribed with warnings: seats over limit/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('hides the confirm control for a read-only member', () => {
+    render(
+      <UpgradePlanModal
+        plans={plans}
+        currentEntitlements={current}
+        currentPlanId="p1"
+        canMutate={false}
+        onClose={vi.fn()}
+        onSubscribed={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Choose a plan'), { target: { value: 'pro' } });
+    expect(screen.queryByRole('button', { name: 'Confirm change' })).toBeNull();
+  });
+});

--- a/packages/dashboard-user/src/components/pricing/UpgradePlanModal.test.tsx
+++ b/packages/dashboard-user/src/components/pricing/UpgradePlanModal.test.tsx
@@ -69,6 +69,58 @@ describe('computeDelta', () => {
     expect(seats?.kind).toBe('loss');
     expect(seats?.violation).toBe(true);
   });
+
+  // Fix 2: an ABSENT metric means "not granted", NOT "unlimited". Metric ordinal
+  // 5 = rag_storage_mb (present on target only) is an ADDED entitlement → a GAIN
+  // labelled with its new finite limit, never "Unlimited".
+  it('labels a metric the target ADDS as a gain with the new limit, not "Unlimited"', () => {
+    const current = [ent({ metricKey: 'seats', limitValue: 5 })];
+    const target = plan([
+      { metricKey: 3, limitValue: 5, period: 'monthly', overageMode: 'block' }, // seats unchanged
+      { metricKey: 5, limitValue: 500, period: 'monthly', overageMode: 'meter' }, // rag_storage_mb ADDED
+    ]);
+
+    const delta = computeDelta(current, target);
+    const rag = delta.find((d) => d.metric === 'Rag Storage Mb');
+    expect(rag?.kind).toBe('gain');
+    expect(rag?.change).toBe('added');
+    expect(rag?.detail).toMatch(/500/);
+    expect(rag?.detail).not.toMatch(/Unlimited/i);
+    expect(rag?.violation).toBe(false);
+    // seats unchanged (5→5) is filtered out.
+    expect(delta.find((d) => d.metric === 'Seats')).toBeUndefined();
+  });
+
+  // A downgrade that DROPS a metric the tenant holds today is a LOSS of that
+  // capability — it must NOT read as "500 → Unlimited" (the old Infinity bug).
+  it('labels a metric the target DROPS as a loss ("Removed"), not "→ Unlimited"', () => {
+    const current = [
+      ent({ metricKey: 'seats', limitValue: 5 }),
+      ent({ metricKey: 'rag_storage_mb', limitValue: 500, currentUsage: 100 }),
+    ];
+    // Target has only seats (unchanged); rag_storage_mb is absent → dropped.
+    const target = plan([{ metricKey: 3, limitValue: 5, period: 'monthly', overageMode: 'block' }]);
+
+    const delta = computeDelta(current, target);
+    const rag = delta.find((d) => d.metric === 'Rag Storage Mb');
+    expect(rag?.kind).toBe('loss');
+    expect(rag?.change).toBe('removed');
+    expect(rag?.detail).not.toMatch(/Unlimited/i);
+    expect(rag?.violation).toBe(false);
+  });
+
+  // Present-on-both with the target dropping to unlimited stays correct: a
+  // present metric whose target limit is null IS genuinely unlimited (a gain).
+  it('treats a present metric with null target limit as unlimited (gain)', () => {
+    const current = [ent({ metricKey: 'seats', limitValue: 5, currentUsage: 3 })];
+    const target = plan([{ metricKey: 3, limitValue: null, period: 'total', overageMode: 'allow' }]);
+
+    const delta = computeDelta(current, target);
+    const seats = delta.find((d) => d.metric === 'Seats');
+    expect(seats?.kind).toBe('gain');
+    expect(seats?.change).toBe('compare');
+    expect(seats?.detail).toMatch(/Unlimited/i);
+  });
 });
 
 describe('UpgradePlanModal', () => {

--- a/packages/dashboard-user/src/components/pricing/UpgradePlanModal.tsx
+++ b/packages/dashboard-user/src/components/pricing/UpgradePlanModal.tsx
@@ -24,6 +24,11 @@ import { ApiError } from '../../api/client';
 interface DeltaLine {
   metric: string;
   kind: 'gain' | 'loss' | 'same';
+  // How the metric changed set-membership between the two plans:
+  //  - 'compare' → present on BOTH plans; the limits are compared
+  //  - 'added'   → present on the TARGET only → a newly granted entitlement
+  //  - 'removed' → present on CURRENT only → an entitlement the target drops
+  change: 'compare' | 'added' | 'removed';
   detail: string;
   violation: boolean;
 }
@@ -39,7 +44,19 @@ function limitText(limit: number | null): string {
   return limit === null ? 'Unlimited' : String(limit);
 }
 
-/** Pure set-diff of target-plan entitlements vs the current resolved set + usage. */
+/**
+ * Pure set-diff of target-plan entitlements vs the current resolved set + usage.
+ *
+ * `GET /api/pricing/entitlements` and a `PlanSnapshot` each return ONLY the
+ * metrics that plan GRANTS — plans define different subsets (e.g. starter omits
+ * rag_storage_mb / benchmark_retention_days). So there are THREE cases, and a
+ * metric absent from a plan means "not granted", NOT "unlimited":
+ *   (a) present on BOTH   → compare limits (server semantic: limitValue null ⇒
+ *                           unlimited, correct only for a PRESENT metric);
+ *   (b) present on TARGET only → an ADDED entitlement (a new capability → gain);
+ *   (c) present on CURRENT only → a REMOVED entitlement (capability dropped → loss).
+ * An absent metric is NEVER folded into Infinity/"Unlimited".
+ */
 export function computeDelta(
   current: ResolvedEntitlementLine[],
   target: PlanSnapshotDto,
@@ -55,12 +72,41 @@ export function computeDelta(
 
   for (const metric of metrics) {
     const cur = currentByMetric.get(metric);
-    const curLimit = cur ? cur.limitValue : null;
+    const hasCurrent = cur !== undefined;
     const hasTarget = targetByMetric.has(metric);
-    const tgtLimit = hasTarget ? (targetByMetric.get(metric) ?? null) : null;
     const usage = cur?.currentUsage ?? 0;
 
-    // Unlimited === Infinity for comparison.
+    // (b) ADDED — granted by the target but not held today. A new capability
+    // (gain). It can still be an immediate over-limit if we already meter usage
+    // for it, so keep the violation check honest.
+    if (hasTarget && !hasCurrent) {
+      const tgtLimit = targetByMetric.get(metric) ?? null;
+      lines.push({
+        metric: prettyMetric(metric),
+        kind: 'gain',
+        change: 'added',
+        detail: `New — ${limitText(tgtLimit)}`,
+        violation: tgtLimit !== null && usage > tgtLimit,
+      });
+      continue;
+    }
+
+    // (c) REMOVED — held today but dropped by the target. A lost capability
+    // (loss). There is no new limit to breach, so it is never a violation.
+    if (hasCurrent && !hasTarget) {
+      lines.push({
+        metric: prettyMetric(metric),
+        kind: 'loss',
+        change: 'removed',
+        detail: 'Removed',
+        violation: false,
+      });
+      continue;
+    }
+
+    // (a) PRESENT on both → compare limits. null ⇒ unlimited (Infinity).
+    const curLimit = cur ? cur.limitValue : null;
+    const tgtLimit = targetByMetric.get(metric) ?? null;
     const curVal = curLimit === null ? Infinity : curLimit;
     const tgtVal = tgtLimit === null ? Infinity : tgtLimit;
 
@@ -76,6 +122,7 @@ export function computeDelta(
     lines.push({
       metric: prettyMetric(metric),
       kind,
+      change: 'compare',
       detail: `${limitText(curLimit)} → ${limitText(tgtLimit)}`,
       violation,
     });
@@ -199,7 +246,15 @@ export function UpgradePlanModal({
                   >
                     <span className="font-medium">{d.metric}</span>
                     <span>
-                      {d.kind === 'gain' ? '▲ ' : d.kind === 'loss' ? '▼ ' : ''}
+                      {d.change === 'added'
+                        ? '＋ '
+                        : d.change === 'removed'
+                          ? '－ '
+                          : d.kind === 'gain'
+                            ? '▲ '
+                            : d.kind === 'loss'
+                              ? '▼ '
+                              : ''}
                       {d.detail}
                       {d.violation ? ' — over new limit' : ''}
                     </span>

--- a/packages/dashboard-user/src/components/pricing/UpgradePlanModal.tsx
+++ b/packages/dashboard-user/src/components/pricing/UpgradePlanModal.tsx
@@ -1,0 +1,252 @@
+/**
+ * Story 34-9 (AC8) — the tenant upgrade/change-plan modal.
+ *
+ * The tenant picks a PUBLIC plan; before committing, the UI computes and shows
+ * the entitlement GAINS and LOSSES by diffing the target plan's entitlements
+ * against the current RESOLVED entitlement set + the `CheckHeadroom` usage
+ * (34-6). A downgrade that would put the tenant over a new limit is flagged as a
+ * non-blocking violation. Commit calls `POST /api/pricing/subscribe` (34-4); the
+ * response's flagged-violation list is surfaced as a non-blocking warning.
+ *
+ * This is a PURE set-diff over server-resolved numbers — no pricing/headroom math
+ * is duplicated here (AC13).
+ */
+
+import { useMemo, useState, type JSX } from 'react';
+import {
+  tenantPricingApi,
+  metricKeyLabel,
+  type PlanSnapshotDto,
+  type ResolvedEntitlementLine,
+} from '../../api/pricing';
+import { ApiError } from '../../api/client';
+
+interface DeltaLine {
+  metric: string;
+  kind: 'gain' | 'loss' | 'same';
+  detail: string;
+  violation: boolean;
+}
+
+function prettyMetric(key: string): string {
+  return key
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function limitText(limit: number | null): string {
+  return limit === null ? 'Unlimited' : String(limit);
+}
+
+/** Pure set-diff of target-plan entitlements vs the current resolved set + usage. */
+export function computeDelta(
+  current: ResolvedEntitlementLine[],
+  target: PlanSnapshotDto,
+): DeltaLine[] {
+  const currentByMetric = new Map<string, ResolvedEntitlementLine>();
+  for (const line of current) currentByMetric.set(metricKeyLabel(line.metricKey), line);
+
+  const targetByMetric = new Map<string, number | null>();
+  for (const e of target.entitlements) targetByMetric.set(metricKeyLabel(e.metricKey), e.limitValue);
+
+  const metrics = new Set<string>([...currentByMetric.keys(), ...targetByMetric.keys()]);
+  const lines: DeltaLine[] = [];
+
+  for (const metric of metrics) {
+    const cur = currentByMetric.get(metric);
+    const curLimit = cur ? cur.limitValue : null;
+    const hasTarget = targetByMetric.has(metric);
+    const tgtLimit = hasTarget ? (targetByMetric.get(metric) ?? null) : null;
+    const usage = cur?.currentUsage ?? 0;
+
+    // Unlimited === Infinity for comparison.
+    const curVal = curLimit === null ? Infinity : curLimit;
+    const tgtVal = tgtLimit === null ? Infinity : tgtLimit;
+
+    let kind: DeltaLine['kind'] = 'same';
+    if (tgtVal > curVal) kind = 'gain';
+    else if (tgtVal < curVal) kind = 'loss';
+
+    // A downgrade that would put current usage over the NEW limit is a violation.
+    const violation = tgtLimit !== null && usage > tgtLimit;
+
+    if (kind === 'same' && !violation) continue;
+
+    lines.push({
+      metric: prettyMetric(metric),
+      kind,
+      detail: `${limitText(curLimit)} → ${limitText(tgtLimit)}`,
+      violation,
+    });
+  }
+
+  return lines.sort((a, b) => a.metric.localeCompare(b.metric));
+}
+
+export function UpgradePlanModal({
+  plans,
+  currentEntitlements,
+  currentPlanId,
+  canMutate,
+  onClose,
+  onSubscribed,
+}: {
+  plans: PlanSnapshotDto[];
+  currentEntitlements: ResolvedEntitlementLine[];
+  currentPlanId: string | null;
+  canMutate: boolean;
+  onClose: () => void;
+  onSubscribed: () => void;
+}): JSX.Element {
+  const [selectedSlug, setSelectedSlug] = useState<string>('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+
+  const selectedPlan = useMemo(
+    () => plans.find((p) => p.slug === selectedSlug) ?? null,
+    [plans, selectedSlug],
+  );
+
+  const delta = useMemo(
+    () => (selectedPlan ? computeDelta(currentEntitlements, selectedPlan) : []),
+    [selectedPlan, currentEntitlements],
+  );
+
+  const commit = async (): Promise<void> => {
+    if (!selectedPlan) return;
+    setSubmitting(true);
+    setError(null);
+    setWarning(null);
+    try {
+      const resp = await tenantPricingApi.subscribe({ planSlug: selectedPlan.slug });
+      if (resp.violations && resp.violations.length > 0) {
+        setWarning(`Subscribed with warnings: ${resp.violations.join('; ')}`);
+      }
+      onSubscribed();
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const body = err.body as { error?: string; message?: string } | null;
+        setError(body?.message ?? body?.error ?? `Subscribe failed (${err.status}).`);
+      } else {
+        setError(err instanceof Error ? err.message : 'Subscribe failed.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-labelledby="upgrade-modal-title"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="bg-white rounded-lg shadow-lg p-5 w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-3">
+          <h2 id="upgrade-modal-title" className="text-lg font-medium">
+            Change plan
+          </h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            ×
+          </button>
+        </div>
+
+        <label className="block text-xs text-gray-600 mb-1" htmlFor="plan-select">
+          Choose a plan
+        </label>
+        <select
+          id="plan-select"
+          aria-label="Choose a plan"
+          value={selectedSlug}
+          onChange={(e) => setSelectedSlug(e.target.value)}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-sm mb-4"
+        >
+          <option value="">Select a plan…</option>
+          {plans.map((p) => (
+            <option key={p.planId} value={p.slug} disabled={p.planId === currentPlanId}>
+              {p.displayName} (v{p.version}){p.planId === currentPlanId ? ' — current' : ''}
+            </option>
+          ))}
+        </select>
+
+        {selectedPlan && (
+          <div className="space-y-2 mb-4">
+            <h3 className="text-sm font-semibold text-gray-800">Entitlement changes</h3>
+            {delta.length === 0 ? (
+              <p className="text-sm text-gray-500">No entitlement changes for this plan.</p>
+            ) : (
+              <ul className="space-y-1">
+                {delta.map((d) => (
+                  <li
+                    key={d.metric}
+                    className={`flex items-center justify-between text-sm px-2 py-1 rounded ${
+                      d.violation
+                        ? 'bg-red-50 text-red-700'
+                        : d.kind === 'gain'
+                          ? 'bg-emerald-50 text-emerald-700'
+                          : d.kind === 'loss'
+                            ? 'bg-amber-50 text-amber-700'
+                            : 'bg-gray-50 text-gray-600'
+                    }`}
+                  >
+                    <span className="font-medium">{d.metric}</span>
+                    <span>
+                      {d.kind === 'gain' ? '▲ ' : d.kind === 'loss' ? '▼ ' : ''}
+                      {d.detail}
+                      {d.violation ? ' — over new limit' : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {delta.some((d) => d.violation) && (
+              <p role="alert" className="text-xs text-red-700">
+                This change would put current usage over a new limit. You can still proceed; the
+                server applies its overage policy.
+              </p>
+            )}
+          </div>
+        )}
+
+        {error !== null && (
+          <div role="alert" className="p-2 text-sm text-red-700 bg-red-50 rounded mb-3">
+            {error}
+          </div>
+        )}
+        {warning !== null && (
+          <div role="status" className="p-2 text-sm text-amber-800 bg-amber-50 rounded mb-3">
+            {warning}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm border border-gray-300 rounded"
+          >
+            Cancel
+          </button>
+          {canMutate && (
+            <button
+              type="button"
+              disabled={!selectedPlan || submitting || selectedPlan.planId === currentPlanId}
+              onClick={() => void commit()}
+              className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            >
+              {submitting ? 'Subscribing…' : 'Confirm change'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard-user/src/layouts/AppLayout.tsx
+++ b/packages/dashboard-user/src/layouts/AppLayout.tsx
@@ -27,6 +27,9 @@ export function AppLayout(): JSX.Element {
           <Link to="/runs" className="px-2 py-1.5 rounded hover:bg-gray-100">
             Runs
           </Link>
+          <Link to="/settings/billing" className="px-2 py-1.5 rounded hover:bg-gray-100">
+            Billing
+          </Link>
           <Link to="/settings" className="px-2 py-1.5 rounded hover:bg-gray-100">
             Settings
           </Link>

--- a/packages/dashboard-user/src/pages/settings/PlanPricingPage.test.tsx
+++ b/packages/dashboard-user/src/pages/settings/PlanPricingPage.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PlanPricingPage } from './PlanPricingPage';
+import { ApiError } from '../../api/client';
+
+const { mockAuth, mockApi } = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockApi: {
+    getEntitlements: vi.fn(),
+    listPublicPlans: vi.fn(),
+    estimate: vi.fn(),
+    subscribe: vi.fn(),
+    getPublicPlan: vi.fn(),
+  },
+}));
+
+vi.mock('../../hooks/useAuth', () => ({ useAuth: () => mockAuth() }));
+
+vi.mock('../../api/pricing', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../api/pricing')>();
+  return { ...actual, tenantPricingApi: mockApi };
+});
+
+const ENTITLEMENTS = {
+  tenantId: 't1',
+  planId: 'p1',
+  planVersion: 2,
+  isCustom: false,
+  limits: [
+    {
+      metricKey: 'seats',
+      limitValue: 10,
+      period: 'monthly',
+      overageMode: 'block',
+      currentUsage: 3,
+      remaining: 7,
+      isOver: false,
+      overagePercent: 30,
+    },
+    {
+      metricKey: 'llm_tokens',
+      limitValue: null,
+      period: 'monthly',
+      overageMode: 'meter',
+      currentUsage: 5000,
+      remaining: null,
+      isOver: false,
+      overagePercent: null,
+    },
+  ],
+};
+
+const PLANS = {
+  plans: [
+    {
+      planId: 'p1',
+      slug: 'pro',
+      displayName: 'Pro',
+      version: 2,
+      status: 'active',
+      isCustom: false,
+      billingInterval: 'monthly',
+      supersedesPlanId: null,
+      features: [],
+      entitlements: [],
+      prices: [],
+    },
+  ],
+};
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PlanPricingPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('PlanPricingPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.mockReturnValue({ user: { id: 'u1', email: 'a@b', role: 'owner', tenantId: 't1' } });
+    mockApi.getEntitlements.mockResolvedValue(ENTITLEMENTS);
+    mockApi.listPublicPlans.mockResolvedValue(PLANS);
+  });
+
+  it('renders the current plan, entitlement bars, and the change-plan control for an owner', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.getByText('Seats')).toBeInTheDocument();
+    expect(screen.getByText('3 / 10')).toBeInTheDocument();
+    // Unlimited entitlement renders as "Unlimited" with no bar.
+    expect(screen.getByText('Unlimited')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Change plan' })).toBeInTheDocument();
+  });
+
+  it('NEVER renders platform cost or margin (tenant sell-price-only surface)', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.queryByText(/margin/i)).toBeNull();
+    expect(screen.queryByText(/cost basis/i)).toBeNull();
+    expect(screen.queryByText(/costBasis/i)).toBeNull();
+  });
+
+  it('renders member as read-only (no change-plan control)', async () => {
+    mockAuth.mockReturnValue({ user: { id: 'u2', email: 'm@b', role: 'member', tenantId: 't1' } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Change plan' })).toBeNull();
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the tenant has no active plan (404)', async () => {
+    mockApi.getEntitlements.mockRejectedValue(new ApiError(404, 'API error', { error: 'no_active_assignment' }));
+    renderPage();
+    await waitFor(() => expect(screen.getByText('No active plan')).toBeInTheDocument());
+  });
+
+  it('surfaces a non-404 error without white-screening', async () => {
+    mockApi.getEntitlements.mockRejectedValue(new ApiError(500, 'boom', {}));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/Failed to load plan & pricing|boom/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/dashboard-user/src/pages/settings/PlanPricingPage.test.tsx
+++ b/packages/dashboard-user/src/pages/settings/PlanPricingPage.test.tsx
@@ -111,6 +111,26 @@ describe('PlanPricingPage', () => {
     expect(screen.getByText(/read-only/i)).toBeInTheDocument();
   });
 
+  // Fix 1: the subscribe route is owner-only (SettingsManage). A tenant_admin
+  // would 403, so the client must NOT offer the change-plan control to admins.
+  it('renders tenant_admin as read-only (no change-plan control) to match owner-only server', async () => {
+    mockAuth.mockReturnValue({ user: { id: 'u3', email: 'ad@b', role: 'admin', tenantId: 't1' } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Change plan' })).toBeNull();
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+  });
+
+  // Sole user (single-user mode) — no membership role → role resolves to ''.
+  // Owner-equivalent; the change-plan control is enabled.
+  it('renders the change-plan control for the single-user sole user (empty role)', async () => {
+    mockAuth.mockReturnValue({ user: { id: 'u4', email: 'solo@b', role: '', tenantId: null } });
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Change plan' })).toBeInTheDocument();
+    expect(screen.queryByText(/read-only/i)).toBeNull();
+  });
+
   it('renders an empty state when the tenant has no active plan (404)', async () => {
     mockApi.getEntitlements.mockRejectedValue(new ApiError(404, 'API error', { error: 'no_active_assignment' }));
     renderPage();

--- a/packages/dashboard-user/src/pages/settings/PlanPricingPage.tsx
+++ b/packages/dashboard-user/src/pages/settings/PlanPricingPage.tsx
@@ -1,0 +1,189 @@
+/**
+ * Story 34-9 (AC6/AC8/AC9/AC11) — the tenant Plan & Pricing page (/settings/billing).
+ *
+ * Renders the current plan + version, the resolved entitlement set with
+ * usage-vs-limit bars (from `GET /api/pricing/entitlements` + `CheckHeadroom`),
+ * a sell-price-only cost estimate widget, and an upgrade/change-plan flow with
+ * an entitlement-delta preview. It NEVER shows platform cost or margin — only the
+ * sell price (AC6/AC7).
+ *
+ * Per-mode gating (AC11): `canMutate = role !== 'member'` — a SaaS `member` sees
+ * everything read-only (no change-plan control), while a single-user sole user
+ * (no role) and SaaS owner/admin can change the plan. The server is authoritative
+ * (SettingsManage on the subscribe route) — the UI gate is UX-only.
+ *
+ * Deferred (dependency endpoints not shipped): BYOK per-provider mode toggle
+ * (34-3), credit balance + trial banner + promo redeem (34-7). They land with
+ * their endpoints.
+ */
+
+import { useCallback, useEffect, useMemo, useState, type JSX } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+import {
+  tenantPricingApi,
+  type PlanSnapshotDto,
+  type ResolvedEntitlementsResponse,
+} from '../../api/pricing';
+import { ApiError } from '../../api/client';
+import { EntitlementBar } from '../../components/pricing/EntitlementBar';
+import { CostEstimateWidget } from '../../components/pricing/CostEstimateWidget';
+import { UpgradePlanModal } from '../../components/pricing/UpgradePlanModal';
+
+export function PlanPricingPage(): JSX.Element {
+  const { user } = useAuth();
+  const role = user?.role ?? '';
+  // member is the only read-only case; sole user (single-user, no role) + owner/admin mutate.
+  const canMutate = role !== 'member';
+
+  const [entitlements, setEntitlements] = useState<ResolvedEntitlementsResponse | null>(null);
+  const [plans, setPlans] = useState<PlanSnapshotDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [noActivePlan, setNoActivePlan] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showUpgrade, setShowUpgrade] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setNoActivePlan(false);
+
+    // Public plans are best-effort (used for the plan name + upgrade picker).
+    try {
+      const p = await tenantPricingApi.listPublicPlans();
+      setPlans(p.plans);
+    } catch {
+      setPlans([]);
+    }
+
+    try {
+      const ent = await tenantPricingApi.getEntitlements();
+      setEntitlements(ent);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 404) {
+        setEntitlements(null);
+        setNoActivePlan(true);
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to load plan & pricing');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const currentPlan = useMemo(() => {
+    if (!entitlements) return null;
+    const match = plans.find((p) => p.planId === entitlements.planId);
+    return {
+      name: entitlements.isCustom ? 'Custom plan' : (match?.displayName ?? 'Current plan'),
+      slug: match?.slug ?? null,
+      version: entitlements.planVersion,
+      isCustom: entitlements.isCustom,
+      planId: entitlements.planId,
+    };
+  }, [entitlements, plans]);
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Plan &amp; Pricing</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Your current plan, entitlement headroom, and cost estimates.
+          {!canMutate && ' You have read-only access; ask an admin to change the plan.'}
+        </p>
+      </div>
+
+      {error !== null && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500">Loading…</p>
+      ) : noActivePlan ? (
+        <div className="bg-white border border-gray-200 rounded-md p-6 text-center">
+          <h2 className="text-lg font-medium text-gray-900">No active plan</h2>
+          <p className="mt-1 text-sm text-gray-500">
+            Your organization is not on a plan yet.
+            {canMutate ? ' Choose one to get started.' : ' Ask an admin to choose a plan.'}
+          </p>
+          {canMutate && plans.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowUpgrade(true)}
+              className="mt-4 px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md"
+            >
+              Choose a plan
+            </button>
+          )}
+        </div>
+      ) : (
+        currentPlan && (
+          <>
+            <section className="bg-white border border-gray-200 rounded-md p-4">
+              <div className="flex items-start justify-between">
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-gray-400">Current plan</div>
+                  <div className="text-xl font-semibold text-gray-900">
+                    {currentPlan.name}
+                    {currentPlan.isCustom && (
+                      <span className="ml-2 inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-800 align-middle">
+                        custom
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-500 mt-1">
+                    Version {currentPlan.version}
+                    {currentPlan.slug ? ` · ${currentPlan.slug}` : ''}
+                  </div>
+                </div>
+                {canMutate && (
+                  <button
+                    type="button"
+                    onClick={() => setShowUpgrade(true)}
+                    className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md"
+                  >
+                    Change plan
+                  </button>
+                )}
+              </div>
+            </section>
+
+            <section className="bg-white border border-gray-200 rounded-md p-4 space-y-4">
+              <h2 className="text-sm font-semibold text-gray-900">Entitlements &amp; headroom</h2>
+              {entitlements && entitlements.limits.length > 0 ? (
+                <div className="space-y-4">
+                  {entitlements.limits.map((line) => (
+                    <EntitlementBar key={line.metricKey} line={line} />
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-gray-500">No entitlements resolved for this plan.</p>
+              )}
+            </section>
+
+            <CostEstimateWidget />
+          </>
+        )
+      )}
+
+      {showUpgrade && (
+        <UpgradePlanModal
+          plans={plans}
+          currentEntitlements={entitlements?.limits ?? []}
+          currentPlanId={entitlements?.planId ?? null}
+          canMutate={canMutate}
+          onClose={() => setShowUpgrade(false)}
+          onSubscribed={() => {
+            setShowUpgrade(false);
+            void load();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-user/src/pages/settings/PlanPricingPage.tsx
+++ b/packages/dashboard-user/src/pages/settings/PlanPricingPage.tsx
@@ -7,10 +7,13 @@
  * an entitlement-delta preview. It NEVER shows platform cost or margin — only the
  * sell price (AC6/AC7).
  *
- * Per-mode gating (AC11): `canMutate = role !== 'member'` — a SaaS `member` sees
- * everything read-only (no change-plan control), while a single-user sole user
- * (no role) and SaaS owner/admin can change the plan. The server is authoritative
- * (SettingsManage on the subscribe route) — the UI gate is UX-only.
+ * Per-mode gating (AC11): the change-plan control matches the SERVER, which
+ * gates `POST /api/pricing/subscribe` with `SettingsManage` = `settings:manage`
+ * = OWNER-ONLY (Permissions.cs). So `canMutate = role === 'owner' || role === ''`
+ * — the SaaS `owner` and the single-user sole user (no membership role → `''`)
+ * can change the plan; a SaaS `tenant_admin` (and `member`) get the plan/
+ * entitlements READ-ONLY, because a `tenant_admin` subscribe would 403. The UI
+ * gate is UX-only — the server stays authoritative.
  *
  * Deferred (dependency endpoints not shipped): BYOK per-provider mode toggle
  * (34-3), credit balance + trial banner + promo redeem (34-7). They land with
@@ -32,8 +35,10 @@ import { UpgradePlanModal } from '../../components/pricing/UpgradePlanModal';
 export function PlanPricingPage(): JSX.Element {
   const { user } = useAuth();
   const role = user?.role ?? '';
-  // member is the only read-only case; sole user (single-user, no role) + owner/admin mutate.
-  const canMutate = role !== 'member';
+  // Change-plan mirrors the server's owner-only SettingsManage on the subscribe
+  // route: only a SaaS owner or the single-user sole user (no role → '') may
+  // mutate. A tenant_admin (and member) are read-only — an admin subscribe 403s.
+  const canMutate = role === 'owner' || role === '';
 
   const [entitlements, setEntitlements] = useState<ResolvedEntitlementsResponse | null>(null);
   const [plans, setPlans] = useState<PlanSnapshotDto[]>([]);
@@ -92,7 +97,7 @@ export function PlanPricingPage(): JSX.Element {
         <h1 className="text-2xl font-bold text-gray-900">Plan &amp; Pricing</h1>
         <p className="mt-1 text-sm text-gray-500">
           Your current plan, entitlement headroom, and cost estimates.
-          {!canMutate && ' You have read-only access; ask an admin to change the plan.'}
+          {!canMutate && ' You have read-only access; ask an owner to change the plan.'}
         </p>
       </div>
 
@@ -109,7 +114,7 @@ export function PlanPricingPage(): JSX.Element {
           <h2 className="text-lg font-medium text-gray-900">No active plan</h2>
           <p className="mt-1 text-sm text-gray-500">
             Your organization is not on a plan yet.
-            {canMutate ? ' Choose one to get started.' : ' Ask an admin to choose a plan.'}
+            {canMutate ? ' Choose one to get started.' : ' Ask an owner to choose a plan.'}
           </p>
           {canMutate && plans.length > 0 && (
             <button

--- a/packages/dashboard/src/pages/admin/AdminLayout.tsx
+++ b/packages/dashboard/src/pages/admin/AdminLayout.tsx
@@ -13,8 +13,10 @@ import { ApiKeysTab } from './ApiKeysTab.js';
 import { HealthTab } from './HealthTab.js';
 import { QuickLinksTab } from './QuickLinksTab.js';
 import { AuditLogTab } from './AuditLogTab.js';
+// Story 34-9 — platform-owner pricing & plan-management dashboards.
+import { PricingTab } from './pricing/PricingTab.js';
 
-type AdminTab = 'users' | 'api-keys' | 'health' | 'links' | 'audit-log' | 'tenants';
+type AdminTab = 'users' | 'api-keys' | 'health' | 'links' | 'audit-log' | 'tenants' | 'pricing';
 
 interface TabDef {
   id: AdminTab;
@@ -24,6 +26,7 @@ interface TabDef {
 const TABS: TabDef[] = [
   { id: 'users', label: 'Users' },
   { id: 'tenants', label: 'Tenants' },
+  { id: 'pricing', label: 'Pricing' },
   { id: 'api-keys', label: 'API Keys' },
   { id: 'health', label: 'System Health' },
   { id: 'links', label: 'Quick Links' },
@@ -76,6 +79,7 @@ export function AdminLayout(): JSX.Element {
       <div>
         {activeTab === 'users' && <UsersTab />}
         {activeTab === 'tenants' && <TenantsLinkPanel />}
+        {activeTab === 'pricing' && <PricingTab />}
         {activeTab === 'api-keys' && <ApiKeysTab />}
         {activeTab === 'health' && <HealthTab />}
         {activeTab === 'links' && <QuickLinksTab />}

--- a/packages/dashboard/src/pages/admin/__tests__/AdminLayout.test.tsx
+++ b/packages/dashboard/src/pages/admin/__tests__/AdminLayout.test.tsx
@@ -19,6 +19,11 @@ vi.mock('../QuickLinksTab.js', () => ({
 vi.mock('../AuditLogTab.js', () => ({
   AuditLogTab: () => <div data-testid="audit-log-tab">Audit Log Tab Content</div>,
 }));
+// Story 34-9 — stub the pricing tab so this layout test stays isolated from
+// the pricing endpoints (the panel's own tests cover the data flow).
+vi.mock('../pricing/PricingTab.js', () => ({
+  PricingTab: () => <div data-testid="pricing-tab">Pricing Tab Content</div>,
+}));
 
 describe('AdminLayout', () => {
   const user = userEvent.setup();
@@ -79,5 +84,15 @@ describe('AdminLayout', () => {
     expect(auditLogBtn).toBeInTheDocument();
     await user.click(auditLogBtn);
     expect(screen.getByTestId('audit-log-tab')).toBeInTheDocument();
+  });
+
+  // Story 34-9 (AC1) — the platform-owner Pricing tab is present and switches in.
+  it('shows the Pricing tab and switches to it', async () => {
+    render(<AdminLayout />);
+    const pricingBtn = screen.getByText('Pricing');
+    expect(pricingBtn).toBeInTheDocument();
+    await user.click(pricingBtn);
+    expect(screen.getByTestId('pricing-tab')).toBeInTheDocument();
+    expect(screen.queryByTestId('users-tab')).not.toBeInTheDocument();
   });
 });

--- a/packages/dashboard/src/pages/admin/pricing/CustomPlanPanel.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/CustomPlanPanel.tsx
@@ -1,0 +1,304 @@
+/**
+ * Story 34-9 (AC5) — the admin CUSTOM-PLAN panel.
+ *
+ * Mints an `IsCustom` plan bound to exactly one tenant via
+ * `POST /api/admin/pricing/plans/custom` and assigns it to that tenant via
+ * `adminTenantsApi.updatePlan(tenantId, planId)` (34-4 — assignment is NOT
+ * duplicated here). Custom plans are visually flagged and are excluded from the
+ * public catalog by construction (the server rejects a public custom plan with
+ * 400 — the `makePublic` guard is never set true by this UI). The panel lists
+ * existing custom plans via `GET /api/admin/pricing/plans?isCustom=true`.
+ */
+
+import { useCallback, useEffect, useState, type JSX } from 'react';
+import {
+  adminPricingApi,
+  METRIC_KEYS,
+  type PlanSnapshot,
+  type PlanEntitlementBody,
+} from '../../../services/admin/admin-pricing-client.js';
+import { adminTenantsApi } from '../../../services/admin/admin-tenants-client.js';
+
+interface EntitlementRow {
+  metricKey: string;
+  limit: string;
+}
+
+export function CustomPlanPanel(): JSX.Element {
+  const [plans, setPlans] = useState<PlanSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [tenantId, setTenantId] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [billingInterval, setBillingInterval] = useState('monthly');
+  const [recurringUsd, setRecurringUsd] = useState('0');
+  const [entitlements, setEntitlements] = useState<EntitlementRow[]>([
+    { metricKey: METRIC_KEYS[0], limit: '' },
+  ]);
+  const [assignAfterMint, setAssignAfterMint] = useState(true);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await adminPricingApi.listPlans({ isCustom: true });
+      setPlans(resp.plans);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load custom plans');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toEntitlementBodies = (): PlanEntitlementBody[] =>
+    entitlements.map((e) => ({
+      metricKey: e.metricKey,
+      limitValue: e.limit.trim() === '' ? null : Number(e.limit),
+      period: 'monthly',
+      overageMode: 'block',
+    }));
+
+  const submit = async (): Promise<void> => {
+    setFormError(null);
+    setResult(null);
+    if (tenantId.trim() === '') {
+      setFormError('Tenant ID is required to bind a custom plan.');
+      return;
+    }
+    if (displayName.trim() === '') {
+      setFormError('Display name is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const plan = await adminPricingApi.mintCustomPlan({
+        tenantId: tenantId.trim(),
+        displayName: displayName.trim(),
+        billingInterval,
+        entitlements: toEntitlementBodies(),
+        prices: [
+          {
+            pricingMode: 'platform_provided',
+            recurringUsd: Number(recurringUsd) || 0,
+            seatUsd: 0,
+          },
+        ],
+        // Never public — a custom plan must never surface in the public catalog.
+      });
+
+      let message = `Minted custom plan ${plan.slug} (v${plan.version}).`;
+      if (assignAfterMint) {
+        await adminTenantsApi.updatePlan(tenantId.trim(), plan.planId);
+        message += ` Assigned to tenant ${tenantId.trim().slice(0, 8)}…`;
+      }
+      setResult(message);
+      setDisplayName('');
+      setRecurringUsd('0');
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Mint failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4 space-y-3 dark:bg-gray-800 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Mint bespoke enterprise plan
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          A custom plan is bound to one tenant and never appears in the public catalog.
+        </p>
+        {formError !== null && (
+          <div role="alert" className="p-2 text-sm text-red-700 bg-red-50 rounded">
+            {formError}
+          </div>
+        )}
+        {result !== null && (
+          <div role="status" className="p-2 text-sm text-green-800 bg-green-50 rounded">
+            {result}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-2 items-end">
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Tenant ID
+            <input
+              aria-label="Tenant ID"
+              value={tenantId}
+              onChange={(e) => setTenantId(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Display name
+            <input
+              aria-label="Custom plan display name"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Billing interval
+            <select
+              aria-label="Custom billing interval"
+              value={billingInterval}
+              onChange={(e) => setBillingInterval(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            >
+              <option value="monthly">monthly</option>
+              <option value="annual">annual</option>
+            </select>
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Recurring $
+            <input
+              aria-label="Custom recurring usd"
+              value={recurringUsd}
+              inputMode="decimal"
+              onChange={(e) => setRecurringUsd(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+              Entitlements
+            </span>
+            <button
+              type="button"
+              onClick={() => setEntitlements([...entitlements, { metricKey: METRIC_KEYS[0], limit: '' }])}
+              className="text-xs px-2 py-0.5 border border-gray-300 rounded hover:bg-gray-50 dark:border-gray-600"
+            >
+              + Add
+            </button>
+          </div>
+          {entitlements.map((r, i) => (
+            <div key={i} className="grid grid-cols-3 gap-2 items-end">
+              <label className="flex flex-col text-[10px] text-gray-500">
+                Metric
+                <select
+                  aria-label={`Custom entitlement metric ${i}`}
+                  value={r.metricKey}
+                  onChange={(e) =>
+                    setEntitlements(
+                      entitlements.map((x, idx) =>
+                        idx === i ? { ...x, metricKey: e.target.value } : x,
+                      ),
+                    )
+                  }
+                  className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+                >
+                  {METRIC_KEYS.map((m) => (
+                    <option key={m} value={m}>
+                      {m}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col text-[10px] text-gray-500">
+                Limit (blank=∞)
+                <input
+                  aria-label={`Custom entitlement limit ${i}`}
+                  value={r.limit}
+                  inputMode="numeric"
+                  onChange={(e) =>
+                    setEntitlements(
+                      entitlements.map((x, idx) => (idx === i ? { ...x, limit: e.target.value } : x)),
+                    )
+                  }
+                  className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() => setEntitlements(entitlements.filter((_, idx) => idx !== i))}
+                className="px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+            <input
+              type="checkbox"
+              checked={assignAfterMint}
+              onChange={(e) => setAssignAfterMint(e.target.checked)}
+            />
+            Assign to the tenant immediately after minting
+          </label>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => void submit()}
+            className="px-3 py-1.5 text-sm bg-purple-600 text-white rounded hover:bg-purple-700 disabled:opacity-50"
+          >
+            {saving ? 'Minting…' : 'Mint custom plan'}
+          </button>
+        </div>
+      </div>
+
+      {error !== null && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading custom plans…</p>
+      ) : plans.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No custom plans yet. Mint one above to bind a bespoke price-book to a single tenant.
+        </p>
+      ) : (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden dark:bg-gray-800 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+              <tr>
+                <th className="px-3 py-2 text-left">Plan</th>
+                <th className="px-3 py-2 text-left">Slug</th>
+                <th className="px-3 py-2 text-right">Version</th>
+                <th className="px-3 py-2 text-left">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {plans.map((p) => (
+                <tr key={p.planId} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                  <td className="px-3 py-2 text-gray-900 dark:text-gray-100">
+                    {p.displayName}
+                    <span className="ml-2 inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-800">
+                      custom
+                    </span>
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {p.slug}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">
+                    v{p.version}
+                  </td>
+                  <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{p.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/admin/pricing/CustomPlanPanel.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/CustomPlanPanel.tsx
@@ -77,6 +77,18 @@ export function CustomPlanPanel(): JSX.Element {
       setFormError('Display name is required.');
       return;
     }
+    // Fix 3: a non-empty limit MUST parse to a finite number. Only a blank means
+    // "unlimited" (null). A typo like "10O0" → NaN must be a VALIDATION ERROR,
+    // never silently coerced to null/unlimited.
+    const invalidLimit = entitlements.find(
+      (e) => e.limit.trim() !== '' && !Number.isFinite(Number(e.limit)),
+    );
+    if (invalidLimit) {
+      setFormError(
+        `Entitlement limit "${invalidLimit.limit}" for ${invalidLimit.metricKey} is not a number. Leave blank for unlimited.`,
+      );
+      return;
+    }
     setSaving(true);
     try {
       const plan = await adminPricingApi.mintCustomPlan({

--- a/packages/dashboard/src/pages/admin/pricing/MarginPolicyPanel.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/MarginPolicyPanel.tsx
@@ -1,0 +1,225 @@
+/**
+ * Story 34-9 (AC3) — the admin MARGIN-POLICY panel.
+ *
+ * Reads `GET /api/admin/pricing/margins` and versions a policy via
+ * `PUT /api/admin/pricing/margins` (AdminPricingEndpoints.cs). Margin writes are
+ * immutable-versioned server-side (a PUT supersedes the prior active row for the
+ * same scope/refKey); the response surfaces the new policy + supersededPolicyId
+ * (the `PRICING.MARGIN.UPDATED` DCB result). Client-side the form validates that
+ * at least one of markup-multiplier / fixed-$-per-1M is set before POST — the
+ * server remains authoritative.
+ *
+ * This is platform-internal economics (the markup knobs) — only ever rendered on
+ * the platform-owner admin surface, never on the tenant `/api/pricing/*` routes.
+ */
+
+import { useCallback, useEffect, useState, type JSX } from 'react';
+import {
+  adminPricingApi,
+  MARGIN_SCOPES,
+  type MarginPolicyDto,
+} from '../../../services/admin/admin-pricing-client.js';
+
+export function MarginPolicyPanel(): JSX.Element {
+  const [policies, setPolicies] = useState<MarginPolicyDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [scope, setScope] = useState<string>('global');
+  const [refKey, setRefKey] = useState('');
+  const [markup, setMarkup] = useState('');
+  const [fixed, setFixed] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await adminPricingApi.listMargins();
+      setPolicies(resp.policies);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load margin policies');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const submit = async (): Promise<void> => {
+    setFormError(null);
+    setResult(null);
+    // AC3 — at least one knob must be set (mirrors the server's has-knob guard).
+    if (markup.trim() === '' && fixed.trim() === '') {
+      setFormError('Set at least one of markup multiplier or fixed $/1M.');
+      return;
+    }
+    if (scope !== 'global' && refKey.trim() === '') {
+      setFormError('A plan/provider-scoped policy requires a ref key.');
+      return;
+    }
+    setSaving(true);
+    try {
+      const resp = await adminPricingApi.versionMargin({
+        scope,
+        refKey: scope === 'global' ? null : refKey.trim(),
+        markupMultiplier: markup.trim() === '' ? null : Number(markup),
+        fixedUsdPer1M: fixed.trim() === '' ? null : Number(fixed),
+      });
+      setResult(
+        resp.supersededPolicyId
+          ? `Policy updated (superseded prior ${resp.supersededPolicyId.slice(0, 8)}…).`
+          : 'Policy created.',
+      );
+      setMarkup('');
+      setFixed('');
+      setRefKey('');
+      await load();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4 space-y-3 dark:bg-gray-800 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Add / update margin policy
+        </h3>
+        {formError !== null && (
+          <div role="alert" className="p-2 text-sm text-red-700 bg-red-50 rounded">
+            {formError}
+          </div>
+        )}
+        {result !== null && (
+          <div role="status" className="p-2 text-sm text-green-800 bg-green-50 rounded">
+            {result}
+          </div>
+        )}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-2 items-end">
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Scope
+            <select
+              aria-label="Margin scope"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            >
+              {MARGIN_SCOPES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Ref key {scope === 'global' ? '(n/a)' : ''}
+            <input
+              aria-label="Margin ref key"
+              value={refKey}
+              disabled={scope === 'global'}
+              onChange={(e) => setRefKey(e.target.value)}
+              placeholder={scope === 'provider' ? 'anthropic' : scope === 'plan' ? 'pro' : ''}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm disabled:bg-gray-100 dark:bg-gray-900 dark:border-gray-600 dark:disabled:bg-gray-700"
+            />
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Markup ×
+            <input
+              aria-label="Markup multiplier"
+              value={markup}
+              inputMode="decimal"
+              onChange={(e) => setMarkup(e.target.value)}
+              placeholder="1.5"
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Fixed $/1M
+            <input
+              aria-label="Fixed usd per 1m"
+              value={fixed}
+              inputMode="decimal"
+              onChange={(e) => setFixed(e.target.value)}
+              placeholder="0.50"
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => void submit()}
+            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save policy'}
+          </button>
+        </div>
+      </div>
+
+      {error !== null && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading margin policies…</p>
+      ) : policies.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No margin policies yet. The global policy is the pricing safety net — add it above.
+        </p>
+      ) : (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden dark:bg-gray-800 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+              <tr>
+                <th className="px-3 py-2 text-left">Scope</th>
+                <th className="px-3 py-2 text-left">Ref key</th>
+                <th className="px-3 py-2 text-right">Markup ×</th>
+                <th className="px-3 py-2 text-right">Fixed $/1M</th>
+                <th className="px-3 py-2 text-left">Effective from</th>
+                <th className="px-3 py-2 text-left">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {policies.map((p) => (
+                <tr key={p.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                  <td className="px-3 py-2 text-gray-900 dark:text-gray-100">{p.scope}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {p.refKey ?? '—'}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">
+                    {p.markupMultiplier ?? '—'}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">
+                    {p.fixedUsdPer1M ?? '—'}
+                  </td>
+                  <td className="px-3 py-2 text-gray-500 text-xs dark:text-gray-400">
+                    {new Date(p.effectiveFrom).toLocaleDateString()}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-flex px-2 py-0.5 text-xs font-medium rounded ${
+                        p.status === 'active'
+                          ? 'bg-green-100 text-green-800'
+                          : 'bg-gray-200 text-gray-600'
+                      }`}
+                    >
+                      {p.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/admin/pricing/PlanVersionEditor.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/PlanVersionEditor.tsx
@@ -303,6 +303,21 @@ function PlanEditorForm({
       setFormError('Display name is required.');
       return;
     }
+    // Fix 3: a non-empty limit MUST parse to a finite number. Only a blank means
+    // "unlimited" (null). A typo like "10O0" → NaN must be a VALIDATION ERROR,
+    // never silently coerced to null/unlimited. Guard only the collection we
+    // actually send (create always sends; version sends only when replacing).
+    if (replaceEntitlements) {
+      const invalid = entitlements.find(
+        (e) => e.limit.trim() !== '' && !Number.isFinite(Number(e.limit)),
+      );
+      if (invalid) {
+        setFormError(
+          `Entitlement limit "${invalid.limit}" for ${invalid.metricKey} is not a number. Leave blank for unlimited.`,
+        );
+        return;
+      }
+    }
     setSaving(true);
     try {
       let snapshot: PlanSnapshot;

--- a/packages/dashboard/src/pages/admin/pricing/PlanVersionEditor.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/PlanVersionEditor.tsx
@@ -1,0 +1,701 @@
+/**
+ * Story 34-9 (AC2) — the admin PLAN-VERSION editor panel.
+ *
+ * Lists the public (non-custom) plan catalog from `GET /api/admin/pricing/plans`
+ * (every status), opens a create/version editor over features / typed
+ * entitlements / prices, and submits via `POST` (create v1) or `PUT` (new
+ * version). Plan versions are immutable after activation (34-1): a save of an
+ * existing slug creates a NEW version + deprecates the prior, so on save we
+ * reload the catalog to re-render the supersede chain. Deprecation surfaces the
+ * server's 409 (active tenant assignments) with the affected-tenant count and a
+ * "Deprecate anyway (force)" opt-in.
+ *
+ * The UI never duplicates the versioning/supersede logic (34-1 owns it) — it
+ * maps the form onto the wire DTOs and renders the returned PlanSnapshot.
+ */
+
+import { useCallback, useEffect, useMemo, useState, type JSX } from 'react';
+import {
+  adminPricingApi,
+  AdminPricingApiError,
+  METRIC_KEYS,
+  ENTITLEMENT_PERIODS,
+  OVERAGE_MODES,
+  PRICING_MODES,
+  metricKeyLabel,
+  type PlanSnapshot,
+  type PlanEntitlementBody,
+  type PlanFeatureBody,
+  type PlanPriceBody,
+} from '../../../services/admin/admin-pricing-client.js';
+import { StatusPill } from './PricingOverviewPanel.js';
+
+interface EntitlementRow {
+  metricKey: string;
+  limit: string; // "" ⇒ unlimited
+  period: string;
+  overageMode: string;
+}
+
+interface FeatureRow {
+  featureKey: string;
+  boolValue: boolean;
+}
+
+interface PriceRow {
+  pricingMode: string;
+  recurringUsd: string;
+  seatUsd: string;
+}
+
+type EditorMode = { kind: 'create' } | { kind: 'version'; slug: string; displayName: string };
+
+const BILLING_INTERVALS = ['monthly', 'annual'];
+
+function defaultEntitlement(): EntitlementRow {
+  return { metricKey: METRIC_KEYS[0], limit: '', period: 'monthly', overageMode: 'block' };
+}
+
+function defaultPrice(): PriceRow {
+  return { pricingMode: 'platform_provided', recurringUsd: '0', seatUsd: '0' };
+}
+
+export function PlanVersionEditor(): JSX.Element {
+  const [plans, setPlans] = useState<PlanSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editor, setEditor] = useState<EditorMode | null>(null);
+  const [saveResult, setSaveResult] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await adminPricingApi.listPlans({ isCustom: false });
+      setPlans(resp.plans);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load plans');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onSaved = useCallback(
+    (snapshot: PlanSnapshot, message: string) => {
+      setEditor(null);
+      setSaveResult(message.replace('{v}', String(snapshot.version)));
+      void load();
+    },
+    [load],
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Public plans</h3>
+        <button
+          type="button"
+          onClick={() => {
+            setSaveResult(null);
+            setEditor({ kind: 'create' });
+          }}
+          className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md"
+        >
+          New plan
+        </button>
+      </div>
+
+      {saveResult !== null && (
+        <div role="status" className="p-3 text-sm text-green-800 bg-green-50 rounded-md">
+          {saveResult}
+        </div>
+      )}
+      {error !== null && (
+        <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+          {error}
+        </div>
+      )}
+
+      {editor !== null && (
+        <PlanEditorForm
+          mode={editor}
+          onCancel={() => setEditor(null)}
+          onSaved={onSaved}
+        />
+      )}
+
+      {loading ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading plans…</p>
+      ) : plans.length === 0 ? (
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No public plans yet. Click “New plan” to create the first price-book entry.
+        </p>
+      ) : (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden dark:bg-gray-800 dark:border-gray-700">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+              <tr>
+                <th className="px-3 py-2 text-left">Plan</th>
+                <th className="px-3 py-2 text-left">Slug</th>
+                <th className="px-3 py-2 text-right">Version</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-left">Entitlements</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {plans.map((p) => (
+                <PlanRow key={p.planId} plan={p} onChanged={load} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PlanRow({
+  plan,
+  onChanged,
+}: {
+  plan: PlanSnapshot;
+  onChanged: () => Promise<void>;
+}): JSX.Element {
+  const [deprecating, setDeprecating] = useState(false);
+  const [affected, setAffected] = useState<number | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const doDeprecate = async (force: boolean): Promise<void> => {
+    setDeprecating(true);
+    setRowError(null);
+    try {
+      await adminPricingApi.deprecateVersion(plan.slug, plan.version, force);
+      setAffected(null);
+      await onChanged();
+    } catch (err) {
+      if (err instanceof AdminPricingApiError && err.status === 409) {
+        const count = (err.body as { affectedTenantCount?: number }).affectedTenantCount ?? 0;
+        setAffected(count);
+      } else {
+        setRowError(err instanceof Error ? err.message : 'Deprecate failed');
+      }
+    } finally {
+      setDeprecating(false);
+    }
+  };
+
+  const entitlementSummary = plan.entitlements
+    .map((e) => `${metricKeyLabel(e.metricKey)}=${e.limitValue ?? '∞'}`)
+    .join(', ');
+
+  return (
+    <tr className="hover:bg-gray-50 dark:hover:bg-gray-700/40 align-top">
+      <td className="px-3 py-2 text-gray-900 dark:text-gray-100">{plan.displayName}</td>
+      <td className="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-400">{plan.slug}</td>
+      <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">v{plan.version}</td>
+      <td className="px-3 py-2">
+        <StatusPill status={plan.status} />
+      </td>
+      <td className="px-3 py-2 text-xs text-gray-500 dark:text-gray-400 max-w-xs truncate">
+        {entitlementSummary || '—'}
+      </td>
+      <td className="px-3 py-2 text-right whitespace-nowrap">
+        {plan.status === 'active' && affected === null && (
+          <button
+            type="button"
+            disabled={deprecating}
+            onClick={() => void doDeprecate(false)}
+            className="px-2 py-1 text-xs border border-red-300 text-red-700 rounded hover:bg-red-50 disabled:opacity-50"
+          >
+            Deprecate
+          </button>
+        )}
+        {affected !== null && (
+          <div className="text-xs text-right space-y-1">
+            <div className="text-amber-700">
+              {affected} tenant{affected === 1 ? '' : 's'} on this version.
+            </div>
+            <div className="flex justify-end gap-1">
+              <button
+                type="button"
+                onClick={() => setAffected(null)}
+                className="px-2 py-1 border border-gray-300 rounded hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={deprecating}
+                onClick={() => void doDeprecate(true)}
+                className="px-2 py-1 border border-red-600 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+              >
+                Deprecate anyway (force)
+              </button>
+            </div>
+          </div>
+        )}
+        {rowError !== null && <div className="text-xs text-red-700 mt-1">{rowError}</div>}
+      </td>
+    </tr>
+  );
+}
+
+function PlanEditorForm({
+  mode,
+  onCancel,
+  onSaved,
+}: {
+  mode: EditorMode;
+  onCancel: () => void;
+  onSaved: (snapshot: PlanSnapshot, message: string) => void;
+}): JSX.Element {
+  const isCreate = mode.kind === 'create';
+  const [slug, setSlug] = useState('');
+  const [displayName, setDisplayName] = useState(mode.kind === 'version' ? mode.displayName : '');
+  const [billingInterval, setBillingInterval] = useState('monthly');
+  const [entitlements, setEntitlements] = useState<EntitlementRow[]>([defaultEntitlement()]);
+  const [prices, setPrices] = useState<PriceRow[]>([defaultPrice()]);
+  const [features, setFeatures] = useState<FeatureRow[]>([]);
+  // Version mode: leaving a collection "unreplaced" sends null ⇒ copy prior version.
+  const [replaceEntitlements, setReplaceEntitlements] = useState(isCreate);
+  const [replacePrices, setReplacePrices] = useState(isCreate);
+  const [replaceFeatures, setReplaceFeatures] = useState(isCreate);
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const title = useMemo(
+    () => (isCreate ? 'Create plan' : `New version of ${mode.kind === 'version' ? mode.slug : ''}`),
+    [isCreate, mode],
+  );
+
+  const toEntitlementBodies = (): PlanEntitlementBody[] =>
+    entitlements.map((e) => ({
+      metricKey: e.metricKey,
+      limitValue: e.limit.trim() === '' ? null : Number(e.limit),
+      period: e.period,
+      overageMode: e.overageMode,
+    }));
+
+  const toPriceBodies = (): PlanPriceBody[] =>
+    prices.map((p) => ({
+      pricingMode: p.pricingMode,
+      recurringUsd: Number(p.recurringUsd) || 0,
+      seatUsd: Number(p.seatUsd) || 0,
+    }));
+
+  const toFeatureBodies = (): PlanFeatureBody[] =>
+    features
+      .filter((f) => f.featureKey.trim() !== '')
+      .map((f) => ({ featureKey: f.featureKey.trim(), boolValue: f.boolValue }));
+
+  const submit = async (): Promise<void> => {
+    setFormError(null);
+    if (isCreate && slug.trim() === '') {
+      setFormError('Slug is required.');
+      return;
+    }
+    if (displayName.trim() === '') {
+      setFormError('Display name is required.');
+      return;
+    }
+    setSaving(true);
+    try {
+      let snapshot: PlanSnapshot;
+      if (isCreate) {
+        snapshot = await adminPricingApi.createPlan({
+          slug: slug.trim(),
+          displayName: displayName.trim(),
+          billingInterval,
+          entitlements: toEntitlementBodies(),
+          prices: toPriceBodies(),
+          features: toFeatureBodies(),
+        });
+        onSaved(snapshot, `Created ${snapshot.slug} v{v}.`);
+      } else if (mode.kind === 'version') {
+        snapshot = await adminPricingApi.versionPlan(mode.slug, {
+          displayName: displayName.trim(),
+          billingInterval,
+          entitlements: replaceEntitlements ? toEntitlementBodies() : null,
+          prices: replacePrices ? toPriceBodies() : null,
+          features: replaceFeatures ? toFeatureBodies() : null,
+        });
+        onSaved(snapshot, `New version created: ${snapshot.slug} v{v} (prior version deprecated).`);
+      }
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-blue-200 shadow-sm p-4 space-y-4 dark:bg-gray-800 dark:border-blue-900">
+      <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</h4>
+
+      {formError !== null && (
+        <div role="alert" className="p-2 text-sm text-red-700 bg-red-50 rounded">
+          {formError}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {isCreate && (
+          <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+            Slug
+            <input
+              aria-label="Slug"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value)}
+              className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+            />
+          </label>
+        )}
+        <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+          Display name
+          <input
+            aria-label="Display name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+          />
+        </label>
+        <label className="flex flex-col text-xs text-gray-600 dark:text-gray-400">
+          Billing interval
+          <select
+            aria-label="Billing interval"
+            value={billingInterval}
+            onChange={(e) => setBillingInterval(e.target.value)}
+            className="mt-1 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+          >
+            {BILLING_INTERVALS.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <EntitlementEditor
+        rows={entitlements}
+        setRows={setEntitlements}
+        replace={replaceEntitlements}
+        setReplace={setReplaceEntitlements}
+        allowCopyPrior={!isCreate}
+      />
+
+      <PriceEditor
+        rows={prices}
+        setRows={setPrices}
+        replace={replacePrices}
+        setReplace={setReplacePrices}
+        allowCopyPrior={!isCreate}
+      />
+
+      <FeatureEditor
+        rows={features}
+        setRows={setFeatures}
+        replace={replaceFeatures}
+        setReplace={setReplaceFeatures}
+        allowCopyPrior={!isCreate}
+      />
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm border border-gray-300 rounded dark:border-gray-600"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          disabled={saving}
+          onClick={() => void submit()}
+          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CollectionHeader({
+  title,
+  replace,
+  setReplace,
+  allowCopyPrior,
+  onAdd,
+}: {
+  title: string;
+  replace: boolean;
+  setReplace: (v: boolean) => void;
+  allowCopyPrior: boolean;
+  onAdd?: () => void;
+}): JSX.Element {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+          {title}
+        </span>
+        {allowCopyPrior && (
+          <label className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+            <input
+              type="checkbox"
+              checked={replace}
+              onChange={(e) => setReplace(e.target.checked)}
+            />
+            Replace (else copy prior version)
+          </label>
+        )}
+      </div>
+      {onAdd && replace && (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="text-xs px-2 py-0.5 border border-gray-300 rounded hover:bg-gray-50 dark:border-gray-600"
+        >
+          + Add
+        </button>
+      )}
+    </div>
+  );
+}
+
+function EntitlementEditor({
+  rows,
+  setRows,
+  replace,
+  setReplace,
+  allowCopyPrior,
+}: {
+  rows: EntitlementRow[];
+  setRows: (r: EntitlementRow[]) => void;
+  replace: boolean;
+  setReplace: (v: boolean) => void;
+  allowCopyPrior: boolean;
+}): JSX.Element {
+  const update = (i: number, patch: Partial<EntitlementRow>): void =>
+    setRows(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+
+  return (
+    <div className="space-y-2">
+      <CollectionHeader
+        title="Entitlements"
+        replace={replace}
+        setReplace={setReplace}
+        allowCopyPrior={allowCopyPrior}
+        onAdd={() => setRows([...rows, defaultEntitlement()])}
+      />
+      {replace &&
+        rows.map((r, i) => (
+          <div key={i} className="grid grid-cols-2 md:grid-cols-5 gap-2 items-end">
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Metric
+              <select
+                aria-label={`Entitlement metric ${i}`}
+                value={r.metricKey}
+                onChange={(e) => update(i, { metricKey: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              >
+                {METRIC_KEYS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Limit (blank=∞)
+              <input
+                aria-label={`Entitlement limit ${i}`}
+                value={r.limit}
+                inputMode="numeric"
+                onChange={(e) => update(i, { limit: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              />
+            </label>
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Period
+              <select
+                aria-label={`Entitlement period ${i}`}
+                value={r.period}
+                onChange={(e) => update(i, { period: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              >
+                {ENTITLEMENT_PERIODS.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Overage
+              <select
+                aria-label={`Entitlement overage ${i}`}
+                value={r.overageMode}
+                onChange={(e) => update(i, { overageMode: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              >
+                {OVERAGE_MODES.map((o) => (
+                  <option key={o} value={o}>
+                    {o}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={() => setRows(rows.filter((_, idx) => idx !== i))}
+              className="px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+    </div>
+  );
+}
+
+function PriceEditor({
+  rows,
+  setRows,
+  replace,
+  setReplace,
+  allowCopyPrior,
+}: {
+  rows: PriceRow[];
+  setRows: (r: PriceRow[]) => void;
+  replace: boolean;
+  setReplace: (v: boolean) => void;
+  allowCopyPrior: boolean;
+}): JSX.Element {
+  const update = (i: number, patch: Partial<PriceRow>): void =>
+    setRows(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+
+  return (
+    <div className="space-y-2">
+      <CollectionHeader
+        title="Prices"
+        replace={replace}
+        setReplace={setReplace}
+        allowCopyPrior={allowCopyPrior}
+        onAdd={() => setRows([...rows, defaultPrice()])}
+      />
+      {replace &&
+        rows.map((r, i) => (
+          <div key={i} className="grid grid-cols-2 md:grid-cols-4 gap-2 items-end">
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Pricing mode
+              <select
+                aria-label={`Price mode ${i}`}
+                value={r.pricingMode}
+                onChange={(e) => update(i, { pricingMode: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              >
+                {PRICING_MODES.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Recurring $
+              <input
+                aria-label={`Price recurring ${i}`}
+                value={r.recurringUsd}
+                inputMode="decimal"
+                onChange={(e) => update(i, { recurringUsd: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              />
+            </label>
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Seat $
+              <input
+                aria-label={`Price seat ${i}`}
+                value={r.seatUsd}
+                inputMode="decimal"
+                onChange={(e) => update(i, { seatUsd: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => setRows(rows.filter((_, idx) => idx !== i))}
+              className="px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+    </div>
+  );
+}
+
+function FeatureEditor({
+  rows,
+  setRows,
+  replace,
+  setReplace,
+  allowCopyPrior,
+}: {
+  rows: FeatureRow[];
+  setRows: (r: FeatureRow[]) => void;
+  replace: boolean;
+  setReplace: (v: boolean) => void;
+  allowCopyPrior: boolean;
+}): JSX.Element {
+  const update = (i: number, patch: Partial<FeatureRow>): void =>
+    setRows(rows.map((r, idx) => (idx === i ? { ...r, ...patch } : r)));
+
+  return (
+    <div className="space-y-2">
+      <CollectionHeader
+        title="Features"
+        replace={replace}
+        setReplace={setReplace}
+        allowCopyPrior={allowCopyPrior}
+        onAdd={() => setRows([...rows, { featureKey: '', boolValue: true }])}
+      />
+      {replace &&
+        rows.map((r, i) => (
+          <div key={i} className="grid grid-cols-2 md:grid-cols-3 gap-2 items-end">
+            <label className="flex flex-col text-[10px] text-gray-500">
+              Feature key
+              <input
+                aria-label={`Feature key ${i}`}
+                value={r.featureKey}
+                onChange={(e) => update(i, { featureKey: e.target.value })}
+                className="mt-0.5 px-2 py-1 border border-gray-300 rounded text-sm dark:bg-gray-900 dark:border-gray-600"
+              />
+            </label>
+            <label className="flex items-center gap-1 text-xs text-gray-500 mt-4">
+              <input
+                type="checkbox"
+                aria-label={`Feature enabled ${i}`}
+                checked={r.boolValue}
+                onChange={(e) => update(i, { boolValue: e.target.checked })}
+              />
+              Enabled
+            </label>
+            <button
+              type="button"
+              onClick={() => setRows(rows.filter((_, idx) => idx !== i))}
+              className="px-2 py-1 text-xs text-red-600 border border-red-200 rounded hover:bg-red-50"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/admin/pricing/PricingOverviewPanel.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/PricingOverviewPanel.tsx
@@ -1,0 +1,193 @@
+/**
+ * Story 34-9 (AC1) — the platform-owner PRICING OVERVIEW panel.
+ *
+ * Consumes the single read-only rollup `GET /api/admin/pricing/overview`
+ * (AdminPricingDashboardEndpoints.cs): headline totals, the full plan catalog
+ * with live per-plan active-tenant counts, and the margin-config summary. This
+ * surface reveals platform-internal economics (list prices + margin knobs) and
+ * is gated `PlatformOwnerAccess` server-side — it is only ever rendered inside
+ * the admin dashboard's AdminGuard chain.
+ */
+
+import { useCallback, useEffect, useState, type JSX } from 'react';
+import {
+  adminPricingApi,
+  type PricingOverviewResponse,
+} from '../../../services/admin/admin-pricing-client.js';
+
+function usd(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  return `$${value.toFixed(2)}`;
+}
+
+function StatCard({ label, value }: { label: string; value: number | string }): JSX.Element {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4 dark:bg-gray-800 dark:border-gray-700">
+      <div className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value}</div>
+      <div className="text-xs uppercase tracking-wide text-gray-500 mt-1 dark:text-gray-400">
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export function PricingOverviewPanel(): JSX.Element {
+  const [data, setData] = useState<PricingOverviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await adminPricingApi.getOverview());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load pricing overview');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">Loading pricing overview…</p>;
+  }
+
+  if (error !== null) {
+    return (
+      <div role="alert" className="p-3 text-sm text-red-700 bg-red-50 rounded-md">
+        {error}
+      </div>
+    );
+  }
+
+  if (data === null) {
+    return <p className="text-sm text-gray-500 dark:text-gray-400">No pricing data.</p>;
+  }
+
+  const { plans, margins, totals } = data;
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+        <StatCard label="Active plans" value={totals.activePlanCount} />
+        <StatCard label="Custom plans" value={totals.customPlanCount} />
+        <StatCard label="Deprecated" value={totals.deprecatedPlanCount} />
+        <StatCard label="Active assignments" value={totals.totalActiveAssignments} />
+        <StatCard label="Plans in use" value={totals.plansWithActiveAssignments} />
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-4 dark:bg-gray-800 dark:border-gray-700">
+        <h3 className="text-sm font-semibold text-gray-900 mb-3 dark:text-gray-100">
+          Margin configuration
+        </h3>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div>
+            <div className="text-gray-500 dark:text-gray-400">Global markup ×</div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              {margins.globalMarkupMultiplier ?? '—'}
+            </div>
+          </div>
+          <div>
+            <div className="text-gray-500 dark:text-gray-400">Global fixed $/1M</div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              {usd(margins.globalFixedUsdPer1M)}
+            </div>
+          </div>
+          <div>
+            <div className="text-gray-500 dark:text-gray-400">Active policies</div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              {margins.activePolicyCount}
+            </div>
+          </div>
+          <div>
+            <div className="text-gray-500 dark:text-gray-400">Plan / provider scoped</div>
+            <div className="font-medium text-gray-900 dark:text-gray-100">
+              {margins.planScopedPolicyCount} / {margins.providerScopedPolicyCount}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden dark:bg-gray-800 dark:border-gray-700">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">Plan catalog</h3>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="text-xs px-2 py-1 border border-gray-300 rounded hover:bg-gray-50 dark:border-gray-600"
+          >
+            Refresh
+          </button>
+        </div>
+        {plans.length === 0 ? (
+          <p className="p-6 text-sm text-gray-500 text-center dark:text-gray-400">
+            No plans in the catalog yet. Create one from the Plans tab.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-xs uppercase text-gray-600 dark:bg-gray-900 dark:text-gray-400">
+              <tr>
+                <th className="px-3 py-2 text-left">Plan</th>
+                <th className="px-3 py-2 text-left">Slug</th>
+                <th className="px-3 py-2 text-right">Version</th>
+                <th className="px-3 py-2 text-left">Status</th>
+                <th className="px-3 py-2 text-left">Interval</th>
+                <th className="px-3 py-2 text-right">Recurring</th>
+                <th className="px-3 py-2 text-right">Active tenants</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+              {plans.map((p) => (
+                <tr key={p.planId} className="hover:bg-gray-50 dark:hover:bg-gray-700/40">
+                  <td className="px-3 py-2 text-gray-900 dark:text-gray-100">
+                    {p.displayName}
+                    {p.isCustom && (
+                      <span className="ml-2 inline-flex px-1.5 py-0.5 text-[10px] font-medium rounded bg-purple-100 text-purple-800">
+                        custom
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {p.slug}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">
+                    v{p.version}
+                  </td>
+                  <td className="px-3 py-2">
+                    <StatusPill status={p.status} />
+                  </td>
+                  <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{p.billingInterval}</td>
+                  <td className="px-3 py-2 text-right text-gray-700 dark:text-gray-300">
+                    {usd(p.recurringUsd)}
+                  </td>
+                  <td className="px-3 py-2 text-right text-gray-900 font-medium dark:text-gray-100">
+                    {p.activeTenantCount}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function StatusPill({ status }: { status: string }): JSX.Element {
+  const colors: Record<string, string> = {
+    active: 'bg-green-100 text-green-800',
+    deprecated: 'bg-gray-200 text-gray-700',
+    draft: 'bg-yellow-100 text-yellow-800',
+  };
+  return (
+    <span
+      className={`inline-flex px-2 py-0.5 text-xs font-medium rounded ${colors[status] ?? 'bg-gray-100 text-gray-700'}`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/packages/dashboard/src/pages/admin/pricing/PricingTab.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/PricingTab.tsx
@@ -1,0 +1,71 @@
+/**
+ * Story 34-9 — the platform-owner PRICING tab shell.
+ *
+ * Rendered only inside the admin dashboard's existing `AdminGuard` chain
+ * (AdminLayout mounts this behind `/admin`, which is wrapped by AdminGuard), so
+ * every sub-panel it hosts is platform-owner-gated UX-side; the server enforces
+ * `PlatformOwnerAccess` on every route regardless (AC1).
+ *
+ * Sub-tabs mirror the shipped admin endpoints:
+ *   Overview      → GET  /api/admin/pricing/overview        (34-9)
+ *   Plans         → CRUD /api/admin/pricing/plans*          (34-2)
+ *   Margins       → GET/PUT /api/admin/pricing/margins      (34-5)
+ *   Custom plans  → POST /api/admin/pricing/plans/custom    (34-2) + assignment (34-4)
+ *
+ * Promo/credit management (AC4) is intentionally NOT surfaced here yet — the
+ * 34-7 promo/credit endpoints are not shipped; the panel lands with them.
+ */
+
+import { useState, type JSX } from 'react';
+import { PricingOverviewPanel } from './PricingOverviewPanel.js';
+import { PlanVersionEditor } from './PlanVersionEditor.js';
+import { MarginPolicyPanel } from './MarginPolicyPanel.js';
+import { CustomPlanPanel } from './CustomPlanPanel.js';
+
+type PricingSubTab = 'overview' | 'plans' | 'margins' | 'custom';
+
+interface SubTabDef {
+  id: PricingSubTab;
+  label: string;
+}
+
+const SUB_TABS: SubTabDef[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'plans', label: 'Plans' },
+  { id: 'margins', label: 'Margins' },
+  { id: 'custom', label: 'Custom Plans' },
+];
+
+export function PricingTab(): JSX.Element {
+  const [active, setActive] = useState<PricingSubTab>('overview');
+
+  return (
+    <div className="space-y-4">
+      <div className="border-b border-gray-200 dark:border-gray-700">
+        <nav className="flex -mb-px space-x-6" aria-label="Pricing sub-tabs">
+          {SUB_TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActive(tab.id)}
+              className={`py-2 px-1 border-b-2 text-sm font-medium transition-colors ${
+                active === tab.id
+                  ? 'border-blue-500 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              } dark:text-gray-400`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      <div>
+        {active === 'overview' && <PricingOverviewPanel />}
+        {active === 'plans' && <PlanVersionEditor />}
+        {active === 'margins' && <MarginPolicyPanel />}
+        {active === 'custom' && <CustomPlanPanel />}
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/CustomPlanPanel.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/CustomPlanPanel.test.tsx
@@ -95,4 +95,45 @@ describe('CustomPlanPanel', () => {
     expect(await screen.findByText(/Tenant ID is required/i)).toBeInTheDocument();
     expect(mockApi.mintCustomPlan).not.toHaveBeenCalled();
   });
+
+  // Fix 3: a non-numeric limit must block the mint with an inline error, NOT be
+  // coerced to null/unlimited via NaN.
+  it('blocks mint when an entitlement limit is a non-numeric typo (NaN)', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Tenant ID'), { target: { value: 'tnt-9' } });
+    fireEvent.change(screen.getByLabelText('Custom plan display name'), {
+      target: { value: 'Bespoke' },
+    });
+    // "10O0" (letter O) → Number(...) === NaN.
+    fireEvent.change(screen.getByLabelText('Custom entitlement limit 0'), {
+      target: { value: '10O0' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Mint custom plan' }));
+
+    expect(await screen.findByText(/is not a number/i)).toBeInTheDocument();
+    expect(mockApi.mintCustomPlan).not.toHaveBeenCalled();
+  });
+
+  it('mints with a blank limit (unlimited → null) and a valid number', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Tenant ID'), { target: { value: 'tnt-9' } });
+    fireEvent.change(screen.getByLabelText('Custom plan display name'), {
+      target: { value: 'Bespoke' },
+    });
+    // First entitlement row: blank → unlimited (null). Add a second with a number.
+    fireEvent.click(screen.getByRole('button', { name: '+ Add' }));
+    fireEvent.change(screen.getByLabelText('Custom entitlement limit 1'), {
+      target: { value: '42' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Mint custom plan' }));
+
+    await waitFor(() => expect(mockApi.mintCustomPlan).toHaveBeenCalled());
+    const body = mockApi.mintCustomPlan.mock.calls[0]![0];
+    expect(body.entitlements[0].limitValue).toBeNull();
+    expect(body.entitlements[1].limitValue).toBe(42);
+  });
 });

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/CustomPlanPanel.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/CustomPlanPanel.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { CustomPlanPanel } from '../CustomPlanPanel.js';
+
+const { mockApi, mockTenantsApi } = vi.hoisted(() => ({
+  mockApi: {
+    listPlans: vi.fn(),
+    mintCustomPlan: vi.fn(),
+  },
+  mockTenantsApi: {
+    updatePlan: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../services/admin/admin-pricing-client.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../services/admin/admin-pricing-client.js')
+  >();
+  return { ...actual, adminPricingApi: mockApi };
+});
+
+vi.mock('../../../../services/admin/admin-tenants-client.js', () => ({
+  adminTenantsApi: mockTenantsApi,
+}));
+
+const CUSTOM_PLAN = {
+  planId: 'cp1',
+  slug: 'custom-abc-1',
+  displayName: 'Bespoke',
+  version: 1,
+  status: 'active',
+  isCustom: true,
+  billingInterval: 'monthly',
+  supersedesPlanId: null,
+  features: [],
+  entitlements: [],
+  prices: [],
+};
+
+describe('CustomPlanPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.listPlans.mockResolvedValue({ plans: [] });
+    mockApi.mintCustomPlan.mockResolvedValue(CUSTOM_PLAN);
+    mockTenantsApi.updatePlan.mockResolvedValue({ tenantId: 'tnt-9', status: 'ok', message: '' });
+  });
+
+  it('lists existing custom plans (isCustom=true) and renders an empty state when none', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalledWith({ isCustom: true }));
+    expect(screen.getByText(/No custom plans yet/i)).toBeInTheDocument();
+  });
+
+  it('mints a custom plan bound to a tenant and assigns it via adminTenantsApi.updatePlan', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Tenant ID'), { target: { value: 'tnt-9' } });
+    fireEvent.change(screen.getByLabelText('Custom plan display name'), {
+      target: { value: 'Bespoke' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Mint custom plan' }));
+
+    await waitFor(() => expect(mockApi.mintCustomPlan).toHaveBeenCalled());
+    const body = mockApi.mintCustomPlan.mock.calls[0]![0];
+    expect(body.tenantId).toBe('tnt-9');
+    expect(body.makePublic).toBeUndefined();
+
+    await waitFor(() =>
+      expect(mockTenantsApi.updatePlan).toHaveBeenCalledWith('tnt-9', 'cp1'),
+    );
+    await waitFor(() => expect(screen.getByText(/Minted custom plan/i)).toBeInTheDocument());
+  });
+
+  it('does not assign when the assign checkbox is unchecked', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+
+    fireEvent.change(screen.getByLabelText('Tenant ID'), { target: { value: 'tnt-9' } });
+    fireEvent.change(screen.getByLabelText('Custom plan display name'), {
+      target: { value: 'Bespoke' },
+    });
+    fireEvent.click(screen.getByLabelText(/Assign to the tenant immediately/i));
+    fireEvent.click(screen.getByRole('button', { name: 'Mint custom plan' }));
+
+    await waitFor(() => expect(mockApi.mintCustomPlan).toHaveBeenCalled());
+    expect(mockTenantsApi.updatePlan).not.toHaveBeenCalled();
+  });
+
+  it('requires tenant id and display name', async () => {
+    render(<CustomPlanPanel />);
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mint custom plan' }));
+    expect(await screen.findByText(/Tenant ID is required/i)).toBeInTheDocument();
+    expect(mockApi.mintCustomPlan).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/MarginPolicyPanel.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/MarginPolicyPanel.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MarginPolicyPanel } from '../MarginPolicyPanel.js';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    listMargins: vi.fn(),
+    versionMargin: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../services/admin/admin-pricing-client.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../services/admin/admin-pricing-client.js')
+  >();
+  return { ...actual, adminPricingApi: mockApi };
+});
+
+const POLICY = {
+  id: 'm1',
+  scope: 'global',
+  refKey: null,
+  markupMultiplier: 1.5,
+  fixedUsdPer1M: null,
+  effectiveFrom: '2026-01-01T00:00:00.000Z',
+  status: 'active',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('MarginPolicyPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.listMargins.mockResolvedValue({ policies: [POLICY] });
+    mockApi.versionMargin.mockResolvedValue({ policy: POLICY, supersededPolicyId: 'old-123456' });
+  });
+
+  it('renders the policy list', async () => {
+    render(<MarginPolicyPanel />);
+    await waitFor(() => expect(screen.getByText('global')).toBeInTheDocument());
+    expect(screen.getByText('1.5')).toBeInTheDocument();
+  });
+
+  it('validates that at least one knob is set before saving', async () => {
+    render(<MarginPolicyPanel />);
+    await waitFor(() => expect(screen.getByText('global')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save policy' }));
+    expect(
+      await screen.findByText(/at least one of markup multiplier or fixed/i),
+    ).toBeInTheDocument();
+    expect(mockApi.versionMargin).not.toHaveBeenCalled();
+  });
+
+  it('calls versionMargin and surfaces the supersede result', async () => {
+    render(<MarginPolicyPanel />);
+    await waitFor(() => expect(screen.getByText('global')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Markup multiplier'), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save policy' }));
+
+    await waitFor(() => expect(mockApi.versionMargin).toHaveBeenCalled());
+    const body = mockApi.versionMargin.mock.calls[0]![0];
+    expect(body.scope).toBe('global');
+    expect(body.markupMultiplier).toBe(2);
+    expect(body.refKey).toBeNull();
+    await waitFor(() => expect(screen.getByText(/superseded prior/i)).toBeInTheDocument());
+  });
+
+  it('requires a ref key for a provider-scoped policy', async () => {
+    render(<MarginPolicyPanel />);
+    await waitFor(() => expect(screen.getByText('global')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByLabelText('Margin scope'), { target: { value: 'provider' } });
+    fireEvent.change(screen.getByLabelText('Markup multiplier'), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save policy' }));
+
+    expect(await screen.findByText(/requires a ref key/i)).toBeInTheDocument();
+    expect(mockApi.versionMargin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx
@@ -75,6 +75,42 @@ describe('PlanVersionEditor', () => {
     expect(mockApi.createPlan).not.toHaveBeenCalled();
   });
 
+  // Fix 3: a non-numeric limit must block submit with an inline error, NOT be
+  // coerced to null/unlimited via NaN.
+  it('blocks save when an entitlement limit is a non-numeric typo (NaN)', async () => {
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'New plan' }));
+    fireEvent.change(screen.getByLabelText('Slug'), { target: { value: 'starter' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Starter' } });
+    // "10O0" (letter O) → Number(...) === NaN.
+    fireEvent.change(screen.getByLabelText('Entitlement limit 0'), { target: { value: '10O0' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText(/is not a number/i)).toBeInTheDocument();
+    expect(mockApi.createPlan).not.toHaveBeenCalled();
+  });
+
+  it('allows save with a blank limit (unlimited → null) and a valid number', async () => {
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'New plan' }));
+    fireEvent.change(screen.getByLabelText('Slug'), { target: { value: 'starter' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Starter' } });
+    // First row: blank → unlimited (null). Add a second row with a valid number.
+    // Three collections each render a "+ Add"; Entitlements is the first.
+    fireEvent.click(screen.getAllByRole('button', { name: '+ Add' })[0]!);
+    fireEvent.change(screen.getByLabelText('Entitlement limit 1'), { target: { value: '250' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockApi.createPlan).toHaveBeenCalled());
+    const body = mockApi.createPlan.mock.calls[0]![0];
+    expect(body.entitlements[0].limitValue).toBeNull();
+    expect(body.entitlements[1].limitValue).toBe(250);
+  });
+
   it('surfaces the 409 affected-tenant count and forces deprecate on confirm', async () => {
     mockApi.deprecateVersion
       .mockRejectedValueOnce(

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/PlanVersionEditor.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { PlanVersionEditor } from '../PlanVersionEditor.js';
+import { AdminPricingApiError } from '../../../../services/admin/admin-pricing-client.js';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    listPlans: vi.fn(),
+    createPlan: vi.fn(),
+    versionPlan: vi.fn(),
+    deprecateVersion: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../services/admin/admin-pricing-client.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../services/admin/admin-pricing-client.js')
+  >();
+  return { ...actual, adminPricingApi: mockApi };
+});
+
+const PLAN = {
+  planId: 'p1',
+  slug: 'pro',
+  displayName: 'Pro',
+  version: 2,
+  status: 'active',
+  isCustom: false,
+  billingInterval: 'monthly',
+  supersedesPlanId: null,
+  features: [],
+  entitlements: [{ metricKey: 3, limitValue: 10, period: 'monthly', overageMode: 'block' }],
+  prices: [],
+};
+
+describe('PlanVersionEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.listPlans.mockResolvedValue({ plans: [PLAN] });
+    mockApi.createPlan.mockResolvedValue({ ...PLAN, slug: 'starter', version: 1 });
+    mockApi.deprecateVersion.mockResolvedValue({ deprecated: true });
+  });
+
+  it('lists non-custom plans with a numeric-ordinal entitlement rendered as a label', async () => {
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(mockApi.listPlans).toHaveBeenCalledWith({ isCustom: false });
+    // metricKey ordinal 3 → "seats" label.
+    expect(screen.getByText(/seats=10/)).toBeInTheDocument();
+  });
+
+  it('creates a new plan from the editor form', async () => {
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'New plan' }));
+    fireEvent.change(screen.getByLabelText('Slug'), { target: { value: 'starter' } });
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Starter' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(mockApi.createPlan).toHaveBeenCalled());
+    const body = mockApi.createPlan.mock.calls[0]![0];
+    expect(body.slug).toBe('starter');
+    expect(body.displayName).toBe('Starter');
+    expect(Array.isArray(body.entitlements)).toBe(true);
+    await waitFor(() => expect(screen.getByText(/Created starter v1/)).toBeInTheDocument());
+  });
+
+  it('blocks save when required fields are missing', async () => {
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'New plan' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText(/Slug is required/i)).toBeInTheDocument();
+    expect(mockApi.createPlan).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the 409 affected-tenant count and forces deprecate on confirm', async () => {
+    mockApi.deprecateVersion
+      .mockRejectedValueOnce(
+        new AdminPricingApiError(409, 'has assignments', { affectedTenantCount: 4 }),
+      )
+      .mockResolvedValueOnce({ deprecated: true });
+
+    render(<PlanVersionEditor />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Deprecate' }));
+    await waitFor(() => expect(screen.getByText(/4 tenants on this version/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Deprecate anyway \(force\)/i }));
+    await waitFor(() =>
+      expect(mockApi.deprecateVersion).toHaveBeenLastCalledWith('pro', 2, true),
+    );
+  });
+});

--- a/packages/dashboard/src/pages/admin/pricing/__tests__/PricingTab.test.tsx
+++ b/packages/dashboard/src/pages/admin/pricing/__tests__/PricingTab.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { PricingTab } from '../PricingTab.js';
+
+const { mockApi } = vi.hoisted(() => ({
+  mockApi: {
+    getOverview: vi.fn(),
+    listPlans: vi.fn(),
+    listMargins: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../services/admin/admin-pricing-client.js', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('../../../../services/admin/admin-pricing-client.js')
+  >();
+  return { ...actual, adminPricingApi: mockApi };
+});
+
+const OVERVIEW = {
+  plans: [
+    {
+      planId: 'p1',
+      slug: 'pro',
+      displayName: 'Pro',
+      version: 1,
+      status: 'active',
+      isCustom: false,
+      billingInterval: 'monthly',
+      recurringUsd: 49,
+      activeTenantCount: 7,
+    },
+  ],
+  margins: {
+    activePolicyCount: 1,
+    globalPolicyCount: 1,
+    planScopedPolicyCount: 0,
+    providerScopedPolicyCount: 0,
+    globalMarkupMultiplier: 1.5,
+    globalFixedUsdPer1M: 0.5,
+  },
+  totals: {
+    activePlanCount: 1,
+    customPlanCount: 0,
+    deprecatedPlanCount: 0,
+    totalActiveAssignments: 7,
+    plansWithActiveAssignments: 1,
+  },
+};
+
+describe('PricingTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApi.getOverview.mockResolvedValue(OVERVIEW);
+    mockApi.listPlans.mockResolvedValue({ plans: [] });
+    mockApi.listMargins.mockResolvedValue({ policies: [] });
+  });
+
+  it('renders the overview panel with plan catalog + margin summary by default', async () => {
+    render(<PricingTab />);
+    await waitFor(() => expect(screen.getByText('Pro')).toBeInTheDocument());
+    expect(screen.getByText('Plan catalog')).toBeInTheDocument();
+    // Margin summary knob is shown (platform-owner economics).
+    expect(screen.getByText('1.5')).toBeInTheDocument();
+    // The plan's recurring list price (admin-only surface).
+    expect(screen.getByText('$49.00')).toBeInTheDocument();
+  });
+
+  it('renders all four sub-tabs and switches to Plans', async () => {
+    render(<PricingTab />);
+    expect(screen.getByRole('button', { name: 'Overview' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Plans' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Margins' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Custom Plans' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Plans' }));
+    await waitFor(() => expect(mockApi.listPlans).toHaveBeenCalled());
+    expect(screen.getByRole('button', { name: 'New plan' })).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the catalog is empty', async () => {
+    mockApi.getOverview.mockResolvedValue({
+      ...OVERVIEW,
+      plans: [],
+      totals: { ...OVERVIEW.totals, activePlanCount: 0 },
+    });
+    render(<PricingTab />);
+    await waitFor(() =>
+      expect(screen.getByText(/No plans in the catalog yet/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/dashboard/src/services/admin/admin-pricing-client.test.ts
+++ b/packages/dashboard/src/services/admin/admin-pricing-client.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Story 34-9 — admin pricing client contract tests. Assert every method builds
+ * the right URL/method/body, a non-2xx surfaces AdminPricingApiError, and the
+ * 409 deprecate path parses affectedTenantCount.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  adminPricingApi,
+  AdminPricingApiError,
+  metricKeyLabel,
+  METRIC_KEYS,
+} from './admin-pricing-client';
+
+function mockJson<T>(body: T, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function lastCall(spy: ReturnType<typeof vi.fn>): [string, RequestInit | undefined] {
+  const call = spy.mock.calls[0] ?? [];
+  return [call[0] as string, call[1] as RequestInit | undefined];
+}
+
+describe('adminPricingApi — URL/method/body matrix', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('getOverview GETs /api/admin/pricing/overview', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(
+      mockJson({ plans: [], margins: {}, totals: {} }),
+    );
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.getOverview();
+
+    const [url] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/overview');
+  });
+
+  it('listPlans forwards status/isCustom/tenantId query params', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ plans: [] }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.listPlans({ status: 'active', isCustom: false, tenantId: 'tnt-1' });
+
+    const [url] = lastCall(spy);
+    expect(url).toContain('/api/admin/pricing/plans?');
+    expect(url).toContain('status=active');
+    expect(url).toContain('isCustom=false');
+    expect(url).toContain('tenantId=tnt-1');
+  });
+
+  it('createPlan POSTs the body to /api/admin/pricing/plans', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ planId: 'p', slug: 'pro' }, 201));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.createPlan({
+      slug: 'pro',
+      displayName: 'Pro',
+      billingInterval: 'monthly',
+      entitlements: [{ metricKey: 'seats', limitValue: 10, period: 'monthly', overageMode: 'block' }],
+    });
+
+    const [url, init] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/plans');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body.slug).toBe('pro');
+    expect(body.entitlements[0].metricKey).toBe('seats');
+  });
+
+  it('versionPlan PUTs to /api/admin/pricing/plans/{slug}', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ planId: 'p', slug: 'pro', version: 2 }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.versionPlan('pro', { displayName: 'Pro v2', entitlements: null });
+
+    const [url, init] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/plans/pro');
+    expect(init?.method).toBe('PUT');
+    const body = JSON.parse(init?.body as string);
+    expect(body.entitlements).toBeNull(); // null ⇒ copy prior version
+  });
+
+  it('mintCustomPlan POSTs to /api/admin/pricing/plans/custom', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ planId: 'cp', slug: 'custom-x', isCustom: true }, 201));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.mintCustomPlan({
+      tenantId: 'tnt-9',
+      displayName: 'Bespoke',
+      billingInterval: 'annual',
+    });
+
+    const [url, init] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/plans/custom');
+    expect(init?.method).toBe('POST');
+    const body = JSON.parse(init?.body as string);
+    expect(body.tenantId).toBe('tnt-9');
+    expect(body.makePublic).toBeUndefined(); // never asks for public visibility
+  });
+
+  it('deprecateVersion DELETEs with force flag and returns deprecated on 204', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(new Response(null, { status: 204 }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    const result = await adminPricingApi.deprecateVersion('pro', 3, true);
+
+    const [url, init] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/plans/pro/versions/3?force=true');
+    expect(init?.method).toBe('DELETE');
+    expect(result.deprecated).toBe(true);
+  });
+
+  it('deprecateVersion surfaces 409 with affectedTenantCount', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(
+      mockJson(
+        {
+          error: 'PLAN.DEPRECATE.HAS_ASSIGNMENTS',
+          message: 'has assignments',
+          affectedTenantCount: 4,
+        },
+        409,
+      ),
+    );
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await expect(adminPricingApi.deprecateVersion('pro', 3, false)).rejects.toMatchObject({
+      status: 409,
+    });
+
+    // Re-run to inspect the thrown body.
+    const spy2 = vi.fn().mockResolvedValueOnce(
+      mockJson({ affectedTenantCount: 4 }, 409),
+    );
+    globalThis.fetch = spy2 as unknown as typeof fetch;
+    try {
+      await adminPricingApi.deprecateVersion('pro', 3, false);
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AdminPricingApiError);
+      expect((err as AdminPricingApiError).status).toBe(409);
+      expect((err as AdminPricingApiError).body).toMatchObject({ affectedTenantCount: 4 });
+    }
+  });
+
+  it('listMargins GETs /api/admin/pricing/margins', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ policies: [] }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.listMargins();
+
+    const [url] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/margins');
+  });
+
+  it('versionMargin PUTs the policy body', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ policy: {}, supersededPolicyId: null }));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await adminPricingApi.versionMargin({ scope: 'global', markupMultiplier: 1.5 });
+
+    const [url, init] = lastCall(spy);
+    expect(url).toBe('/api/admin/pricing/margins');
+    expect(init?.method).toBe('PUT');
+    const body = JSON.parse(init?.body as string);
+    expect(body.scope).toBe('global');
+    expect(body.markupMultiplier).toBe(1.5);
+  });
+
+  it('surfaces a typed AdminPricingApiError on non-2xx', async () => {
+    const spy = vi.fn().mockResolvedValueOnce(mockJson({ error: 'boom' }, 500));
+    globalThis.fetch = spy as unknown as typeof fetch;
+
+    await expect(adminPricingApi.getOverview()).rejects.toBeInstanceOf(AdminPricingApiError);
+  });
+});
+
+describe('metricKeyLabel', () => {
+  it('maps numeric ordinals to snake_case keys', () => {
+    expect(metricKeyLabel(0)).toBe('agents');
+    expect(metricKeyLabel(3)).toBe('seats');
+    expect(metricKeyLabel(METRIC_KEYS.length - 1)).toBe('benchmark_retention_days');
+  });
+
+  it('passes through a string metric key unchanged', () => {
+    expect(metricKeyLabel('llm_tokens')).toBe('llm_tokens');
+  });
+
+  it('falls back for an out-of-range ordinal', () => {
+    expect(metricKeyLabel(99)).toBe('metric_99');
+  });
+});

--- a/packages/dashboard/src/services/admin/admin-pricing-client.ts
+++ b/packages/dashboard/src/services/admin/admin-pricing-client.ts
@@ -1,0 +1,313 @@
+/**
+ * Story 34-9 — typed HTTP client for the platform-owner PRICING dashboard.
+ * Mirrors the `admin-tenants-client.ts` `fetchJSON<T>` + typed-error pattern.
+ *
+ * Every route below is gated server-side by `PlatformOwnerAccess` (the price
+ * book + margin policies are platform-GLOBAL in both single-user and SaaS
+ * modes). The admin dashboard UI is already inside the `AdminGuard` chain, but
+ * the server is authoritative — the UI gate is UX-only.
+ *
+ * Routes consumed (all under `/api`, mirroring AdminPricing*Endpoints.cs):
+ *   GET    /api/admin/pricing/overview                              (34-9 dashboard rollup)
+ *   GET    /api/admin/pricing/plans?status=&isCustom=&tenantId=     (34-2 admin catalog)
+ *   POST   /api/admin/pricing/plans                                 (34-2 create v1 → 201)
+ *   PUT    /api/admin/pricing/plans/{slug}                          (34-2 version → 200)
+ *   POST   /api/admin/pricing/plans/custom                          (34-2 mint bespoke → 201)
+ *   DELETE /api/admin/pricing/plans/{slug}/versions/{version}?force= (34-2 deprecate → 204/409)
+ *   GET    /api/admin/pricing/margins                               (34-5 list policies)
+ *   PUT    /api/admin/pricing/margins                               (34-5 version policy)
+ *
+ * Plan assignment (34-4) is NOT duplicated here — the CustomPlanPanel reuses
+ * `adminTenantsApi.updatePlan(tenantId, planId)` from admin-tenants-client.ts.
+ *
+ * Wire field names are camelCase because the API's default System.Text.Json
+ * policy lower-cases the C# PascalCase records (see admin-tenants-client.ts).
+ * NOTE: there is NO global JsonStringEnumConverter, so PlanSnapshot entitlement
+ * `metricKey` arrives as a NUMERIC ordinal (see METRIC_KEYS / metricKeyLabel).
+ */
+
+const API_BASE = (import.meta.env as { VITE_API_BASE_URL?: string }).VITE_API_BASE_URL ?? '/api';
+
+export class AdminPricingApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = 'AdminPricingApiError';
+  }
+}
+
+async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${url}`, {
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'include',
+    ...options,
+  });
+  if (!response.ok) {
+    const err = (await response.json().catch(() => ({ error: response.statusText }))) as Record<
+      string,
+      unknown
+    >;
+    const message =
+      (err.message as string | undefined) ??
+      (err.error as string | undefined) ??
+      `HTTP ${response.status}`;
+    throw new AdminPricingApiError(response.status, message, err);
+  }
+  if (response.status === 204) return undefined as unknown as T;
+  return (await response.json()) as T;
+}
+
+// ── Entitlement metric keys ──────────────────────────────────────────
+// Canonical snake_case list in EntitlementMetricKey enum-declaration order.
+// The write DTO (PlanEntitlementDto.MetricKey) is the snake_case string; a
+// PlanSnapshot READ returns the numeric ordinal (no string-enum converter),
+// so `metricKeyLabel` maps ordinal → snake_case for display.
+export const METRIC_KEYS = [
+  'agents',
+  'workflow_runs',
+  'llm_tokens',
+  'seats',
+  'repos',
+  'rag_storage_mb',
+  'benchmark_retention_days',
+] as const;
+
+export type EntitlementMetricKey = (typeof METRIC_KEYS)[number];
+
+/** Map a PlanSnapshot entitlement `metricKey` (numeric ordinal OR already a string) to its snake_case label. */
+export function metricKeyLabel(metricKey: number | string): string {
+  if (typeof metricKey === 'string') return metricKey;
+  return METRIC_KEYS[metricKey] ?? `metric_${metricKey}`;
+}
+
+export const ENTITLEMENT_PERIODS = ['monthly', 'total'] as const;
+export type EntitlementPeriod = (typeof ENTITLEMENT_PERIODS)[number];
+
+export const OVERAGE_MODES = ['block', 'allow', 'meter'] as const;
+export type OverageMode = (typeof OVERAGE_MODES)[number];
+
+export const PRICING_MODES = ['platform_provided', 'byok'] as const;
+export type PricingMode = (typeof PRICING_MODES)[number];
+
+export const MARGIN_SCOPES = ['global', 'plan', 'provider'] as const;
+export type MarginScope = (typeof MARGIN_SCOPES)[number];
+
+// ── Plan snapshot wire types (PlanSnapshot.cs) ───────────────────────
+
+export interface PlanFeatureView {
+  featureKey: string;
+  boolValue: boolean | null;
+  stringValue: string | null;
+}
+
+export interface PlanEntitlementView {
+  /** Numeric ordinal on the wire (no string-enum converter). Use metricKeyLabel(). */
+  metricKey: number | string;
+  limitValue: number | null;
+  period: string;
+  overageMode: string;
+}
+
+export interface PlanPriceView {
+  pricingMode: string;
+  recurringUsd: number;
+  seatUsd: number;
+  meteredComponent: string;
+}
+
+export interface PlanSnapshot {
+  planId: string;
+  slug: string;
+  displayName: string;
+  version: number;
+  status: string;
+  isCustom: boolean;
+  billingInterval: string;
+  supersedesPlanId: string | null;
+  features: PlanFeatureView[];
+  entitlements: PlanEntitlementView[];
+  prices: PlanPriceView[];
+}
+
+// ── Overview wire types (AdminPricingDashboardEndpoints.cs) ───────────
+
+export interface PlanOverviewRow {
+  planId: string;
+  slug: string;
+  displayName: string;
+  version: number;
+  status: string;
+  isCustom: boolean;
+  billingInterval: string;
+  recurringUsd: number | null;
+  activeTenantCount: number;
+}
+
+export interface MarginSummary {
+  activePolicyCount: number;
+  globalPolicyCount: number;
+  planScopedPolicyCount: number;
+  providerScopedPolicyCount: number;
+  globalMarkupMultiplier: number | null;
+  globalFixedUsdPer1M: number | null;
+}
+
+export interface PricingOverviewTotals {
+  activePlanCount: number;
+  customPlanCount: number;
+  deprecatedPlanCount: number;
+  totalActiveAssignments: number;
+  plansWithActiveAssignments: number;
+}
+
+export interface PricingOverviewResponse {
+  plans: PlanOverviewRow[];
+  margins: MarginSummary;
+  totals: PricingOverviewTotals;
+}
+
+// ── Margin policy wire types (AdminPricingEndpoints.cs) ───────────────
+
+export interface MarginPolicyDto {
+  id: string;
+  scope: string;
+  refKey: string | null;
+  markupMultiplier: number | null;
+  fixedUsdPer1M: number | null;
+  effectiveFrom: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface VersionMarginResponse {
+  policy: MarginPolicyDto;
+  supersededPolicyId: string | null;
+}
+
+// ── Request bodies ───────────────────────────────────────────────────
+
+export interface PlanFeatureBody {
+  featureKey: string;
+  boolValue?: boolean | null;
+  stringValue?: string | null;
+}
+
+export interface PlanEntitlementBody {
+  /** snake_case string validated against EntitlementMetricKey server-side. */
+  metricKey: string;
+  limitValue: number | null;
+  period: string;
+  overageMode: string;
+}
+
+export interface PlanPriceBody {
+  pricingMode: string;
+  recurringUsd: number;
+  seatUsd: number;
+  meteredComponentJson?: string | null;
+}
+
+export interface CreatePlanBody {
+  slug: string;
+  displayName: string;
+  billingInterval: string;
+  features?: PlanFeatureBody[] | null;
+  entitlements?: PlanEntitlementBody[] | null;
+  prices?: PlanPriceBody[] | null;
+}
+
+/** Null child collections mean "copy from the prior version" (PlanDraftSpec semantics). */
+export interface VersionPlanBody {
+  displayName?: string | null;
+  billingInterval?: string | null;
+  features?: PlanFeatureBody[] | null;
+  entitlements?: PlanEntitlementBody[] | null;
+  prices?: PlanPriceBody[] | null;
+}
+
+export interface MintCustomPlanBody {
+  tenantId: string;
+  displayName: string;
+  billingInterval: string;
+  features?: PlanFeatureBody[] | null;
+  entitlements?: PlanEntitlementBody[] | null;
+  prices?: PlanPriceBody[] | null;
+  /** Never sent true by the UI; server rejects a public custom plan with 400 (AC5). */
+  makePublic?: boolean;
+}
+
+export interface VersionMarginBody {
+  scope: string;
+  refKey?: string | null;
+  markupMultiplier?: number | null;
+  fixedUsdPer1M?: number | null;
+  effectiveFrom?: string | null;
+}
+
+export interface ListPlansOpts {
+  status?: string;
+  isCustom?: boolean;
+  tenantId?: string;
+}
+
+/** Result of a deprecate call: success is 204; a 409 throws AdminPricingApiError. */
+export interface DeprecateResult {
+  deprecated: boolean;
+}
+
+function planQuery(opts?: ListPlansOpts): string {
+  if (!opts) return '';
+  const params = new URLSearchParams();
+  if (opts.status) params.set('status', opts.status);
+  if (opts.isCustom !== undefined) params.set('isCustom', String(opts.isCustom));
+  if (opts.tenantId) params.set('tenantId', opts.tenantId);
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export const adminPricingApi = {
+  // 34-9 dashboard rollup
+  getOverview: (): Promise<PricingOverviewResponse> => fetchJSON('/admin/pricing/overview'),
+
+  // 34-2 plan catalog
+  listPlans: (opts?: ListPlansOpts): Promise<{ plans: PlanSnapshot[] }> =>
+    fetchJSON(`/admin/pricing/plans${planQuery(opts)}`),
+
+  createPlan: (body: CreatePlanBody): Promise<PlanSnapshot> =>
+    fetchJSON('/admin/pricing/plans', { method: 'POST', body: JSON.stringify(body) }),
+
+  versionPlan: (slug: string, body: VersionPlanBody): Promise<PlanSnapshot> =>
+    fetchJSON(`/admin/pricing/plans/${encodeURIComponent(slug)}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
+
+  mintCustomPlan: (body: MintCustomPlanBody): Promise<PlanSnapshot> =>
+    fetchJSON('/admin/pricing/plans/custom', { method: 'POST', body: JSON.stringify(body) }),
+
+  deprecateVersion: async (
+    slug: string,
+    version: number,
+    force = false,
+  ): Promise<DeprecateResult> => {
+    await fetchJSON<void>(
+      `/admin/pricing/plans/${encodeURIComponent(slug)}/versions/${version}?force=${force}`,
+      { method: 'DELETE' },
+    );
+    // 204 → success; a 409 (active assignments, no force) throws
+    // AdminPricingApiError whose body carries { affectedTenantCount }.
+    return { deprecated: true };
+  },
+
+  // 34-5 margins
+  listMargins: (): Promise<{ policies: MarginPolicyDto[] }> => fetchJSON('/admin/pricing/margins'),
+
+  versionMargin: (body: VersionMarginBody): Promise<VersionMarginResponse> =>
+    fetchJSON('/admin/pricing/margins', { method: 'PUT', body: JSON.stringify(body) }),
+};


### PR DESCRIPTION
## What

Story 34-9's dashboard UI (React), consuming the already-shipped pricing backend — no .NET/EF touched.

- **Admin (`packages/dashboard`, PlatformOwner-gated):** Pricing tab — plan catalog overview (`/api/admin/pricing/overview`: plans + per-plan active-tenant counts + margin rollup), plan version editor (create/deprecate with affected-count + force), margin editor, custom-plan mint + assign.
- **Tenant (`packages/dashboard-user`):** `/settings/billing` — current plan, entitlement bars, **sell-price-only** estimate, change-plan modal with entitlement gain/loss diff.
- Deferred (backend not yet shipped): AC-4/AC-10 promo/credit (34-7) + AC-7 BYOK toggle UI (34-3 endpoints now merging — a quick follow-up once live).

## Review + fixes (all applied)

Focused review confirmed **no cost/margin leak** (verified in the payload, not just JSX — tenant types carry only sell price, never call admin routes; enum-ordinal mapper correct; admin economics `PlatformOwnerAccess`-gated). Fixed 3:
- **RBAC-UI vs server:** change-plan was shown to `tenant_admin` but `/subscribe` is owner-only → invited 403. Gated to owner + sole-user (`role === 'owner' || role === ''`) to match the server.
- **Entitlement delta inversion:** absent metrics were folded into `Infinity`, so a downgrade dropping a metric rendered as "→ Unlimited". Now three cases (present-both / added / removed) — a dropped metric is a labelled loss.
- **NaN plan limit:** a mistyped admin limit (`10O0`) silently became `null`=unlimited → now a blocking validation error.

## Verification

- `pnpm --filter @tamma/dashboard-user test` → 103 passed; `pnpm --filter @tamma/dashboard test` → 302 passed. Both packages build clean. (Pre-existing typecheck errors in unrelated files — `TenantAlertFeed.tsx`, `AccountPage.tsx` — confirmed present on clean HEAD, not from this PR, not build-gating.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)