### PR TITLE
feat(epic-3-4): ResearchWorkflow (Assessment skeleton, mediated LLM, RESEARCH.* events)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Research/EmitResearchEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Research/EmitResearchEventActivity.cs
@@ -1,0 +1,118 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Research;
+
+/// <summary>
+/// Story 3.4 — emits a <c>RESEARCH.*</c> DCB event for the <c>research</c> sub-workflow
+/// by appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c> transient
+/// list via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list <i>durably</i>
+/// to the tenant <c>domain_events</c> store — the same pattern
+/// <see cref="Tamma.Activities.Clarify.EmitClarifyEventActivity"/> and
+/// <see cref="Tamma.Activities.Blocker.EmitBlockerEventActivity"/> use. No activity holds a
+/// DB / repository dependency of its own (none is registered in the Elsa engine — a
+/// directly injected repository would be inert and silently drop every event).
+/// </summary>
+[Activity(
+    "Tamma.Research",
+    "Emit Research Event",
+    "Emit a RESEARCH.* DCB event for the research workflow audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitResearchEventActivity : Activity
+{
+    private readonly ILogger<EmitResearchEventActivity>? _logger;
+
+    [Input(Description = "Event type — RESEARCH.STARTED / .CONTEXT_GATHERED / .COMPLETED / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Research session id (unguessable Guid string)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / topic id the research is about")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Number of ranked findings synthesized")]
+    public Input<int> FindingCount { get; set; } = new(0);
+
+    [Input(Description = "Overall confidence score (0..1) of the synthesized research")]
+    public Input<double> Confidence { get; set; } = new(0d);
+
+    [Input(Description = "Free-text detail for the audit payload")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitResearchEventActivity() { }
+
+    public EmitResearchEventActivity(ILogger<EmitResearchEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? ResearchEvents.Failed;
+        var sessionId = SessionId.Get(context);
+        var issueId = IssueId.Get(context);
+        var tenantId = ResearchEvents.ParseTenantId(TenantId.Get(context));
+        var findingCount = FindingCount.Get(context);
+        var confidence = Confidence.Get(context);
+        var detail = Detail.Get(context);
+
+        var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, findingCount, confidence, detail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for research session {Session} issue {Issue} (findings={Count})",
+            type, sessionId, issueId, findingCount);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the research event inputs onto a <see cref="TammaEvent"/> expressed as the
+    /// engine's transient-list event so the merged drain persists it. Tags carry the
+    /// queryable DCB index keys (<c>sessionId</c>/<c>issueId</c>/<c>tenantId</c>);
+    /// <c>Data</c> carries the per-transition payload (<c>findingCount</c>/
+    /// <c>confidence</c>/<c>detail</c>). Status is driven off the event type
+    /// (<see cref="ResearchEvents.StatusForEvent"/>) so a failed terminal is a LOUD error
+    /// row, never a false success. Pure (no Elsa context); exposed for unit testing the
+    /// mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? issueId,
+        Guid? tenantId,
+        int findingCount,
+        double confidence,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (findingCount > 0) data["findingCount"] = findingCount;
+        if (confidence > 0d) data["confidence"] = confidence;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = ResearchEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Research/Models/ResearchModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Research/Models/ResearchModels.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.Research.Models;
+
+/// <summary>
+/// Story 3.4 — one synthesized, relevance-and-confidence-scored research finding
+/// recovered from the mediated <c>llm-call</c> synthesis response. Parsed defensively
+/// by <see cref="ResearchParsing.ParseReport"/>; the workflow fails closed (routes to
+/// its <c>RESEARCH.FAILED</c> error terminal) when no structured findings can be
+/// recovered rather than emitting a fabricated finding.
+/// </summary>
+public sealed class ResearchFinding
+{
+    /// <summary>Short title / headline for the finding.</summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>The finding body — what was learned and why it matters.</summary>
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Relevance score (0..1) — how directly the finding bears on the topic.</summary>
+    [JsonPropertyName("relevance")]
+    public decimal Relevance { get; set; }
+
+    /// <summary>Confidence score (0..1) — how well-supported / cross-referenced the finding is.</summary>
+    [JsonPropertyName("confidence")]
+    public decimal Confidence { get; set; }
+
+    /// <summary>Citations (file paths, URLs, doc refs) that back the finding for traceability.</summary>
+    [JsonPropertyName("citations")]
+    public List<string> Citations { get; set; } = new();
+}
+
+/// <summary>
+/// Story 3.4 — the synthesized research report for an issue / topic: an overview
+/// summary plus the ranked, scored <see cref="ResearchFinding"/> set. Serialised into
+/// the workflow's <c>reportJson</c> output variable and carried onto the
+/// <c>RESEARCH.COMPLETED</c> DCB event so the research is fully auditable and linked
+/// back to the originating issue (Story 3.4 AC "Research results are stored and linked
+/// to original issues for traceability").
+/// </summary>
+public sealed class ResearchReport
+{
+    /// <summary>The topic / question the research investigated.</summary>
+    [JsonPropertyName("topic")]
+    public string Topic { get; set; } = string.Empty;
+
+    /// <summary>Overview summary of the synthesized research.</summary>
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>Findings, ranked most-relevant-first (relevance desc, then confidence desc).</summary>
+    [JsonPropertyName("findings")]
+    public List<ResearchFinding> Findings { get; set; } = new();
+
+    /// <summary>Overall confidence (0..1) across the findings.</summary>
+    [JsonPropertyName("overallConfidence")]
+    public decimal OverallConfidence { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Research/ResearchEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Research/ResearchEvents.cs
@@ -1,0 +1,73 @@
+namespace Tamma.Activities.Research;
+
+/// <summary>
+/// Story 3.4 (Research Workflow) — central catalogue of the <c>RESEARCH.*</c> DCB
+/// event types emitted by the <c>research</c> sub-workflow via
+/// <see cref="EmitResearchEventActivity"/>. Type pattern follows the platform's
+/// <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors the sibling
+/// event catalogues (<see cref="Tamma.Activities.Clarify.ClarifyEvents"/>,
+/// <see cref="Tamma.Activities.Blocker.BlockerEvents"/>).
+///
+/// <para>The research workflow is triggered when ambiguity is detected in a
+/// requirement: it investigates the codebase / prior art (reusing the
+/// <c>context-gathering</c> sub-workflow) and asks the LLM (via the mediated
+/// <c>llm-call</c> path — the engine holds no LLM credential) to synthesize the gathered
+/// context into a ranked, confidence-scored research report. Each transition is an
+/// auditable step so time-travel debugging and the Epic-32 learning loop can reconstruct
+/// WHAT was researched, WHICH sources were investigated, and HOW confident the findings
+/// are (Story 3.4 ACs "Research results are stored and linked to original issues for
+/// traceability" + "System generates research reports with citations and confidence
+/// scores"). Without these events the research is invisible to the audit trail.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern the
+/// sibling catalogues use. No activity holds a DB / repository dependency of its own; the
+/// drain resolves the tenant from the workflow scope and each event carries a
+/// <c>tenantId</c> tag so per-tenant data stays tenant-scoped.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>RESEARCH.STARTED</c> — the research workflow began
+///     investigating the topic / ambiguous requirement.</description></item>
+///   <item><description><c>RESEARCH.CONTEXT_GATHERED</c> — the codebase / prior-art
+///     context was gathered (via the reused <c>context-gathering</c> sub-workflow) and is
+///     ready for synthesis.</description></item>
+///   <item><description><c>RESEARCH.COMPLETED</c> — terminal success: the LLM synthesized
+///     a non-empty, ranked, confidence-scored research report.</description></item>
+///   <item><description><c>RESEARCH.FAILED</c> — LOUD (error-status): the synthesis
+///     <c>llm-call</c> failed or returned unparseable output; the workflow fails closed
+///     rather than emitting a fabricated report.</description></item>
+/// </list>
+/// </summary>
+public static class ResearchEvents
+{
+    public const string Started = "RESEARCH.STARTED";
+    public const string ContextGathered = "RESEARCH.CONTEXT_GATHERED";
+    public const string Completed = "RESEARCH.COMPLETED";
+
+    // LOUD (error-status) terminal — a fabricated / degraded outcome must never be
+    // recorded as a false success.
+    public const string Failed = "RESEARCH.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values (research
+    /// events in single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Clarify.ClarifyEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed synthesis is a LOUD (error-status) audit row; the
+    /// start transition is an informational (started) row; every other transition
+    /// (context gathered, completed) is a normal (success-status) row. Keeps a degraded
+    /// terminal from ever being recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        Failed => "error",
+        Started => "started",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Research/ResearchParsing.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Research/ResearchParsing.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using Tamma.Activities.Research.Models;
+
+namespace Tamma.Activities.Research;
+
+/// <summary>
+/// Story 3.4 — pure, context-free parser that recovers the structured
+/// <see cref="ResearchReport"/> from a mediated <c>llm-call</c> synthesis response.
+/// Kept side-effect-free (no Elsa context) so the fail-closed behaviour is unit-testable
+/// without a live LLM. Mirrors the JSON-slice approach in <c>ClarifyParsing</c> /
+/// <c>AssessmentWorkflow</c> / <c>ContextGatheringWorkflow</c>.
+///
+/// <para>The parser is <b>fail-closed</b>: an empty response, a response with no JSON
+/// object, a report missing its load-bearing <c>summary</c>, or a report with no usable
+/// findings all yield <c>null</c>. The workflow routes a <c>null</c> parse to its
+/// <c>RESEARCH.FAILED</c> error terminal — it NEVER fabricates a summary, a finding, or a
+/// confidence score the downstream would act on.</para>
+/// </summary>
+public static class ResearchParsing
+{
+    /// <summary>
+    /// Extract the synthesized research report from an <c>llm-call</c> text response.
+    /// Expects a JSON object of the shape
+    /// <c>{"summary":"...","findings":[{"title":"...","summary":"...","relevance":0.9,
+    /// "confidence":0.8,"citations":["..."]}],"overallConfidence":0.85}</c>.
+    ///
+    /// <para>Findings are ranked most-relevant-first (relevance desc, then confidence
+    /// desc) — the AC "findings are synthesized and ranked by relevance and confidence".
+    /// <c>overallConfidence</c> is read from the object when present, otherwise computed
+    /// as the mean of the findings' confidence (never invented from nothing).</para>
+    ///
+    /// <para>Returns <c>null</c> (fail-closed) when the text is empty, carries no JSON
+    /// object, has no non-empty <c>summary</c>, or contains no usable findings.</para>
+    /// </summary>
+    /// <param name="llmText">The raw LLM synthesis response.</param>
+    /// <param name="topic">Fallback topic when the response omits its own <c>topic</c>.</param>
+    public static ResearchReport? ParseReport(string? llmText, string? topic = null)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return null;
+
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart < 0 || objEnd <= objStart)
+            return null;
+
+        try
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+
+            var summary = element.TryGetProperty("summary", out var sv) && sv.ValueKind == JsonValueKind.String
+                ? sv.GetString() ?? string.Empty
+                : string.Empty;
+
+            // Fail-closed: a research report with no overview summary is not actionable.
+            if (string.IsNullOrWhiteSpace(summary))
+                return null;
+
+            var findings = ParseFindings(element);
+
+            // Fail-closed: no findings → nothing was actually researched.
+            if (findings.Count == 0)
+                return null;
+
+            // Rank by relevance desc, then confidence desc (AC: ranked by relevance and confidence).
+            findings = findings
+                .OrderByDescending(f => f.Relevance)
+                .ThenByDescending(f => f.Confidence)
+                .ToList();
+
+            var overall = element.TryGetProperty("overallConfidence", out var oc) && oc.ValueKind == JsonValueKind.Number
+                ? (decimal)oc.GetDouble()
+                : AverageConfidence(findings);
+
+            return new ResearchReport
+            {
+                Topic = element.TryGetProperty("topic", out var tv) && tv.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(tv.GetString())
+                    ? tv.GetString()!
+                    : topic ?? string.Empty,
+                Summary = summary,
+                Findings = findings,
+                OverallConfidence = overall,
+            };
+        }
+        catch
+        {
+            // Malformed JSON → fail closed.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Recover the finding list from the report object. Each finding must carry at
+    /// least a title or a summary — empty shells are dropped (item-level fail-closed).
+    /// </summary>
+    private static List<ResearchFinding> ParseFindings(JsonElement element)
+    {
+        if (!element.TryGetProperty("findings", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<ResearchFinding>();
+
+        var findings = new List<ResearchFinding>();
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var title = ReadString(item, "title");
+            var summary = ReadString(item, "summary");
+
+            // A finding with neither a title nor a summary is an empty shell — skip it
+            // rather than admit a fabricated blank finding.
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(summary))
+                continue;
+
+            findings.Add(new ResearchFinding
+            {
+                Title = title,
+                Summary = summary,
+                Relevance = ReadNumber(item, "relevance"),
+                Confidence = ReadNumber(item, "confidence"),
+                Citations = ExtractStringList(item, "citations"),
+            });
+        }
+
+        return findings;
+    }
+
+    private static string ReadString(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static decimal ReadNumber(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.Number
+            ? (decimal)v.GetDouble()
+            : 0m;
+
+    private static decimal AverageConfidence(IReadOnlyList<ResearchFinding> findings)
+        => findings.Count == 0 ? 0m : Math.Round(findings.Sum(f => f.Confidence) / findings.Count, 4);
+
+    private static List<string> ExtractStringList(JsonElement element, string key)
+    {
+        if (!element.TryGetProperty(key, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<string>();
+
+        return arr.EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.String)
+            .Select(e => e.GetString())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!.Trim())
+            .ToList();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
@@ -1,0 +1,380 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using System.Text.Json;
+using Tamma.Activities;
+using Tamma.Activities.Research;
+using Tamma.Activities.Research.Models;
+using Tamma.Api.Services.Agents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 3.4 — Research sub-workflow. Given an issue / topic (typically when ambiguity is
+/// detected in a requirement) it investigates the codebase / prior art and uses the LLM
+/// (via the MEDIATED <c>llm-call</c> path — the engine holds no LLM credential, TAMMA001)
+/// to synthesize the gathered context into a ranked, confidence-scored research report,
+/// then emits the results as <c>RESEARCH.*</c> DCB events.
+///
+/// Flow:
+///   1. Read inputs (issue/topic + repository + tenantId; mint a session id if none)
+///   2. Emit RESEARCH.STARTED
+///   3. Gather codebase / prior-art context by REUSING DispatchWorkflow("context-gathering")
+///      (Story 7-1F multi-role scan) — same reuse as <see cref="AssessmentWorkflow"/>
+///   4. Emit RESEARCH.CONTEXT_GATHERED
+///   5. Synthesize a ranked research report via DispatchWorkflow("llm-call")
+///      role=product_owner / action=summarize-stakeholder
+///   6. Parse the synthesis fail-closed (empty/unparseable → error terminal)
+///   7a. On success: emit RESEARCH.COMPLETED, set outputs (report, confidence, findings)
+///   7b. On failure: emit RESEARCH.FAILED (LOUD) and route to the ResearchError terminal
+///
+/// Reuses the <see cref="AssessmentWorkflow"/> skeleton (gather-context → llm-call → parse
+/// → fail-closed gate + error terminal). The research is AUTONOMOUS — there is no human
+/// gate / bookmark (the ambiguity that triggers research is resolved by the sibling
+/// <see cref="ClarifyingQuestionsWorkflow"/>; research itself just investigates and reports).
+///
+/// Fail-closed: if the synthesis <c>llm-call</c> returns success=false, or the response
+/// cannot be parsed into a non-empty ranked report, the workflow emits a LOUD
+/// <c>RESEARCH.FAILED</c> event and routes to the ResearchError terminal — it NEVER
+/// proceeds with a fabricated report. Prompt resolution is tenant→system→error (the
+/// <c>llm-call</c> registry never falls back to an empty/plain prompt).
+///
+/// NOTE (taxonomy): Tamma's action taxonomy has no dedicated <c>research</c>/<c>investigate</c>
+/// action (the legacy TS <c>researcher</c> role maps onto <c>product_owner</c> in
+/// <c>RolePhaseMap.LegacyRoleAliases</c>). The synthesis therefore dispatches the closest
+/// eligible pair, <c>product_owner</c> / <c>summarize-stakeholder</c>, so the workflow is
+/// taxonomy-drift-clean and prompt resolution works. A future story that adds a dedicated
+/// research action + a structured-findings prompt template (a cross-cutting taxonomy change)
+/// only needs to swap the action constant below.
+/// </summary>
+public class ResearchWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "Research";
+        builder.DefinitionId = "research";
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description = "Investigate an issue/topic and synthesize a ranked, confidence-scored research report via the mediated LLM";
+
+        // ── Workflow variables ──────────────────────────────────────────
+        var sessionId       = builder.WithVariable<Guid>();
+        var issueId         = builder.WithVariable<string>();
+        var topic           = builder.WithVariable<string>();
+        var repository      = builder.WithVariable<string>();
+        var issueNumber     = builder.WithVariable<int>();
+        var workItemJson    = builder.WithVariable<string>();
+        var tenantId        = builder.WithVariable<string>("TenantId", "");
+
+        var researchContext = builder.WithVariable<string>();
+        var contextIds      = builder.WithVariable<string>("[]");
+        var reportJson      = builder.WithVariable<string>();
+        var findingCount    = builder.WithVariable<int>();
+        var overallConfidence = builder.WithVariable<double>();
+
+        // Dispatched-workflow result containers
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
+        var synthesizeLlm       = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flag (fail-closed guard)
+        var researchLlmOk   = builder.WithVariable<bool>();
+
+        // Captured parse output
+        var researchReport  = builder.WithVariable<ResearchReport>();
+
+        // Output variables (readable by a parent workflow)
+        var outputStatus    = builder.WithVariable<string>();
+
+        // ── Step 1: Read inputs ────────────────────────────────────────
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs",
+            Name = "Read Inputs",
+            Variable = sessionId,
+            Value = new(context =>
+            {
+                var sid = context.GetInput<Guid>("sessionId");
+                if (sid == Guid.Empty) sid = Guid.NewGuid();
+
+                issueId.Set(context, context.GetInput<string>("issueId") ?? string.Empty);
+                topic.Set(context, context.GetInput<string>("topic") ?? string.Empty);
+                repository.Set(context, context.GetInput<string>("repository") ?? string.Empty);
+                issueNumber.Set(context, context.GetInput<int>("issueNumber"));
+                workItemJson.Set(context, context.GetInput<string>("workItemJson") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
+                return sid;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ── Step 2: Emit RESEARCH.STARTED ──────────────────────────────
+        var emitStarted = new EmitResearchEventActivity
+        {
+            Id = "EmitResearchStarted",
+            Name = "Emit Research Started",
+            EventType = new(ResearchEvents.Started),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Research investigation started"),
+        };
+        emitStarted.SetDisplayText("Emit Research Started");
+
+        // ── Step 3: Gather context via ContextGathering workflow (7-1F) ─
+        var gatherContext = new DispatchWorkflow
+        {
+            Id = "GatherContext",
+            Name = "Gather Context",
+            WorkflowDefinitionId = new("context-gathering"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["repository"]   = repository.Get(ctx) ?? "",
+                ["issueNumber"]  = issueNumber.Get(ctx),
+                ["workItemJson"] = BuildWorkItem(topic.Get(ctx), workItemJson.Get(ctx), issueId.Get(ctx)),
+                ["tenantId"]     = tenantId.Get(ctx) ?? "",
+            }),
+            WaitForCompletion = new(true),
+            Result = new(contextGatherResult),
+        };
+        gatherContext.SetDisplayText("Gather Context");
+
+        var storeContextResult = new SetVariable
+        {
+            Id = "StoreContextResult",
+            Name = "Store Context Result",
+            Variable = researchContext,
+            Value = new(ctx =>
+            {
+                var result = contextGatherResult.Get(ctx);
+                if (result != null && result.TryGetValue("contextIds", out var ids) && ids != null)
+                    contextIds.Set(ctx, ids.ToString() ?? "[]");
+                if (result != null && result.TryGetValue("summary", out var s) && s != null)
+                    return s.ToString() ?? string.Empty;
+                return string.Empty;
+            })
+        };
+        storeContextResult.SetDisplayText("Store Context Result");
+
+        // ── Step 4: Emit RESEARCH.CONTEXT_GATHERED ─────────────────────
+        var emitContextGathered = new EmitResearchEventActivity
+        {
+            Id = "EmitContextGathered",
+            Name = "Emit Context Gathered",
+            EventType = new(ResearchEvents.ContextGathered),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Codebase / prior-art context gathered via context-gathering"),
+        };
+        emitContextGathered.SetDisplayText("Emit Context Gathered");
+
+        // ── Step 5: Synthesize a ranked research report via llm-call ───
+        var synthesizeResearchLlm = new DispatchWorkflow
+        {
+            Id = "SynthesizeResearchLlm",
+            Name = "Synthesize Research (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                // No dedicated research action exists; product_owner/summarize-stakeholder
+                // is the closest eligible pair (see class remarks). tenant→system→error.
+                ["role"]     = AgentRole.ProductOwner.ToWire(),
+                ["action"]   = AgentAction.SummarizeStakeholder.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"] = BuildWorkItem(topic.Get(ctx), workItemJson.Get(ctx), issueId.Get(ctx)),
+                    ["findings"]     = researchContext.Get(ctx) ?? "",
+                    ["audience"]     = "engineering-team",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(synthesizeLlm),
+        };
+        synthesizeResearchLlm.SetDisplayText("Synthesize Research (LLM)");
+
+        // ── Step 6: Parse the synthesis (fail-closed) ──────────────────
+        var parseResearch = new SetVariable
+        {
+            Id = "ParseResearch",
+            Name = "Parse Research",
+            Variable = reportJson,
+            Value = new(ctx =>
+            {
+                var result = synthesizeLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    researchLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var report = ResearchParsing.ParseReport(text, topic.Get(ctx));
+                if (report is null)
+                {
+                    // Fail-closed — no fabricated report.
+                    researchLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                researchLlmOk.Set(ctx, true);
+                researchReport.Set(ctx, report);
+                findingCount.Set(ctx, report.Findings.Count);
+                overallConfidence.Set(ctx, (double)report.OverallConfidence);
+                return JsonSerializer.Serialize(report);
+            })
+        };
+        parseResearch.SetDisplayText("Parse Research");
+
+        // Fail-closed gate: route to error terminal if synthesis failed / unparseable.
+        var researchSuccessCheck = new FlowDecision(ctx => researchLlmOk.Get(ctx))
+        { Id = "ResearchLlmOk", Name = "Research LLM OK?" };
+        researchSuccessCheck.SetDisplayText("Research LLM OK?");
+
+        // ── Step 7a: Success path ──────────────────────────────────────
+        var emitResearchCompleted = new EmitResearchEventActivity
+        {
+            Id = "EmitResearchCompleted",
+            Name = "Emit Research Completed",
+            EventType = new(ResearchEvents.Completed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            FindingCount = new(ctx => findingCount.Get(ctx)),
+            Confidence = new(ctx => overallConfidence.Get(ctx)),
+            Detail = new("Ranked, confidence-scored research report synthesized"),
+        };
+        emitResearchCompleted.SetDisplayText("Emit Research Completed");
+
+        var setOutputResult = new SetVariable
+        {
+            Id = "SetOutputResult",
+            Name = "Set Output Result",
+            Variable = outputStatus,
+            Value = new(_ => "completed")
+        };
+        setOutputResult.SetDisplayText("Set Output Result");
+
+        var exposeOutput = new Sequence
+        {
+            Id = "ExposeOutput",
+            Name = "Expose Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionId", Name = "Output Session Id", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id"),
+                WithLabel(new SetOutput { Id = "OutputStatus", Name = "Output Status", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status"),
+                WithLabel(new SetOutput { Id = "OutputReport", Name = "Output Report", OutputName = new("report"), OutputValue = new(ctx => (object)(reportJson.Get(ctx) ?? "{}")) }, "Output Report"),
+                WithLabel(new SetOutput { Id = "OutputFindingCount", Name = "Output Finding Count", OutputName = new("findingCount"), OutputValue = new(ctx => (object)findingCount.Get(ctx)) }, "Output Finding Count"),
+                WithLabel(new SetOutput { Id = "OutputConfidence", Name = "Output Confidence", OutputName = new("confidence"), OutputValue = new(ctx => (object)overallConfidence.Get(ctx)) }, "Output Confidence"),
+                WithLabel(new SetOutput { Id = "OutputContextIds", Name = "Output Context Ids", OutputName = new("contextIds"), OutputValue = new(ctx => (object)(contextIds.Get(ctx) ?? "[]")) }, "Output Context Ids"),
+            }
+        };
+        exposeOutput.SetDisplayText("Expose Output");
+
+        // ── Step 7b: Fail-closed error terminal (LOUD event + Finish) ──
+        var emitResearchFailed = new EmitResearchEventActivity
+        {
+            Id = "EmitResearchFailed",
+            Name = "Emit Research Failed",
+            EventType = new(ResearchEvents.Failed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for research synthesis failed or returned unparseable output"),
+        };
+        emitResearchFailed.SetDisplayText("Emit Research Failed");
+
+        var researchError = new Finish
+        {
+            Id = "ResearchError",
+            Name = "Research Error"
+        };
+        researchError.SetDisplayText("Research Error");
+
+        // ── Build the flowchart ────────────────────────────────────────
+        builder.Root = new Flowchart
+        {
+            Id = "ResearchFlowchart",
+            Name = "Research Flowchart",
+            Start = readInputs,
+            Activities =
+            {
+                readInputs,
+                emitStarted,
+                gatherContext,
+                storeContextResult,
+                emitContextGathered,
+                synthesizeResearchLlm,
+                parseResearch,
+                researchSuccessCheck,
+
+                // Success path
+                emitResearchCompleted,
+                setOutputResult,
+                exposeOutput,
+
+                // Fail-closed error terminal
+                emitResearchFailed,
+                researchError,
+            },
+            Connections =
+            {
+                new(readInputs, emitStarted),
+                new(emitStarted, gatherContext),
+                new(gatherContext, storeContextResult),
+                new(storeContextResult, emitContextGathered),
+                new(emitContextGathered, synthesizeResearchLlm),
+                new(synthesizeResearchLlm, parseResearch),
+                new(parseResearch, researchSuccessCheck),
+
+                // Success path
+                new(new FlowEndpoint(researchSuccessCheck, "True"),  new FlowEndpoint(emitResearchCompleted)),
+                new(emitResearchCompleted, setOutputResult),
+                new(setOutputResult, exposeOutput),
+
+                // Fail-closed error path
+                new(new FlowEndpoint(researchSuccessCheck, "False"), new FlowEndpoint(emitResearchFailed)),
+                new(emitResearchFailed, researchError),
+            }
+        };
+    }
+
+    /// <summary>
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary.
+    /// Returns <c>false</c> if the dictionary is null, the key is absent, or the value is
+    /// falsy — fail-closed by design. Uses the tolerant <see cref="ResumeInput.AsBool"/>
+    /// read (boxed bool / string / JsonElement).
+    /// </summary>
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return ResumeInput.AsBool(s);
+    }
+
+    /// <summary>
+    /// Compose the work-item JSON handed to the context-gathering scan and the synthesis
+    /// prompt. Prefers an explicit <paramref name="workItemJson"/>; otherwise wraps the
+    /// free-text <paramref name="topic"/> (plus the issue id) into a minimal JSON object
+    /// so the downstream template has a stable shape. Pure; exposed for unit testing.
+    /// </summary>
+    internal static string BuildWorkItem(string? topic, string? workItemJson, string? issueId)
+    {
+        if (!string.IsNullOrWhiteSpace(workItemJson))
+            return workItemJson!;
+
+        return JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["type"] = "research",
+            ["issueId"] = issueId ?? "",
+            ["topic"] = topic ?? "",
+        });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/EmitResearchEventActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/EmitResearchEventActivityTests.cs
@@ -1,0 +1,82 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Research;
+
+namespace Tamma.Activities.Tests.Research;
+
+/// <summary>
+/// Story 3.4 — unit coverage for the RESEARCH.* event mapping
+/// (<see cref="EmitResearchEventActivity.BuildTammaEvent"/> +
+/// <see cref="ResearchEvents.StatusForEvent"/>). Verifies the queryable DCB tags, the
+/// per-transition data payload, and — critically — that the failed terminal is a LOUD
+/// error-status row (never a false success).
+/// </summary>
+[TestFixture]
+public class EmitResearchEventActivityTests
+{
+    private static readonly Guid Tenant = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
+    [Test]
+    public void BuildTammaEvent_Completed_CarriesTagsAndData()
+    {
+        var evt = EmitResearchEventActivity.BuildTammaEvent(
+            ResearchEvents.Completed, "sess-1", "issue-9", Tenant, findingCount: 3, confidence: 0.82, detail: "done");
+
+        evt.EventType.Should().Be("RESEARCH.COMPLETED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags["issueId"].Should().Be("issue-9");
+        evt.Tags["tenantId"].Should().Be(Tenant.ToString("D"));
+        evt.Data["findingCount"].Should().Be(3);
+        evt.Data["confidence"].Should().Be(0.82);
+        evt.Data["detail"].Should().Be("done");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_IsLoudErrorStatus()
+    {
+        var evt = EmitResearchEventActivity.BuildTammaEvent(
+            ResearchEvents.Failed, "sess-1", "issue-9", Tenant, findingCount: 0, confidence: 0d, detail: "boom");
+
+        evt.Status.Should().Be("error",
+            "a failed synthesis must be a LOUD error-status row, never a false success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Started_IsStartedStatus()
+    {
+        var evt = EmitResearchEventActivity.BuildTammaEvent(
+            ResearchEvents.Started, "sess-1", "issue-9", Tenant, findingCount: 0, confidence: 0d, detail: null);
+
+        evt.Status.Should().Be("started");
+        evt.Data.Should().NotContainKey("findingCount", "no findings yet at start (count 0 is omitted)");
+        evt.Data.Should().NotContainKey("detail", "a null detail is omitted");
+    }
+
+    [Test]
+    public void BuildTammaEvent_NullTenant_OmitsTenantTag()
+    {
+        var evt = EmitResearchEventActivity.BuildTammaEvent(
+            ResearchEvents.Completed, "sess-1", "issue-9", tenantId: null, findingCount: 1, confidence: 0.5, detail: null);
+
+        evt.Tags.Should().NotContainKey("tenantId",
+            "single-user / platform-scope research events carry no tenantId tag");
+    }
+
+    [Test]
+    public void ParseTenantId_RoundTrips_AndRejectsGarbage()
+    {
+        ResearchEvents.ParseTenantId(Tenant.ToString()).Should().Be(Tenant);
+        ResearchEvents.ParseTenantId("").Should().BeNull();
+        ResearchEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    [TestCase("RESEARCH.STARTED", "started")]
+    [TestCase("RESEARCH.CONTEXT_GATHERED", "success")]
+    [TestCase("RESEARCH.COMPLETED", "success")]
+    [TestCase("RESEARCH.FAILED", "error")]
+    public void StatusForEvent_MapsCorrectly(string type, string expected)
+    {
+        ResearchEvents.StatusForEvent(type).Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/ResearchParsingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/ResearchParsingTests.cs
@@ -1,0 +1,137 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Research;
+
+namespace Tamma.Activities.Tests.Research;
+
+/// <summary>
+/// Story 3.4 — unit coverage for <see cref="ResearchParsing.ParseReport"/>. Proves the
+/// parser recovers the structured report on a well-formed synthesis response, RANKS
+/// findings by relevance then confidence, and FAILS CLOSED (returns null) on every
+/// degraded/empty/malformed input so the workflow routes to RESEARCH.FAILED rather than
+/// fabricating a report.
+/// </summary>
+[TestFixture]
+public class ResearchParsingTests
+{
+    private const string ValidReport =
+        """
+        Here is the synthesized research:
+        {
+          "topic": "caching layer",
+          "summary": "Redis is the incumbent cache; no per-tenant isolation exists yet.",
+          "findings": [
+            { "title": "Low relevance", "summary": "Minor note", "relevance": 0.2, "confidence": 0.9, "citations": ["a.cs"] },
+            { "title": "High relevance", "summary": "Core finding", "relevance": 0.95, "confidence": 0.6, "citations": ["b.cs", "https://x"] },
+            { "title": "Mid relevance", "summary": "Secondary", "relevance": 0.5, "confidence": 0.8 }
+          ],
+          "overallConfidence": 0.77
+        }
+        """;
+
+    [Test]
+    public void ParseReport_ValidResponse_RecoversReport()
+    {
+        var report = ResearchParsing.ParseReport(ValidReport);
+
+        report.Should().NotBeNull();
+        report!.Topic.Should().Be("caching layer");
+        report.Summary.Should().Contain("Redis");
+        report.Findings.Should().HaveCount(3);
+        report.OverallConfidence.Should().Be(0.77m);
+        // After ranking, "High relevance" (the finding carrying the citations) is first.
+        report.Findings[0].Title.Should().Be("High relevance");
+        report.Findings[0].Citations.Should().Contain("https://x");
+    }
+
+    [Test]
+    public void ParseReport_RanksFindings_ByRelevanceThenConfidence()
+    {
+        var report = ResearchParsing.ParseReport(ValidReport);
+
+        report!.Findings.Select(f => f.Title).ToList()
+            .Should().Equal(
+                new[] { "High relevance", "Mid relevance", "Low relevance" },
+                "findings must be ranked by relevance descending (AC: ranked by relevance and confidence)");
+    }
+
+    [Test]
+    public void ParseReport_MissingOverallConfidence_ComputesMean()
+    {
+        const string noOverall =
+            """
+            { "summary": "s", "findings": [
+              { "summary": "a", "relevance": 0.5, "confidence": 0.4 },
+              { "summary": "b", "relevance": 0.5, "confidence": 0.6 }
+            ] }
+            """;
+
+        var report = ResearchParsing.ParseReport(noOverall);
+
+        report.Should().NotBeNull();
+        report!.OverallConfidence.Should().Be(0.5m, "mean of 0.4 and 0.6 when overallConfidence is omitted");
+    }
+
+    [Test]
+    public void ParseReport_UsesFallbackTopic_WhenResponseOmitsTopic()
+    {
+        const string noTopic = """{ "summary": "s", "findings": [ { "summary": "a" } ] }""";
+
+        var report = ResearchParsing.ParseReport(noTopic, topic: "fallback-topic");
+
+        report!.Topic.Should().Be("fallback-topic");
+    }
+
+    [Test]
+    public void ParseReport_DropsEmptyShellFindings()
+    {
+        const string withShell =
+            """
+            { "summary": "s", "findings": [
+              { "title": "", "summary": "" },
+              { "summary": "real finding" }
+            ] }
+            """;
+
+        var report = ResearchParsing.ParseReport(withShell);
+
+        report!.Findings.Should().ContainSingle(f => f.Summary == "real finding",
+            "empty-shell findings (no title and no summary) must be dropped, not admitted blank");
+    }
+
+    // ── Fail-closed cases (all → null) ─────────────────────────────────
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("no json here at all")]
+    [TestCase("{ not valid json")]
+    public void ParseReport_DegradedInput_FailsClosed(string? input)
+    {
+        ResearchParsing.ParseReport(input).Should().BeNull(
+            "degraded/empty/malformed synthesis output must fail closed (no fabricated report)");
+    }
+
+    [Test]
+    public void ParseReport_MissingSummary_FailsClosed()
+    {
+        const string noSummary = """{ "findings": [ { "summary": "a" } ] }""";
+        ResearchParsing.ParseReport(noSummary).Should().BeNull(
+            "the overview summary is load-bearing — a report without it must fail closed");
+    }
+
+    [Test]
+    public void ParseReport_NoFindings_FailsClosed()
+    {
+        const string emptyFindings = """{ "summary": "s", "findings": [] }""";
+        ResearchParsing.ParseReport(emptyFindings).Should().BeNull(
+            "a report with no findings researched nothing — it must fail closed");
+    }
+
+    [Test]
+    public void ParseReport_AllShellFindings_FailsClosed()
+    {
+        const string allShells = """{ "summary": "s", "findings": [ { "title": "", "summary": "" } ] }""";
+        ResearchParsing.ParseReport(allShells).Should().BeNull(
+            "when every finding is an empty shell the report has no usable content — fail closed");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResearchWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResearchWorkflowStructureTests.cs
@@ -1,0 +1,149 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Research;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 3.4 — structural verification for <see cref="ResearchWorkflow"/>.
+///
+/// Asserts the workflow:
+/// 1. Builds and has DefinitionId "research".
+/// 2. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts
+///    (resolution is tenant→system→error — never empty/plain).
+/// 3. Investigates the codebase / prior art by REUSING the <c>context-gathering</c>
+///    sub-workflow (not reinventing a scan).
+/// 4. Synthesizes the research report via <c>DispatchWorkflow("llm-call")</c> (mediated —
+///    the engine holds no LLM credential, TAMMA001) rather than any in-engine provider call.
+/// 5. Is fail-closed: a <c>ResearchError</c> terminal exists and a <c>FlowDecision</c> gate
+///    checks LLM-call success before proceeding.
+/// 6. Emits the required RESEARCH.* DCB events (started / context gathered / completed /
+///    failed) via <see cref="EmitResearchEventActivity"/> nodes.
+/// 7. Is AUTONOMOUS — no human gate / bookmark (no suspend activity in the graph).
+/// </summary>
+[TestFixture]
+public class ResearchWorkflowStructureTests
+{
+    private static Flowchart Flowchart()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ResearchWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithoutError()
+    {
+        var act = () => WorkflowTestHelper.BuildWorkflow(new ResearchWorkflow());
+        act.Should().NotThrow("ResearchWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void Workflow_HasCorrectDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ResearchWorkflow());
+        builder.Object.DefinitionId.Should().Be("research");
+    }
+
+    [Test]
+    public void Workflow_ThreadsTenantId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new ResearchWorkflow());
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "the workflow must thread TenantId so llm-call resolves tenant-scoped prompts " +
+                "(tenant→system→error) for the research synthesis");
+    }
+
+    [Test]
+    public void Workflow_ReusesContextGatheringForInvestigation()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "GatherContext",
+                "the workflow must investigate the codebase / prior art by REUSING the " +
+                "context-gathering sub-workflow rather than reinventing a scan");
+    }
+
+    [Test]
+    public void Workflow_SynthesizesViaMediatedLlmCall()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "SynthesizeResearchLlm",
+                "the research report must be synthesized via the mediated llm-call " +
+                "(engine holds no LLM credential, TAMMA001)");
+    }
+
+    [Test]
+    public void Workflow_HasFailClosedErrorTerminal()
+    {
+        Flowchart().Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "ResearchError",
+                "a fail-closed ResearchError terminal must exist — synthesis failures route " +
+                "there, never proceeding with a fabricated research report");
+    }
+
+    [Test]
+    public void Workflow_HasSuccessGateForSynthesis()
+    {
+        Flowchart().Activities
+            .OfType<FlowDecision>()
+            .Select(d => d.Id)
+            .Should().Contain("ResearchLlmOk",
+                "the report output must be gated behind a ResearchLlmOk decision (fail-closed)");
+    }
+
+    [Test]
+    public void Workflow_EmitsRequiredResearchEvents()
+    {
+        var emitIds = Flowchart().Activities
+            .OfType<EmitResearchEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitResearchStarted",
+            "must emit RESEARCH.STARTED when the investigation begins");
+        emitIds.Should().Contain("EmitContextGathered",
+            "must emit RESEARCH.CONTEXT_GATHERED when the codebase/prior-art context is gathered");
+        emitIds.Should().Contain("EmitResearchCompleted",
+            "must emit RESEARCH.COMPLETED when a ranked report is synthesized");
+        emitIds.Should().Contain("EmitResearchFailed",
+            "must emit a LOUD RESEARCH.FAILED when synthesis fails / is unparseable");
+    }
+
+    [Test]
+    public void Workflow_IsAutonomous_NoHumanBookmark()
+    {
+        // Research is autonomous: unlike ClarifyingQuestionsWorkflow (which suspends on a
+        // WaitForClarifyingAnswersActivity bookmark awaiting human answers) it has no human
+        // gate. Assert no bookmark-style "Wait*" activity is present in the graph.
+        var waitActivities = Flowchart().Activities
+            .Where(a => a.GetType().Name.StartsWith("Wait", StringComparison.Ordinal))
+            .Select(a => a.GetType().Name)
+            .ToList();
+
+        waitActivities.Should().BeEmpty(
+            "the research workflow is autonomous — it must not suspend on a human bookmark " +
+            "(no Wait* activity), unlike the clarifying-questions workflow");
+    }
+
+    [Test]
+    public void Workflow_OnlyDispatchesContextGatheringAndLlmCall()
+    {
+        var dispatchIds = Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Select(d => d.Id)
+            .OrderBy(x => x)
+            .ToList();
+
+        dispatchIds.Should().BeEquivalentTo(new[] { "GatherContext", "SynthesizeResearchLlm" },
+            "research reuses context-gathering for investigation and the mediated llm-call for " +
+            "synthesis — no other dispatch and, crucially, no direct in-engine provider call");
+    }
+}


### PR DESCRIPTION
## What

Story 3.4 — `ResearchWorkflow` (`DefinitionId: research`) on the proven Assessment/3.5 skeleton: read inputs → gather context (`DispatchWorkflow("context-gathering")`) → synthesize via mediated LLM → parse (fail-closed) → emit. `RESEARCH.STARTED/CONTEXT_GATHERED/COMPLETED` + loud `RESEARCH.FAILED` DCB events. New `Tamma.Activities/Research/*` (events, emit activity, strict parsing, models).

- **No Program.cs touch** (auto-registered by the existing assembly sweep). **Non-migration** (DCB events + workflow state; both `has-pending-model-changes` "No changes"). **Mediated LLM** (`DispatchWorkflow("llm-call")`) — build clean, no TAMMA001.

## ⚠️ Known follow-up (tracked)

There is **no dedicated `research` action** in the prompt taxonomy, so the synthesis dispatches the closest eligible pair (`product_owner`/`summarize-stakeholder`). Rather than invent a taxonomy entry mid-PR (it's a cross-cutting change — enum count, `SystemPrompts` switch, `RolePhaseMap`, convention seed, count-asserting tests), the scaffold is shipped honest: **a real run fails *loud* (fail-closed parse) rather than fabricating findings**. A single follow-up will add `research` + `design` actions + structured-findings templates (batched with #158 Design, which shares the same taxonomy files) and swap the action constant — then the happy path emits real ranked findings.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Tests: Activities 94 + Api 220 (enum count still 74, prompt resolution intact, TaxonomyDrift accepts the dispatch pair).

Deferred (aspirational ACs): web/API multi-source, research cache, cross-referencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)