### PR TITLE
feat(epic-23-3): Event Store Explorer monitoring page

### DIFF
--- a/packages/dashboard/src/components/monitoring/events/EventDetailPanel.tsx
+++ b/packages/dashboard/src/components/monitoring/events/EventDetailPanel.tsx
@@ -1,0 +1,123 @@
+/**
+ * EventDetailPanel — inline detail view for a single DCB event (Story 23-3,
+ * AC11/AC12). Shows the full event returned by the 4-7 query API
+ * (id / timestamp / sequence / issue / tags / data) with the tag bag and data
+ * payload pretty-printed, plus a "Copy JSON" action.
+ *
+ * Note: the 4-7 query projection does not surface the event `metadata`
+ * envelope separately — the panel renders every field the query API returns.
+ */
+
+import { useMemo, useState, type JSX } from 'react';
+import { StatusBadge } from '../StatusBadge.js';
+import { eventTone, tagValue } from './event-explorer-utils.js';
+import type { DomainEventRow } from '../../../hooks/monitoring/useEventQuery.js';
+
+interface EventDetailPanelProps {
+  event: DomainEventRow;
+  onClose: () => void;
+}
+
+function Field({ label, children }: { label: string; children: JSX.Element | string }): JSX.Element {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        {label}
+      </dt>
+      <dd className="mt-0.5 break-words text-sm text-gray-800 dark:text-gray-200">{children}</dd>
+    </div>
+  );
+}
+
+function JsonBlock({ label, value }: { label: string; value: unknown }): JSX.Element {
+  return (
+    <div>
+      <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-400 dark:text-gray-500">
+        {label}
+      </p>
+      <pre className="max-h-72 overflow-auto rounded-md border border-gray-200 bg-gray-50 p-3 text-xs text-gray-800 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200">
+        {JSON.stringify(value ?? {}, null, 2)}
+      </pre>
+    </div>
+  );
+}
+
+export function EventDetailPanel({ event, onClose }: EventDetailPanelProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const json = useMemo(() => JSON.stringify(event, null, 2), [event]);
+
+  const handleCopy = async (): Promise<void> => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(json);
+        setCopied(true);
+        globalThis.setTimeout(() => setCopied(false), 1500);
+      }
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  };
+
+  const correlationId = tagValue(event.tags, 'correlationId');
+  const actor = tagValue(event.tags, 'userId') || tagValue(event.tags, 'actor');
+
+  return (
+    <section
+      data-testid="event-detail-panel"
+      aria-label="Event detail"
+      className="mb-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+    >
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <StatusBadge status={eventTone(event.type)} showDot={false}>
+            {event.type}
+          </StatusBadge>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            {copied ? 'Copied!' : 'Copy JSON'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close detail"
+            className="rounded-md p-1 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              className="h-4 w-4"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <dl className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <Field label="Event ID">
+          <code className="text-xs">{event.id}</code>
+        </Field>
+        <Field label="Sequence">{String(event.sequenceNumber)}</Field>
+        <Field label="Timestamp">{event.createdAt}</Field>
+        <Field label="Issue #">{event.issueNumber != null ? `#${event.issueNumber}` : '—'}</Field>
+        <Field label="Correlation">
+          {correlationId ? <code className="text-xs">{correlationId}</code> : '—'}
+        </Field>
+        <Field label="Actor">{actor || '—'}</Field>
+      </dl>
+
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <JsonBlock label="Tags" value={event.tags} />
+        <JsonBlock label="Data" value={event.data} />
+      </div>
+    </section>
+  );
+}

--- a/packages/dashboard/src/components/monitoring/events/__tests__/event-explorer-utils.test.ts
+++ b/packages/dashboard/src/components/monitoring/events/__tests__/event-explorer-utils.test.ts
@@ -1,0 +1,136 @@
+import {
+  bucketOverTime,
+  eventTone,
+  eventsToCsv,
+  eventsToJson,
+  exportFilename,
+  formatTagsPreview,
+  groupByType,
+  tagValue,
+} from '../event-explorer-utils.js';
+import type { DomainEventRow } from '../../../../hooks/monitoring/useEventQuery.js';
+
+function ev(partial: Partial<DomainEventRow>): DomainEventRow {
+  return {
+    id: partial.id ?? 'id-1',
+    type: partial.type ?? 'CODE.GENERATED.SUCCESS',
+    tags: partial.tags ?? null,
+    data: partial.data ?? null,
+    createdAt: partial.createdAt ?? '2026-07-05T12:00:00.000Z',
+    issueNumber: partial.issueNumber ?? null,
+    sequenceNumber: partial.sequenceNumber ?? 1,
+  };
+}
+
+describe('eventTone', () => {
+  it('maps success events to green', () => {
+    expect(eventTone('CODE.GENERATED.SUCCESS')).toBe('green');
+    expect(eventTone('PLAN_APPROVED')).toBe('green');
+    expect(eventTone('PR_MERGED')).toBe('green');
+  });
+
+  it('maps failure events to red (checked before success)', () => {
+    expect(eventTone('CODE.GENERATED.FAILED')).toBe('red');
+    expect(eventTone('IMPLEMENTATION_FAILED')).toBe('red');
+    expect(eventTone('ERROR_OCCURRED')).toBe('red');
+    expect(eventTone('PLAN_REJECTED')).toBe('red');
+  });
+
+  it('maps monitoring events to yellow and cleanup to gray', () => {
+    expect(eventTone('STATE_TRANSITION')).toBe('yellow');
+    expect(eventTone('CI_CHECK_STARTED')).toBe('yellow');
+    expect(eventTone('BRANCH_DELETED')).toBe('gray');
+  });
+
+  it('falls back to blue for progress / informational events', () => {
+    expect(eventTone('ISSUE_SELECTED')).toBe('blue');
+    expect(eventTone('SOME.RANDOM.EVENT')).toBe('blue');
+  });
+});
+
+describe('tagValue / formatTagsPreview', () => {
+  it('extracts a string tag safely', () => {
+    expect(tagValue({ correlationId: 'run-9' }, 'correlationId')).toBe('run-9');
+    expect(tagValue(null, 'correlationId')).toBe('');
+    expect(tagValue({ n: 7 }, 'n')).toBe('7');
+  });
+
+  it('previews a bounded number of tag pairs', () => {
+    expect(formatTagsPreview({ a: '1', b: '2' })).toBe('a=1, b=2');
+    expect(formatTagsPreview({ a: '1', b: '2', c: '3', d: '4' })).toBe('a=1, b=2, c=3, +1 more');
+    expect(formatTagsPreview(null)).toBe('');
+  });
+});
+
+describe('groupByType', () => {
+  it('counts by type sorted by count desc', () => {
+    const rows = [
+      ev({ type: 'A' }),
+      ev({ type: 'B' }),
+      ev({ type: 'A' }),
+      ev({ type: 'A' }),
+    ];
+    expect(groupByType(rows)).toEqual([
+      { type: 'A', count: 3 },
+      { type: 'B', count: 1 },
+    ]);
+  });
+});
+
+describe('bucketOverTime', () => {
+  it('returns a single bucket when all timestamps are equal', () => {
+    const rows = [ev({ createdAt: '2026-07-05T12:00:00.000Z' }), ev({ createdAt: '2026-07-05T12:00:00.000Z' })];
+    const series = bucketOverTime(rows, 24);
+    expect(series).toHaveLength(1);
+    expect(series[0]?.value).toBe(2);
+  });
+
+  it('distributes events across buckets and preserves the total count', () => {
+    const rows = [
+      ev({ createdAt: '2026-07-05T00:00:00.000Z' }),
+      ev({ createdAt: '2026-07-05T06:00:00.000Z' }),
+      ev({ createdAt: '2026-07-05T12:00:00.000Z' }),
+      ev({ createdAt: '2026-07-05T23:59:00.000Z' }),
+    ];
+    const series = bucketOverTime(rows, 4);
+    expect(series).toHaveLength(4);
+    expect(series.reduce((sum, p) => sum + p.value, 0)).toBe(4);
+  });
+
+  it('returns empty for no events', () => {
+    expect(bucketOverTime([], 24)).toEqual([]);
+  });
+});
+
+describe('export helpers', () => {
+  it('produces parseable JSON', () => {
+    const rows = [ev({ id: 'x', type: 'A' })];
+    const parsed = JSON.parse(eventsToJson(rows)) as DomainEventRow[];
+    expect(parsed[0]?.id).toBe('x');
+  });
+
+  it('produces a CSV with a header and one row per event, escaping commas', () => {
+    const rows = [
+      ev({
+        id: 'e1',
+        type: 'CODE.GENERATED.SUCCESS',
+        issueNumber: 42,
+        tags: { correlationId: 'run-1', userId: 'u9' },
+        data: { note: 'a,b' },
+      }),
+    ];
+    const csv = eventsToCsv(rows);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe('id,type,createdAt,sequenceNumber,issueNumber,correlationId,actor,data');
+    expect(lines[1]).toContain('e1,CODE.GENERATED.SUCCESS');
+    expect(lines[1]).toContain('run-1');
+    expect(lines[1]).toContain('u9');
+    // data field with an embedded comma is quoted.
+    expect(csv).toContain('"{""note"":""a,b""}"');
+  });
+
+  it('builds a filter-aware filename', () => {
+    expect(exportFilename('json', 'AGENT.TASK')).toMatch(/^tamma-events-AGENT\.TASK-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(exportFilename('csv')).toMatch(/^tamma-events-\d{4}-\d{2}-\d{2}\.csv$/);
+  });
+});

--- a/packages/dashboard/src/components/monitoring/events/event-explorer-utils.ts
+++ b/packages/dashboard/src/components/monitoring/events/event-explorer-utils.ts
@@ -1,0 +1,186 @@
+/**
+ * Pure helpers for the Event Store Explorer (Story 23-3): event-type color
+ * coding (AC3), tag extraction, client-side summary aggregation (group-by-type
+ * + over-time bucketing for the frequency panel, AC17), and client-side JSON /
+ * CSV export of the loaded result set (AC20/AC21).
+ *
+ * These are all deterministic and side-effect-free (except the DOM download
+ * trigger, which is guarded) so they can be unit-tested in isolation.
+ */
+
+import type { DomainEventRow } from '../../../hooks/monitoring/useEventQuery.js';
+import type { StatusTone } from '../StatusBadge.js';
+import type { TimeSeriesPoint } from '../TimeSeriesChart.js';
+
+// Explicit event names from AC3. Our DCB events also follow the
+// AGGREGATE.ACTION.STATUS convention (e.g. CODE.GENERATED.SUCCESS), so the
+// keyword fallbacks below catch the dotted variants too.
+const SUCCESS_NAMES = new Set([
+  'PLAN_APPROVED',
+  'IMPLEMENTATION_COMPLETED',
+  'PR_MERGED',
+  'ISSUE_CLOSED',
+]);
+const FAILURE_NAMES = new Set(['IMPLEMENTATION_FAILED', 'ERROR_OCCURRED', 'PLAN_REJECTED']);
+const PROGRESS_NAMES = new Set([
+  'ISSUE_SELECTED',
+  'ISSUE_ANALYZED',
+  'PLAN_GENERATED',
+  'BRANCH_CREATED',
+  'PR_CREATED',
+]);
+const MONITORING_NAMES = new Set(['STATE_TRANSITION', 'CI_CHECK_STARTED']);
+const CLEANUP_NAMES = new Set(['BRANCH_DELETED']);
+
+/**
+ * Map an event type to a {@link StatusTone} for color coding (AC3):
+ * green = success, red = failure, blue = progress, yellow = monitoring,
+ * gray = cleanup. Failure is checked before success so a `.FAILED` never reads
+ * as green.
+ */
+export function eventTone(type: string): StatusTone {
+  const t = type.toUpperCase();
+
+  if (FAILURE_NAMES.has(t) || t.endsWith('.FAILED') || /FAIL|ERROR|REJECT|DENIED/.test(t)) {
+    return 'red';
+  }
+  if (
+    SUCCESS_NAMES.has(t) ||
+    t.endsWith('.SUCCESS') ||
+    /APPROVED|COMPLETED|MERGED|SUCCESS|CLOSED|PASSED/.test(t)
+  ) {
+    return 'green';
+  }
+  if (CLEANUP_NAMES.has(t) || /DELETED|CLEANUP|REMOVED|PURGED/.test(t)) {
+    return 'gray';
+  }
+  if (MONITORING_NAMES.has(t) || /TRANSITION|CHECK_STARTED|HEARTBEAT|STARTED/.test(t)) {
+    return 'yellow';
+  }
+  if (PROGRESS_NAMES.has(t)) {
+    return 'blue';
+  }
+  // Everything else (in-flight / informational) reads as progress.
+  return 'blue';
+}
+
+/** Safe string extraction of a single tag value. */
+export function tagValue(tags: Record<string, unknown> | null | undefined, key: string): string {
+  if (!tags) return '';
+  const v = tags[key];
+  if (v == null) return '';
+  return typeof v === 'string' ? v : String(v);
+}
+
+/** A short one-line preview of the tag bag for a table cell. */
+export function formatTagsPreview(
+  tags: Record<string, unknown> | null | undefined,
+  max = 3,
+): string {
+  if (!tags) return '';
+  const entries = Object.entries(tags).filter(([, v]) => v != null);
+  if (entries.length === 0) return '';
+  const shown = entries
+    .slice(0, max)
+    .map(([k, v]) => `${k}=${typeof v === 'string' ? v : JSON.stringify(v)}`)
+    .join(', ');
+  return entries.length > max ? `${shown}, +${entries.length - max} more` : shown;
+}
+
+/** Count events per type, sorted by count desc then type asc (AC17). */
+export function groupByType(events: DomainEventRow[]): Array<{ type: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const e of events) counts.set(e.type, (counts.get(e.type) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count || a.type.localeCompare(b.type));
+}
+
+/**
+ * Bucket loaded events into `bucketCount` equal time buckets across the
+ * observed [min,max] window and count events per bucket, for the frequency
+ * chart (AC17). Returns an ascending-by-time series.
+ */
+export function bucketOverTime(events: DomainEventRow[], bucketCount = 24): TimeSeriesPoint[] {
+  if (events.length === 0 || bucketCount < 1) return [];
+  const times = events
+    .map((e) => new Date(e.createdAt).getTime())
+    .filter((n) => Number.isFinite(n));
+  if (times.length === 0) return [];
+
+  const min = Math.min(...times);
+  const max = Math.max(...times);
+  if (min === max) return [{ timestamp: min, value: times.length }];
+
+  const width = (max - min) / bucketCount;
+  const counts = new Array<number>(bucketCount).fill(0);
+  for (const t of times) {
+    let idx = Math.floor((t - min) / width);
+    if (idx >= bucketCount) idx = bucketCount - 1;
+    if (idx < 0) idx = 0;
+    counts[idx] = (counts[idx] ?? 0) + 1;
+  }
+  return counts.map((value, i) => ({ timestamp: min + i * width, value }));
+}
+
+/** Pretty-printed JSON export of the loaded event objects (AC21). */
+export function eventsToJson(events: DomainEventRow[]): string {
+  return JSON.stringify(events, null, 2);
+}
+
+const CSV_COLUMNS = [
+  'id',
+  'type',
+  'createdAt',
+  'sequenceNumber',
+  'issueNumber',
+  'correlationId',
+  'actor',
+  'data',
+] as const;
+
+function csvCell(value: string | number | null | undefined): string {
+  const s = value == null ? '' : String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+/** CSV export flattening the data field to a single stringified column (AC21). */
+export function eventsToCsv(events: DomainEventRow[]): string {
+  const header = CSV_COLUMNS.join(',');
+  const rows = events.map((e) =>
+    [
+      e.id,
+      e.type,
+      e.createdAt,
+      e.sequenceNumber,
+      e.issueNumber ?? '',
+      tagValue(e.tags, 'correlationId'),
+      tagValue(e.tags, 'userId') || tagValue(e.tags, 'actor'),
+      JSON.stringify(e.data ?? {}),
+    ]
+      .map(csvCell)
+      .join(','),
+  );
+  return [header, ...rows].join('\r\n');
+}
+
+/** Build a filter-aware export filename, e.g. `tamma-events-AGENT.TASK-2026-07-05.json`. */
+export function exportFilename(ext: 'json' | 'csv', typeContext?: string): string {
+  const date = new Date().toISOString().slice(0, 10);
+  const suffix = typeContext ? `-${typeContext.replace(/[^A-Za-z0-9._-]/g, '_')}` : '';
+  return `tamma-events${suffix}-${date}.${ext}`;
+}
+
+/** Trigger a client-side file download. No-op outside a DOM environment. */
+export function triggerDownload(filename: string, mime: string, content: string): void {
+  if (typeof document === 'undefined') return;
+  const blob = new Blob([content], { type: mime });
+  const url = typeof URL.createObjectURL === 'function' ? URL.createObjectURL(blob) : '';
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  if (url && typeof URL.revokeObjectURL === 'function') URL.revokeObjectURL(url);
+}

--- a/packages/dashboard/src/hooks/monitoring/__tests__/useEventQuery.test.ts
+++ b/packages/dashboard/src/hooks/monitoring/__tests__/useEventQuery.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEventQuery } from '../useEventQuery.js';
+
+interface WireEvent {
+  id: string;
+  type: string;
+  tags: unknown;
+  data: unknown;
+  createdAt: string;
+  issueNumber: number | null;
+  sequenceNumber: number;
+}
+
+function wireEvent(seq: number): WireEvent {
+  return {
+    id: `id-${seq}`,
+    type: 'AGENT.TASK.SUCCESS',
+    tags: { correlationId: 'run-1' },
+    data: { seq },
+    createdAt: '2026-07-05T12:00:00.000Z',
+    issueNumber: seq,
+    sequenceNumber: seq,
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useEventQuery', () => {
+  it('runQuery fetches the first page with includeTotal and the requested limit', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse({ events: [wireEvent(3), wireEvent(2)], total: 2, limit: 25, nextCursor: null, hasMore: false }),
+    );
+
+    const { result } = renderHook(() => useEventQuery());
+    await act(async () => {
+      await result.current.runQuery({ limit: 25, type: 'AGENT.TASK', typeMatch: 'prefix' });
+    });
+
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.total).toBe(2);
+    expect(result.current.hasMore).toBe(false);
+
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/engine/events/query');
+    expect(url).toContain('type=AGENT.TASK');
+    expect(url).toContain('prefix=true');
+    expect(url).toContain('limit=25');
+    expect(url).toContain('includeTotal=true');
+  });
+
+  it('loadMore appends the next page using the retained cursor', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse({ events: [wireEvent(5)], total: 3, limit: 1, nextCursor: 5, hasMore: true }),
+      )
+      .mockResolvedValueOnce(
+        okResponse({ events: [wireEvent(4)], total: null, limit: 1, nextCursor: 4, hasMore: true }),
+      );
+
+    const { result } = renderHook(() => useEventQuery());
+    await act(async () => {
+      await result.current.runQuery({ limit: 1 });
+    });
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.events.map((e) => e.sequenceNumber)).toEqual([5, 4]);
+    const secondUrl = String(fetchMock.mock.calls[1]?.[0]);
+    expect(secondUrl).toContain('cursor=5');
+    expect(secondUrl).not.toContain('includeTotal=true');
+  });
+
+  it('surfaces an error message on a failed request', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'invalid time range' }),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useEventQuery());
+    await act(async () => {
+      await result.current.runQuery({ limit: 50 });
+    });
+
+    await waitFor(() => expect(result.current.error).toBe('invalid time range'));
+    expect(result.current.events).toHaveLength(0);
+  });
+});

--- a/packages/dashboard/src/hooks/monitoring/useEventQuery.ts
+++ b/packages/dashboard/src/hooks/monitoring/useEventQuery.ts
@@ -1,0 +1,192 @@
+/**
+ * useEventQuery — data hook for the Event Store Explorer (Story 23-3).
+ *
+ * Wraps the Story 4-7 keyset-paginated query API:
+ *   `GET /api/engine/events/query`
+ * (EngineEndpoints.QueryEvents — tenant-scoped, WorkflowsView, filters by
+ * time window / correlationId / actor / event type exact|prefix, keyset cursor).
+ *
+ * The endpoint is forward-only (each `nextCursor` is the oldest sequence number
+ * on the page; the next page is strictly older), so pagination here is an
+ * accumulate / "load more" model: {@link UseEventQueryResult.runQuery} resets
+ * and fetches the first page; {@link UseEventQueryResult.loadMore} appends the
+ * next page using the retained cursor + filters.
+ *
+ * The response is emitted with ASP.NET Core's default camelCase policy, so the
+ * anonymous projection `{ Id, Type, tags, data, CreatedAt, IssueNumber,
+ * SequenceNumber }` arrives as `{ id, type, tags, data, createdAt, issueNumber,
+ * sequenceNumber }`. `tags` / `data` are already JSON-parsed server-side.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+
+/** A single DCB event row as returned by the 4-7 query projection. */
+export interface DomainEventRow {
+  id: string;
+  type: string;
+  /** Parsed JSONB tag bag (correlationId, userId, issueId, …) or null. */
+  tags: Record<string, unknown> | null;
+  /** Parsed JSONB event payload or null. */
+  data: Record<string, unknown> | null;
+  /** ISO-8601 event timestamp. */
+  createdAt: string;
+  issueNumber: number | null;
+  sequenceNumber: number;
+}
+
+export type EventTypeMatch = 'exact' | 'prefix';
+
+/** The filter set applied to a query. All fields optional except `limit`. */
+export interface EventQueryFilters {
+  type?: string;
+  typeMatch?: EventTypeMatch;
+  correlationId?: string;
+  actor?: string;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+  /** Request the exact match count (an unbounded scan; only on the first page). */
+  includeTotal?: boolean;
+}
+
+export interface UseEventQueryResult {
+  events: DomainEventRow[];
+  /** Exact match count when computed (first page requests it), else null. */
+  total: number | null;
+  hasMore: boolean;
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  /** Reset + fetch the first page for `filters`. */
+  runQuery: (filters: EventQueryFilters) => Promise<void>;
+  /** Append the next (older) page using the retained cursor + filters. */
+  loadMore: () => Promise<void>;
+}
+
+interface WireEvent {
+  id: string;
+  type: string;
+  tags: unknown;
+  data: unknown;
+  createdAt: string;
+  issueNumber: number | null;
+  sequenceNumber: number;
+}
+
+interface WireResponse {
+  events: WireEvent[];
+  total: number | null;
+  limit: number;
+  nextCursor: number | null;
+  hasMore: boolean;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toRow(e: WireEvent): DomainEventRow {
+  return {
+    id: e.id,
+    type: e.type,
+    tags: isRecord(e.tags) ? e.tags : null,
+    data: isRecord(e.data) ? e.data : null,
+    createdAt: e.createdAt,
+    issueNumber: e.issueNumber,
+    sequenceNumber: e.sequenceNumber,
+  };
+}
+
+function buildUrl(filters: EventQueryFilters, cursor: number | null): string {
+  const params = new URLSearchParams();
+  const type = filters.type?.trim();
+  if (type) {
+    params.set('type', type);
+    if (filters.typeMatch === 'prefix') params.set('prefix', 'true');
+  }
+  const correlationId = filters.correlationId?.trim();
+  if (correlationId) params.set('correlationId', correlationId);
+  const actor = filters.actor?.trim();
+  if (actor) params.set('actor', actor);
+  if (filters.from) params.set('from', filters.from.toISOString());
+  if (filters.to) params.set('to', filters.to.toISOString());
+  params.set('limit', String(filters.limit ?? 50));
+  if (filters.includeTotal) params.set('includeTotal', 'true');
+  if (cursor != null) params.set('cursor', String(cursor));
+  return `${API_BASE}/api/engine/events/query?${params.toString()}`;
+}
+
+async function fetchEvents(url: string): Promise<WireResponse> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // keep the default status message
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as WireResponse;
+}
+
+export function useEventQuery(): UseEventQueryResult {
+  const [events, setEvents] = useState<DomainEventRow[]>([]);
+  const [total, setTotal] = useState<number | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  // Retained across renders so loadMore re-uses the exact filters + cursor of
+  // the active query without re-triggering React state churn.
+  const filtersRef = useRef<EventQueryFilters | null>(null);
+  const cursorRef = useRef<number | null>(null);
+
+  const runQuery = useCallback(async (filters: EventQueryFilters): Promise<void> => {
+    filtersRef.current = filters;
+    cursorRef.current = null;
+    setLoading(true);
+    setError(null);
+    try {
+      // Force includeTotal on the first page so the footer can show a count.
+      const res = await fetchEvents(buildUrl({ ...filters, includeTotal: true }, null));
+      setEvents(res.events.map(toRow));
+      setTotal(res.total);
+      setHasMore(res.hasMore);
+      cursorRef.current = res.nextCursor;
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load events');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadMore = useCallback(async (): Promise<void> => {
+    const filters = filtersRef.current;
+    const cursor = cursorRef.current;
+    if (!filters || cursor == null) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchEvents(buildUrl({ ...filters, includeTotal: false }, cursor));
+      setEvents((prev) => [...prev, ...res.events.map(toRow)]);
+      setHasMore(res.hasMore);
+      cursorRef.current = res.nextCursor;
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load more events');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { events, total, hasMore, loading, error, lastUpdated, runQuery, loadMore };
+}

--- a/packages/dashboard/src/pages/monitoring/EventExplorerPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/EventExplorerPage.tsx
@@ -1,21 +1,367 @@
 /**
- * Event Store Explorer page. Scaffold from Story 23-12; full dashboard arrives
- * in Story 23-3.
+ * Event Store Explorer (Story 23-3).
+ *
+ * Operator page to browse / search / inspect the DCB `domain_events` stream.
+ * Data source is the Story 4-7 keyset query API
+ * (`GET /api/engine/events/query`, tenant-scoped, WorkflowsView) via
+ * {@link useEventQuery}; the UI is built entirely on the Story 23-12 monitoring
+ * primitives (MonitoringLayout, DataTable, TimeSeriesChart, StatusBadge,
+ * EmptyState, ErrorBanner) and hooks (useTimeRange, useAutoRefresh).
+ *
+ * The route is already `AdminGuard`-gated and lazy-mounted by Story 23-12
+ * (`pages/monitoring/index.tsx`); this module only supplies the page body.
+ *
+ * Frequency/summary aggregation and CSV/JSON export are computed client-side
+ * over the loaded result set (no extra backend endpoint required).
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import {
+  DataTable,
+  type DataTableColumn,
+} from '../../components/monitoring/DataTable.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { TimeSeriesChart } from '../../components/monitoring/TimeSeriesChart.js';
+import { EventDetailPanel } from '../../components/monitoring/events/EventDetailPanel.js';
+import {
+  bucketOverTime,
+  eventTone,
+  eventsToCsv,
+  eventsToJson,
+  exportFilename,
+  formatTagsPreview,
+  groupByType,
+  tagValue,
+  triggerDownload,
+} from '../../components/monitoring/events/event-explorer-utils.js';
+import { useEventQuery, type DomainEventRow } from '../../hooks/monitoring/useEventQuery.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import { useTimeRange } from '../../hooks/monitoring/useTimeRange.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/events');
+const PAGE_SIZES = [25, 50, 100] as const;
+
+const INPUT_CLASS =
+  'rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100';
 
 export function EventExplorerPage(): JSX.Element {
+  const { preset, range, setPreset } = useTimeRange('24h');
+  const eventQuery = useEventQuery();
+  const { events, total, hasMore, loading, error, lastUpdated, runQuery, loadMore } = eventQuery;
+
+  // Draft filter state (applied on Search / time-range change / auto-refresh).
+  const [typeFilter, setTypeFilter] = useState('');
+  const [typeMatch, setTypeMatch] = useState<'exact' | 'prefix'>('prefix');
+  const [correlationId, setCorrelationId] = useState('');
+  const [actor, setActor] = useState('');
+  const [pageSize, setPageSize] = useState<number>(50);
+
+  const [selected, setSelected] = useState<DomainEventRow | null>(null);
+  const [showSummary, setShowSummary] = useState(false);
+
+  // Build the current filter snapshot from the live form + time range.
+  const buildFilters = useCallback(
+    () => ({
+      ...(typeFilter.trim() ? { type: typeFilter.trim(), typeMatch } : {}),
+      ...(correlationId.trim() ? { correlationId: correlationId.trim() } : {}),
+      ...(actor.trim() ? { actor: actor.trim() } : {}),
+      from: range.start,
+      to: range.end,
+      limit: pageSize,
+    }),
+    [typeFilter, typeMatch, correlationId, actor, range, pageSize],
+  );
+
+  // Keep a stable trigger that always reads the latest filters, so it can be
+  // used by the interval timer, the manual refresh, and the search button
+  // without re-arming the auto-refresh interval on every keystroke.
+  const searchRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    searchRef.current = () => {
+      void runQuery(buildFilters());
+    };
+  }, [runQuery, buildFilters]);
+
+  const triggerSearch = useCallback(() => searchRef.current(), []);
+
+  const autoRefresh = useAutoRefresh(triggerSearch, {
+    storageKey: NAV.storageKey,
+    defaultInterval: null,
+  });
+
+  // Run on mount and whenever the time-range preset or server page size changes.
+  useEffect(() => {
+    triggerSearch();
+  }, [triggerSearch, preset, pageSize]);
+
+  const summaryByType = useMemo(() => groupByType(events), [events]);
+  const frequencySeries = useMemo(() => bucketOverTime(events), [events]);
+
+  const handleExport = useCallback(
+    (format: 'json' | 'csv') => {
+      if (events.length === 0) return;
+      const typeContext = typeFilter.trim() || undefined;
+      if (format === 'json') {
+        triggerDownload(exportFilename('json', typeContext), 'application/json', eventsToJson(events));
+      } else {
+        triggerDownload(exportFilename('csv', typeContext), 'text/csv', eventsToCsv(events));
+      }
+    },
+    [events, typeFilter],
+  );
+
+  const columns: DataTableColumn<DomainEventRow>[] = useMemo(
+    () => [
+      {
+        key: 'createdAt',
+        header: 'Timestamp',
+        accessor: (r) => r.createdAt,
+        render: (r) => (
+          <span title={r.createdAt} className="whitespace-nowrap text-gray-600 dark:text-gray-300">
+            {new Date(r.createdAt).toLocaleString()}
+          </span>
+        ),
+        sortable: true,
+      },
+      {
+        key: 'type',
+        header: 'Type',
+        accessor: (r) => r.type,
+        render: (r) => (
+          <StatusBadge status={eventTone(r.type)} showDot={false}>
+            {r.type}
+          </StatusBadge>
+        ),
+        sortable: true,
+      },
+      {
+        key: 'issueNumber',
+        header: 'Issue #',
+        accessor: (r) => r.issueNumber,
+        render: (r) => (r.issueNumber != null ? `#${r.issueNumber}` : '—'),
+        sortable: true,
+        align: 'right',
+      },
+      {
+        key: 'correlationId',
+        header: 'Correlation',
+        accessor: (r) => tagValue(r.tags, 'correlationId'),
+        render: (r) => {
+          const c = tagValue(r.tags, 'correlationId');
+          return c ? <code className="text-xs">{c}</code> : '—';
+        },
+      },
+      {
+        key: 'tags',
+        header: 'Tags',
+        accessor: (r) => JSON.stringify(r.tags ?? {}),
+        render: (r) => (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {formatTagsPreview(r.tags) || '—'}
+          </span>
+        ),
+      },
+    ],
+    [],
+  );
+
   return (
-    <MonitoringPlaceholder
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="Search, filter and inspect the DCB event store — the primary workflow-execution debugging tool."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={triggerSearch}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      timeRange={preset}
+      onTimeRangeChange={setPreset}
+      showTimeRange
+      actions={
+        <>
+          <button
+            type="button"
+            onClick={() => setShowSummary((s) => !s)}
+            aria-pressed={showSummary}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            {showSummary ? 'Hide summary' : 'Summary'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleExport('json')}
+            disabled={events.length === 0}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Export JSON
+          </button>
+          <button
+            type="button"
+            onClick={() => handleExport('csv')}
+            disabled={events.length === 0}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Export CSV
+          </button>
+        </>
+      }
+    >
+      {/* Filter bar */}
+      <form
+        aria-label="Event filters"
+        className="mb-4 flex flex-wrap items-end gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/50"
+        onSubmit={(e) => {
+          e.preventDefault();
+          triggerSearch();
+        }}
+      >
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Event type
+          <input
+            type="text"
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            placeholder="e.g. AGENT.TASK"
+            aria-label="Event type"
+            className={`${INPUT_CLASS} w-52`}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Match
+          <select
+            value={typeMatch}
+            onChange={(e) => setTypeMatch(e.target.value as 'exact' | 'prefix')}
+            aria-label="Type match mode"
+            className={INPUT_CLASS}
+          >
+            <option value="prefix">Prefix</option>
+            <option value="exact">Exact</option>
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Correlation ID
+          <input
+            type="text"
+            value={correlationId}
+            onChange={(e) => setCorrelationId(e.target.value)}
+            placeholder="run / workflow id"
+            aria-label="Correlation ID"
+            className={`${INPUT_CLASS} w-52`}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Actor
+          <input
+            type="text"
+            value={actor}
+            onChange={(e) => setActor(e.target.value)}
+            placeholder="userId"
+            aria-label="Actor"
+            className={`${INPUT_CLASS} w-40`}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Page size
+          <select
+            value={pageSize}
+            onChange={(e) => setPageSize(Number(e.target.value))}
+            aria-label="Page size"
+            className={INPUT_CLASS}
+          >
+            {PAGE_SIZES.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+        >
+          Search
+        </button>
+      </form>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={triggerSearch} />
+        </div>
+      )}
+
+      {showSummary && (
+        <section
+          data-testid="event-summary"
+          aria-label="Event summary"
+          className="mb-4 grid grid-cols-1 gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900 lg:grid-cols-2"
+        >
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              Events over time ({events.length} loaded)
+            </h3>
+            <TimeSeriesChart
+              data={frequencySeries}
+              variant="area"
+              ariaLabel="Event frequency over time"
+              emptyMessage="No events in the loaded set."
+            />
+          </div>
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              By type
+            </h3>
+            <ul className="flex flex-wrap gap-2">
+              {summaryByType.map((s) => (
+                <li key={s.type}>
+                  <StatusBadge status={eventTone(s.type)} showDot={false}>
+                    {s.type} · {s.count}
+                  </StatusBadge>
+                </li>
+              ))}
+              {summaryByType.length === 0 && (
+                <li className="text-sm text-gray-500 dark:text-gray-400">No events loaded.</li>
+              )}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {selected && <EventDetailPanel event={selected} onClose={() => setSelected(null)} />}
+
+      <DataTable
+        columns={columns}
+        rows={events}
+        getRowId={(row) => row.id}
+        pageSize={100000}
+        initialSort={{ key: 'createdAt', direction: 'desc' }}
+        filterPlaceholder="Quick-filter loaded events…"
+        emptyTitle="No events"
+        emptyMessage="No events match the current filters and time range."
+        onRowClick={(row) => setSelected(row)}
+      />
+
+      <div
+        className="mt-4 flex items-center justify-between text-sm text-gray-500 dark:text-gray-400"
+        data-testid="event-footer"
+      >
+        <span>
+          Showing {events.length}
+          {total != null ? ` of ${total}` : ''} event{events.length === 1 ? '' : 's'}
+        </span>
+        {hasMore && (
+          <button
+            type="button"
+            onClick={() => void loadMore()}
+            disabled={loading}
+            className="rounded-md border border-gray-300 px-3 py-1.5 font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Load more
+          </button>
+        )}
+      </div>
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/event-explorer-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/event-explorer-page.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { EventExplorerPage } from '../EventExplorerPage.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+interface WireEvent {
+  id: string;
+  type: string;
+  tags: unknown;
+  data: unknown;
+  createdAt: string;
+  issueNumber: number | null;
+  sequenceNumber: number;
+}
+
+function wireEvent(over: Partial<WireEvent>): WireEvent {
+  return {
+    id: over.id ?? 'id-1',
+    type: over.type ?? 'CODE.GENERATED.SUCCESS',
+    tags: over.tags ?? { correlationId: 'run-1', userId: 'u1' },
+    data: over.data ?? { note: 'ok' },
+    createdAt: over.createdAt ?? '2026-07-05T12:00:00.000Z',
+    issueNumber: over.issueNumber ?? 42,
+    sequenceNumber: over.sequenceNumber ?? 1,
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function page(events: WireEvent[], over: Partial<{ total: number | null; nextCursor: number | null; hasMore: boolean }> = {}): unknown {
+  return {
+    events,
+    total: over.total ?? events.length,
+    limit: 50,
+    nextCursor: over.nextCursor ?? null,
+    hasMore: over.hasMore ?? false,
+  };
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(okResponse(page([])));
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/events']}>
+      <EventExplorerPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('EventExplorerPage', () => {
+  it('renders query results returned by the 4-7 query API', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse(
+        page([
+          wireEvent({ id: 'id-1', type: 'CODE.GENERATED.SUCCESS', sequenceNumber: 2 }),
+          wireEvent({ id: 'id-2', type: 'CODE.GENERATED.FAILED', sequenceNumber: 1 }),
+        ]),
+      ),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText('CODE.GENERATED.SUCCESS')).toBeInTheDocument();
+    expect(screen.getByText('CODE.GENERATED.FAILED')).toBeInTheDocument();
+    expect(screen.getByTestId('event-footer')).toHaveTextContent('Showing 2 of 2 events');
+  });
+
+  it('drives the query from the filter form (type + prefix)', async () => {
+    renderPage();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    await userEvent.type(screen.getByLabelText('Event type'), 'AGENT.TASK');
+    await userEvent.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      const lastUrl = String(fetchMock.mock.calls[fetchMock.mock.calls.length - 1]?.[0]);
+      expect(lastUrl).toContain('type=AGENT.TASK');
+      expect(lastUrl).toContain('prefix=true');
+    });
+  });
+
+  it('appends the next page via cursor pagination (Load more)', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        okResponse(
+          page([wireEvent({ id: 'id-5', type: 'A.B.SUCCESS', sequenceNumber: 5 })], {
+            nextCursor: 5,
+            hasMore: true,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        okResponse(
+          page([wireEvent({ id: 'id-4', type: 'A.B.FAILED', sequenceNumber: 4 })], {
+            total: null,
+            nextCursor: null,
+            hasMore: false,
+          }),
+        ),
+      );
+
+    renderPage();
+    const loadMore = await screen.findByRole('button', { name: 'Load more' });
+    await userEvent.click(loadMore);
+
+    expect(await screen.findByText('A.B.FAILED')).toBeInTheDocument();
+    expect(screen.getByText('A.B.SUCCESS')).toBeInTheDocument();
+    const secondUrl = String(fetchMock.mock.calls[1]?.[0]);
+    expect(secondUrl).toContain('cursor=5');
+  });
+
+  it('opens the detail view when a row is clicked', async () => {
+    fetchMock.mockResolvedValueOnce(
+      okResponse(page([wireEvent({ id: 'id-9', type: 'CODE.GENERATED.SUCCESS', sequenceNumber: 9 })])),
+    );
+
+    renderPage();
+    await userEvent.click(await screen.findByText('CODE.GENERATED.SUCCESS'));
+
+    const panel = screen.getByTestId('event-detail-panel');
+    expect(within(panel).getByText('id-9')).toBeInTheDocument();
+    expect(within(panel).getByRole('button', { name: 'Copy JSON' })).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the query returns no events', async () => {
+    fetchMock.mockResolvedValue(okResponse(page([])));
+    renderPage();
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+  });
+});
+
+describe('EventExplorerPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/events']}>
+        <AdminGuard>
+          <EventExplorerPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'Event Explorer' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/events']}>
+        <AdminGuard>
+          <EventExplorerPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'Event Explorer' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Story 23.3 — fills the #289 `EventExplorerPage` stub with an operator page over the DCB `domain_events` stream. **Frontend-only** — reuses the shipped 4-7 query API + 23-12 primitives.

- Filter bar (event-type exact/prefix, correlationId, actor, time-range) → `GET /api/engine/events/query`; `DataTable` results with color-coded type badges + row-click detail; forward-only keyset "load more" pagination; auto-refresh.
- Event detail panel (id/seq/timestamp/issue/correlation/actor + pretty-printed Tags & Data + copy JSON).
- Client-side summary (events-over-time `TimeSeriesChart` + group-by-type) and JSON/CSV export of the loaded set.

## Reuse / safety

Sole data source is Story 4-7's tenant-scoped `WorkflowsView` query endpoint (own-events-only enforced + already reviewed); primitives + `AdminGuard`-gated route from Story 23-12. **No backend change** (summary computed client-side) → no migration / TAMMA001 / leak surface.

## Verification

- `pnpm --filter @tamma/dashboard test` → 372 passed (23 new: hook pagination/append/error, utils, page render/filter/detail/empty-state/RBAC). Build clean (page code-split). Typecheck: 0 errors in changed files (pre-existing errors in unrelated files; fresh worktree pulled a newer TS, inflating the baseline count — none in this PR's files).

Deferred (aspirational story ACs beyond scope): SVG zoom/pan timeline, "replay from here" (needs a backend write endpoint), related-events navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)