### PR TITLE
feat(epic-34-3): BYOK enable/disable toggle endpoints (raw provider identity)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
@@ -60,6 +60,15 @@ public static class Permissions
         // Single-user mode is unaffected — every signed-up user is auto-owner
         // of their personal tenant.
         ["agents:manage"] = ["admin", "owner"],
+        // Story 34-3 — BYOK pricing-mode management. Mirrors prompts:manage /
+        // conventions:manage / agents:manage: CLAUDE.md "Operating Modes" makes
+        // per-(tenant, provider) BYOK a tenant-scoped setting reachable by
+        // tenant_owner OR tenant_admin (member → 403). The owner-only
+        // settings:manage (the spec's SettingsManage label) would 403 every
+        // tenant_admin, so the dedicated pricing:manage permission grants
+        // admin+owner reach. Single-user mode is unaffected — every signed-up
+        // user is auto-owner of their personal tenant.
+        ["pricing:manage"] = ["admin", "owner"],
     };
 
     public static bool HasPermission(string? role, string? permission)

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -1,8 +1,11 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Tamma.Api.Auth;
+using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Pricing;
 using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
 using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data;
@@ -289,7 +292,200 @@ public static class PricingEndpoints
             return Tamma.Api.Endpoints.Admin.AdminTenantsEndpoints.MapPlanAssignmentError(ex);
         }
     }
+
+    // ── BYOK toggle (Story 34-3) ──────────────────────────────────────────
+    // The tenant chooses, per provider, byok (their own key) vs platform
+    // (Tamma's key). The tenant is resolved STRICTLY from ITenantContext (SaaS)
+    // / the sole user's instance (single-user) — a caller-supplied tenantId is
+    // never accepted, so there is no cross-tenant IDOR (stronger than the spec's
+    // route-tenant 404). Writes are gated to tenant_owner / tenant_admin by the
+    // PricingManage route policy (member → 403). The raw key is NEVER echoed
+    // back (reveal-once cabinet rule) — responses carry { provider, mode, keySet }.
+
+    private const int MinByokKeyLength = 8;
+    private const int MaxByokKeyLength = 8192;
+
+    // ── POST /api/pricing/providers/{provider}/byok ── (PricingManage)
+    //
+    // Body { apiKey }. Stores the key in the tenant's Epic 29 cabinet under the
+    // canonical slug 32-3 reads, flips the (tenant, provider) owner row to byok,
+    // invalidates 32-3's credential cache, emits PRICING.BYOK.ENABLED. A provider
+    // that is NOT SaaS-eligible (a cli-token harness provider, or an unknown
+    // provider — fail-closed) is rejected 422 in SaaS via Story 32-4's
+    // IProviderAuthLookup (single-user is unaffected — CLI providers are
+    // single-user only). Idempotent: a re-enable rotates the key + updates the
+    // one active row (never a duplicate).
+    public static async Task<IResult> EnableByok(
+        string provider,
+        EnableByokRequest? body,
+        ClaimsPrincipal user,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider,
+        IProviderAuthLookup authLookup,
+        [FromServices] ITenantProviderBillingService billing,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.Endpoints.PricingEndpoints");
+
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        var apiKey = body?.ApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            return Results.BadRequest(new { error = "invalid_key", detail = "apiKey is required." });
+        }
+        if (apiKey.Length is < MinByokKeyLength or > MaxByokKeyLength)
+        {
+            return Results.BadRequest(new
+            {
+                error = "invalid_key",
+                detail = $"apiKey must be between {MinByokKeyLength} and {MaxByokKeyLength} chars.",
+            });
+        }
+
+        // Tenant strictly from context (never the body). Single-user resolves to
+        // the sole user's personal tenant, so this is populated in both modes.
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.BadRequest(new
+            {
+                error = "no_tenant_context",
+                detail = "enabling BYOK requires tenant context.",
+            });
+        }
+
+        var canonical = BillingProviderKey.Canonicalize(provider);
+        if (canonical.Length == 0)
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        // 32-4 SaaS eligibility gate — only api-key providers are BYOK-eligible in
+        // SaaS. A cli-token / unknown provider (fail-closed) → 422. Single-user is
+        // a hard no-op ("CLI providers are single-user only"). Uses the canonical
+        // family key so a vendor handle ("anthropic-claude") still classifies.
+        if (modeProvider.Mode == TammaMode.SaaS)
+        {
+            var authModel = await authLookup.AuthModelAsync(canonical, ct).ConfigureAwait(false);
+            if (authModel != ProviderAuthModel.ApiKey)
+            {
+                logger.LogWarning(
+                    "BYOK enable rejected — provider not SaaS-eligible: tenantId={TenantId} provider={Provider}",
+                    tid, canonical);
+                return Results.UnprocessableEntity(new { error = "CLI providers are single-user only" });
+            }
+        }
+
+        try
+        {
+            var result = await billing
+                .EnableByokAsync(tid, canonical, apiKey, user.GetUserId(), ct)
+                .ConfigureAwait(false);
+            // Reveal-safe: provider + mode + keySet only, NEVER the key.
+            return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
+        }
+        catch (ArgumentException)
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+    }
+
+    // ── DELETE /api/pricing/providers/{provider}/byok ── (PricingManage)
+    //
+    // Flips the (tenant, provider) owner row back to platform, retires the cabinet
+    // secret, invalidates 32-3's credential cache, emits PRICING.BYOK.DISABLED.
+    // Idempotent (a disable with no active byok row still returns mode=platform).
+    public static async Task<IResult> DisableByok(
+        string provider,
+        ClaimsPrincipal user,
+        ITenantContext tenantContext,
+        [FromServices] ITenantProviderBillingService billing,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.NotFound();
+        }
+
+        var canonical = BillingProviderKey.Canonicalize(provider);
+        if (canonical.Length == 0)
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        var result = await billing
+            .DisableByokAsync(tid, canonical, user.GetUserId(), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
+    }
+
+    // ── GET /api/pricing/providers/{provider} ── (MemberAccess: read)
+    //
+    // The current mode for the caller's OWN (tenant, provider) + whether a key is
+    // set. Never returns the key value (keySet only).
+    public static async Task<IResult> GetProviderMode(
+        string provider,
+        ITenantContext tenantContext,
+        [FromServices] ITenantProviderBillingService billing,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        var canonical = BillingProviderKey.Canonicalize(provider);
+        if (canonical.Length == 0)
+        {
+            return Results.BadRequest(new { error = "invalid_provider" });
+        }
+
+        var result = await billing.GetModeAsync(tid, canonical, ct).ConfigureAwait(false);
+        return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
+    }
+
+    // ── GET /api/pricing/providers ── (MemberAccess: read)
+    //
+    // The caller's OWN active per-provider modes. Empty when no tenant context or
+    // no explicit rows (platform is the default). Never returns any key value.
+    public static async Task<IResult> ListProviderModes(
+        ITenantContext tenantContext,
+        [FromServices] ITenantProviderBillingService billing,
+        CancellationToken ct)
+    {
+        if (tenantContext.TenantId is not Guid tid)
+        {
+            return Results.Ok(new { providers = Array.Empty<object>() });
+        }
+
+        var modes = await billing.ListModesAsync(tid, ct).ConfigureAwait(false);
+        var providers = modes
+            .Select(m => new { provider = m.Provider, mode = m.Mode, keySet = m.KeySet })
+            .ToList();
+        return Results.Ok(new { providers });
+    }
 }
 
 /// <summary>Story 34-4 — request body for <c>POST /api/pricing/subscribe</c>.</summary>
 public sealed record SubscribeRequest(string PlanSlug);
+
+/// <summary>
+/// Story 34-3 — request body for <c>POST /api/pricing/providers/{provider}/byok</c>.
+/// The key is write-only; it is stored in the Epic 29 cabinet and NEVER echoed back.
+/// </summary>
+public sealed record EnableByokRequest(string? ApiKey);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PricingEndpoints.cs
@@ -1,9 +1,11 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Tamma.Api.Auth;
 using Tamma.Api.Services.Billing;
 using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
 using Tamma.Api.Services.PromptStore;
 using Tamma.Api.Services.Security;
 using Tamma.Core;
@@ -358,24 +360,26 @@ public static class PricingEndpoints
             });
         }
 
-        var canonical = BillingProviderKey.Canonicalize(provider);
-        if (canonical.Length == 0)
+        var normalized = ProviderIdentity.Normalize(provider);
+        if (normalized.Length == 0)
         {
             return Results.BadRequest(new { error = "invalid_provider" });
         }
 
         // 32-4 SaaS eligibility gate — only api-key providers are BYOK-eligible in
         // SaaS. A cli-token / unknown provider (fail-closed) → 422. Single-user is
-        // a hard no-op ("CLI providers are single-user only"). Uses the canonical
-        // family key so a vendor handle ("anthropic-claude") still classifies.
+        // a hard no-op ("CLI providers are single-user only"). Keyed on the RAW
+        // provider IDENTITY the auth lookup classifies (github-copilot ≠ openai) — the
+        // same handle 34-3 persists and 32-3 reads, so eligibility and the credential
+        // read never diverge.
         if (modeProvider.Mode == TammaMode.SaaS)
         {
-            var authModel = await authLookup.AuthModelAsync(canonical, ct).ConfigureAwait(false);
+            var authModel = await authLookup.AuthModelAsync(normalized, ct).ConfigureAwait(false);
             if (authModel != ProviderAuthModel.ApiKey)
             {
                 logger.LogWarning(
                     "BYOK enable rejected — provider not SaaS-eligible: tenantId={TenantId} provider={Provider}",
-                    tid, canonical);
+                    tid, normalized);
                 return Results.UnprocessableEntity(new { error = "CLI providers are single-user only" });
             }
         }
@@ -383,7 +387,7 @@ public static class PricingEndpoints
         try
         {
             var result = await billing
-                .EnableByokAsync(tid, canonical, apiKey, user.GetUserId(), ct)
+                .EnableByokAsync(tid, normalized, apiKey, user.GetUserId(), ct)
                 .ConfigureAwait(false);
             // Reveal-safe: provider + mode + keySet only, NEVER the key.
             return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
@@ -392,7 +396,34 @@ public static class PricingEndpoints
         {
             return Results.BadRequest(new { error = "invalid_provider" });
         }
+        catch (DbUpdateException ex) when (IsUniqueViolation(ex))
+        {
+            // Two concurrent first-time enables raced past the check-then-insert window
+            // and both INSERTed; the loser hits ux_tpb_active_provider (Postgres 23505).
+            // Surface 409 (a retry re-resolves the now-existing active row and supersedes)
+            // instead of leaking the DbUpdateException as a 500.
+            logger.LogWarning(
+                "BYOK enable conflict (concurrent first enable) for tenantId={TenantId} provider={Provider}.",
+                tid, normalized);
+            return Results.Conflict(new
+            {
+                error = "BYOK_ENABLE_CONFLICT",
+                detail = "a concurrent enable for this provider won; retry.",
+            });
+        }
     }
+
+    /// <summary>
+    /// Detects the Postgres <c>23505</c> unique-violation raised when two concurrent
+    /// first-time BYOK enables race past the service's check-then-insert window and both
+    /// INSERT, tripping the <c>ux_tpb_active_provider</c> partial unique index. Only the
+    /// exact <c>SqlState == "23505"</c> maps to 409 — any other
+    /// <see cref="DbUpdateException"/> stays a fault. Mirrors the <c>PromptEndpoints</c> /
+    /// <c>ConventionStoreEndpoints</c> pattern.
+    /// </summary>
+    internal static bool IsUniqueViolation(DbUpdateException ex) =>
+        ex.InnerException is Npgsql.PostgresException pg
+        && string.Equals(pg.SqlState, "23505", StringComparison.Ordinal);
 
     // ── DELETE /api/pricing/providers/{provider}/byok ── (PricingManage)
     //
@@ -417,14 +448,14 @@ public static class PricingEndpoints
             return Results.NotFound();
         }
 
-        var canonical = BillingProviderKey.Canonicalize(provider);
-        if (canonical.Length == 0)
+        var normalized = ProviderIdentity.Normalize(provider);
+        if (normalized.Length == 0)
         {
             return Results.BadRequest(new { error = "invalid_provider" });
         }
 
         var result = await billing
-            .DisableByokAsync(tid, canonical, user.GetUserId(), ct)
+            .DisableByokAsync(tid, normalized, user.GetUserId(), ct)
             .ConfigureAwait(false);
         return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
     }
@@ -449,13 +480,13 @@ public static class PricingEndpoints
             return Results.NotFound(new { error = "no_active_tenant" });
         }
 
-        var canonical = BillingProviderKey.Canonicalize(provider);
-        if (canonical.Length == 0)
+        var normalized = ProviderIdentity.Normalize(provider);
+        if (normalized.Length == 0)
         {
             return Results.BadRequest(new { error = "invalid_provider" });
         }
 
-        var result = await billing.GetModeAsync(tid, canonical, ct).ConfigureAwait(false);
+        var result = await billing.GetModeAsync(tid, normalized, ct).ConfigureAwait(false);
         return Results.Ok(new { provider = result.Provider, mode = result.Mode, keySet = result.KeySet });
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -656,6 +656,30 @@ builder.Services.AddScoped<Tamma.Api.Services.EmailMediation.IEmailMediationServ
 // factory signal are already present.
 builder.Services.AddIntegrationCredentialResolution();
 
+// Story 34-3 — BYOK toggle WRITE side. TenantProviderBillingService enables /
+// disables BYOK: it writes the tenant's key into the Epic 29 cabinet (via the
+// governed ProviderByokSecretCabinet, under the canonical provider/<name>/api-key
+// slug Story 32-3 reads), upserts the one active TenantProviderBilling owner row
+// the read-side resolver consumes, invalidates 32-3's credential cache, and emits
+// PRICING.BYOK.*. Scoped (composes the scoped ControlPlaneDbContext + ISecretStore
+// facade). The cabinet is only meaningful with the secret store wired — guarded on
+// the SecretsDbContext factory exactly like AddIntegrationCredentialResolution.
+// NON-migration: reuses the existing tenant_provider_billing owner table + the
+// secrets / secret_versions cabinet tables.
+if (builder.Services.Any(d =>
+    d.ServiceType == typeof(IDbContextFactory<Tamma.Api.Services.Secrets.Postgres.SecretsDbContext>)))
+{
+    builder.Services.TryAddScoped<
+        Tamma.Api.Services.Pricing.IProviderByokSecretCabinet,
+        Tamma.Api.Services.Pricing.ProviderByokSecretCabinet>();
+    // The service composes the cabinet, so it is only wired when the secret store
+    // is present (the byok endpoints are inert — and 500 rather than silently
+    // mis-store — without it). Mirrors AddIntegrationCredentialResolution's guard.
+    builder.Services.TryAddScoped<
+        Tamma.Api.Services.Pricing.ITenantProviderBillingService,
+        Tamma.Api.Services.Pricing.TenantProviderBillingService>();
+}
+
 // Story 32-5 (T4) — provider-side DI for the server-side tool loop, FORMALIZED
 // in the API process (replacing T3's best-effort GetService factory). The loop
 // (extracted verbatim into InlineToolLoopRunner) now executes HERE, where the
@@ -1484,6 +1508,18 @@ if (!string.IsNullOrEmpty(jwtSecret))
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
             p.AddRequirements(new PermissionRequirement("agents:manage"));
         });
+        // Story 34-3 — BYOK pricing-mode management (enable/disable). Mirrors
+        // PromptManage / ConventionManage / AgentManage: CLAUDE.md "Operating
+        // Modes" makes per-(tenant, provider) BYOK a tenant-scoped setting
+        // reachable by tenant_owner OR tenant_admin (member → 403). The spec
+        // names SettingsManage, but that policy is owner-only (settings:manage)
+        // and would 403 every tenant_admin, so the dedicated PricingManage gate
+        // (pricing:manage, admin+owner) is used for the BYOK mutations.
+        options.AddPolicy("PricingManage", p =>
+        {
+            p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
+            p.AddRequirements(new PermissionRequirement("pricing:manage"));
+        });
         options.AddPolicy("WorkflowsView", p =>
         {
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
@@ -1575,7 +1611,7 @@ else if (builder.Environment.IsDevelopment())
             .Build();
         // Register all named policies with permissive default
         foreach (var name in new[] { "AdminAccess", "OwnerAccess", "PlatformOwnerAccess", "MemberAccess", "SettingsView",
-            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
+            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "PricingManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
             "SelfOrApiKeysManage", "SelfOrUsersView", "AuthenticatedAny", "EngineServiceOnly" })
         {
             options.AddPolicy(name, p => p.AddRequirements(new Tamma.Api.Infrastructure.AllowAnonymousRequirement()));
@@ -2118,6 +2154,20 @@ pricing.MapGet("/plans/{slug}", Tamma.Api.Endpoints.PricingEndpoints.GetPublicPl
 // or unknown plans return 422.
 pricing.MapPost("/subscribe", Tamma.Api.Endpoints.PricingEndpoints.Subscribe)
     .RequireAuthorization("SettingsManage");
+
+// Story 34-3 — per-(tenant, provider) BYOK toggle. Reads inherit the group's
+// MemberAccess (any authenticated tenant member sees their OWN modes); the byok
+// mutations use PricingManage (tenant_owner OR tenant_admin — a member-role
+// caller gets 403). The tenant is resolved STRICTLY from ITenantContext (never a
+// route/body tenantId), so there is no cross-tenant IDOR. The 422 SaaS-eligibility
+// gate (cli-token / unknown provider) is applied inside EnableByok via Story 32-4's
+// IProviderAuthLookup. Reveal-safe: responses carry { provider, mode, keySet }.
+pricing.MapGet("/providers", Tamma.Api.Endpoints.PricingEndpoints.ListProviderModes);
+pricing.MapGet("/providers/{provider}", Tamma.Api.Endpoints.PricingEndpoints.GetProviderMode);
+pricing.MapPost("/providers/{provider}/byok", Tamma.Api.Endpoints.PricingEndpoints.EnableByok)
+    .RequireAuthorization("PricingManage");
+pricing.MapDelete("/providers/{provider}/byok", Tamma.Api.Endpoints.PricingEndpoints.DisableByok)
+    .RequireAuthorization("PricingManage");
 
 var orgs = app.MapGroup("/api/v1/orgs").RequireAuthorization("MemberAccess");
 orgs.MapPost("/", OrgEndpoints.CreateOrg);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Billing/BillingModeTagger.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
 using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data.Entities;
@@ -42,10 +43,11 @@ public sealed class BillingModeTagger : IBillingModeTagger
         string? credentialSource = null,
         CancellationToken ct = default)
     {
-        // Fix 2 — canonicalize the provider to the family key the owner row is stored
-        // under BEFORE resolution + logging, so the owner lookup and every reader agree
-        // on one key (the vendor handle "anthropic-claude" resolves the "anthropic" row).
-        providerKey = BillingProviderKey.Canonicalize(providerKey);
+        // Key on the RAW provider IDENTITY (Trim + lower, NO alias-family reduction)
+        // BEFORE resolution + logging, so the owner lookup and every reader agree on the
+        // one handle the proxy passes and 34-3 persisted — never collapsed to a rate-card
+        // family (github-copilot ≠ openai, gemini ≠ google).
+        providerKey = ProviderIdentity.Normalize(providerKey);
 
         // 1) The DECLARED mode from the 34-3 owner (default: platform).
         var declared = await _owner.ResolveModeAsync(tenantId, providerKey, ct).ConfigureAwait(false);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IProviderByokSecretCabinet.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IProviderByokSecretCabinet.cs
@@ -1,0 +1,53 @@
+using Tamma.Api.Services.Secrets;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — the governed write surface for a tenant's BYOK provider API key in
+/// the Epic 29 secret cabinet, backing the pricing BYOK toggle endpoints
+/// (<c>PricingEndpoints.EnableByok</c> / <c>DisableByok</c>). The sibling of Story
+/// 32-3's <c>ProviderCredentialEndpoints</c> secret write and Story integration-BYOK's
+/// <see cref="Integrations.IIntegrationCredentialCabinet"/> — same cabinet, same slug.
+///
+/// <para>The key is stored under the CANONICAL cabinet slug
+/// <c>provider/&lt;providerKey&gt;/api-key</c> (scope <c>Tenant</c>, purpose
+/// <c>ApiKey</c>) — the SAME name Story 32-3's <c>IProviderCredentialResolver</c> reads
+/// at LLM-call time, so the key written here on enable is the key 32-3 later resolves.
+/// <paramref name="providerCanonical"/> MUST already be the lowercase canonical family
+/// key (<c>BillingProviderKey.Canonicalize</c>) so the resolver's canonicalized read
+/// matches.</para>
+///
+/// <para><b>Write</b> is idempotent (remove-then-create) so a re-enable rotates the
+/// key to a new v1-active immediately (matching the one-active-row owner invariant).
+/// <b>Remove</b> deletes the secret row + version rows and scrubs the backend bytes —
+/// the merged <see cref="ISecretStore"/> facade exposes no row-delete and its
+/// <c>RetireVersionAsync</c> refuses the active version, so a clean "drop the key"
+/// (that a later enable can re-create) is expressed here, exactly like
+/// <see cref="Integrations.IIntegrationCredentialCabinet"/>. NON-migration: both paths
+/// reuse the existing <c>secrets</c> / <c>secret_versions</c> tables.</para>
+/// </summary>
+public interface IProviderByokSecretCabinet
+{
+    /// <summary>
+    /// Store <paramref name="apiKey"/> as the tenant's active BYOK key for
+    /// <paramref name="providerCanonical"/>. Idempotent: an existing key for the same
+    /// <c>(tenant, provider)</c> is replaced (removed then re-created) so a re-enable
+    /// rotates the value to a fresh v1-active. Returns the persisted metadata (the
+    /// active version) — never the key.
+    /// </summary>
+    Task<SecretMetadata> WriteAsync(
+        Guid tenantId,
+        string providerCanonical,
+        string apiKey,
+        Guid ownerUserId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Retire the tenant's BYOK key for <paramref name="providerCanonical"/> so the
+    /// next 32-3 resolve falls back to the platform leg and a later enable can
+    /// re-create the same slug. Returns <c>true</c> when a row existed and was removed,
+    /// <c>false</c> when nothing matched (idempotent disable).
+    /// </summary>
+    Task<bool> RemoveAsync(
+        Guid tenantId, string providerCanonical, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IProviderByokSecretCabinet.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/IProviderByokSecretCabinet.cs
@@ -9,13 +9,14 @@ namespace Tamma.Api.Services.Pricing;
 /// 32-3's <c>ProviderCredentialEndpoints</c> secret write and Story integration-BYOK's
 /// <see cref="Integrations.IIntegrationCredentialCabinet"/> — same cabinet, same slug.
 ///
-/// <para>The key is stored under the CANONICAL cabinet slug
+/// <para>The key is stored under the cabinet slug
 /// <c>provider/&lt;providerKey&gt;/api-key</c> (scope <c>Tenant</c>, purpose
 /// <c>ApiKey</c>) — the SAME name Story 32-3's <c>IProviderCredentialResolver</c> reads
 /// at LLM-call time, so the key written here on enable is the key 32-3 later resolves.
-/// <paramref name="providerCanonical"/> MUST already be the lowercase canonical family
-/// key (<c>BillingProviderKey.Canonicalize</c>) so the resolver's canonicalized read
-/// matches.</para>
+/// <paramref name="providerCanonical"/> MUST already be the RAW provider IDENTITY
+/// (<c>ProviderIdentity.Normalize</c> — <c>Trim().ToLowerInvariant()</c>, NO alias-family
+/// reduction) so the resolver's read for that same handle matches
+/// (<c>gemini</c> stays <c>gemini</c>, never the rate-card family <c>google</c>).</para>
 ///
 /// <para><b>Write</b> is idempotent (remove-then-create) so a re-enable rotates the
 /// key to a new v1-active immediately (matching the one-active-row owner invariant).

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingService.cs
@@ -12,8 +12,11 @@ namespace Tamma.Api.Services.Pricing;
 /// Story 32-3's credential cache, and emits <c>PRICING.BYOK.ENABLED</c>. <b>Disable</b>
 /// flips the owner row back to <c>platform</c> (secret ref tombstoned), retires the
 /// cabinet secret, invalidates the cache, and emits <c>PRICING.BYOK.DISABLED</c>. The
-/// provider key is ALWAYS stored / matched under
-/// <c>BillingProviderKey.Canonicalize</c> so it lines up with the resolver's read.</para>
+/// provider key is ALWAYS the RAW provider IDENTITY
+/// (<c>ProviderIdentity.Normalize</c> — <c>Trim().ToLowerInvariant()</c>, NO
+/// alias-family reduction) for both the owner row and the cabinet slug, so it lines up
+/// byte-for-byte with the credential resolver's read for that same handle
+/// (<c>github-copilot</c> ≠ <c>openai</c>).</para>
 /// </summary>
 public interface ITenantProviderBillingService
 {
@@ -54,7 +57,7 @@ public interface ITenantProviderBillingService
 
 /// <summary>
 /// Reveal-SAFE projection of a <c>(tenant, provider)</c> billing mode. Carries the
-/// canonical provider key, the mode wire token (<c>byok</c> | <c>platform</c>) and a
+/// raw-identity provider key, the mode wire token (<c>byok</c> | <c>platform</c>) and a
 /// <c>KeySet</c> flag — NEVER the API key value (Epic 29 reveal-once rule).
 /// </summary>
 public sealed record ByokModeResult(string Provider, string Mode, bool KeySet);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ITenantProviderBillingService.cs
@@ -1,0 +1,60 @@
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — the WRITE side of the authoritative per-<c>(tenant, provider)</c>
+/// billing-mode owner (<c>TenantProviderBilling</c>). Enables / disables BYOK and reads
+/// the current mode. The read-only <see cref="ITenantProviderBillingResolver"/> (used by
+/// the pricing engine + billing-mode tagger) consumes the rows this service writes.
+///
+/// <para><b>Enable</b> writes the tenant's key into the Epic 29 cabinet (via
+/// <see cref="IProviderByokSecretCabinet"/>) under the canonical slug, upserts the ONE
+/// active owner row to <c>byok</c> (idempotent — no duplicate active row), invalidates
+/// Story 32-3's credential cache, and emits <c>PRICING.BYOK.ENABLED</c>. <b>Disable</b>
+/// flips the owner row back to <c>platform</c> (secret ref tombstoned), retires the
+/// cabinet secret, invalidates the cache, and emits <c>PRICING.BYOK.DISABLED</c>. The
+/// provider key is ALWAYS stored / matched under
+/// <c>BillingProviderKey.Canonicalize</c> so it lines up with the resolver's read.</para>
+/// </summary>
+public interface ITenantProviderBillingService
+{
+    /// <summary>
+    /// Enable BYOK for <c>(tenantId, provider)</c>: store <paramref name="apiKey"/> in
+    /// the cabinet + upsert the active owner row to <c>byok</c>. Idempotent (a re-enable
+    /// updates the existing active row + rotates the key). Throws
+    /// <see cref="ArgumentException"/> on a blank provider / key (fail-loud, no partial
+    /// write). NEVER echoes the key.
+    /// </summary>
+    Task<ByokModeResult> EnableByokAsync(
+        Guid tenantId, string provider, string apiKey, Guid? actorUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Disable BYOK for <c>(tenantId, provider)</c>: flip the active owner row back to
+    /// <c>platform</c> (SecretName tombstoned) + retire the cabinet secret. Idempotent
+    /// (a disable with no active byok row is a no-op that still reports <c>platform</c>).
+    /// </summary>
+    Task<ByokModeResult> DisableByokAsync(
+        Guid tenantId, string provider, Guid? actorUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// The current mode for <c>(tenantId, provider)</c> — <c>byok</c> when an active
+    /// byok owner row exists, else <c>platform</c> (the safe default). <c>KeySet</c>
+    /// reflects whether a BYOK key is configured; the raw key is NEVER returned.
+    /// </summary>
+    Task<ByokModeResult> GetModeAsync(
+        Guid tenantId, string provider, CancellationToken ct = default);
+
+    /// <summary>
+    /// Every active owner row for the tenant, projected to <see cref="ByokModeResult"/>
+    /// (provider + mode + keySet). Providers with no active row are simply absent
+    /// (platform by default); the raw key is NEVER returned.
+    /// </summary>
+    Task<IReadOnlyList<ByokModeResult>> ListModesAsync(
+        Guid tenantId, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Reveal-SAFE projection of a <c>(tenant, provider)</c> billing mode. Carries the
+/// canonical provider key, the mode wire token (<c>byok</c> | <c>platform</c>) and a
+/// <c>KeySet</c> flag — NEVER the API key value (Epic 29 reveal-once rule).
+/// </summary>
+public sealed record ByokModeResult(string Provider, string Mode, bool KeySet);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
@@ -16,14 +16,14 @@ public static class PricingEventTypes
     /// Story 34-3 (AC9) — a tenant enabled BYOK for a <c>(tenant, provider)</c>: their
     /// own key was stored in the Epic 29 cabinet and the authoritative
     /// <c>TenantProviderBilling</c> owner row flipped to <c>byok</c>. Tagged
-    /// <c>tenantId</c>, <c>provider</c> (canonical family key), <c>mode=byok</c>.
+    /// <c>tenantId</c>, <c>provider</c> (raw provider identity), <c>mode=byok</c>.
     /// </summary>
     public const string ByokEnabled = "PRICING.BYOK.ENABLED";
 
     /// <summary>
     /// Story 34-3 (AC9) — a tenant disabled BYOK for a <c>(tenant, provider)</c>: the
     /// owner row flipped back to <c>platform</c> and the cabinet secret was retired.
-    /// Tagged <c>tenantId</c>, <c>provider</c> (canonical family key), <c>mode=platform</c>.
+    /// Tagged <c>tenantId</c>, <c>provider</c> (raw provider identity), <c>mode=platform</c>.
     /// </summary>
     public const string ByokDisabled = "PRICING.BYOK.DISABLED";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/PricingEventTypes.cs
@@ -11,4 +11,19 @@ public static class PricingEventTypes
 {
     /// <summary>A margin policy was versioned (supersede prior active + insert new active).</summary>
     public const string MarginUpdated = "PRICING.MARGIN.UPDATED";
+
+    /// <summary>
+    /// Story 34-3 (AC9) — a tenant enabled BYOK for a <c>(tenant, provider)</c>: their
+    /// own key was stored in the Epic 29 cabinet and the authoritative
+    /// <c>TenantProviderBilling</c> owner row flipped to <c>byok</c>. Tagged
+    /// <c>tenantId</c>, <c>provider</c> (canonical family key), <c>mode=byok</c>.
+    /// </summary>
+    public const string ByokEnabled = "PRICING.BYOK.ENABLED";
+
+    /// <summary>
+    /// Story 34-3 (AC9) — a tenant disabled BYOK for a <c>(tenant, provider)</c>: the
+    /// owner row flipped back to <c>platform</c> and the cabinet secret was retired.
+    /// Tagged <c>tenantId</c>, <c>provider</c> (canonical family key), <c>mode=platform</c>.
+    /// </summary>
+    public const string ByokDisabled = "PRICING.BYOK.DISABLED";
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ProviderByokSecretCabinet.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/ProviderByokSecretCabinet.cs
@@ -1,0 +1,134 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Services.Secrets.Postgres;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Default <see cref="IProviderByokSecretCabinet"/>. Write → the merged
+/// <see cref="ISecretStore"/> facade (<c>CreateAsync</c> mints v1 active + emits the
+/// <c>SECRET.WRITE</c> cabinet audit); remove → the cabinet's own
+/// <see cref="SecretsDbContext"/> + <see cref="ISecretStoreBackend"/> seam (the facade
+/// has no row-delete). Mirrors <see cref="Integrations.IntegrationCredentialCabinet"/>
+/// but pins the provider-BYOK slug (<c>provider/&lt;name&gt;/api-key</c>) via
+/// <see cref="ProviderCabinetNames.Byok"/> so the key it writes is byte-identical to
+/// the one Story 32-3's resolver reads.
+/// </summary>
+public sealed class ProviderByokSecretCabinet : IProviderByokSecretCabinet
+{
+    private readonly ISecretStore _secretStore;
+    private readonly IDbContextFactory<SecretsDbContext> _secretsFactory;
+    private readonly ISecretStoreBackend _backend;
+    private readonly ILogger<ProviderByokSecretCabinet> _logger;
+
+    public ProviderByokSecretCabinet(
+        ISecretStore secretStore,
+        IDbContextFactory<SecretsDbContext> secretsFactory,
+        ISecretStoreBackend backend,
+        ILogger<ProviderByokSecretCabinet> logger)
+    {
+        _secretStore = secretStore ?? throw new ArgumentNullException(nameof(secretStore));
+        _secretsFactory = secretsFactory ?? throw new ArgumentNullException(nameof(secretsFactory));
+        _backend = backend ?? throw new ArgumentNullException(nameof(backend));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<SecretMetadata> WriteAsync(
+        Guid tenantId,
+        string providerCanonical,
+        string apiKey,
+        Guid ownerUserId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerCanonical);
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+
+        var cabinetName = ProviderCabinetNames.Byok(providerCanonical);
+
+        // Idempotent re-enable (AC12): a prior key for this (tenant, provider) is
+        // removed first so CreateAsync mints a FRESH v1-active — the tenant's newly
+        // supplied key becomes the active version immediately (the facade's RotateAsync
+        // leaves the successor PENDING, which would NOT swap the active key). NEVER logs
+        // the value.
+        await RemoveAsync(tenantId, providerCanonical, ct).ConfigureAwait(false);
+
+        // CreateAsync mints v1 active + emits SECRET.WRITE; it is atomic (compensates a
+        // partial create) so a bad key surfaces as a throw with NO partial write.
+        return await _secretStore.CreateAsync(
+            new CreateSecretRequest(
+                Name: cabinetName,
+                Scope: SecretScope.Tenant,
+                TenantId: tenantId,
+                Purpose: SecretPurpose.ApiKey,
+                ConsumerRefs: new[] { new ConsumerRef(providerCanonical, "api-key") },
+                OwnerUserId: ownerUserId,
+                RotationSchedule: RotationSchedule.None,
+                InitialPlaintext: apiKey),
+            ct)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveAsync(
+        Guid tenantId, string providerCanonical, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerCanonical);
+
+        var cabinetName = ProviderCabinetNames.Byok(providerCanonical);
+
+        await using var ctx = await _secretsFactory
+            .CreateDbContextAsync(ct).ConfigureAwait(false);
+
+        var row = await ctx.Secrets
+            .FirstOrDefaultAsync(
+                s => s.Name == cabinetName
+                     && s.Scope == "tenant"
+                     && s.TenantId == tenantId,
+                ct)
+            .ConfigureAwait(false);
+        if (row is null)
+        {
+            return false;
+        }
+
+        var versions = await ctx.SecretVersions
+            .Where(v => v.SecretId == row.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        // Scrub the ciphertext bytes out of the backend first (best-effort; idempotent
+        // — a KeyNotFound means the bytes were never stored / already gone). NEVER logs
+        // the bytes.
+        foreach (var v in versions)
+        {
+            try
+            {
+                await _backend.DeleteVersionAsync(row.Id, v.VersionNumber, ct).ConfigureAwait(false);
+            }
+            catch (KeyNotFoundException)
+            {
+                // never stored
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Best-effort backend scrub failed removing BYOK key {CabinetName} v{Version} "
+                    + "for tenant {TenantId}.", cabinetName, v.VersionNumber, tenantId);
+            }
+        }
+
+        if (versions.Count > 0)
+        {
+            ctx.SecretVersions.RemoveRange(versions);
+        }
+        ctx.Secrets.Remove(row);
+        await ctx.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Retired BYOK key {CabinetName} for tenant {TenantId}.", cabinetName, tenantId);
+        return true;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingResolver.cs
@@ -1,6 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Providers;
 using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data;
@@ -47,12 +47,12 @@ public sealed class TenantProviderBillingResolver : ITenantProviderBillingResolv
             return MetricBillingMode.PlatformProvided;
         }
 
-        // Fix 2 — canonicalize the (possibly vendor-handle / mixed-case) provider to
-        // the lowercase family key the owner row is stored under, so a call keyed
-        // "anthropic-claude" matches an owner row keyed "anthropic". r.ProviderKey is
-        // ALSO lowercased for the compare so a legacy mixed-case stored key still
-        // matches; the write path is documented to persist the canonical key.
-        var normalized = BillingProviderKey.Canonicalize(provider);
+        // Key the read on the RAW provider IDENTITY the proxy passes (Trim + lower, NO
+        // alias-family reduction) — the SAME handle 34-3's write persists and 32-3's
+        // credential resolver reads. A "gemini" call matches the "gemini" owner row (NOT
+        // "google"); "github-copilot" matches its own row (NOT "openai"). r.ProviderKey is
+        // ALSO lowercased for the compare so a legacy mixed-case stored key still matches.
+        var normalized = ProviderIdentity.Normalize(provider);
 
         var mode = await _db.TenantProviderBillings
             .AsNoTracking()

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs
@@ -2,7 +2,8 @@ using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.LlmCall.Credentials;
-using Tamma.Api.Services.Billing;
+using Tamma.Api.Services.Providers;
+using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data;
 using Tamma.Data.Entities;
@@ -21,16 +22,24 @@ namespace Tamma.Api.Services.Pricing;
 ///     mode change), THEN upsert the owner row to <c>byok</c>. If the row write throws,
 ///     the key is orphaned but the mode stays <c>platform</c> (safe) — never a
 ///     <c>byok</c> row with no key.</item>
-///   <item><b>Disable</b> — flip the owner row to <c>platform</c> FIRST (the resolver
-///     stops returning <c>byok</c>), THEN retire the cabinet secret. If the retire
-///     throws, the mode is already <c>platform</c> (safe).</item>
+///   <item><b>Disable</b> — flip the owner row to <c>platform</c> FIRST, THEN retire
+///     the cabinet secret. Row-first is deliberate: a key-first ordering could leave a
+///     <c>byok</c> row with no cabinet key (a SecretName-XOR violation) — strictly
+///     worse. Note this ordering flips the BILLING mode immediately but NOT the runtime
+///     credential: Story 32-3's credential resolver keys off cabinet PRESENCE, so it
+///     keeps resolving the tenant key until the secret is actually retired. A retire
+///     failure therefore surfaces a RETRIABLE error (after the invalidate + DISABLED
+///     event still run) rather than a mid-way 500 that silently leaves the key live.</item>
 /// </list>
 ///
 /// <para>Every mutation invalidates Story 32-3's credential cache
 /// (<see cref="IProviderCredentialResolver.Invalidate"/>) and emits a
-/// <c>PRICING.BYOK.*</c> DCB event. The provider key is ALWAYS canonicalized
-/// (<see cref="BillingProviderKey.Canonicalize"/>) before storage / lookup so the owner
-/// row matches the resolver's canonicalized read.</para>
+/// <c>PRICING.BYOK.*</c> DCB event. The provider key is ALWAYS the RAW provider
+/// IDENTITY (<see cref="ProviderIdentity.Normalize"/> — <c>Trim().ToLowerInvariant()</c>,
+/// NO alias-family reduction) for BOTH the owner-row <c>ProviderKey</c> and the cabinet
+/// slug, so the write slug is byte-identical to what the credential resolver reads for
+/// that same handle (<c>github-copilot</c> ≠ <c>openai</c>, <c>gemini</c> ≠
+/// <c>google</c>). The rate-card family alias is NOT applied here.</para>
 /// </summary>
 public sealed class TenantProviderBillingService : ITenantProviderBillingService
 {
@@ -65,7 +74,7 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
     public async Task<ByokModeResult> EnableByokAsync(
         Guid tenantId, string provider, string apiKey, Guid? actorUserId, CancellationToken ct = default)
     {
-        var canonical = Canonicalize(provider);
+        var normalized = NormalizeProvider(provider);
         if (string.IsNullOrWhiteSpace(apiKey))
         {
             throw new ArgumentException("A BYOK api key is required.", nameof(apiKey));
@@ -74,14 +83,18 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
         var now = _time.GetUtcNow().UtcDateTime;
 
         // 1) Cabinet key FIRST — a bad key throws here, before any mode change (no
-        //    partial write). The cabinet stores it under the canonical slug 32-3 reads.
+        //    partial write). The cabinet stores it under the RAW-identity slug 32-3
+        //    reads for this same handle (provider/<handle>/api-key).
         var secret = await _cabinet
-            .WriteAsync(tenantId, canonical, apiKey, actorUserId ?? Guid.Empty, ct)
+            .WriteAsync(tenantId, normalized, apiKey, actorUserId ?? Guid.Empty, ct)
             .ConfigureAwait(false);
-        var secretName = ProviderCabinetName(canonical);
+        var secretName = ProviderCabinetName(normalized);
 
-        // 2) Upsert the ONE active owner row (AC12 — no duplicate active row).
-        var existing = await FindActiveRowAsync(tenantId, canonical, tracking: true, ct)
+        // 2) Upsert the ONE active owner row (AC12 — no duplicate active row). A
+        //    concurrent first-time enable races the check-then-insert window; the loser
+        //    hits ux_tpb_active_provider (23505) as a DbUpdateException, mapped to 409 at
+        //    the endpoint (never a 500).
+        var existing = await FindActiveRowAsync(tenantId, normalized, tracking: true, ct)
             .ConfigureAwait(false);
         if (existing is null)
         {
@@ -89,7 +102,7 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
             {
                 Id = Guid.NewGuid(),
                 TenantId = tenantId,
-                ProviderKey = canonical,
+                ProviderKey = normalized,
                 Mode = ModeByok,
                 SecretName = secretName,
                 Status = StatusActive,
@@ -110,28 +123,32 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
         await _db.SaveChangesAsync(ct).ConfigureAwait(false);
 
         // 3) Invalidate 32-3's cached credential so the next LLM call re-resolves BYOK.
-        _credentialResolver.Invalidate(tenantId, canonical);
+        _credentialResolver.Invalidate(tenantId, normalized);
 
         _logger.LogInformation(
             "BYOK enabled: tenantId={TenantId} provider={Provider} mode=byok secretVersion={Version}",
-            tenantId, canonical, secret.ActiveVersionNumber);
+            tenantId, normalized, secret.ActiveVersionNumber);
 
-        await EmitAsync(PricingEventTypes.ByokEnabled, tenantId, canonical, ModeByok, now, ct)
+        await EmitAsync(PricingEventTypes.ByokEnabled, tenantId, normalized, ModeByok, now, ct)
             .ConfigureAwait(false);
 
-        return new ByokModeResult(canonical, ModeByok, KeySet: true);
+        return new ByokModeResult(normalized, ModeByok, KeySet: true);
     }
 
     /// <inheritdoc />
     public async Task<ByokModeResult> DisableByokAsync(
         Guid tenantId, string provider, Guid? actorUserId, CancellationToken ct = default)
     {
-        var canonical = Canonicalize(provider);
+        var normalized = NormalizeProvider(provider);
         var now = _time.GetUtcNow().UtcDateTime;
 
         // 1) Flip the owner row to platform FIRST (secret ref tombstoned; row kept for
-        //    audit). Idempotent — a missing / already-platform row is a no-op.
-        var existing = await FindActiveRowAsync(tenantId, canonical, tracking: true, ct)
+        //    audit). Idempotent — a missing / already-platform row is a no-op. Row-first
+        //    (not key-first) is deliberate: a key-first order could leave a byok row with
+        //    no cabinet key (a SecretName-XOR violation). This flips the BILLING mode; the
+        //    32-3 credential resolver still resolves the tenant key until step 2 actually
+        //    retires the secret (it reads cabinet PRESENCE, not this row).
+        var existing = await FindActiveRowAsync(tenantId, normalized, tracking: true, ct)
             .ConfigureAwait(false);
         if (existing is not null && existing.Mode != ModePlatform)
         {
@@ -142,31 +159,71 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
             await _db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
 
-        // 2) Retire the cabinet secret (best-effort; idempotent).
-        await _cabinet.RemoveAsync(tenantId, canonical, ct).ConfigureAwait(false);
+        // 2) Retire the cabinet secret (idempotent). A failure here MUST NOT skip the
+        //    cache-invalidate / DISABLED event (the billing mode already flipped), and it
+        //    MUST NOT report clean success either — the credential resolver reads cabinet
+        //    PRESENCE, so a still-present key keeps resolving byok. Log it, run steps 3/4
+        //    anyway, then surface a RETRIABLE error so the caller re-runs the idempotent
+        //    disable to actually retire the key (rather than a mid-way 500 that leaves the
+        //    key live AND skips the event).
+        Exception? retireFailure = null;
+        try
+        {
+            await _cabinet.RemoveAsync(tenantId, normalized, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            retireFailure = ex;
+            _logger.LogError(
+                ex,
+                "BYOK disable: cabinet retire FAILED for tenantId={TenantId} provider={Provider}; "
+                + "owner row is already platform but the key is still present — surfacing a "
+                + "retriable error so the disable is re-run.",
+                tenantId, normalized);
+        }
 
-        // 3) Invalidate 32-3's cached credential so the next LLM call falls back to
-        //    the platform leg.
-        _credentialResolver.Invalidate(tenantId, canonical);
+        // 3) Invalidate 32-3's cached credential so the next LLM call re-resolves.
+        _credentialResolver.Invalidate(tenantId, normalized);
 
         _logger.LogInformation(
             "BYOK disabled: tenantId={TenantId} provider={Provider} mode=platform",
-            tenantId, canonical);
+            tenantId, normalized);
 
-        await EmitAsync(PricingEventTypes.ByokDisabled, tenantId, canonical, ModePlatform, now, ct)
+        // 4) Emit the DISABLED event ALWAYS — the mode change is authoritative even when
+        //    the cabinet retire needs a retry.
+        await EmitAsync(PricingEventTypes.ByokDisabled, tenantId, normalized, ModePlatform, now, ct)
             .ConfigureAwait(false);
 
-        return new ByokModeResult(canonical, ModePlatform, KeySet: false);
+        if (retireFailure is not null)
+        {
+            throw new TammaError(
+                "BYOK.DISABLE.CABINET_RETIRE_FAILED",
+                $"BYOK owner row for provider '{normalized}' was flipped to platform, but retiring "
+                + "the cabinet key failed; retry the disable to remove the key.",
+                new Dictionary<string, object?>
+                {
+                    ["tenantId"] = tenantId,
+                    ["provider"] = normalized,
+                },
+                retryable: true,
+                severity: TammaErrorSeverity.Medium);
+        }
+
+        return new ByokModeResult(normalized, ModePlatform, KeySet: false);
     }
 
     /// <inheritdoc />
     public async Task<ByokModeResult> GetModeAsync(
         Guid tenantId, string provider, CancellationToken ct = default)
     {
-        var canonical = Canonicalize(provider);
-        var row = await FindActiveRowAsync(tenantId, canonical, tracking: false, ct)
+        var normalized = NormalizeProvider(provider);
+        var row = await FindActiveRowAsync(tenantId, normalized, tracking: false, ct)
             .ConfigureAwait(false);
-        return Project(canonical, row?.Mode, row?.SecretName);
+        return Project(normalized, row?.Mode, row?.SecretName);
     }
 
     /// <inheritdoc />
@@ -186,7 +243,7 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
     }
 
     private Task<TenantProviderBilling?> FindActiveRowAsync(
-        Guid tenantId, string canonical, bool tracking, CancellationToken ct)
+        Guid tenantId, string normalized, bool tracking, CancellationToken ct)
     {
         IQueryable<TenantProviderBilling> q = tracking
             ? _db.TenantProviderBillings
@@ -194,31 +251,33 @@ public sealed class TenantProviderBillingService : ITenantProviderBillingService
         return q.FirstOrDefaultAsync(
             r => r.TenantId == tenantId
                  && r.Status == StatusActive
-                 && r.ProviderKey.ToLower() == canonical,
+                 && r.ProviderKey.ToLower() == normalized,
             ct);
     }
 
-    private static ByokModeResult Project(string canonical, string? mode, string? secretName)
+    private static ByokModeResult Project(string normalized, string? mode, string? secretName)
     {
         var isByok = string.Equals(mode, ModeByok, StringComparison.Ordinal);
         return new ByokModeResult(
-            canonical,
+            normalized,
             isByok ? ModeByok : ModePlatform,
             KeySet: isByok && !string.IsNullOrEmpty(secretName));
     }
 
-    private static string Canonicalize(string? provider)
+    // The RAW provider IDENTITY (Trim + lower, NO alias-family reduction) — the exact
+    // string the credential resolver reads for this handle. See ProviderIdentity.
+    private static string NormalizeProvider(string? provider)
     {
-        var canonical = BillingProviderKey.Canonicalize(provider);
-        if (canonical.Length == 0)
+        var normalized = ProviderIdentity.Normalize(provider);
+        if (normalized.Length == 0)
         {
             throw new ArgumentException("A provider key is required.", nameof(provider));
         }
-        return canonical;
+        return normalized;
     }
 
-    private static string ProviderCabinetName(string canonical) =>
-        ProviderCabinetNames.Byok(canonical);
+    private static string ProviderCabinetName(string normalized) =>
+        ProviderCabinetNames.Byok(normalized);
 
     private async Task EmitAsync(
         string type, Guid tenantId, string provider, string mode, DateTime now, CancellationToken ct)

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Pricing/TenantProviderBillingService.cs
@@ -1,0 +1,251 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.Billing;
+using Tamma.Core.Enums;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Pricing;
+
+/// <summary>
+/// Story 34-3 — default <see cref="ITenantProviderBillingService"/>. Owns the WRITE
+/// path that populates the authoritative <c>TenantProviderBilling</c> owner rows the
+/// read-side <see cref="TenantProviderBillingResolver"/> consumes.
+///
+/// <para>Ordering is fail-loud and partial-write-safe:</para>
+/// <list type="bullet">
+///   <item><b>Enable</b> — write the cabinet key FIRST (a bad key throws before any
+///     mode change), THEN upsert the owner row to <c>byok</c>. If the row write throws,
+///     the key is orphaned but the mode stays <c>platform</c> (safe) — never a
+///     <c>byok</c> row with no key.</item>
+///   <item><b>Disable</b> — flip the owner row to <c>platform</c> FIRST (the resolver
+///     stops returning <c>byok</c>), THEN retire the cabinet secret. If the retire
+///     throws, the mode is already <c>platform</c> (safe).</item>
+/// </list>
+///
+/// <para>Every mutation invalidates Story 32-3's credential cache
+/// (<see cref="IProviderCredentialResolver.Invalidate"/>) and emits a
+/// <c>PRICING.BYOK.*</c> DCB event. The provider key is ALWAYS canonicalized
+/// (<see cref="BillingProviderKey.Canonicalize"/>) before storage / lookup so the owner
+/// row matches the resolver's canonicalized read.</para>
+/// </summary>
+public sealed class TenantProviderBillingService : ITenantProviderBillingService
+{
+    private const string ModePlatform = MetricBillingModeExtensions.PlatformToken;
+    private const string ModeByok = MetricBillingModeExtensions.ByokToken;
+    private const string StatusActive = "active";
+
+    private readonly ControlPlaneDbContext _db;
+    private readonly IProviderByokSecretCabinet _cabinet;
+    private readonly IEventRepository _events;
+    private readonly IProviderCredentialResolver _credentialResolver;
+    private readonly TimeProvider _time;
+    private readonly ILogger<TenantProviderBillingService> _logger;
+
+    public TenantProviderBillingService(
+        ControlPlaneDbContext db,
+        IProviderByokSecretCabinet cabinet,
+        IEventRepository events,
+        IProviderCredentialResolver credentialResolver,
+        TimeProvider time,
+        ILogger<TenantProviderBillingService> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _cabinet = cabinet ?? throw new ArgumentNullException(nameof(cabinet));
+        _events = events ?? throw new ArgumentNullException(nameof(events));
+        _credentialResolver = credentialResolver ?? throw new ArgumentNullException(nameof(credentialResolver));
+        _time = time ?? throw new ArgumentNullException(nameof(time));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc />
+    public async Task<ByokModeResult> EnableByokAsync(
+        Guid tenantId, string provider, string apiKey, Guid? actorUserId, CancellationToken ct = default)
+    {
+        var canonical = Canonicalize(provider);
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            throw new ArgumentException("A BYOK api key is required.", nameof(apiKey));
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        // 1) Cabinet key FIRST — a bad key throws here, before any mode change (no
+        //    partial write). The cabinet stores it under the canonical slug 32-3 reads.
+        var secret = await _cabinet
+            .WriteAsync(tenantId, canonical, apiKey, actorUserId ?? Guid.Empty, ct)
+            .ConfigureAwait(false);
+        var secretName = ProviderCabinetName(canonical);
+
+        // 2) Upsert the ONE active owner row (AC12 — no duplicate active row).
+        var existing = await FindActiveRowAsync(tenantId, canonical, tracking: true, ct)
+            .ConfigureAwait(false);
+        if (existing is null)
+        {
+            _db.TenantProviderBillings.Add(new TenantProviderBilling
+            {
+                Id = Guid.NewGuid(),
+                TenantId = tenantId,
+                ProviderKey = canonical,
+                Mode = ModeByok,
+                SecretName = secretName,
+                Status = StatusActive,
+                CreatedAt = now,
+                UpdatedAt = now,
+                CreatedBy = actorUserId,
+                UpdatedBy = actorUserId,
+            });
+        }
+        else
+        {
+            existing.Mode = ModeByok;
+            existing.SecretName = secretName;
+            existing.UpdatedAt = now;
+            existing.UpdatedBy = actorUserId;
+        }
+
+        await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // 3) Invalidate 32-3's cached credential so the next LLM call re-resolves BYOK.
+        _credentialResolver.Invalidate(tenantId, canonical);
+
+        _logger.LogInformation(
+            "BYOK enabled: tenantId={TenantId} provider={Provider} mode=byok secretVersion={Version}",
+            tenantId, canonical, secret.ActiveVersionNumber);
+
+        await EmitAsync(PricingEventTypes.ByokEnabled, tenantId, canonical, ModeByok, now, ct)
+            .ConfigureAwait(false);
+
+        return new ByokModeResult(canonical, ModeByok, KeySet: true);
+    }
+
+    /// <inheritdoc />
+    public async Task<ByokModeResult> DisableByokAsync(
+        Guid tenantId, string provider, Guid? actorUserId, CancellationToken ct = default)
+    {
+        var canonical = Canonicalize(provider);
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        // 1) Flip the owner row to platform FIRST (secret ref tombstoned; row kept for
+        //    audit). Idempotent — a missing / already-platform row is a no-op.
+        var existing = await FindActiveRowAsync(tenantId, canonical, tracking: true, ct)
+            .ConfigureAwait(false);
+        if (existing is not null && existing.Mode != ModePlatform)
+        {
+            existing.Mode = ModePlatform;
+            existing.SecretName = null;
+            existing.UpdatedAt = now;
+            existing.UpdatedBy = actorUserId;
+            await _db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+
+        // 2) Retire the cabinet secret (best-effort; idempotent).
+        await _cabinet.RemoveAsync(tenantId, canonical, ct).ConfigureAwait(false);
+
+        // 3) Invalidate 32-3's cached credential so the next LLM call falls back to
+        //    the platform leg.
+        _credentialResolver.Invalidate(tenantId, canonical);
+
+        _logger.LogInformation(
+            "BYOK disabled: tenantId={TenantId} provider={Provider} mode=platform",
+            tenantId, canonical);
+
+        await EmitAsync(PricingEventTypes.ByokDisabled, tenantId, canonical, ModePlatform, now, ct)
+            .ConfigureAwait(false);
+
+        return new ByokModeResult(canonical, ModePlatform, KeySet: false);
+    }
+
+    /// <inheritdoc />
+    public async Task<ByokModeResult> GetModeAsync(
+        Guid tenantId, string provider, CancellationToken ct = default)
+    {
+        var canonical = Canonicalize(provider);
+        var row = await FindActiveRowAsync(tenantId, canonical, tracking: false, ct)
+            .ConfigureAwait(false);
+        return Project(canonical, row?.Mode, row?.SecretName);
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<ByokModeResult>> ListModesAsync(
+        Guid tenantId, CancellationToken ct = default)
+    {
+        var rows = await _db.TenantProviderBillings
+            .AsNoTracking()
+            .Where(r => r.TenantId == tenantId && r.Status == StatusActive)
+            .Select(r => new { r.ProviderKey, r.Mode, r.SecretName })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return rows
+            .Select(r => Project(r.ProviderKey.ToLowerInvariant(), r.Mode, r.SecretName))
+            .ToList();
+    }
+
+    private Task<TenantProviderBilling?> FindActiveRowAsync(
+        Guid tenantId, string canonical, bool tracking, CancellationToken ct)
+    {
+        IQueryable<TenantProviderBilling> q = tracking
+            ? _db.TenantProviderBillings
+            : _db.TenantProviderBillings.AsNoTracking();
+        return q.FirstOrDefaultAsync(
+            r => r.TenantId == tenantId
+                 && r.Status == StatusActive
+                 && r.ProviderKey.ToLower() == canonical,
+            ct);
+    }
+
+    private static ByokModeResult Project(string canonical, string? mode, string? secretName)
+    {
+        var isByok = string.Equals(mode, ModeByok, StringComparison.Ordinal);
+        return new ByokModeResult(
+            canonical,
+            isByok ? ModeByok : ModePlatform,
+            KeySet: isByok && !string.IsNullOrEmpty(secretName));
+    }
+
+    private static string Canonicalize(string? provider)
+    {
+        var canonical = BillingProviderKey.Canonicalize(provider);
+        if (canonical.Length == 0)
+        {
+            throw new ArgumentException("A provider key is required.", nameof(provider));
+        }
+        return canonical;
+    }
+
+    private static string ProviderCabinetName(string canonical) =>
+        ProviderCabinetNames.Byok(canonical);
+
+    private async Task EmitAsync(
+        string type, Guid tenantId, string provider, string mode, DateTime now, CancellationToken ct)
+    {
+        var tenantTag = tenantId.ToString();
+        await _events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantTag,
+                provider,
+                mode,
+            }),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new
+            {
+                provider,
+                mode,
+            }),
+            CreatedAt = now,
+        }).ConfigureAwait(false);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderIdentity.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderIdentity.cs
@@ -1,0 +1,47 @@
+namespace Tamma.Api.Services.Providers;
+
+/// <summary>
+/// Story 34-3 (Fix) — the ONE raw provider-IDENTITY normalization for the BYOK /
+/// billing-mode owner path. A provider handle is normalized to
+/// <c>Trim().ToLowerInvariant()</c> with <b>NO alias-family reduction</b> — the
+/// SAME string <see cref="DefaultProviderCredentialResolver"/> (its private
+/// <c>Normalize</c>) and <c>ProviderCredentialEndpoints.NormalizeProvider</c>
+/// compute when they build the Epic-29 cabinet slug
+/// (<c>provider/&lt;handle&gt;/api-key</c>). Keying the owner row
+/// <c>TenantProviderBilling.ProviderKey</c>, the BYOK cabinet slug, AND the
+/// billing-mode read ALL on this handle makes the write slug byte-identical to
+/// the resolver read.
+///
+/// <para><b>Why raw identity, not the rate-card family.</b> BYOK is a
+/// per-PROVIDER-IDENTITY decision: <c>github-copilot</c> and <c>openai</c> are
+/// DIFFERENT keys, different toggles, different owner rows. Collapsing them to a
+/// family (as <c>BillingProviderKey.Canonicalize</c> /
+/// <see cref="ProviderRateLookup.Aliases"/> do) makes a <c>github-copilot</c>
+/// write land under <c>provider/openai/api-key</c> — clobbering the tenant's
+/// OpenAI key and flipping the <c>openai</c> owner row — while a <c>gemini</c>
+/// write lands under <c>provider/google/api-key</c>, where the resolver (which
+/// reads <c>provider/gemini/api-key</c>) never finds it: the tenant's key is
+/// silently unused and the call is billed as BYOK on the platform key. Raw
+/// identity closes both gaps.</para>
+///
+/// <para>The rate-card path (<see cref="ProviderRateLookup"/> and the pricing /
+/// cost / margin resolvers) KEEPS the alias-family map — that map answers "how
+/// much does a call cost", not "whose key is this". This helper is deliberately
+/// separate from it and never reduces to a family.</para>
+///
+/// <para><b>No allowlist gate here.</b> The BYOK toggle surface is BROADER than
+/// <c>ProviderAllowlist.DefaultProviders</c>: single-user tenants legitimately
+/// BYOK non-allowlisted CLI providers (e.g. <c>claude-code</c>), and the legacy
+/// Anthropic proxy tags on the vendor handle <c>anthropic-claude</c>. Unknown /
+/// bogus providers are rejected upstream by the SaaS eligibility gate
+/// (<c>IProviderAuthLookup</c> → 422), not by collapsing the identity here.</para>
+/// </summary>
+public static class ProviderIdentity
+{
+    /// <summary>
+    /// Raw provider-identity key: <c>Trim().ToLowerInvariant()</c>, no alias
+    /// reduction. Empty / whitespace → <see cref="string.Empty"/>.
+    /// </summary>
+    public static string Normalize(string? provider) =>
+        (provider ?? string.Empty).Trim().ToLowerInvariant();
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/TenantProviderBilling.cs
@@ -19,14 +19,15 @@ namespace Tamma.Data.Entities;
 /// (the current reality). BYOK is opt-in and only ever the result of an explicit
 /// <c>active</c> row with <see cref="Mode"/> = <c>"byok"</c>.</para>
 ///
-/// <para><b>ProviderKey overload:</b> <see cref="ProviderKey"/> here is the
-/// CANONICAL provider FAMILY key (<c>"anthropic"</c>) — NOT the Cranl tenancy
-/// backend label. It is NOT necessarily byte-identical to
-/// <c>ProviderDiagnostic.ProviderKey</c>, which carries the vendor HANDLE
-/// (<c>"anthropic-claude"</c>): the read path canonicalizes the handle to the
-/// family key via <c>BillingProviderKey.Canonicalize</c> before matching this row,
-/// and a BYOK write endpoint MUST persist the canonical (lowercase family) key here
-/// so the match is exact.</para>
+/// <para><b>ProviderKey overload:</b> <see cref="ProviderKey"/> here is the RAW
+/// provider IDENTITY (<c>ProviderIdentity.Normalize</c> — <c>Trim().ToLowerInvariant()</c>,
+/// NO alias-family reduction), e.g. <c>"gemini"</c> / <c>"github-copilot"</c> — NOT the
+/// Cranl tenancy backend label and NOT the rate-card family (which would collapse
+/// <c>gemini</c>→<c>google</c>, <c>github-copilot</c>→<c>openai</c> and clobber a sibling
+/// provider's key). This is the SAME handle Story 32-3's credential resolver reads and
+/// the LLM proxy passes, so both the BYOK write (34-3) and the billing-mode read match
+/// this row on that raw handle exactly. (The pricing/rate-card path keeps its own
+/// alias-family map — that answers "what does a call cost", not "whose key is this".)</para>
 /// </summary>
 public class TenantProviderBilling
 {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokEnableConflictTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokEnableConflictTests.cs
@@ -1,0 +1,130 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Tests.Security;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 (Fix 2) — two concurrent FIRST-time BYOK enables race past the service's
+/// check-then-insert window and both INSERT; the loser trips the
+/// <c>ux_tpb_active_provider</c> partial unique index (Postgres 23505) as a raw
+/// <see cref="DbUpdateException"/>. The <c>EnableByok</c> endpoint must map that to
+/// <c>409 Conflict</c> (<c>BYOK_ENABLE_CONFLICT</c>), NOT leak it as a 500.
+///
+/// <para>The control-plane context is subclassed to throw the exact
+/// <see cref="DbUpdateException"/>/<see cref="PostgresException"/> shape on
+/// <c>SaveChangesAsync</c> — the InMemory provider does not enforce the unique index, so
+/// the race is simulated deterministically (same technique as
+/// <c>PromptEndpointsUpsertConflictTests</c>).</para>
+/// </summary>
+[TestFixture]
+public class PricingByokEnableConflictTests
+{
+    private const string Key = "sk-fake-byok-key-value";
+
+    [Test]
+    public async Task EnableByok_OnUniqueViolation_Returns409Conflict_Noterror500()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = new ThrowingControlPlaneDbContext(
+            new DbContextOptionsBuilder<ControlPlaneDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options);
+
+        var service = new TenantProviderBillingService(
+            db, new NoopCabinet(), new RecordingGateEventRepository(), new NoopResolver(),
+            TimeProvider.System, NullLogger<TenantProviderBillingService>.Instance);
+
+        // Single-user mode skips the SaaS eligibility gate → straight to the service,
+        // whose SaveChanges throws the simulated 23505.
+        var result = await PricingEndpoints.EnableByok(
+            "anthropic", new EnableByokRequest(Key), Principal(), new StubTenant(tenant),
+            new StubMode(TammaMode.SingleUser), FakeAuthLookup.Default(), service,
+            NullLoggerFactory.Instance, CancellationToken.None);
+
+        await AssertConflict(result);
+    }
+
+    [Test]
+    public void IsUniqueViolation_OnlyMatchesSqlState23505()
+    {
+        PricingEndpoints.IsUniqueViolation(MakeUniqueViolation()).Should().BeTrue();
+        PricingEndpoints.IsUniqueViolation(
+            new DbUpdateException("wrong table", new PostgresException("x", "ERROR", "ERROR", "42P01")))
+            .Should().BeFalse();
+        PricingEndpoints.IsUniqueViolation(
+            new DbUpdateException("generic", new InvalidOperationException("not pg")))
+            .Should().BeFalse();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static DbUpdateException MakeUniqueViolation() =>
+        new("duplicate key value violates unique constraint",
+            new PostgresException(
+                "duplicate key value violates unique constraint", "ERROR", "ERROR", "23505"));
+
+    private static ClaimsPrincipal Principal() =>
+        new(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()) }, "test"));
+
+    private static async Task AssertConflict(IResult result)
+    {
+        var ctx = new DefaultHttpContext { Response = { Body = new MemoryStream() } };
+        ctx.RequestServices = new ServiceCollection().AddLogging().BuildServiceProvider();
+        await result.ExecuteAsync(ctx);
+
+        ctx.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+
+        ctx.Response.Body.Position = 0;
+        using var reader = new StreamReader(ctx.Response.Body);
+        (await reader.ReadToEndAsync()).Should().Contain("BYOK_ENABLE_CONFLICT");
+    }
+
+    // A CP context that throws the simulated 23505 on SaveChanges (the insert path).
+    private sealed class ThrowingControlPlaneDbContext(DbContextOptions<ControlPlaneDbContext> options)
+        : ControlPlaneDbContext(options)
+    {
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default) =>
+            throw MakeUniqueViolation();
+    }
+
+    private sealed class StubTenant(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class NoopCabinet : IProviderByokSecretCabinet
+    {
+        public Task<SecretMetadata> WriteAsync(
+            Guid tenantId, string providerCanonical, string apiKey, Guid ownerUserId, CancellationToken ct = default) =>
+            Task.FromResult(new SecretMetadata(
+                Guid.NewGuid(), $"provider/{providerCanonical}/api-key", SecretScope.Tenant, tenantId,
+                SecretPurpose.ApiKey, Array.Empty<ConsumerRef>(), ownerUserId, RotationSchedule.None,
+                LastRotatedAt: null, NextRotationDueAt: null, ActiveVersionNumber: 1,
+                CreatedAt: DateTimeOffset.UtcNow, UpdatedAt: DateTimeOffset.UtcNow));
+
+        public Task<bool> RemoveAsync(Guid tenantId, string providerCanonical, CancellationToken ct = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class NoopResolver : IProviderCredentialResolver
+    {
+        public Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+        public void Invalidate(Guid? tenantId, string providerName) { }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokEndpointsTests.cs
@@ -1,0 +1,201 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Services.Security;
+using Tamma.Api.Tests.Security;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 — the BYOK toggle endpoints driven directly against the static handlers
+/// with service/lookup fakes (mirrors <c>IntegrationCredentialEndpointsTests</c>).
+/// Pins: enable → Ok + reveal-SAFE (no key in the response) + the service is called;
+/// a cli-token / unknown provider in SaaS → 422 (single-user is a no-op); missing key /
+/// no tenant handling; disable → Ok mode=platform; GET mode read. (Member-role 403 is
+/// enforced by the PricingManage route policy and pinned by <c>PricingByokRbacTests</c>.)
+/// </summary>
+[TestFixture]
+public class PricingByokEndpointsTests
+{
+    private const string Key = "sk-fake-byok-key-value";
+    private static readonly Guid Tenant = Guid.NewGuid();
+
+    private FakeBillingService _service = null!;
+
+    [SetUp]
+    public void SetUp() => _service = new FakeBillingService();
+
+    private static ClaimsPrincipal Principal() =>
+        new(new ClaimsIdentity(new[] { new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()) }, "test"));
+
+    private static ITenantContext TenantCtx(Guid? id) => new StubTenant(id);
+    private static ILoggerFactory Lf => NullLoggerFactory.Instance;
+
+    private static object? Value(IResult result) =>
+        result.GetType().GetProperty("Value")?.GetValue(result);
+
+    // ── enable ──────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Enable_SaaS_ApiKeyProvider_Ok_RevealSafe_CallsService()
+    {
+        var result = await PricingEndpoints.EnableByok(
+            "anthropic", new EnableByokRequest(Key), Principal(), TenantCtx(Tenant),
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("Ok");
+        JsonSerializer.Serialize(Value(result)).Should().Contain("byok").And.NotContain(Key);
+        _service.EnableCalls.Should().ContainSingle();
+        _service.EnableCalls[0].Provider.Should().Be("anthropic");
+        _service.EnableCalls[0].ApiKey.Should().Be(Key);
+        _service.EnableCalls[0].Tenant.Should().Be(Tenant);
+    }
+
+    [Test]
+    public async Task Enable_SaaS_CliTokenProvider_422_NotCalled()
+    {
+        var result = await PricingEndpoints.EnableByok(
+            "claude-code", new EnableByokRequest(Key), Principal(), TenantCtx(Tenant),
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("UnprocessableEntity");
+        JsonSerializer.Serialize(Value(result)).Should().Contain("CLI providers are single-user only");
+        _service.EnableCalls.Should().BeEmpty("a cli-token provider is not BYOK-eligible in SaaS");
+    }
+
+    [Test]
+    public async Task Enable_SaaS_UnknownProvider_422_FailClosed()
+    {
+        var result = await PricingEndpoints.EnableByok(
+            "totally-unknown", new EnableByokRequest(Key), Principal(), TenantCtx(Tenant),
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("UnprocessableEntity");
+        _service.EnableCalls.Should().BeEmpty("an unknown provider fails closed in SaaS");
+    }
+
+    [Test]
+    public async Task Enable_SingleUser_CliTokenProvider_Allowed_NoLookup()
+    {
+        var lookup = FakeAuthLookup.Default();
+        var result = await PricingEndpoints.EnableByok(
+            "claude-code", new EnableByokRequest(Key), Principal(), TenantCtx(Tenant),
+            new StubMode(TammaMode.SingleUser), lookup, _service, Lf, CancellationToken.None);
+
+        // "CLI providers are single-user only" — the sole user may BYOK a CLI provider.
+        result.GetType().Name.Should().Contain("Ok");
+        _service.EnableCalls.Should().ContainSingle();
+        lookup.Calls.Should().BeEmpty("the SaaS eligibility gate is a hard no-op in single-user");
+    }
+
+    [Test]
+    public async Task Enable_MissingKey_BadRequest_NotCalled()
+    {
+        var result = await PricingEndpoints.EnableByok(
+            "anthropic", new EnableByokRequest("  "), Principal(), TenantCtx(Tenant),
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("BadRequest");
+        _service.EnableCalls.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task Enable_NoTenantContext_BadRequest_NotCalled()
+    {
+        var result = await PricingEndpoints.EnableByok(
+            "anthropic", new EnableByokRequest(Key), Principal(), TenantCtx(null),
+            new StubMode(TammaMode.SaaS), FakeAuthLookup.Default(), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("BadRequest");
+        _service.EnableCalls.Should().BeEmpty();
+    }
+
+    // ── disable ───────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Disable_Ok_Platform_CallsService()
+    {
+        var result = await PricingEndpoints.DisableByok(
+            "anthropic", Principal(), TenantCtx(Tenant), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("Ok");
+        JsonSerializer.Serialize(Value(result)).Should().Contain("platform");
+        _service.DisableCalls.Should().ContainSingle().Which.Provider.Should().Be("anthropic");
+    }
+
+    [Test]
+    public async Task Disable_NoTenantContext_NotFound()
+    {
+        var result = await PricingEndpoints.DisableByok(
+            "anthropic", Principal(), TenantCtx(null), _service, Lf, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("NotFound");
+        _service.DisableCalls.Should().BeEmpty();
+    }
+
+    // ── read ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetMode_Ok_RevealSafe()
+    {
+        _service.GetResult = new ByokModeResult("anthropic", "byok", KeySet: true);
+        var result = await PricingEndpoints.GetProviderMode(
+            "anthropic", TenantCtx(Tenant), _service, CancellationToken.None);
+
+        result.GetType().Name.Should().Contain("Ok");
+        var json = JsonSerializer.Serialize(Value(result));
+        json.Should().Contain("keySet").And.Contain("byok").And.NotContain(Key);
+    }
+
+    [Test]
+    public async Task List_NoTenant_EmptyOk()
+    {
+        var result = await PricingEndpoints.ListProviderModes(
+            TenantCtx(null), _service, CancellationToken.None);
+        result.GetType().Name.Should().Contain("Ok");
+    }
+
+    // ── fakes ─────────────────────────────────────────────────────────────────
+
+    private sealed class StubTenant(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class FakeBillingService : ITenantProviderBillingService
+    {
+        public List<(Guid Tenant, string Provider, string ApiKey)> EnableCalls { get; } = new();
+        public List<(Guid Tenant, string Provider)> DisableCalls { get; } = new();
+        public ByokModeResult? GetResult { get; set; }
+
+        public Task<ByokModeResult> EnableByokAsync(
+            Guid tenantId, string provider, string apiKey, Guid? actorUserId, CancellationToken ct = default)
+        {
+            EnableCalls.Add((tenantId, provider, apiKey));
+            return Task.FromResult(new ByokModeResult(provider, "byok", KeySet: true));
+        }
+
+        public Task<ByokModeResult> DisableByokAsync(
+            Guid tenantId, string provider, Guid? actorUserId, CancellationToken ct = default)
+        {
+            DisableCalls.Add((tenantId, provider));
+            return Task.FromResult(new ByokModeResult(provider, "platform", KeySet: false));
+        }
+
+        public Task<ByokModeResult> GetModeAsync(Guid tenantId, string provider, CancellationToken ct = default) =>
+            Task.FromResult(GetResult ?? new ByokModeResult(provider, "platform", KeySet: false));
+
+        public Task<IReadOnlyList<ByokModeResult>> ListModesAsync(Guid tenantId, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<ByokModeResult>>(Array.Empty<ByokModeResult>());
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokRbacTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/PricingByokRbacTests.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 — the BYOK toggle mutations (<c>POST/DELETE
+/// /api/pricing/providers/{provider}/byok</c>) are gated by the <c>PricingManage</c>
+/// route policy → the <c>pricing:manage</c> permission. This pins the RBAC contract
+/// the routes rely on: member → 403, tenant_admin / tenant_owner → allowed. (The spec
+/// names <c>SettingsManage</c>, but that is owner-only and would 403 every
+/// tenant_admin; per CLAUDE.md the prompt/convention/agent precedent grants
+/// owner+admin via a dedicated gate — <c>PricingManage</c> here.)
+/// </summary>
+[TestFixture]
+public class PricingByokRbacTests
+{
+    private const string Permission = "pricing:manage";
+
+    [Test]
+    public void Member_IsDenied()
+    {
+        Permissions.HasPermission("member", Permission).Should().BeFalse(
+            "a member-role SaaS caller must hit 403 on the BYOK toggle mutations");
+    }
+
+    [TestCase("admin")]
+    [TestCase("owner")]
+    public void AdminAndOwner_AreAllowed(string role)
+    {
+        Permissions.HasPermission(role, Permission).Should().BeTrue(
+            "tenant_admin and tenant_owner may enable/disable BYOK for their tenant");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingResolverTests.cs
@@ -85,27 +85,37 @@ public class TenantProviderBillingResolverTests
         (await NewResolver(db).ResolveModeAsync(tenantId, "ANTHROPIC")).Should().Be(MetricBillingMode.Byok);
     }
 
-    // ── Fix 2 — the call site uses the vendor handle "anthropic-claude"; the owner
-    //    row is stored under the canonical family key "anthropic". Canonical
-    //    normalization must make them MATCH (else a declared BYOK row is silently
-    //    ignored and the tenant is billed platform markup on their own key). ──
+    // ── The read matches on the RAW provider IDENTITY the proxy passes (Trim + lower,
+    //    NO alias-family reduction) — the SAME handle 34-3 persists and 32-3 reads. A
+    //    "gemini" BYOK row is read for a "gemini" call, and is DISTINCT from the rate-card
+    //    family "google" (keying on the family would silently unbill / mis-tag the wrong
+    //    provider). Mixed case still matches (case-insensitive on the identity). ──
     [Test]
-    public async Task ResolveMode_CanonicalizesVendorHandle_MatchesOwnerRow()
+    public async Task ResolveMode_KeysOnRawProviderIdentity_NotRateCardFamily()
     {
         var tenantId = Guid.NewGuid();
         await using var db = NewContext();
-        // Owner row stored under the CANONICAL provider key.
-        db.TenantProviderBillings.Add(Row(tenantId, "anthropic", "byok"));
+        // Owner rows keyed on the RAW handle.
+        db.TenantProviderBillings.AddRange(
+            Row(tenantId, "gemini", "byok"),
+            Row(tenantId, "github-copilot", "byok"));
         await db.SaveChangesAsync();
 
         var resolver = NewResolver(db);
-        // The proxy resolves under the vendor handle "anthropic-claude".
-        (await resolver.ResolveModeAsync(tenantId, "anthropic-claude"))
-            .Should().Be(MetricBillingMode.Byok,
-                "'anthropic-claude' canonicalizes to 'anthropic' — the declared BYOK row must match");
-        // Mixed case + vendor handle still canonicalizes.
-        (await resolver.ResolveModeAsync(tenantId, "Anthropic-Claude"))
-            .Should().Be(MetricBillingMode.Byok);
+
+        // The raw handle matches its own row.
+        (await resolver.ResolveModeAsync(tenantId, "gemini")).Should().Be(MetricBillingMode.Byok);
+        (await resolver.ResolveModeAsync(tenantId, "GEMINI")).Should().Be(
+            MetricBillingMode.Byok, "the identity match is case-insensitive");
+        (await resolver.ResolveModeAsync(tenantId, "github-copilot")).Should().Be(MetricBillingMode.Byok);
+
+        // The rate-card FAMILY is a DIFFERENT identity — a "google" / "openai" call does
+        // NOT pick up the gemini / github-copilot BYOK row (fail-before: the old
+        // family-canonicalized read collapsed gemini→google and matched wrongly).
+        (await resolver.ResolveModeAsync(tenantId, "google")).Should().Be(
+            MetricBillingMode.PlatformProvided, "'gemini' BYOK must not leak onto a 'google' call");
+        (await resolver.ResolveModeAsync(tenantId, "openai")).Should().Be(
+            MetricBillingMode.PlatformProvided, "'github-copilot' BYOK must not leak onto an 'openai' call");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs
@@ -1,0 +1,242 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Secrets;
+using Tamma.Api.Tests.Security;
+using Tamma.Core.Enums;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Pricing;
+
+/// <summary>
+/// Story 34-3 — WRITE side. <see cref="TenantProviderBillingService"/> enable/disable
+/// populates the authoritative <c>TenantProviderBilling</c> owner rows the read-side
+/// <see cref="TenantProviderBillingResolver"/> consumes. Pins: enable writes the
+/// cabinet key + one active byok row (canonical key) + PRICING.BYOK.ENABLED + 32-3
+/// cache invalidation; disable retires the secret + flips to platform +
+/// PRICING.BYOK.DISABLED + invalidation; one-active-row on re-enable; and the real
+/// resolver reads byok after enable / platform after disable. InMemory CP — the SQL
+/// invariants (CHECK + partial unique index) are pinned by the Postgres model tests.
+/// </summary>
+[TestFixture]
+public class TenantProviderBillingServiceTests
+{
+    private const string Key = "sk-fake-byok-key-value";
+
+    private static ControlPlaneDbContext NewContext() =>
+        new(new DbContextOptionsBuilder<ControlPlaneDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static TenantProviderBillingResolver NewResolver(ControlPlaneDbContext db) =>
+        new(db, NullLogger<TenantProviderBillingResolver>.Instance);
+
+    private static (TenantProviderBillingService Service, FakeByokCabinet Cabinet,
+        RecordingGateEventRepository Events, SpyCredentialResolver Resolver)
+        NewService(ControlPlaneDbContext db)
+    {
+        var cabinet = new FakeByokCabinet();
+        var events = new RecordingGateEventRepository();
+        var resolver = new SpyCredentialResolver();
+        var service = new TenantProviderBillingService(
+            db, cabinet, events, resolver, TimeProvider.System,
+            NullLogger<TenantProviderBillingService>.Instance);
+        return (service, cabinet, events, resolver);
+    }
+
+    [Test]
+    public async Task Enable_WritesCabinetKey_FlipsRowToByok_EmitsEnabled_Invalidates()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, events, resolver) = NewService(db);
+
+        var result = await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: Guid.NewGuid());
+
+        result.Mode.Should().Be("byok");
+        result.KeySet.Should().BeTrue();
+        result.Provider.Should().Be("anthropic");
+
+        // Cabinet key written under the canonical slug 32-3 reads.
+        cabinet.Writes.Should().ContainSingle();
+        cabinet.Writes[0].Provider.Should().Be("anthropic");
+        cabinet.Writes[0].ApiKey.Should().Be(Key);
+
+        // One active byok owner row under the canonical key + the exact cabinet name.
+        var row = await db.TenantProviderBillings.SingleAsync();
+        row.TenantId.Should().Be(tenant);
+        row.ProviderKey.Should().Be("anthropic");
+        row.Mode.Should().Be("byok");
+        row.Status.Should().Be("active");
+        row.SecretName.Should().Be("provider/anthropic/api-key");
+
+        // PRICING.BYOK.ENABLED emitted (tags carry tenantId/provider/mode).
+        events.Appended.Should().ContainSingle();
+        events.Appended[0].Type.Should().Be(PricingEventTypes.ByokEnabled);
+        events.Appended[0].TenantId.Should().Be(tenant);
+        events.Appended[0].Tags.Should().Contain("anthropic").And.Contain("byok");
+        // The key is NEVER serialized into the event.
+        events.Appended[0].Data.Should().NotContain(Key);
+        events.Appended[0].Tags.Should().NotContain(Key);
+
+        // 32-3 credential cache invalidated for (tenant, canonical).
+        resolver.Invalidated.Should().ContainSingle().Which.Should().Be((tenant, "anthropic"));
+    }
+
+    [Test]
+    public async Task Enable_CanonicalizesVendorHandle_StoresUnderFamilyKey()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, _, resolver) = NewService(db);
+
+        // The caller passes the vendor handle; storage MUST be the canonical family key.
+        var result = await service.EnableByokAsync(tenant, "anthropic-claude", Key, actorUserId: null);
+
+        result.Provider.Should().Be("anthropic");
+        (await db.TenantProviderBillings.SingleAsync()).ProviderKey.Should().Be("anthropic");
+        cabinet.Writes[0].Provider.Should().Be("anthropic");
+        resolver.Invalidated[0].Should().Be((tenant, "anthropic"));
+
+        // The real resolver (reads canonical) now returns byok for the vendor handle.
+        (await NewResolver(db).ResolveModeAsync(tenant, "anthropic-claude"))
+            .Should().Be(MetricBillingMode.Byok);
+    }
+
+    [Test]
+    public async Task Enable_Idempotent_ReEnable_NoDuplicateActiveRow()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, _, _) = NewService(db);
+
+        await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: null);
+        await service.EnableByokAsync(tenant, "anthropic", "sk-fake-rotated-value", actorUserId: null);
+
+        // Exactly ONE active row (the second enable updated, not duplicated).
+        (await db.TenantProviderBillings.CountAsync(r => r.Status == "active")).Should().Be(1);
+        // The cabinet was written both times (the key rotates on re-enable).
+        cabinet.Writes.Should().HaveCount(2);
+    }
+
+    [Test]
+    public async Task Disable_RetiresSecret_FlipsToPlatform_EmitsDisabled_Invalidates()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, events, resolver) = NewService(db);
+
+        await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: null);
+        resolver.Invalidated.Clear();
+        events.Appended.Clear();
+
+        var result = await service.DisableByokAsync(tenant, "anthropic", actorUserId: null);
+
+        result.Mode.Should().Be("platform");
+        result.KeySet.Should().BeFalse();
+
+        // Row kept for audit but flipped to platform + secret ref tombstoned (XOR).
+        var row = await db.TenantProviderBillings.SingleAsync();
+        row.Mode.Should().Be("platform");
+        row.SecretName.Should().BeNull();
+        row.Status.Should().Be("active");
+
+        // Cabinet secret retired.
+        cabinet.Removes.Should().Contain("anthropic");
+        // PRICING.BYOK.DISABLED emitted + cache invalidated.
+        events.Appended.Should().ContainSingle().Which.Type.Should().Be(PricingEventTypes.ByokDisabled);
+        resolver.Invalidated.Should().ContainSingle().Which.Should().Be((tenant, "anthropic"));
+
+        // The real resolver now reads platform.
+        (await NewResolver(db).ResolveModeAsync(tenant, "anthropic"))
+            .Should().Be(MetricBillingMode.PlatformProvided);
+    }
+
+    [Test]
+    public async Task Disable_NoPriorRow_Idempotent_ReturnsPlatform()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, events, _) = NewService(db);
+
+        var result = await service.DisableByokAsync(tenant, "anthropic", actorUserId: null);
+
+        result.Mode.Should().Be("platform");
+        (await db.TenantProviderBillings.CountAsync()).Should().Be(0, "a disable with no row creates nothing");
+        cabinet.Removes.Should().Contain("anthropic", "the cabinet retire is best-effort / idempotent");
+        events.Appended.Should().ContainSingle().Which.Type.Should().Be(PricingEventTypes.ByokDisabled);
+    }
+
+    [Test]
+    public async Task GetMode_NoRow_Platform_KeySetFalse()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, _, _, _) = NewService(db);
+
+        var result = await service.GetModeAsync(tenant, "anthropic");
+        result.Mode.Should().Be("platform");
+        result.KeySet.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetMode_ActiveByok_KeySetTrue()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, _, _, _) = NewService(db);
+        await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: null);
+
+        var result = await service.GetModeAsync(tenant, "anthropic-claude"); // canonicalizes
+        result.Mode.Should().Be("byok");
+        result.KeySet.Should().BeTrue();
+    }
+
+    [Test]
+    public void Enable_BlankProvider_Throws_NoPartialWrite()
+    {
+        var tenant = Guid.NewGuid();
+        using var db = NewContext();
+        var (service, cabinet, _, _) = NewService(db);
+
+        var act = async () => await service.EnableByokAsync(tenant, "   ", Key, actorUserId: null);
+        act.Should().ThrowAsync<ArgumentException>();
+        cabinet.Writes.Should().BeEmpty("a blank provider must not reach the cabinet");
+    }
+
+    // ── fakes ─────────────────────────────────────────────────────────────
+
+    private sealed class FakeByokCabinet : IProviderByokSecretCabinet
+    {
+        public List<(Guid Tenant, string Provider, string ApiKey)> Writes { get; } = new();
+        public List<string> Removes { get; } = new();
+
+        public Task<SecretMetadata> WriteAsync(
+            Guid tenantId, string providerCanonical, string apiKey, Guid ownerUserId, CancellationToken ct = default)
+        {
+            Writes.Add((tenantId, providerCanonical, apiKey));
+            return Task.FromResult(new SecretMetadata(
+                Guid.NewGuid(), $"provider/{providerCanonical}/api-key", SecretScope.Tenant, tenantId,
+                SecretPurpose.ApiKey, Array.Empty<ConsumerRef>(), ownerUserId, RotationSchedule.None,
+                LastRotatedAt: null, NextRotationDueAt: null, ActiveVersionNumber: 1,
+                CreatedAt: DateTimeOffset.UtcNow, UpdatedAt: DateTimeOffset.UtcNow));
+        }
+
+        public Task<bool> RemoveAsync(Guid tenantId, string providerCanonical, CancellationToken ct = default)
+        {
+            Removes.Add(providerCanonical);
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class SpyCredentialResolver : IProviderCredentialResolver
+    {
+        public List<(Guid?, string)> Invalidated { get; } = new();
+        public Task<ProviderCredential> ResolveAsync(Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            throw new NotSupportedException("34-3 never resolves keys.");
+        public void Invalidate(Guid? tenantId, string providerName) => Invalidated.Add((tenantId, providerName));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Pricing/TenantProviderBillingServiceTests.cs
@@ -3,9 +3,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
 using Tamma.Api.Services.Pricing;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.PromptStore;
 using Tamma.Api.Services.Secrets;
 using Tamma.Api.Tests.Security;
+using Tamma.Core;
 using Tamma.Core.Enums;
 using Tamma.Data;
 
@@ -86,24 +90,93 @@ public class TenantProviderBillingServiceTests
         resolver.Invalidated.Should().ContainSingle().Which.Should().Be((tenant, "anthropic"));
     }
 
+    // ── Fix 1 (a) — gemini keys on the RAW identity, NOT the rate-card family. The
+    //    cabinet slug + owner row are "gemini" / "provider/gemini/api-key" — byte-
+    //    identical to what the REAL 32-3 credential resolver reads for a "gemini" call,
+    //    so the call resolves BOTH byok mode AND the tenant's key. Fail-before: the old
+    //    family-canonicalized write stored provider/google/api-key, which the "gemini"
+    //    read never finds → the tenant's key is silently unused / billed BYOK on the
+    //    platform key. ──
     [Test]
-    public async Task Enable_CanonicalizesVendorHandle_StoresUnderFamilyKey()
+    public async Task Enable_Gemini_KeysRawIdentity_ResolverReadsByokAndTenantKey()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, _, _) = NewService(db);
+
+        var result = await service.EnableByokAsync(tenant, "gemini", Key, actorUserId: null);
+
+        // Owner row + cabinet slug key on the RAW handle "gemini" (NOT the family "google").
+        result.Provider.Should().Be("gemini");
+        var row = await db.TenantProviderBillings.SingleAsync();
+        row.ProviderKey.Should().Be("gemini");
+        row.SecretName.Should().Be("provider/gemini/api-key");
+        cabinet.Writes.Should().ContainSingle().Which.Provider.Should().Be("gemini");
+
+        // The billing resolver reads byok for the raw handle; "google" is a DIFFERENT
+        // identity that does not pick up the gemini row.
+        (await NewResolver(db).ResolveModeAsync(tenant, "gemini")).Should().Be(MetricBillingMode.Byok);
+        (await NewResolver(db).ResolveModeAsync(tenant, "google")).Should().Be(MetricBillingMode.PlatformProvided);
+
+        // The REAL 32-3 credential resolver reads the tenant key at the EXACT slug the
+        // service wrote (seed the cabinet reader at the owner row's SecretName). Only a
+        // matching slug resolves byok; a mismatch would fail-closed (fallback denied).
+        var byokReader = new SeededByokReader();
+        byokReader.Seed(tenant, row.SecretName!, Key, version: 1);
+        var cred = await NewCredentialResolver(byokReader).ResolveAsync(tenant, "gemini");
+        cred.Source.Should().Be(CredentialSource.Byok);
+        cred.ApiKey.Should().Be(Key);
+    }
+
+    // ── Fix 1 (b) — github-copilot keys on its OWN identity and never clobbers openai.
+    //    Fail-before: github-copilot canonicalized to "openai", so the write stored the
+    //    tenant's Copilot key under provider/openai/api-key and flipped the openai owner
+    //    row — overwriting a separately-configured OpenAI key. ──
+    [Test]
+    public async Task Enable_GithubCopilot_DoesNotClobberOpenAi_TwoDistinctRowsAndKeys()
     {
         var tenant = Guid.NewGuid();
         await using var db = NewContext();
         var (service, cabinet, _, resolver) = NewService(db);
 
-        // The caller passes the vendor handle; storage MUST be the canonical family key.
+        await service.EnableByokAsync(tenant, "github-copilot", "sk-copilot-key-value", actorUserId: null);
+
+        // The github-copilot enable touched ONLY the github-copilot slug/row — never openai.
+        cabinet.Writes.Should().ContainSingle().Which.Provider.Should().Be("github-copilot");
+        resolver.Invalidated.Should().ContainSingle().Which.Should().Be((tenant, "github-copilot"));
+
+        await service.EnableByokAsync(tenant, "openai", "sk-openai-key-value", actorUserId: null);
+
+        // TWO distinct owner rows + TWO distinct cabinet keys — no clobber.
+        var rows = await db.TenantProviderBillings.Where(r => r.Status == "active").ToListAsync();
+        rows.Select(r => r.ProviderKey).Should().BeEquivalentTo(new[] { "github-copilot", "openai" });
+        cabinet.Writes.Select(w => w.Provider).Should().BeEquivalentTo(new[] { "github-copilot", "openai" });
+        cabinet.Writes.Should().Contain(w => w.Provider == "github-copilot" && w.ApiKey == "sk-copilot-key-value");
+        cabinet.Writes.Should().Contain(w => w.Provider == "openai" && w.ApiKey == "sk-openai-key-value");
+    }
+
+    // ── Fix 1 (c) — the vendor handle "anthropic-claude" round-trips on the RAW handle:
+    //    write "anthropic-claude" → owner row "anthropic-claude" → the billing resolver
+    //    reads "anthropic-claude" and matches. It is NOT collapsed to the family
+    //    "anthropic" (fail-before: the old write stored "anthropic"). ──
+    [Test]
+    public async Task Enable_AnthropicClaudeVendorHandle_RoundTripsOnRawHandle()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, _, resolver) = NewService(db);
+
         var result = await service.EnableByokAsync(tenant, "anthropic-claude", Key, actorUserId: null);
 
-        result.Provider.Should().Be("anthropic");
-        (await db.TenantProviderBillings.SingleAsync()).ProviderKey.Should().Be("anthropic");
-        cabinet.Writes[0].Provider.Should().Be("anthropic");
-        resolver.Invalidated[0].Should().Be((tenant, "anthropic"));
+        result.Provider.Should().Be("anthropic-claude");
+        (await db.TenantProviderBillings.SingleAsync()).ProviderKey.Should().Be("anthropic-claude");
+        cabinet.Writes[0].Provider.Should().Be("anthropic-claude");
+        resolver.Invalidated[0].Should().Be((tenant, "anthropic-claude"));
 
-        // The real resolver (reads canonical) now returns byok for the vendor handle.
-        (await NewResolver(db).ResolveModeAsync(tenant, "anthropic-claude"))
-            .Should().Be(MetricBillingMode.Byok);
+        // The billing resolver reads byok for the SAME raw handle; the family "anthropic"
+        // is a distinct identity here (no cross-family collapse).
+        (await NewResolver(db).ResolveModeAsync(tenant, "anthropic-claude")).Should().Be(MetricBillingMode.Byok);
+        (await NewResolver(db).ResolveModeAsync(tenant, "anthropic")).Should().Be(MetricBillingMode.PlatformProvided);
     }
 
     [Test]
@@ -170,6 +243,41 @@ public class TenantProviderBillingServiceTests
         events.Appended.Should().ContainSingle().Which.Type.Should().Be(PricingEventTypes.ByokDisabled);
     }
 
+    // ── Fix 3 — a disable whose cabinet retire THROWS must still end with row=platform,
+    //    still emit PRICING.BYOK.DISABLED (not skipped), and surface a RETRIABLE error —
+    //    never a mid-way 500 that leaves the (still-live) key AND skips the event. ──
+    [Test]
+    public async Task Disable_CabinetRemoveThrows_RowIsPlatform_EventEmitted_RetriableError()
+    {
+        var tenant = Guid.NewGuid();
+        await using var db = NewContext();
+        var (service, cabinet, events, resolver) = NewService(db);
+
+        await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: null);
+        events.Appended.Clear();
+        resolver.Invalidated.Clear();
+
+        cabinet.ThrowOnRemove = true;
+
+        var act = async () => await service.DisableByokAsync(tenant, "anthropic", actorUserId: null);
+
+        // A RETRIABLE, typed error surfaces (not a raw 500), so the caller re-runs the
+        // idempotent disable to actually retire the key.
+        var ex = (await act.Should().ThrowAsync<TammaError>()).Which;
+        ex.Code.Should().Be("BYOK.DISABLE.CABINET_RETIRE_FAILED");
+        ex.Retryable.Should().BeTrue();
+
+        // The owner row is ALREADY platform (billing mode flipped) …
+        var row = await db.TenantProviderBillings.SingleAsync();
+        row.Mode.Should().Be("platform");
+        row.SecretName.Should().BeNull();
+
+        // … the DISABLED event still ran (the mode change is authoritative), and the
+        // credential cache was still invalidated.
+        events.Appended.Should().ContainSingle().Which.Type.Should().Be(PricingEventTypes.ByokDisabled);
+        resolver.Invalidated.Should().ContainSingle().Which.Should().Be((tenant, "anthropic"));
+    }
+
     [Test]
     public async Task GetMode_NoRow_Platform_KeySetFalse()
     {
@@ -190,7 +298,7 @@ public class TenantProviderBillingServiceTests
         var (service, _, _, _) = NewService(db);
         await service.EnableByokAsync(tenant, "anthropic", Key, actorUserId: null);
 
-        var result = await service.GetModeAsync(tenant, "anthropic-claude"); // canonicalizes
+        var result = await service.GetModeAsync(tenant, "ANTHROPIC"); // same identity, case-insensitive
         result.Mode.Should().Be("byok");
         result.KeySet.Should().BeTrue();
     }
@@ -214,6 +322,9 @@ public class TenantProviderBillingServiceTests
         public List<(Guid Tenant, string Provider, string ApiKey)> Writes { get; } = new();
         public List<string> Removes { get; } = new();
 
+        /// <summary>Fix 3 — simulate a cabinet-retire failure on disable.</summary>
+        public bool ThrowOnRemove { get; set; }
+
         public Task<SecretMetadata> WriteAsync(
             Guid tenantId, string providerCanonical, string apiKey, Guid ownerUserId, CancellationToken ct = default)
         {
@@ -227,10 +338,41 @@ public class TenantProviderBillingServiceTests
 
         public Task<bool> RemoveAsync(Guid tenantId, string providerCanonical, CancellationToken ct = default)
         {
+            if (ThrowOnRemove)
+            {
+                throw new InvalidOperationException("cabinet backend down");
+            }
             Removes.Add(providerCanonical);
             return Task.FromResult(true);
         }
     }
+
+    // A cabinet-backed BYOK reader for the REAL 32-3 resolver, seeded by (tenant,
+    // cabinetName) — the round-trip closes on the SLUG the service wrote.
+    private sealed class SeededByokReader : ITenantProviderKeyReader
+    {
+        private readonly Dictionary<(Guid, string), TenantProviderKey> _store = new();
+
+        public void Seed(Guid tenantId, string cabinetName, string plaintext, int version) =>
+            _store[(tenantId, cabinetName)] = new TenantProviderKey(plaintext, version);
+
+        public Task<TenantProviderKey?> TryReadAsync(
+            Guid tenantId, string cabinetName, CancellationToken ct = default) =>
+            Task.FromResult(_store.TryGetValue((tenantId, cabinetName), out var v) ? v : null);
+    }
+
+    // Platform fallback denied — so an unmatched BYOK slug fails closed (proving the
+    // resolver read only succeeds when the slug is byte-identical to the write).
+    private sealed class DenyFallback : IPlatformFallbackPolicy
+    {
+        public bool IsPlatformFallbackAllowed(Guid? tenantId, string providerName) => false;
+    }
+
+    private static DefaultProviderCredentialResolver NewCredentialResolver(ITenantProviderKeyReader byok) =>
+        new(
+            byok, platformKeys: null, new DenyFallback(), new RecordingGateEventRepository(),
+            new StubMode(TammaMode.SaaS), new ProviderAllowlist(),
+            NullLogger<DefaultProviderCredentialResolver>.Instance);
 
     private sealed class SpyCredentialResolver : IProviderCredentialResolver
     {


### PR DESCRIPTION
## What

The deferred WRITE side of #19 — `POST/DELETE /api/pricing/providers/{provider}/byok` (`PricingManage`; tenant from `ITenantContext`, no IDOR) that populate the `TenantProviderBilling` owner rows + store the BYOK key in the Epic-29 cabinet, gated by a 32-4 SaaS-eligibility check (422), emitting `PRICING.BYOK.ENABLED/DISABLED`. Plus `GET .../providers[/{provider}]` (MemberAccess). Reveal-safe, idempotent supersede, XOR-honouring, fail-loud (key-first). Non-migration (owner table + cabinet pre-exist).

## Review + fixes (all applied)

Adversarial review confirmed the 422 gate, XOR, cross-tenant isolation, reveal-safety, and no-silent-catch. Fixed a **Critical** + 2 minor:
- **Critical — provider-key drift:** 34-3 keyed the cabinet slug + owner row via the rate-family alias (`gemini→google`, `github-copilot→openai`), but the credential resolver reads the raw handle → a Gemini BYOK key was stored where it's never read (billed BYOK on the platform key = revenue leak), and Copilot BYOK overwrote the tenant's OpenAI key. Fixed: a new `ProviderIdentity.Normalize` (raw `Trim().ToLowerInvariant()`, **no** alias-family) keys the owner row + cabinet slug + billing-mode read + eligibility gate consistently — so identity is per-provider and matches 32-3's cabinet read. Reconciled #19's resolver/tagger off the family collapse. **Rate-card family map (`ProviderRateLookup.Aliases`) left untouched** (Copilot still bills at OpenAI rates). Round-trip tests (gemini keys raw + resolves; copilot ≠ openai, no clobber; anthropic-claude round-trips) — fail-before verified.
- **Minor:** concurrent enable → 409 (23505 catch) not 500; disable now retries gracefully on a cabinet-retire failure (event still emitted) + corrected doc.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes" (value/logic only). Tests: `Byok|Billing|Pricing|TenantProviderBilling|CredentialResolver` filter — 604 passed (incl. the Testcontainer parity tests, no flake). #19 tests updated (family-collapse → raw-identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)