### PR TITLE
feat(epic-3-5): ClarifyingQuestionsWorkflow + secure resume endpoint

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/ClarifyEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/ClarifyEvents.cs
@@ -1,0 +1,87 @@
+namespace Tamma.Activities.Clarify;
+
+/// <summary>
+/// Story 3.5 (Clarifying Questions Workflow) — central catalogue of the
+/// <c>CLARIFY.*</c> DCB event types emitted by the <c>clarifying-questions</c>
+/// sub-workflow via <see cref="EmitClarifyEventActivity"/>. Type pattern follows
+/// the platform's <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and
+/// mirrors the sibling event catalogues
+/// (<see cref="Tamma.Activities.Blocker.BlockerEvents"/>,
+/// <see cref="Tamma.Activities.ADL.BranchEvents"/>).
+///
+/// <para>The clarifying-questions workflow resolves ambiguity in an issue /
+/// requirement: it asks the LLM (via the mediated <c>llm-call</c> path — the engine
+/// holds no LLM credential) to generate clarifying questions, DELIVERS them to the
+/// issue, SUSPENDS on a bookmark awaiting the human answers, then RESUMES and
+/// incorporates the answers into a disambiguated requirement. Each transition is an
+/// auditable step so time-travel debugging and the Epic-32 learning loop can
+/// reconstruct WHAT was ambiguous, WHICH questions were asked, and HOW the answers
+/// resolved it. Without these events the clarification is invisible to the audit
+/// trail (Story 3.5 AC "System tracks question status" + "Question-answer pairs are
+/// stored for future learning").</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="Tamma.Activities.Blocker.EmitBlockerEventActivity"/> uses. No
+/// activity holds a DB / repository dependency of its own; the drain resolves the
+/// tenant from the workflow scope and each event carries a <c>tenantId</c> tag so
+/// per-tenant data stays tenant-scoped.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>CLARIFY.QUESTIONS.GENERATED</c> — the LLM produced a
+///     non-empty set of clarifying questions for the ambiguous requirement.</description></item>
+///   <item><description><c>CLARIFY.QUESTIONS.DELIVERED</c> — the questions were
+///     posted to the issue / surfaced to the stakeholder (carries channel).</description></item>
+///   <item><description><c>CLARIFY.ANSWERS.RECEIVED</c> — the human answered; the
+///     workflow resumed from its bookmark with the answers.</description></item>
+///   <item><description><c>CLARIFY.REQUIREMENTS.CLARIFIED</c> — terminal success:
+///     the answers were incorporated into a disambiguated requirement.</description></item>
+///   <item><description><c>CLARIFY.QUESTIONS.FAILED</c> — LOUD (error-status): the
+///     question-generation <c>llm-call</c> failed or returned unparseable output;
+///     the workflow fails closed rather than proceeding with fabricated questions.</description></item>
+///   <item><description><c>CLARIFY.INCORPORATION.FAILED</c> — LOUD (error-status):
+///     the answer-incorporation <c>llm-call</c> failed or returned unparseable
+///     output; fail-closed, never a fabricated clarification.</description></item>
+///   <item><description><c>CLARIFY.ANSWERS.TIMED_OUT</c> — LOUD (error-status):
+///     the answer SLA expired with no human response. A distinct, auditable
+///     terminal, NEVER a silent false success.</description></item>
+/// </list>
+/// </summary>
+public static class ClarifyEvents
+{
+    public const string QuestionsGenerated = "CLARIFY.QUESTIONS.GENERATED";
+    public const string QuestionsDelivered = "CLARIFY.QUESTIONS.DELIVERED";
+    public const string AnswersReceived = "CLARIFY.ANSWERS.RECEIVED";
+    public const string RequirementsClarified = "CLARIFY.REQUIREMENTS.CLARIFIED";
+
+    // LOUD (error-status) terminals — a fabricated / degraded outcome must never be
+    // recorded as a false success.
+    public const string QuestionsFailed = "CLARIFY.QUESTIONS.FAILED";
+    public const string IncorporationFailed = "CLARIFY.INCORPORATION.FAILED";
+    public const string AnswersTimedOut = "CLARIFY.ANSWERS.TIMED_OUT";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (clarify events in single-user mode are platform-scope, TenantId null).
+    /// Mirrors <see cref="Tamma.Activities.Blocker.BlockerEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed generation / incorporation and an answer SLA
+    /// expiry are LOUD (error-status) audit rows; every other transition
+    /// (generated, delivered, answers received, requirements clarified) is a normal
+    /// (success-status) row. Keeps a degraded/expired terminal from ever being
+    /// recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        QuestionsFailed => "error",
+        IncorporationFailed => "error",
+        AnswersTimedOut => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/ClarifyParsing.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/ClarifyParsing.cs
@@ -1,0 +1,131 @@
+using System.Text.Json;
+using Tamma.Activities.Clarify.Models;
+
+namespace Tamma.Activities.Clarify;
+
+/// <summary>
+/// Story 3.5 — pure, context-free parsers that recover the structured shapes from a
+/// mediated <c>llm-call</c> text response. Kept side-effect-free (no Elsa context) so
+/// the fail-closed behaviour is unit-testable without a live LLM. Mirrors the
+/// JSON-slice approach in <c>AssessmentWorkflow</c> / <c>ContextGatheringWorkflow</c>.
+///
+/// <para>Every parser is <b>fail-closed</b>: unparseable / empty output yields an
+/// empty question list (or a null clarification), which the workflow routes to its
+/// <c>CLARIFY.*.FAILED</c> error terminal — it NEVER fabricates questions or a
+/// clarification the downstream would act on.</para>
+/// </summary>
+public static class ClarifyParsing
+{
+    /// <summary>
+    /// Extract the clarifying questions from an <c>llm-call</c> text response.
+    /// Tolerant of three shapes the prompt may produce:
+    /// a bare JSON array of strings (<c>["Q1","Q2"]</c>), a
+    /// <c>{"questions":[...]}</c> / <c>{"clarifyingQuestions":[...]}</c> object.
+    /// Returns an EMPTY list when nothing parseable is found (fail-closed).
+    /// </summary>
+    public static List<string> ParseQuestions(string? llmText)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return new List<string>();
+
+        // Shape 1: a bare JSON array of strings anywhere in the text.
+        var arrStart = llmText.IndexOf('[');
+        var arrEnd = llmText.LastIndexOf(']');
+        if (arrStart >= 0 && arrEnd > arrStart)
+        {
+            try
+            {
+                var list = JsonSerializer.Deserialize<List<string>>(llmText[arrStart..(arrEnd + 1)]);
+                var cleaned = Clean(list);
+                if (cleaned.Count > 0)
+                    return cleaned;
+            }
+            catch { /* fall through to object shapes */ }
+        }
+
+        // Shape 2/3: a JSON object carrying a "questions" / "clarifyingQuestions" array.
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart >= 0 && objEnd > objStart)
+        {
+            try
+            {
+                var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+                foreach (var key in new[] { "questions", "clarifyingQuestions" })
+                {
+                    var cleaned = ExtractStringList(element, key);
+                    if (cleaned.Count > 0)
+                        return cleaned;
+                }
+            }
+            catch { /* fail closed below */ }
+        }
+
+        return new List<string>();
+    }
+
+    /// <summary>
+    /// Extract the disambiguated requirement from the incorporation <c>llm-call</c>
+    /// response. Expects a JSON object
+    /// <c>{"clarifiedRequirement":"...","remainingAmbiguities":[...],"resolved":bool}</c>.
+    /// Returns <c>null</c> when the object or the required <c>clarifiedRequirement</c>
+    /// field is missing / empty (fail-closed) so the workflow routes to its error
+    /// terminal rather than emitting an empty clarification.
+    /// </summary>
+    public static ClarificationResult? ParseClarification(string? llmText)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return null;
+
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart < 0 || objEnd <= objStart)
+            return null;
+
+        try
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+
+            var requirement = element.TryGetProperty("clarifiedRequirement", out var cr) && cr.ValueKind == JsonValueKind.String
+                ? cr.GetString() ?? string.Empty
+                : string.Empty;
+
+            // Fail-closed: the clarified requirement is the load-bearing field.
+            if (string.IsNullOrWhiteSpace(requirement))
+                return null;
+
+            var resolved = element.TryGetProperty("resolved", out var rv)
+                && (rv.ValueKind == JsonValueKind.True
+                    || (rv.ValueKind == JsonValueKind.String
+                        && string.Equals(rv.GetString(), "true", StringComparison.OrdinalIgnoreCase)));
+
+            return new ClarificationResult
+            {
+                ClarifiedRequirement = requirement,
+                RemainingAmbiguities = ExtractStringList(element, "remainingAmbiguities"),
+                Resolved = resolved,
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static List<string> ExtractStringList(JsonElement element, string key)
+    {
+        if (!element.TryGetProperty(key, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<string>();
+
+        return Clean(arr.EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.String)
+            .Select(e => e.GetString())
+            .ToList());
+    }
+
+    private static List<string> Clean(IEnumerable<string?>? values)
+        => (values ?? Enumerable.Empty<string?>())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!.Trim())
+            .ToList();
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/DeliverClarifyingQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/DeliverClarifyingQuestionsActivity.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
+using Tamma.Activities.Clarify.Models;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Clarify;
+
+/// <summary>
+/// Story 3.5 — delivers the generated clarifying questions to the stakeholder. When
+/// a repository + issue number are supplied the questions are posted to the issue as a
+/// comment via the MEDIATED git seam (<see cref="TammaApiClient.UpdateIssueStatusAsync"/>
+/// → <c>PATCH /api/v1/git/{repo}/issues/{n}</c>); the per-tenant git token is resolved
+/// and used server-side and NEVER travels to the engine (TAMMA001 — the engine holds no
+/// git credential). When no issue coordinates are supplied the activity falls back to
+/// "api" mode: the questions are already durable in workflow state / on the answer
+/// bookmark, so a stakeholder can answer via the resume API.
+///
+/// <para>Fail-soft (mirrors <c>DeliverQuestionsActivity</c>): a delivery failure returns
+/// a <c>Success=false</c> <see cref="ClarifyDeliveryResult"/> rather than throwing, so
+/// the workflow still arms the answer bookmark (the human can still respond via API) and
+/// records a truthful <c>CLARIFY.QUESTIONS.DELIVERED</c> audit row.</para>
+/// </summary>
+[Activity(
+    "Tamma.Clarify",
+    "Deliver Clarifying Questions",
+    "Post clarifying questions to the issue via the mediated git seam, or surface via workflow state",
+    Kind = ActivityKind.Task
+)]
+public class DeliverClarifyingQuestionsActivity : CodeActivity<ClarifyDeliveryResult>
+{
+    private readonly ILogger<DeliverClarifyingQuestionsActivity>? _logger;
+    private readonly TammaApiClient? _apiClient;
+
+    [Input(Description = "Clarify session id")]
+    public Input<Guid> SessionId { get; set; } = default!;
+
+    [Input(Description = "Issue / requirement id the ambiguity is about")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Repository slug (owner/repo) for the mediated issue-comment post; empty → api mode")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue number for the mediated issue-comment post; <= 0 → api mode")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Generated clarifying questions (JSON ClarifyQuestionSet)")]
+    public Input<string> QuestionsJson { get; set; } = default!;
+
+    [Input(Description = "Tenant id (GUID string) for the acting scope; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public DeliverClarifyingQuestionsActivity() { }
+
+    public DeliverClarifyingQuestionsActivity(
+        ILogger<DeliverClarifyingQuestionsActivity> logger,
+        TammaApiClient apiClient)
+    {
+        _logger = logger;
+        _apiClient = apiClient;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var repository = Repository.Get(context);
+        var issueNumber = IssueNumber.Get(context);
+        var questionsJson = QuestionsJson.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var ct = context.CancellationToken;
+
+        var message = FormatQuestionMessage(questionsJson, sessionId);
+
+        // api mode — no issue coordinates: the questions are already durable in workflow
+        // state / on the answer bookmark, surfaced to a stakeholder via the resume API.
+        if (string.IsNullOrWhiteSpace(repository) || issueNumber <= 0)
+        {
+            _logger?.LogInformation(
+                "API delivery mode: clarifying questions surfaced in workflow state for session {SessionId}",
+                sessionId);
+            context.SetResult(new ClarifyDeliveryResult
+            {
+                Success = true,
+                Channel = "api",
+                Message = "Questions available via workflow state / resume API",
+                DeliveredAt = DateTime.UtcNow,
+            });
+            return;
+        }
+
+        try
+        {
+            var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+            var response = await apiClient.UpdateIssueStatusAsync(
+                repository,
+                issueNumber,
+                new GitUpdateIssueRequest { Body = message, CorrelationId = correlationId },
+                tenantId,
+                ct).ConfigureAwait(false);
+
+            var success = response is { Success: true };
+            _logger?.LogInformation(
+                "Delivered clarifying questions to {Repo}#{Issue} for session {SessionId} (success={Success})",
+                repository, issueNumber, sessionId, success);
+
+            context.SetResult(new ClarifyDeliveryResult
+            {
+                Success = success,
+                Channel = "issue-comment",
+                Message = success
+                    ? $"Questions posted to {repository}#{issueNumber}"
+                    : $"Delivery failed: {response?.FailureReason ?? "git mediation endpoint unavailable"}",
+                DeliveredAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex,
+                "Failed to deliver clarifying questions for session {SessionId}", sessionId);
+            context.SetResult(new ClarifyDeliveryResult
+            {
+                Success = false,
+                Channel = "issue-comment",
+                Message = $"Delivery failed: {ex.Message}",
+                DeliveredAt = DateTime.UtcNow,
+            });
+        }
+    }
+
+    /// <summary>Format the clarifying-question set into a human-readable comment body.
+    /// Pure — exposed for unit testing.</summary>
+    public static string FormatQuestionMessage(string? questionsJson, Guid sessionId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("**Tamma: Clarifying Questions**");
+        sb.AppendLine();
+        sb.AppendLine("This requirement has some ambiguities. Please answer the questions below so development can proceed with a clear, unambiguous spec.");
+        sb.AppendLine();
+
+        try
+        {
+            var set = JsonSerializer.Deserialize<ClarifyQuestionSet>(questionsJson ?? "");
+            if (set is not null)
+            {
+                if (!string.IsNullOrWhiteSpace(set.ContextSummary))
+                {
+                    sb.AppendLine("**Context:**");
+                    sb.AppendLine(set.ContextSummary);
+                    sb.AppendLine();
+                }
+
+                for (var i = 0; i < set.Questions.Count; i++)
+                {
+                    sb.AppendLine($"{i + 1}. {set.Questions[i]}");
+                }
+            }
+        }
+        catch
+        {
+            sb.AppendLine(questionsJson);
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("---");
+        sb.AppendLine($"_Reply with your answers. Clarify session: {sessionId}_");
+        return sb.ToString();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/EmitClarifyEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/EmitClarifyEventActivity.cs
@@ -1,0 +1,117 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Clarify;
+
+/// <summary>
+/// Story 3.5 — emits a <c>CLARIFY.*</c> DCB event for the <c>clarifying-questions</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's
+/// <c>tamma:events</c> transient list via <see cref="TammaEventEmitter.Emit"/>. The
+/// merged engine event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>)
+/// flushes that list <i>durably</i> to the tenant <c>domain_events</c> store — the
+/// same pattern <see cref="Tamma.Activities.Blocker.EmitBlockerEventActivity"/> and
+/// <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> use. No activity holds
+/// a DB / repository dependency of its own (none is registered in the Elsa engine — a
+/// directly injected repository would be inert and silently drop every event).
+/// </summary>
+[Activity(
+    "Tamma.Clarify",
+    "Emit Clarify Event",
+    "Emit a CLARIFY.* DCB event for the clarifying-questions audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitClarifyEventActivity : Activity
+{
+    private readonly ILogger<EmitClarifyEventActivity>? _logger;
+
+    [Input(Description = "Event type — CLARIFY.QUESTIONS.GENERATED / .DELIVERED / CLARIFY.ANSWERS.RECEIVED / CLARIFY.REQUIREMENTS.CLARIFIED / CLARIFY.QUESTIONS.FAILED / CLARIFY.INCORPORATION.FAILED / CLARIFY.ANSWERS.TIMED_OUT")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Clarify session id (unguessable Guid string)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id the ambiguity is about")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Delivery channel (issue-comment / api) for DELIVERED events")]
+    public Input<string?> Channel { get; set; } = new((string?)null);
+
+    [Input(Description = "Number of clarifying questions generated / answered")]
+    public Input<int> QuestionCount { get; set; } = new(0);
+
+    [Input(Description = "Free-text detail for the audit payload")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitClarifyEventActivity() { }
+
+    public EmitClarifyEventActivity(ILogger<EmitClarifyEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? ClarifyEvents.QuestionsFailed;
+        var sessionId = SessionId.Get(context);
+        var issueId = IssueId.Get(context);
+        var tenantId = ClarifyEvents.ParseTenantId(TenantId.Get(context));
+        var channel = Channel.Get(context);
+        var questionCount = QuestionCount.Get(context);
+        var detail = Detail.Get(context);
+
+        var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, channel, questionCount, detail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for clarify session {Session} issue {Issue} (questions={Count})",
+            type, sessionId, issueId, questionCount);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the clarify event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>sessionId</c>/<c>issueId</c>/<c>channel</c>/
+    /// <c>tenantId</c>); <c>Data</c> carries the per-transition payload. Status is
+    /// driven off the event type (<see cref="ClarifyEvents.StatusForEvent"/>) so a
+    /// failed/timed-out terminal is a LOUD error row, never a false success. Pure (no
+    /// Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? issueId,
+        Guid? tenantId,
+        string? channel,
+        int questionCount,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (!string.IsNullOrWhiteSpace(channel)) tags["channel"] = channel;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (questionCount > 0) data["questionCount"] = questionCount;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = ClarifyEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/Models/ClarifyModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/Models/ClarifyModels.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.Clarify.Models;
+
+/// <summary>
+/// Story 3.5 — the set of clarifying questions generated for an ambiguous
+/// requirement. Serialised into the workflow's <c>questionsJson</c> variable and
+/// surfaced to the stakeholder by <see cref="DeliverClarifyingQuestionsActivity"/>.
+/// </summary>
+public sealed class ClarifyQuestionSet
+{
+    /// <summary>The clarifying questions, prioritised (most impactful first).</summary>
+    [JsonPropertyName("questions")]
+    public List<string> Questions { get; set; } = new();
+
+    /// <summary>Optional context summary the stakeholder can reference when answering.</summary>
+    [JsonPropertyName("contextSummary")]
+    public string? ContextSummary { get; set; }
+}
+
+/// <summary>Outcome of delivering the clarifying questions to the stakeholder.</summary>
+public sealed class ClarifyDeliveryResult
+{
+    public bool Success { get; set; }
+    public string Channel { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public DateTime DeliveredAt { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// The disambiguated requirement produced by incorporating the human answers.
+/// Parsed defensively from the incorporation <c>llm-call</c> output; the workflow
+/// fails closed (routes to the error terminal) if it cannot be recovered.
+/// </summary>
+public sealed class ClarificationResult
+{
+    /// <summary>The clarified / disambiguated requirement text.</summary>
+    [JsonPropertyName("clarifiedRequirement")]
+    public string ClarifiedRequirement { get; set; } = string.Empty;
+
+    /// <summary>Remaining open points (empty when fully resolved).</summary>
+    [JsonPropertyName("remainingAmbiguities")]
+    public List<string> RemainingAmbiguities { get; set; } = new();
+
+    /// <summary>Whether the workflow considers the requirement resolved.</summary>
+    [JsonPropertyName("resolved")]
+    public bool Resolved { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/WaitForClarifyingAnswersActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/WaitForClarifyingAnswersActivity.cs
@@ -1,0 +1,182 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Clarify;
+
+/// <summary>
+/// Story 3.5 — bookmark-based human gate: suspend the <c>clarifying-questions</c>
+/// workflow until the stakeholder answers the delivered questions, then surface the
+/// answers as a typed outcome the flowchart branches on.
+///
+/// <para>Two resume paths are armed when the activity suspends:
+/// <list type="bullet">
+///   <item><description>an answer bookmark
+///   (<c>clarify-answers-{tenant}-{session}</c>, see <see cref="AnswersBookmarkName"/>)
+///   resumed by the stakeholder's answers via the secure resume endpoint →
+///   <c>Answered</c>;</description></item>
+///   <item><description>a DURABLE delay bookmark via
+///   <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+///   at the answer SLA (<c>Clarify:AnswerTimeoutMinutes</c>, default 4320 = 3 days)
+///   → <c>Timeout</c>.</description></item>
+/// </list>
+/// The Delay bookmark is EF-persisted and re-armed by <c>Elsa.Scheduling</c>'s startup
+/// task on rehydration, so a host restart mid-wait no longer drops the SLA (same
+/// hardening as <see cref="Tamma.Activities.Blocker.EscalateToSeniorActivity"/>).
+/// Whichever path resumes first completes the activity; Elsa burns the remaining
+/// bookmark, so there is no orphaned timer / stale double-resume.</para>
+///
+/// <para><b>SECURITY (IDOR)</b> — the bookmark name folds in the tenant id (the
+/// merge/deploy-gate posture, <see cref="WaitForMergeApprovalActivity.BookmarkName"/>).
+/// A resume caller scoped to tenant A computes a name keyed by tenant A, so it can NEVER
+/// resolve tenant B's gate; a cross-tenant attempt simply 404s (bookmark not found), it
+/// never acts. This is table-free (no clarify-session row is minted — Story 3.5 is a
+/// NON-MIGRATION change) yet strictly cross-tenant-safe. The session id is itself an
+/// unguessable 128-bit Guid, so within a tenant the name is unguessable too.</para>
+/// </summary>
+[Activity(
+    "Tamma.Clarify",
+    "Wait For Clarifying Answers",
+    "Suspend workflow until the stakeholder answers the clarifying questions or the SLA expires",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Answered", "Timeout")]
+public class WaitForClarifyingAnswersActivity : Activity
+{
+    private readonly ILogger<WaitForClarifyingAnswersActivity>? _logger;
+    private readonly IConfiguration? _configuration;
+
+    [Input(Description = "Clarify session id (bookmark scoping)")]
+    public Input<Guid> SessionId { get; set; } = default!;
+
+    /// <summary>Tenant id (GUID string or empty for single-user). Folded into the
+    /// bookmark name so a cross-tenant resume can never resolve this gate.</summary>
+    [Input(Description = "Tenant id (bookmark scoping — prevents cross-tenant resume/IDOR)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    /// <summary>The stakeholder's answers (set on bookmark resume).</summary>
+    [Output(Description = "Stakeholder's answers text")]
+    public Output<string?> Answers { get; set; } = default!;
+
+    /// <summary>Whether answers were received (vs a timeout).</summary>
+    [Output(Description = "Whether answers were received")]
+    public Output<bool> Answered { get; set; } = default!;
+
+    /// <summary>Whether the answer SLA expired with no response (durable timeout).</summary>
+    [Output(Description = "Whether the answer SLA expired with no response")]
+    public Output<bool> TimedOut { get; set; } = default!;
+
+    [JsonConstructor]
+    public WaitForClarifyingAnswersActivity() { }
+
+    public WaitForClarifyingAnswersActivity(
+        ILogger<WaitForClarifyingAnswersActivity> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// The SINGLE canonical answer-bookmark name (<c>clarify-answers-{tenant}-{session}</c>).
+    /// Shared by the suspend side (<see cref="ExecuteAsync"/>) and the resume side
+    /// (<c>ClarifyResumeEndpoint</c>) so the two match byte-for-byte — the same
+    /// suspend/resume-name-parity discipline as
+    /// <see cref="WaitForMergeApprovalActivity.BookmarkName"/>. The tenant segment is
+    /// normalised via the SAME <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/>
+    /// transform on both sides so the names always agree.
+    /// </summary>
+    public static string AnswersBookmarkName(string? tenantId, Guid sessionId)
+    {
+        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
+        return $"clarify-answers-{tenant}-{sessionId}";
+    }
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var tenantId = TenantId.Get(context);
+        var bookmarkName = AnswersBookmarkName(tenantId, sessionId);
+
+        _logger?.LogInformation(
+            "Waiting for clarifying answers: bookmark={BookmarkName} for session {SessionId}",
+            bookmarkName, sessionId);
+
+        // 1) Answer bookmark — resumed by the stakeholder via the secure resume endpoint.
+        context.CreateBookmark(new CreateBookmarkArgs
+        {
+            BookmarkName = bookmarkName,
+            Callback = OnAnswersReceivedAsync,
+            AutoBurn = true,
+            IncludeActivityInstanceId = false,
+        });
+
+        // 2) Durable answer SLA — a DelayFor (Delay) bookmark that Elsa.Scheduling's
+        //    startup task re-arms after a host restart (EF-persisted, not an in-memory
+        //    timer). A never-answered clarification terminates as a real Timeout even
+        //    across a VPS restart inside the (default 3-day) SLA window.
+        var slaMinutes = _configuration?.GetValue<int?>("Clarify:AnswerTimeoutMinutes") ?? 4320;
+        context.DelayFor(TimeSpan.FromMinutes(Math.Max(1, slaMinutes)), OnTimeoutAsync);
+
+        _logger?.LogInformation(
+            "Clarify answer wait armed; durable SLA timeout at +{SlaMinutes}min for session {SessionId}",
+            slaMinutes, sessionId);
+    }
+
+    /// <summary>External resume path: the stakeholder answered. Reads the answers from
+    /// the resume input and completes — Elsa burns the still-armed SLA Delay bookmark on
+    /// completion (no orphaned timer).</summary>
+    private async ValueTask OnAnswersReceivedAsync(ActivityExecutionContext context)
+    {
+        var (answered, answers) = ReadAnswers(context.WorkflowInput);
+
+        _logger?.LogInformation(
+            "Clarify answers resumed (external): Answered={Answered}, length={Length}",
+            answered, answers?.Length ?? 0);
+
+        context.Set(Answers, answers);
+        context.Set(Answered, answered);
+        context.Set(TimedOut, false);
+
+        await context.CompleteActivityWithOutcomesAsync("Answered");
+    }
+
+    /// <summary>Durable timeout path: the answer SLA elapsed with no response. Flags
+    /// <see cref="TimedOut"/> (not <see cref="Answered"/>) so the workflow reports the
+    /// real Timeout terminal instead of suspending forever.</summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        _logger?.LogWarning(
+            "Clarify answer SLA expired (durable timeout) for session {SessionId} — taking the Timeout terminal",
+            sessionId);
+
+        context.Set(Answers, null);
+        context.Set(Answered, false);
+        context.Set(TimedOut, true);
+
+        await context.CompleteActivityWithOutcomesAsync("Timeout");
+    }
+
+    /// <summary>
+    /// Pure read-back of the stakeholder outcome from the bookmark resume input
+    /// (exposed for unit testing). <c>Answered</c> is coerced via
+    /// <see cref="ResumeInput.AsBool"/> so it is correct whether the runtime delivers the
+    /// flag as a boxed <see cref="bool"/> (in-process) or as a <see cref="string"/> /
+    /// <see cref="System.Text.Json.JsonElement"/> (serializing dispatcher) — the #15/#437
+    /// lesson: never a bare <c>is true</c> on resume input. <c>Answers</c> is read via
+    /// <c>.ToString()</c>, which is already serialization-tolerant.
+    /// </summary>
+    public static (bool Answered, string? Answers) ReadAnswers(IDictionary<string, object> input)
+    {
+        var answered = input.TryGetValue("Answered", out var a) && ResumeInput.AsBool(a);
+        var answers = input.TryGetValue("Answers", out var ans) ? ans?.ToString() : null;
+        return (answered, answers);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -339,6 +339,87 @@ public static class AdlEndpoints
         }
     }
 
+    // ================================================================
+    // Clarifying-questions human-answer gate (Story 3.5) —
+    // POST /api/adl/clarify/resume. Same RBAC (WorkflowsManage, enforced at
+    // the route group) + I2 (server-derived resolver) posture as the merge/
+    // deploy gates. The cross-tenant guard uses the SAME mechanism as the merge
+    // gate: the caller's ambient tenant id is folded into the bookmark name by
+    // the engine, so a caller can only resume a gate in its OWN tenant (a
+    // cross-tenant/unknown session → 404). This is table-free — Story 3.5 mints
+    // no clarify-session row (NON-MIGRATION).
+    // ================================================================
+
+    /// <summary>
+    /// Resume request for the clarifying-questions answer gate. <c>Resolver</c> is
+    /// intentionally absent — the acting identity is derived from the authenticated
+    /// caller (I2), never trusted from the client.
+    /// </summary>
+    public sealed record ClarifyAnswersRequest(
+        Guid SessionId,
+        string Answers);
+
+    /// <summary>
+    /// Resume the clarifying-questions workflow with a stakeholder's answers.
+    /// Route: <c>POST /api/adl/clarify/resume</c>.
+    /// </summary>
+    public static async Task<IResult> ResumeClarify(
+        [FromBody] ClarifyAnswersRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
+
+        if (req.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+        if (string.IsNullOrWhiteSpace(req.Answers))
+            return Results.BadRequest(new { error = "answers is required" });
+
+        // SECURITY (IDOR) — scope the resume to the caller's ambient tenant. The engine
+        // folds this tenant id into the bookmark name, so a caller can only ever resolve a
+        // gate in its OWN tenant. (Ambient null = self-hosted single-user scope.)
+        var tenantId = tenantContext.TenantId?.ToString();
+
+        // I2 — the resolver is the authenticated caller, derived server-side. A
+        // client-supplied resolver is never honoured so the audit trail can't be forged.
+        var resolver = ResolveApprover(principal);
+
+        try
+        {
+            var result = await elsa.ResumeClarifyingQuestionsAsync(
+                req.SessionId, tenantId, req.Answers, resolver);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No clarifying-questions wait is currently suspended for this session.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove clarify gate for session {SessionId} (resolver {Resolver})",
+                req.SessionId, LogSanitizer.Clean(resolver));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to resume clarify gate for session {SessionId}", req.SessionId);
+            return Results.Problem(
+                detail: "Failed to resume the clarifying-questions gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
     /// <summary>Map a case-insensitive level onto the workflow's exact PascalCase segment
     /// ("Hint"/"Guidance"/"Assistance"); null for anything else.</summary>
     internal static string? CanonicalBlockerLevel(string? level)

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2656,6 +2656,12 @@ adl.MapPost("/deploy-approval/resume", AdlEndpoints.ResumeDeploymentApproval);
 // handler verifies the caller's ambient tenant OWNS the session (tenant-scoped
 // session lookup) before forwarding — a cross-tenant/unknown session → 404.
 adl.MapPost("/blocker/resume", AdlEndpoints.ResumeBlocker);
+// Clarifying-questions answer gate (Story 3.5). Resumes the tenant+session-scoped
+// clarify-answers-{tenant}-{session} bookmark with the stakeholder's answers so the
+// workflow can incorporate them. WorkflowsManage = tenant owner/admin (members 403);
+// resolver derived server-side (I2). IDOR guard: the engine folds the caller's ambient
+// tenant id into the bookmark name, so a cross-tenant/unknown session → 404.
+adl.MapPost("/clarify/resume", AdlEndpoints.ResumeClarify);
 
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -467,6 +467,50 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
             WorkflowInstanceId: result?.WorkflowInstanceId);
     }
 
+    /// <summary>
+    /// Story 3.5 — forward a clarifying-questions answer-gate resume to the engine's
+    /// in-process resume endpoint, which looks up the tenant+session-scoped
+    /// <c>clarify-answers-{tenant}-{session}</c> bookmark and runs the owning instance with
+    /// <c>{Answered, Answers}</c> injected as input. A 404 (no gate waiting) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeClarifyingQuestionsAsync(
+        Guid sessionId, string? tenantId, string answers, string? resolver)
+    {
+        _logger.LogInformation(
+            "Resuming clarify gate for session {SessionId}", sessionId);
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            sessionId,
+            // Tenant scopes the engine's bookmark lookup (folded into the name).
+            tenantId,
+            answers,
+            // I2 — server-derived acting identity, forwarded for the engine's audit log.
+            resolver,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/adl/clarify/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No clarify gate waiting for session {SessionId}", sessionId);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
     private sealed class EngineResumeResponse
     {
         public bool Resumed { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -84,6 +84,22 @@ public interface IElsaWorkflowService
     Task<MergeApprovalResumeResult> ResumeBlockerResolutionAsync(
         Guid sessionId, string kind, string? level, bool resolved,
         string? progressType, string? details, string? seniorResponse, string? resolver);
+
+    /// <summary>
+    /// Story 3.5 — resume the clarifying-questions workflow's answer gate. Forwards to the
+    /// engine's in-process resume endpoint (which owns <c>IBookmarkStore</c>/
+    /// <c>IWorkflowRuntime</c>), which looks up the tenant+session-scoped
+    /// <c>clarify-answers-{tenant}-{session}</c> bookmark and runs the owning instance with
+    /// <c>{Answered, Answers}</c> injected as input. A 404 (no wait suspended) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    ///
+    /// <para>SECURITY — the bookmark name folds in <paramref name="tenantId"/> (the caller's
+    /// ambient tenant, derived server-side by <c>AdlEndpoints</c>), so a caller can only ever
+    /// resolve a gate in its OWN tenant (cross-tenant → 404). <paramref name="resolver"/> is
+    /// the server-derived acting identity (I2), logged by the engine for the audit trail.</para>
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeClarifyingQuestionsAsync(
+        Guid sessionId, string? tenantId, string answers, string? resolver);
 }
 
 /// <summary>Outcome of a merge-approval (or deploy-approval) gate resume.</summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/ClarifyResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/ClarifyResumeEndpoint.cs
@@ -1,0 +1,150 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.Clarify;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// Story 3.5 — in-process resume seam for the <c>clarifying-questions</c> workflow's
+/// human-answer gate. Mirrors <see cref="MergeApprovalResumeEndpoint"/> exactly.
+///
+/// <para>The gate (<see cref="WaitForClarifyingAnswersActivity"/>) suspends on the
+/// named bookmark <c>clarify-answers-{tenant}-{session}</c> (tenant folded in) and, on
+/// resume, reads <c>{Answered, Answers}</c> from the workflow input. This endpoint looks
+/// the bookmark up by name, then runs the owning instance from that bookmark with the
+/// answers payload INJECTED as workflow input
+/// (<c>IWorkflowClient.RunInstanceAsync</c> with <c>RunWorkflowInstanceRequest.Input</c>,
+/// which lands in <c>ActivityExecutionContext.WorkflowInput</c> that the gate reads).</para>
+///
+/// <para>This lives in the engine process because <c>IBookmarkStore</c> /
+/// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the RBAC-gated,
+/// tenant-scoped public surface (<c>POST /api/adl/clarify/resume</c>) and forwards to
+/// this engine endpoint.</para>
+///
+/// <para><b>SECURITY (mirrors the merge/deploy gate posture):</b>
+/// <list type="bullet">
+///   <item><description><b>No IDOR</b> — the bookmark name carries the tenant id that
+///   the (tenant-scoped) <c>Tamma.Api</c> caller supplies (derived server-side from the
+///   authenticated principal, never trusted from the client). A caller scoped to tenant
+///   A computes a name with tenant A, so it can NEVER resolve tenant B's gate: a
+///   cross-tenant attempt simply 404s (bookmark not found), it never acts. The session
+///   id is itself an unguessable 128-bit Guid, so within a tenant the name is unguessable
+///   too. This is table-free — Story 3.5 mints no clarify-session row (NON-MIGRATION) —
+///   yet strictly cross-tenant-safe, exactly like the merge gate.</description></item>
+///   <item><description><b>Collision refusal</b> — the name is globally unique
+///   (tenant + session); &gt;1 match is an integrity violation, so we REFUSE with 409
+///   rather than resume an arbitrary <c>bookmarks[0]</c>.</description></item>
+///   <item><description><b>Engine-service-only</b> — the route is mapped with
+///   <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only the Tamma.Api→engine hop
+///   (presenting the Elsa admin API key) reaches it; anonymous public callers get 401. It
+///   is also excluded from the public nginx <c>/elsa/api/</c> block (internal hop only).
+///   </description></item>
+/// </list></para>
+/// </summary>
+public static class ClarifyResumeEndpoint
+{
+    public sealed record ResumeRequest(
+        Guid SessionId,
+        // Tenant scope — folded into the bookmark name so the lookup can only match a
+        // gate in the caller's own tenant. Supplied by the tenant-scoped Tamma.Api caller.
+        string? TenantId,
+        // The stakeholder's answers to the clarifying questions.
+        string Answers,
+        // Non-repudiation — the acting identity, derived server-side by Tamma.Api from the
+        // authenticated principal. Logged here for the audit trail; never trusted from a
+        // client (the public request record carries no resolver field).
+        string? Resolver);
+
+    /// <summary>Bookmark name the gate registers — delegates to the SINGLE canonical
+    /// builder shared with <see cref="WaitForClarifyingAnswersActivity"/> so suspend-side
+    /// and resume-side names match byte-for-byte.</summary>
+    public static string BookmarkName(ResumeRequest request)
+        => WaitForClarifyingAnswersActivity.AnswersBookmarkName(request.TenantId, request.SessionId);
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.ClarifyResume");
+
+        if (request.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+        if (string.IsNullOrWhiteSpace(request.Answers))
+            return Results.BadRequest(new { error = "answers is required" });
+
+        // The name carries the caller's tenant + session. A caller in tenant A produces a
+        // name keyed by tenant A and therefore can only ever resolve tenant A's gate.
+        var name = BookmarkName(request);
+
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended clarify bookmark {Bookmark} — gate not waiting (already answered/advanced, wrong session, wrong tenant, or timed out)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No clarifying-questions wait is currently suspended for this session.",
+            });
+        }
+
+        // The name is unique per tenant+session; >1 match is an integrity violation, not a
+        // "pick the first" situation. REFUSE rather than resume an arbitrary instance.
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous clarify bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this clarify bookmark; refusing to resume an arbitrary one.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        // Inject the payload using the EXACT keys the suspend-side callback reads
+        // (WaitForClarifyingAnswersActivity.ReadAnswers).
+        var input = new Dictionary<string, object>
+        {
+            ["Answered"] = true,
+            ["Answers"] = request.Answers,
+        };
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed clarify gate {Bookmark} (instance {InstanceId}) by {Resolver}",
+            name, bookmark.WorkflowInstanceId, request.Resolver ?? "unknown");
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -417,6 +417,16 @@ app.MapPost("/elsa/api/adl/blocker/resume",
     Tamma.ElsaServer.Endpoints.BlockerResumeEndpoint.Resume)
     .RequireAuthorization();
 
+// Story 3.5 — in-process resume seam for the clarifying-questions workflow's
+// human-answer gate. Tamma.Api's RBAC-gated, tenant-scoped POST /api/adl/clarify/resume
+// forwards here; this endpoint looks up the tenant+session-scoped
+// clarify-answers-{tenant}-{session} bookmark and runs the owning instance with the
+// {Answered, Answers} payload injected. Same engine-control-surface /
+// RequireAuthorization rationale as the merge/deploy/blocker gates.
+app.MapPost("/elsa/api/adl/clarify/resume",
+    Tamma.ElsaServer.Endpoints.ClarifyResumeEndpoint.Resume)
+    .RequireAuthorization();
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs
@@ -1,0 +1,516 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using System.Text.Json;
+using Tamma.Activities;
+using Tamma.Activities.Clarify;
+using Tamma.Activities.Clarify.Models;
+using Tamma.Api.Services.Agents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 3.5 — Clarifying Questions sub-workflow. Given an ambiguous issue /
+/// requirement it uses the LLM (via the MEDIATED <c>llm-call</c> path — the engine
+/// holds no LLM credential, TAMMA001) to generate clarifying questions, DELIVERS them
+/// to the issue, SUSPENDS on a bookmark awaiting the human answers, then RESUMES (via
+/// the secure <c>ClarifyResumeEndpoint</c>) and incorporates the answers into a
+/// disambiguated requirement.
+///
+/// Flow:
+///   1. Read inputs (issue/requirement + tenantId; mint a session id if none)
+///   2. Generate clarifying questions via DispatchWorkflow("llm-call")
+///      role=product_owner / action=clarify-requirements
+///   3. Deliver questions to the issue (mediated git seam) — emit CLARIFY.QUESTIONS.DELIVERED
+///   4. Wait for answers (bookmark, durable SLA timeout)
+///   5a. On answer: incorporate via DispatchWorkflow("llm-call"), emit
+///       CLARIFY.REQUIREMENTS.CLARIFIED, set outputs
+///   5b. On timeout: emit CLARIFY.ANSWERS.TIMED_OUT (LOUD), set outputs
+///
+/// Reuses the <see cref="AssessmentWorkflow"/> skeleton (llm-call → deliver →
+/// bookmark-wait → analyze/resume, fail-closed gates + error terminal).
+///
+/// Fail-closed: if either <c>llm-call</c> returns success=false, or the JSON response
+/// cannot be parsed into the expected shape, the workflow emits a LOUD
+/// <c>CLARIFY.*.FAILED</c> event and routes to the LlmCallError terminal — it NEVER
+/// proceeds with fabricated questions or a fabricated clarification. Prompt resolution
+/// is tenant→system→error (the <c>llm-call</c> registry never falls back to an
+/// empty/plain prompt).
+///
+/// CLARIFY.* DCB events (AGGREGATE.ACTION.STATUS) are emitted at every transition so
+/// the clarification is fully auditable and feeds the Epic-32 learning loop.
+/// </summary>
+public class ClarifyingQuestionsWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "ClarifyingQuestions";
+        builder.DefinitionId = "clarifying-questions";
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description = "Resolve requirement ambiguity via LLM-generated clarifying questions + human answers";
+
+        // ── Workflow variables ──────────────────────────────────────────
+        var sessionId       = builder.WithVariable<Guid>();
+        var issueId         = builder.WithVariable<string>();
+        var requirement     = builder.WithVariable<string>();
+        var repository      = builder.WithVariable<string>();
+        var issueNumber     = builder.WithVariable<int>();
+        var ambiguityContext = builder.WithVariable<string>();
+        var tenantId        = builder.WithVariable<string>("TenantId", "");
+
+        var questionsJson   = builder.WithVariable<string>();
+        var questionCount   = builder.WithVariable<int>();
+        var answers         = builder.WithVariable<string>();
+        var clarifiedJson   = builder.WithVariable<string>();
+
+        // llm-call result containers
+        var questionLlm     = builder.WithVariable<IDictionary<string, object>?>();
+        var incorporateLlm  = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flags (fail-closed guards)
+        var questionsLlmOk      = builder.WithVariable<bool>();
+        var incorporationLlmOk  = builder.WithVariable<bool>();
+
+        // Activity output capture
+        var deliveryResult      = builder.WithVariable<ClarifyDeliveryResult>();
+        var waitAnswers         = builder.WithVariable<string>();
+        var waitAnswered        = builder.WithVariable<bool>();
+        var waitTimedOut        = builder.WithVariable<bool>();
+        var clarificationOutput = builder.WithVariable<ClarificationResult>();
+
+        // Output variables (readable by a parent workflow)
+        var outputStatus        = builder.WithVariable<string>();
+        var outputClarifiedJson = builder.WithVariable<string>();
+        var outputResolved      = builder.WithVariable<bool>();
+
+        // ── Step 1: Read inputs ────────────────────────────────────────
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs",
+            Name = "Read Inputs",
+            Variable = sessionId,
+            Value = new(context =>
+            {
+                var sid = context.GetInput<Guid>("sessionId");
+                if (sid == Guid.Empty) sid = Guid.NewGuid();
+
+                issueId.Set(context, context.GetInput<string>("issueId") ?? string.Empty);
+                requirement.Set(context, context.GetInput<string>("requirement") ?? string.Empty);
+                repository.Set(context, context.GetInput<string>("repository") ?? string.Empty);
+                issueNumber.Set(context, context.GetInput<int>("issueNumber"));
+                ambiguityContext.Set(context, context.GetInput<string>("ambiguityContext") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
+                return sid;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ── Step 2: Generate clarifying questions via llm-call ─────────
+        var generateQuestionsLlm = new DispatchWorkflow
+        {
+            Id = "GenerateQuestionsLlm",
+            Name = "Generate Clarifying Questions (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"]     = AgentRole.ProductOwner.ToWire(),
+                ["action"]   = AgentAction.ClarifyRequirements.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"]    = requirement.Get(ctx) ?? "",
+                    ["contextFindings"] = ambiguityContext.Get(ctx) ?? "",
+                    ["conventions"]     = "",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(questionLlm),
+        };
+        generateQuestionsLlm.SetDisplayText("Generate Clarifying Questions (LLM)");
+
+        // Parse llm-call response into a question set; set questionsLlmOk (fail-closed).
+        var parseQuestions = new SetVariable
+        {
+            Id = "ParseQuestions",
+            Name = "Parse Questions",
+            Variable = questionsJson,
+            Value = new(ctx =>
+            {
+                var result = questionLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    questionsLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var qs = ClarifyParsing.ParseQuestions(text);
+                if (qs.Count == 0)
+                {
+                    // Fail-closed — no fabricated / empty question set.
+                    questionsLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                questionsLlmOk.Set(ctx, true);
+                questionCount.Set(ctx, qs.Count);
+                return JsonSerializer.Serialize(new ClarifyQuestionSet
+                {
+                    Questions = qs,
+                    ContextSummary = ambiguityContext.Get(ctx),
+                });
+            })
+        };
+        parseQuestions.SetDisplayText("Parse Questions");
+
+        var questionsSuccessCheck = new FlowDecision(ctx => questionsLlmOk.Get(ctx))
+        { Id = "QuestionsLlmOk", Name = "Questions LLM OK?" };
+        questionsSuccessCheck.SetDisplayText("Questions LLM OK?");
+
+        // ── Step 3: Emit GENERATED + deliver + emit DELIVERED ──────────
+        var emitQuestionsGenerated = new EmitClarifyEventActivity
+        {
+            Id = "EmitQuestionsGenerated",
+            Name = "Emit Questions Generated",
+            EventType = new(ClarifyEvents.QuestionsGenerated),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            QuestionCount = new(ctx => questionCount.Get(ctx)),
+        };
+        emitQuestionsGenerated.SetDisplayText("Emit Questions Generated");
+
+        var deliverQuestions = new DeliverClarifyingQuestionsActivity
+        {
+            Id = "DeliverClarifyingQuestions",
+            Name = "Deliver Clarifying Questions",
+            SessionId = new(ctx => sessionId.Get(ctx)),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            Repository = new(ctx => repository.Get(ctx)),
+            IssueNumber = new(ctx => issueNumber.Get(ctx)),
+            QuestionsJson = new(ctx => questionsJson.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Result = new(deliveryResult),
+        };
+        deliverQuestions.SetDisplayText("Deliver Clarifying Questions");
+
+        var emitQuestionsDelivered = new EmitClarifyEventActivity
+        {
+            Id = "EmitQuestionsDelivered",
+            Name = "Emit Questions Delivered",
+            EventType = new(ClarifyEvents.QuestionsDelivered),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Channel = new(ctx => deliveryResult.Get(ctx)?.Channel ?? "api"),
+            QuestionCount = new(ctx => questionCount.Get(ctx)),
+        };
+        emitQuestionsDelivered.SetDisplayText("Emit Questions Delivered");
+
+        // ── Step 4: Wait for answers (bookmark + durable SLA) ──────────
+        var waitForAnswers = new WaitForClarifyingAnswersActivity
+        {
+            Id = "WaitForAnswers",
+            Name = "Wait For Answers",
+            SessionId = new(ctx => sessionId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Answers = new(waitAnswers),
+            Answered = new(waitAnswered),
+            TimedOut = new(waitTimedOut),
+        };
+        waitForAnswers.SetDisplayText("Wait For Answers");
+
+        // ── Step 5a: Answer path ───────────────────────────────────────
+        var storeAnswers = new SetVariable
+        {
+            Id = "StoreAnswers",
+            Name = "Store Answers",
+            Variable = answers,
+            Value = new(ctx => waitAnswers.Get(ctx) ?? string.Empty)
+        };
+        storeAnswers.SetDisplayText("Store Answers");
+
+        var emitAnswersReceived = new EmitClarifyEventActivity
+        {
+            Id = "EmitAnswersReceived",
+            Name = "Emit Answers Received",
+            EventType = new(ClarifyEvents.AnswersReceived),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            QuestionCount = new(ctx => questionCount.Get(ctx)),
+        };
+        emitAnswersReceived.SetDisplayText("Emit Answers Received");
+
+        var incorporateAnswersLlm = new DispatchWorkflow
+        {
+            Id = "IncorporateAnswersLlm",
+            Name = "Incorporate Answers (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"]     = AgentRole.ProductOwner.ToWire(),
+                ["action"]   = AgentAction.ClarifyRequirements.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"]    = requirement.Get(ctx) ?? "",
+                    ["contextFindings"] = BuildIncorporationContext(
+                        ambiguityContext.Get(ctx), questionsJson.Get(ctx), answers.Get(ctx)),
+                    ["conventions"]     = "",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(incorporateLlm),
+        };
+        incorporateAnswersLlm.SetDisplayText("Incorporate Answers (LLM)");
+
+        var parseIncorporation = new SetVariable
+        {
+            Id = "ParseIncorporation",
+            Name = "Parse Incorporation",
+            Variable = clarifiedJson,
+            Value = new(ctx =>
+            {
+                var result = incorporateLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    incorporationLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var parsed = ClarifyParsing.ParseClarification(text);
+                if (parsed is null)
+                {
+                    // Fail-closed — no fabricated clarification.
+                    incorporationLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                incorporationLlmOk.Set(ctx, true);
+                clarificationOutput.Set(ctx, parsed);
+                return JsonSerializer.Serialize(parsed);
+            })
+        };
+        parseIncorporation.SetDisplayText("Parse Incorporation");
+
+        var incorporationSuccessCheck = new FlowDecision(ctx => incorporationLlmOk.Get(ctx))
+        { Id = "IncorporationLlmOk", Name = "Incorporation LLM OK?" };
+        incorporationSuccessCheck.SetDisplayText("Incorporation LLM OK?");
+
+        var emitRequirementsClarified = new EmitClarifyEventActivity
+        {
+            Id = "EmitRequirementsClarified",
+            Name = "Emit Requirements Clarified",
+            EventType = new(ClarifyEvents.RequirementsClarified),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            QuestionCount = new(ctx => questionCount.Get(ctx)),
+        };
+        emitRequirementsClarified.SetDisplayText("Emit Requirements Clarified");
+
+        var setOutputResult = new SetVariable
+        {
+            Id = "SetOutputResult",
+            Name = "Set Output Result",
+            Variable = outputStatus,
+            Value = new(ctx =>
+            {
+                var parsed = clarificationOutput.Get(ctx);
+                outputClarifiedJson.Set(ctx, clarifiedJson.Get(ctx) ?? "{}");
+                outputResolved.Set(ctx, parsed?.Resolved ?? false);
+                return "clarified";
+            })
+        };
+        setOutputResult.SetDisplayText("Set Output Result");
+
+        var exposeOutputResponse = new Sequence
+        {
+            Id = "ExposeOutputResponse",
+            Name = "Expose Output Response",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionId", Name = "Output Session Id", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id"),
+                WithLabel(new SetOutput { Id = "OutputStatus", Name = "Output Status", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status"),
+                WithLabel(new SetOutput { Id = "OutputClarifiedRequirement", Name = "Output Clarified Requirement", OutputName = new("clarifiedRequirement"), OutputValue = new(ctx => (object)(outputClarifiedJson.Get(ctx) ?? "{}")) }, "Output Clarified Requirement"),
+                WithLabel(new SetOutput { Id = "OutputResolved", Name = "Output Resolved", OutputName = new("resolved"), OutputValue = new(ctx => (object)outputResolved.Get(ctx)) }, "Output Resolved"),
+            }
+        };
+        exposeOutputResponse.SetDisplayText("Expose Output Response");
+
+        // ── Step 5b: Timeout path ──────────────────────────────────────
+        var setTimeoutResult = new SetVariable
+        {
+            Id = "SetTimeoutResult",
+            Name = "Set Timeout Result",
+            Variable = outputStatus,
+            Value = new(ctx =>
+            {
+                outputClarifiedJson.Set(ctx, "{}");
+                outputResolved.Set(ctx, false);
+                return "timed_out";
+            })
+        };
+        setTimeoutResult.SetDisplayText("Set Timeout Result");
+
+        var emitTimedOut = new EmitClarifyEventActivity
+        {
+            Id = "EmitTimedOut",
+            Name = "Emit Timed Out",
+            EventType = new(ClarifyEvents.AnswersTimedOut),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Answer SLA expired with no stakeholder response"),
+        };
+        emitTimedOut.SetDisplayText("Emit Timed Out");
+
+        var exposeOutputTimeout = new Sequence
+        {
+            Id = "ExposeOutputTimeout",
+            Name = "Expose Output Timeout",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionIdTimeout", Name = "Output Session Id (Timeout)", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id (Timeout)"),
+                WithLabel(new SetOutput { Id = "OutputStatusTimeout", Name = "Output Status (Timeout)", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status (Timeout)"),
+                WithLabel(new SetOutput { Id = "OutputResolvedTimeout", Name = "Output Resolved (Timeout)", OutputName = new("resolved"), OutputValue = new(ctx => (object)outputResolved.Get(ctx)) }, "Output Resolved (Timeout)"),
+            }
+        };
+        exposeOutputTimeout.SetDisplayText("Expose Output Timeout");
+
+        // ── Fail-closed error terminals (LOUD events + Finish) ─────────
+        var emitQuestionsFailed = new EmitClarifyEventActivity
+        {
+            Id = "EmitQuestionsFailed",
+            Name = "Emit Questions Failed",
+            EventType = new(ClarifyEvents.QuestionsFailed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for question generation failed or returned unparseable output"),
+        };
+        emitQuestionsFailed.SetDisplayText("Emit Questions Failed");
+
+        var emitIncorporationFailed = new EmitClarifyEventActivity
+        {
+            Id = "EmitIncorporationFailed",
+            Name = "Emit Incorporation Failed",
+            EventType = new(ClarifyEvents.IncorporationFailed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for answer incorporation failed or returned unparseable output"),
+        };
+        emitIncorporationFailed.SetDisplayText("Emit Incorporation Failed");
+
+        var llmCallError = new Finish
+        {
+            Id = "LlmCallError",
+            Name = "LLM Call Error"
+        };
+        llmCallError.SetDisplayText("LLM Call Error");
+
+        // ── Build the flowchart ────────────────────────────────────────
+        builder.Root = new Flowchart
+        {
+            Id = "ClarifyingQuestionsFlowchart",
+            Name = "Clarifying Questions Flowchart",
+            Activities =
+            {
+                readInputs,
+                generateQuestionsLlm,
+                parseQuestions,
+                questionsSuccessCheck,
+                emitQuestionsGenerated,
+                deliverQuestions,
+                emitQuestionsDelivered,
+                waitForAnswers,
+
+                // Answer path
+                storeAnswers,
+                emitAnswersReceived,
+                incorporateAnswersLlm,
+                parseIncorporation,
+                incorporationSuccessCheck,
+                emitRequirementsClarified,
+                setOutputResult,
+                exposeOutputResponse,
+
+                // Timeout path
+                setTimeoutResult,
+                emitTimedOut,
+                exposeOutputTimeout,
+
+                // Fail-closed error terminals
+                emitQuestionsFailed,
+                emitIncorporationFailed,
+                llmCallError
+            },
+            Connections =
+            {
+                new(readInputs, generateQuestionsLlm),
+                new(generateQuestionsLlm, parseQuestions),
+                new(parseQuestions, questionsSuccessCheck),
+                new(new FlowEndpoint(questionsSuccessCheck, "True"),  new FlowEndpoint(emitQuestionsGenerated)),
+                new(new FlowEndpoint(questionsSuccessCheck, "False"), new FlowEndpoint(emitQuestionsFailed)),
+                new(emitQuestionsFailed, llmCallError),
+
+                new(emitQuestionsGenerated, deliverQuestions),
+                new(deliverQuestions, emitQuestionsDelivered),
+                new(emitQuestionsDelivered, waitForAnswers),
+
+                // Answer path
+                new(new FlowEndpoint(waitForAnswers, "Answered"), new FlowEndpoint(storeAnswers)),
+                new(storeAnswers, emitAnswersReceived),
+                new(emitAnswersReceived, incorporateAnswersLlm),
+                new(incorporateAnswersLlm, parseIncorporation),
+                new(parseIncorporation, incorporationSuccessCheck),
+                new(new FlowEndpoint(incorporationSuccessCheck, "True"),  new FlowEndpoint(emitRequirementsClarified)),
+                new(new FlowEndpoint(incorporationSuccessCheck, "False"), new FlowEndpoint(emitIncorporationFailed)),
+                new(emitIncorporationFailed, llmCallError),
+                new(emitRequirementsClarified, setOutputResult),
+                new(setOutputResult, exposeOutputResponse),
+
+                // Timeout path
+                new(new FlowEndpoint(waitForAnswers, "Timeout"), new FlowEndpoint(setTimeoutResult)),
+                new(setTimeoutResult, emitTimedOut),
+                new(emitTimedOut, exposeOutputTimeout)
+            }
+        };
+    }
+
+    /// <summary>
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary.
+    /// Returns <c>false</c> if the dictionary is null, the key is absent, or the value
+    /// is falsy — fail-closed by design. Uses the tolerant <see cref="ResumeInput.AsBool"/>
+    /// read (boxed bool / string / JsonElement).
+    /// </summary>
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return ResumeInput.AsBool(s);
+    }
+
+    /// <summary>
+    /// Compose the context findings for the incorporation llm-call — the original
+    /// ambiguity context plus the asked questions and the stakeholder's answers, so the
+    /// model incorporates the answers into a disambiguated requirement. Pure; exposed
+    /// for unit testing.
+    /// </summary>
+    internal static string BuildIncorporationContext(string? ambiguityContext, string? questionsJson, string? answers)
+    {
+        return $"{ambiguityContext ?? ""}\n\n## Clarifying Questions Asked\n{questionsJson ?? ""}\n\n## Stakeholder Answers\n{answers ?? ""}";
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Clarify/ClarifyResumeReadBackTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Clarify/ClarifyResumeReadBackTests.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Clarify;
+
+namespace Tamma.Activities.Tests.Clarify;
+
+/// <summary>
+/// Story 3.5 — the clarify workflow's resume callback must read its control-flow boolean
+/// (<c>Answered</c>) tolerant of a SERIALIZING workflow runtime (the #15/#437 lesson): the
+/// in-process runtime keeps the resumed value a boxed <see cref="bool"/>, but a distributed
+/// dispatcher round-trips it to a <see cref="string"/> or a <see cref="JsonElement"/>. A bare
+/// <c>is true</c> pattern only matches the boxed-bool path — under serialization it silently
+/// evaluates <c>false</c>, returning HTTP 200 while taking the WRONG branch. These tests also
+/// cover the fail-closed <see cref="ClarifyParsing"/> helpers and the canonical bookmark-name
+/// builder (suspend/resume parity + tenant folding).
+/// </summary>
+[TestFixture]
+public class ClarifyResumeReadBackTests
+{
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    private static IDictionary<string, object> Input(params (string Key, object Value)[] entries)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
+    }
+
+    // ── ReadAnswers — Answered coercion tolerant of serialization ──────────
+
+    [Test]
+    public void ReadAnswers_BoxedBoolTrue_ReachesAnswered()
+    {
+        var (answered, answers) = WaitForClarifyingAnswersActivity.ReadAnswers(
+            Input(("Answered", true), ("Answers", "use OAuth2")));
+        answered.Should().BeTrue();
+        answers.Should().Be("use OAuth2");
+    }
+
+    [Test]
+    public void ReadAnswers_StringTrue_ReachesAnswered()
+    {
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", "true"))).Answered.Should().BeTrue();
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", "True"))).Answered.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadAnswers_JsonElementTrue_ReachesAnswered()
+    {
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", JsonBool(true)))).Answered.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadAnswers_FalseRepresentations_ReachNotAnswered()
+    {
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", false))).Answered.Should().BeFalse();
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", "false"))).Answered.Should().BeFalse();
+        WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answered", JsonBool(false)))).Answered.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadAnswers_MissingKey_ReachesNotAnswered()
+    {
+        var (answered, answers) = WaitForClarifyingAnswersActivity.ReadAnswers(Input(("Answers", "n/a")));
+        answered.Should().BeFalse();
+        answers.Should().Be("n/a");
+    }
+
+    [Test]
+    public void ReadAnswers_JsonElementAnswers_ReadThrough()
+    {
+        var input = Input(
+            ("Answered", JsonBool(true)),
+            ("Answers", (object)JsonDocument.Parse("\"the timeout is 30s\"").RootElement));
+        var (answered, answers) = WaitForClarifyingAnswersActivity.ReadAnswers(input);
+        answered.Should().BeTrue();
+        answers.Should().Be("the timeout is 30s");
+    }
+
+    // ── Canonical bookmark name — suspend/resume parity + tenant folding ───
+
+    [Test]
+    public void AnswersBookmarkName_IsDeterministic_AndFoldsTenant()
+    {
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+
+        var a1 = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenantA, session);
+        var a2 = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenantA, session);
+        var b1 = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenantB, session);
+
+        a1.Should().Be(a2, "the builder must be deterministic so suspend + resume names match byte-for-byte");
+        a1.Should().StartWith("clarify-answers-");
+        a1.Should().Contain(session.ToString());
+        a1.Should().NotBe(b1,
+            "folding the tenant into the name is the IDOR guard — a different tenant yields a " +
+            "different bookmark so a cross-tenant resume can never resolve this gate");
+    }
+
+    [Test]
+    public void AnswersBookmarkName_NullTenant_UsesStablePlaceholder()
+    {
+        var session = Guid.NewGuid();
+        WaitForClarifyingAnswersActivity.AnswersBookmarkName(null, session)
+            .Should().Be($"clarify-answers-none-{session}");
+    }
+
+    // ── ClarifyParsing.ParseQuestions — tolerant + fail-closed ─────────────
+
+    [Test]
+    public void ParseQuestions_BareJsonArray_Parses()
+    {
+        var qs = ClarifyParsing.ParseQuestions("Here you go: [\"What DB?\", \"What SLA?\"] done");
+        qs.Should().Equal("What DB?", "What SLA?");
+    }
+
+    [Test]
+    public void ParseQuestions_QuestionsObject_Parses()
+    {
+        var qs = ClarifyParsing.ParseQuestions("{\"questions\":[\"Q1\",\"Q2\",\"Q3\"]}");
+        qs.Should().Equal("Q1", "Q2", "Q3");
+    }
+
+    [Test]
+    public void ParseQuestions_ClarifyingQuestionsObject_Parses()
+    {
+        var qs = ClarifyParsing.ParseQuestions("{\"clarifyingQuestions\":[\"Only one\"]}");
+        qs.Should().Equal("Only one");
+    }
+
+    [Test]
+    public void ParseQuestions_Unparseable_IsEmpty_FailClosed()
+    {
+        ClarifyParsing.ParseQuestions("no json here").Should().BeEmpty();
+        ClarifyParsing.ParseQuestions("").Should().BeEmpty();
+        ClarifyParsing.ParseQuestions(null).Should().BeEmpty();
+        ClarifyParsing.ParseQuestions("[]").Should().BeEmpty();
+    }
+
+    // ── ClarifyParsing.ParseClarification — required field + fail-closed ───
+
+    [Test]
+    public void ParseClarification_FullObject_Parses()
+    {
+        var result = ClarifyParsing.ParseClarification(
+            "{\"clarifiedRequirement\":\"Use PostgreSQL 17\",\"remainingAmbiguities\":[\"none\"],\"resolved\":true}");
+        result.Should().NotBeNull();
+        result!.ClarifiedRequirement.Should().Be("Use PostgreSQL 17");
+        result.RemainingAmbiguities.Should().Equal("none");
+        result.Resolved.Should().BeTrue();
+    }
+
+    [Test]
+    public void ParseClarification_MissingRequirement_IsNull_FailClosed()
+    {
+        ClarifyParsing.ParseClarification("{\"resolved\":true}").Should().BeNull();
+        ClarifyParsing.ParseClarification("{\"clarifiedRequirement\":\"\"}").Should().BeNull();
+        ClarifyParsing.ParseClarification("not json").Should().BeNull();
+        ClarifyParsing.ParseClarification(null).Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/ClarifyResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/ClarifyResumeEndpointTests.cs
@@ -1,0 +1,155 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Clarify;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// Story 3.5 — the engine-side clarify resume seam (<c>POST /elsa/api/adl/clarify/resume</c>).
+/// Verifies it:
+///   - computes the SAME tenant+session-scoped bookmark name as the suspend-side activity
+///     (<c>clarify-answers-{tenant}-{session}</c>) and resumes the matching (single) instance
+///     with the EXACT input keys the callback reads (<c>Answered</c> + <c>Answers</c>);
+///   - is IDOR-safe: a caller scoped to a DIFFERENT tenant computes a different name and 404s
+///     (never resolves the victim's gate);
+///   - REFUSES with 409 when more than one instance matches a (unique) name rather than
+///     resuming an arbitrary <c>bookmarks[0]</c>;
+///   - 404s when no bookmark matches (already answered / advanced / timed out);
+///   - 400s a malformed request (empty session, empty answers).
+/// </summary>
+[TestFixture]
+public class ClarifyResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static ClarifyResumeEndpoint.ResumeRequest Req(Guid session, string? tenant, string answers = "the answer") =>
+        new(session, tenant, answers, Resolver: "who@x.test");
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    private Task<IResult> Invoke(ClarifyResumeEndpoint.ResumeRequest req)
+        => ClarifyResumeEndpoint.Resume(
+            req, _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Test]
+    public async Task Resume_Valid_UsesCanonicalBookmarkName_InjectsAnsweredAndAnswers_ResumesMatch()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenant, session);
+        SetupFind(expected, Bookmark(expected, "wf-c1"));
+
+        var result = await Invoke(Req(session, tenant, "we mean 30s and PostgreSQL"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (bool)r.Input!["Answered"] == true
+                && (string)r.Input!["Answers"] == "we mean 30s and PostgreSQL"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _runtime.Verify(r => r.CreateClientAsync("wf-c1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_CrossTenant_DifferentName_Returns404_NeverResumes()
+    {
+        // IDOR — the gate was armed under tenant A. A caller scoped to tenant B computes a
+        // DIFFERENT bookmark name, so the store returns zero matches for B's name; the victim's
+        // (A's) gate is never touched. We arm ONLY tenant A's name and resume as tenant B.
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+        var nameA = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenantA, session);
+        var nameB = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenantB, session);
+        SetupFind(nameA, Bookmark(nameA, "wf-victim")); // A's gate is live
+        SetupFind(nameB /* zero matches for B */);
+
+        var result = await Invoke(Req(session, tenantB));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant caller computes a different bookmark name and must 404, never resolving the victim's gate");
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Resume_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenant, session);
+        SetupFind(name /* zero matches */);
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a miss must never resume any instance");
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForClarifyingAnswersActivity.AnswersBookmarkName(tenant, session);
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptySession_Returns400()
+    {
+        var result = await Invoke(Req(Guid.Empty, Guid.NewGuid().ToString()));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task Resume_EmptyAnswers_Returns400(string answers)
+    {
+        var result = await Invoke(Req(Guid.NewGuid(), Guid.NewGuid().ToString(), answers));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ClarifyingQuestionsWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ClarifyingQuestionsWorkflowStructureTests.cs
@@ -1,0 +1,134 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Clarify;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 3.5 — structural verification for <see cref="ClarifyingQuestionsWorkflow"/>.
+///
+/// Asserts the workflow:
+/// 1. Builds and has DefinitionId "clarifying-questions".
+/// 2. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts
+///    (resolution is tenant→system→error — never empty/plain).
+/// 3. Generates questions and incorporates answers via <c>DispatchWorkflow("llm-call")</c>
+///    (mediated — the engine holds no LLM credential, TAMMA001) rather than any in-engine
+///    provider call.
+/// 4. Suspends on the <see cref="WaitForClarifyingAnswersActivity"/> bookmark awaiting the
+///    human answers.
+/// 5. Is fail-closed: an <c>LlmCallError</c> terminal exists and <c>FlowDecision</c> gates
+///    check LLM-call success before proceeding.
+/// 6. Emits the required CLARIFY.* DCB events (generated / delivered / answers received)
+///    via <see cref="EmitClarifyEventActivity"/> nodes.
+/// </summary>
+[TestFixture]
+public class ClarifyingQuestionsWorkflowStructureTests
+{
+    private static Flowchart Flowchart()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ClarifyingQuestionsWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithoutError()
+    {
+        var act = () => WorkflowTestHelper.BuildWorkflow(new ClarifyingQuestionsWorkflow());
+        act.Should().NotThrow("ClarifyingQuestionsWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void Workflow_HasCorrectDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ClarifyingQuestionsWorkflow());
+        builder.Object.DefinitionId.Should().Be("clarifying-questions");
+    }
+
+    [Test]
+    public void Workflow_ThreadsTenantId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ClarifyingQuestionsWorkflow());
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "the workflow must thread TenantId so llm-call resolves tenant-scoped prompts " +
+                "(tenant→system→error) for clarify-requirements");
+    }
+
+    [Test]
+    public void Workflow_DispatchesLlmCallForQuestionGeneration()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "GenerateQuestionsLlm",
+                "questions must be generated via the mediated llm-call (engine holds no LLM credential)");
+    }
+
+    [Test]
+    public void Workflow_DispatchesLlmCallForAnswerIncorporation()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "IncorporateAnswersLlm",
+                "the human answers must be incorporated via the mediated llm-call");
+    }
+
+    [Test]
+    public void Workflow_SuspendsOnAnswerBookmark()
+    {
+        Flowchart().Activities
+            .OfType<WaitForClarifyingAnswersActivity>()
+            .Should().ContainSingle(a => a.Id == "WaitForAnswers",
+                "the workflow must suspend on the WaitForClarifyingAnswersActivity bookmark " +
+                "awaiting the human answers");
+    }
+
+    [Test]
+    public void Workflow_HasFailClosedErrorTerminal()
+    {
+        Flowchart().Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "LlmCallError",
+                "a fail-closed LlmCallError terminal must exist — LLM-call failures route there, " +
+                "never proceeding with fabricated questions or a fabricated clarification");
+    }
+
+    [Test]
+    public void Workflow_HasSuccessGatesForBothLlmCalls()
+    {
+        var decisions = Flowchart().Activities.OfType<FlowDecision>().Select(d => d.Id).ToList();
+        decisions.Should().Contain("QuestionsLlmOk",
+            "question delivery must be gated behind a QuestionsLlmOk decision (fail-closed)");
+        decisions.Should().Contain("IncorporationLlmOk",
+            "the clarified output must be gated behind an IncorporationLlmOk decision (fail-closed)");
+    }
+
+    [Test]
+    public void Workflow_EmitsRequiredClarifyEvents()
+    {
+        var emitIds = Flowchart().Activities
+            .OfType<EmitClarifyEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitQuestionsGenerated",
+            "must emit CLARIFY.QUESTIONS.GENERATED when questions are produced");
+        emitIds.Should().Contain("EmitQuestionsDelivered",
+            "must emit CLARIFY.QUESTIONS.DELIVERED when questions are delivered");
+        emitIds.Should().Contain("EmitAnswersReceived",
+            "must emit CLARIFY.ANSWERS.RECEIVED when the human answers arrive");
+    }
+
+    [Test]
+    public void Workflow_DeliversQuestions()
+    {
+        Flowchart().Activities
+            .OfType<DeliverClarifyingQuestionsActivity>()
+            .Should().ContainSingle(a => a.Id == "DeliverClarifyingQuestions",
+                "the workflow must deliver the questions to the stakeholder");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -104,6 +104,7 @@ public class TaxonomyDriftBuildTests
     {
         "AssessmentWorkflow",           // P0 fix 2026-06-30: dispatches generate-assessment-questions + analyze-assessment-response
         "BlockerDiagnosisWorkflow",
+        "ClarifyingQuestionsWorkflow",  // Story 3.5: dispatches clarify-requirements (generate questions + incorporate answers)
         "ContextGatheringWorkflow",
         "DebuggingWorkflow",
         "DeploymentPipelineWorkflow",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/ClarifyResumeApiTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/ClarifyResumeApiTests.cs
@@ -1,0 +1,155 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// Story 3.5 — the RBAC-gated clarify resume surface (<c>POST /api/adl/clarify/resume</c>).
+/// Verifies the handler:
+///   - forwards a well-formed answer to the engine with the caller's AMBIENT tenant id so the
+///     engine can only resolve THIS tenant's gate (IDOR guard via tenant-in-bookmark-name);
+///   - derives the resolver from the authenticated principal (a client-supplied resolver is
+///     impossible — the request type carries none);
+///   - validates the session + answers and rejects junk with 400 before forwarding;
+///   - maps a "no gate waiting" engine response (incl. a cross-tenant miss) to 404.
+///
+/// The route group applies <c>WorkflowsManage</c> (tenant owner/admin; member SaaS callers hit
+/// 403 at the policy) — the same posture as the merge/deploy/blocker resume routes.
+/// </summary>
+[TestFixture]
+public class ClarifyResumeApiTests
+{
+    private Mock<IElsaWorkflowService> _elsa = null!;
+    private readonly NullLoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    [SetUp]
+    public void SetUp() => _elsa = new Mock<IElsaWorkflowService>();
+
+    private static ITenantContext TenantContext(Guid? tenantId)
+    {
+        var ctx = new Mock<ITenantContext>();
+        ctx.SetupGet(c => c.TenantId).Returns(tenantId);
+        return ctx.Object;
+    }
+
+    private static ClaimsPrincipal Principal(string email)
+        => new(new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Email, email) }, "test"));
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Test]
+    public async Task ResumeClarify_Valid_ForwardsAmbientTenantAndDerivedResolver_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeClarifyingQuestionsAsync(
+                session, tenant.ToString(), "we mean 30s", "alice@example.com"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-c1"));
+
+        var req = new AdlEndpoints.ClarifyAnswersRequest(session, "we mean 30s");
+
+        var result = await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(tenant), Principal("alice@example.com"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _elsa.Verify(s => s.ResumeClarifyingQuestionsAsync(
+            session, tenant.ToString(), "we mean 30s", "alice@example.com"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeClarify_ResolverDerivedFromPrincipal_NotForgeable()
+    {
+        var tenant = Guid.NewGuid();
+        string? capturedResolver = null;
+        _elsa
+            .Setup(s => s.ResumeClarifyingQuestionsAsync(
+                It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, string, string?>((_, _, _, resolver) => capturedResolver = resolver)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-9"));
+
+        var req = new AdlEndpoints.ClarifyAnswersRequest(Guid.NewGuid(), "answer text");
+
+        await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(tenant), Principal("bob@corp.test"), _loggerFactory);
+
+        capturedResolver.Should().Be("bob@corp.test",
+            "the resolver must be derived from the authenticated principal for non-repudiation");
+    }
+
+    [Test]
+    public async Task ResumeClarify_CrossTenantGate_Returns404_NeverActs()
+    {
+        // The victim's gate lives under a different bookmark name (keyed by the victim's tenant),
+        // so the engine reports GateNotFound for the caller's ambient tenant. The handler must
+        // surface 404 and forward the CALLER's tenant id, never the victim's.
+        var callerTenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeClarifyingQuestionsAsync(
+                session, callerTenant.ToString(), "sneaky", It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.ClarifyAnswersRequest(session, "sneaky");
+
+        var result = await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(callerTenant), Principal("attacker@evil.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant resume must be a not-found, never an action on the victim's gate");
+        _elsa.Verify(s => s.ResumeClarifyingQuestionsAsync(
+            session, callerTenant.ToString(), "sneaky", It.IsAny<string?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeClarify_GateNotWaiting_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeClarifyingQuestionsAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.ClarifyAnswersRequest(session, "answered");
+
+        var result = await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(tenant), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task ResumeClarify_EmptySession_Returns400_NoForward()
+    {
+        var req = new AdlEndpoints.ClarifyAnswersRequest(Guid.Empty, "answered");
+        var result = await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeClarifyingQuestionsAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public async Task ResumeClarify_EmptyAnswers_Returns400_NoForward(string answers)
+    {
+        var req = new AdlEndpoints.ClarifyAnswersRequest(Guid.NewGuid(), answers);
+        var result = await AdlEndpoints.ResumeClarify(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeClarifyingQuestionsAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
@@ -174,5 +174,7 @@ public sealed class RotationTriggerServiceTests
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
         public Task<MergeApprovalResumeResult> ResumeBlockerResolutionAsync(Guid sid, string k, string? l, bool res, string? pt, string? det, string? sr, string? resolver) =>
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+        public Task<MergeApprovalResumeResult> ResumeClarifyingQuestionsAsync(Guid sid, string? t, string answers, string? resolver) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
     }
 }


### PR DESCRIPTION
## What

Story 3.5 — `ClarifyingQuestionsWorkflow` on the `AssessmentWorkflow` skeleton: generate clarifying questions (mediated LLM) → deliver to the issue → suspend on a bookmark (durable SLA timeout) → resume → incorporate answers. `CLARIFY.*` DCB events (`QUESTIONS.GENERATED/DELIVERED`, `ANSWERS.RECEIVED`, `REQUIREMENTS.CLARIFIED`, + loud `*.FAILED`/`ANSWERS.TIMED_OUT`).

- **Secure resume** — `ClarifyResumeEndpoint` (engine, `/elsa/api/adl/clarify/resume`) + `AdlEndpoints.ResumeClarify` (API, `WorkflowsManage` → member 403). Mirrors the **merge-approval** IDOR-safe pattern (table-free, non-migration): the tenant is folded into the bookmark name and derived **server-side** from the authenticated principal → a cross-tenant caller computes a different name → 0 matches → 404; >1 → 409. Canonical bookmark-name builder used on both suspend + resume (no drift). Resume-input read is tolerant (`ResumeInput.AsBool`: bool/string/JsonElement).
- **Mediated LLM (TAMMA001):** both LLM steps go via `DispatchWorkflow("llm-call")` (`role=product_owner`, `action=clarify-requirements` — existing action, resolves non-empty → prompt resolution stays tenant→system→error, no empty/plain fallback). No credential type injected.

## Verification

- Build: 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes" (non-migration). Tests: Activities 56 (`Clarify|Assessment`) + TaxonomyDrift 6 + Api 31 (`Clarify|ResumeBlocker|ResumeMergeApproval` — incl. cross-tenant→404, non-forgeable resolver, tolerant read) + SystemPrompts 111.

Program.cs: one additive route line each (Api `adl` group + ElsaServer), adjacent to the blocker-resume routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)