### PR TITLE
feat(epic-3-7): DesignProposalWorkflow (approval gate + secure resume, DESIGN.* events)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Design/DeliverDesignProposalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/DeliverDesignProposalActivity.cs
@@ -1,0 +1,195 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
+using Tamma.Activities.Design.Models;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Design;
+
+/// <summary>
+/// Story 3.7 — delivers the generated design proposal to the reviewer. When a repository +
+/// issue number are supplied the proposal is posted to the issue as a comment via the
+/// MEDIATED git seam (<see cref="TammaApiClient.UpdateIssueStatusAsync"/> →
+/// <c>PATCH /api/v1/git/{repo}/issues/{n}</c>); the per-tenant git token is resolved and
+/// used server-side and NEVER travels to the engine (TAMMA001 — the engine holds no git
+/// credential). When no issue coordinates are supplied the activity falls back to "api"
+/// mode: the proposal is already durable in workflow state / on the approval bookmark, so a
+/// reviewer can decide via the resume API.
+///
+/// <para>Fail-soft (mirrors <c>DeliverClarifyingQuestionsActivity</c>): a delivery failure
+/// returns a <c>Success=false</c> <see cref="DesignDeliveryResult"/> rather than throwing,
+/// so the workflow still arms the approval bookmark (the reviewer can still decide via API)
+/// and records a truthful <c>DESIGN.PROPOSAL.DELIVERED</c> audit row.</para>
+/// </summary>
+[Activity(
+    "Tamma.Design",
+    "Deliver Design Proposal",
+    "Post the design proposal to the issue via the mediated git seam, or surface via workflow state",
+    Kind = ActivityKind.Task
+)]
+public class DeliverDesignProposalActivity : CodeActivity<DesignDeliveryResult>
+{
+    private readonly ILogger<DeliverDesignProposalActivity>? _logger;
+    private readonly TammaApiClient? _apiClient;
+
+    [Input(Description = "Design session id")]
+    public Input<Guid> SessionId { get; set; } = default!;
+
+    [Input(Description = "Issue / requirement id the design is for")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Repository slug (owner/repo) for the mediated issue-comment post; empty → api mode")]
+    public Input<string?> Repository { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue number for the mediated issue-comment post; <= 0 → api mode")]
+    public Input<int> IssueNumber { get; set; } = new(0);
+
+    [Input(Description = "Generated design proposal (JSON DesignProposal)")]
+    public Input<string> ProposalJson { get; set; } = default!;
+
+    [Input(Description = "Tenant id (GUID string) for the acting scope; empty = single-user/platform")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public DeliverDesignProposalActivity() { }
+
+    public DeliverDesignProposalActivity(
+        ILogger<DeliverDesignProposalActivity> logger,
+        TammaApiClient apiClient)
+    {
+        _logger = logger;
+        _apiClient = apiClient;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var repository = Repository.Get(context);
+        var issueNumber = IssueNumber.Get(context);
+        var proposalJson = ProposalJson.Get(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var correlationId = context.WorkflowExecutionContext.Id;
+        var ct = context.CancellationToken;
+
+        var message = FormatProposalMessage(proposalJson, sessionId);
+
+        // api mode — no issue coordinates: the proposal is already durable in workflow state
+        // / on the approval bookmark, surfaced to a reviewer via the resume API.
+        if (string.IsNullOrWhiteSpace(repository) || issueNumber <= 0)
+        {
+            _logger?.LogInformation(
+                "API delivery mode: design proposal surfaced in workflow state for session {SessionId}",
+                sessionId);
+            context.SetResult(new DesignDeliveryResult
+            {
+                Success = true,
+                Channel = "api",
+                Message = "Design proposal available via workflow state / resume API",
+                DeliveredAt = DateTime.UtcNow,
+            });
+            return;
+        }
+
+        try
+        {
+            var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
+            var response = await apiClient.UpdateIssueStatusAsync(
+                repository,
+                issueNumber,
+                new GitUpdateIssueRequest { Body = message, CorrelationId = correlationId },
+                tenantId,
+                ct).ConfigureAwait(false);
+
+            var success = response is { Success: true };
+            _logger?.LogInformation(
+                "Delivered design proposal to {Repo}#{Issue} for session {SessionId} (success={Success})",
+                repository, issueNumber, sessionId, success);
+
+            context.SetResult(new DesignDeliveryResult
+            {
+                Success = success,
+                Channel = "issue-comment",
+                Message = success
+                    ? $"Design proposal posted to {repository}#{issueNumber}"
+                    : $"Delivery failed: {response?.FailureReason ?? "git mediation endpoint unavailable"}",
+                DeliveredAt = DateTime.UtcNow,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex,
+                "Failed to deliver design proposal for session {SessionId}", sessionId);
+            context.SetResult(new DesignDeliveryResult
+            {
+                Success = false,
+                Channel = "issue-comment",
+                Message = $"Delivery failed: {ex.Message}",
+                DeliveredAt = DateTime.UtcNow,
+            });
+        }
+    }
+
+    /// <summary>Format the design proposal into a human-readable review comment body. Pure —
+    /// exposed for unit testing.</summary>
+    public static string FormatProposalMessage(string? proposalJson, Guid sessionId)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("**Tamma: Design Proposal for Review**");
+        sb.AppendLine();
+
+        try
+        {
+            var proposal = JsonSerializer.Deserialize<DesignProposal>(proposalJson ?? "");
+            if (proposal is not null && !string.IsNullOrWhiteSpace(proposal.Summary))
+            {
+                sb.AppendLine("**Summary**");
+                sb.AppendLine(proposal.Summary);
+                sb.AppendLine();
+
+                if (proposal.Alternatives.Count > 0)
+                {
+                    sb.AppendLine("**Alternatives considered**");
+                    for (var i = 0; i < proposal.Alternatives.Count; i++)
+                    {
+                        var alt = proposal.Alternatives[i];
+                        sb.AppendLine($"{i + 1}. **{alt.Name}** — {alt.Tradeoffs}");
+                    }
+                    sb.AppendLine();
+                }
+
+                if (!string.IsNullOrWhiteSpace(proposal.Recommendation))
+                {
+                    sb.AppendLine("**Recommendation**");
+                    sb.AppendLine(proposal.Recommendation);
+                    sb.AppendLine();
+                }
+
+                if (!string.IsNullOrWhiteSpace(proposal.ConstraintEvaluation))
+                {
+                    sb.AppendLine("**Constraint evaluation**");
+                    sb.AppendLine(proposal.ConstraintEvaluation);
+                    sb.AppendLine();
+                }
+            }
+            else
+            {
+                sb.AppendLine(proposalJson);
+            }
+        }
+        catch
+        {
+            sb.AppendLine(proposalJson);
+        }
+
+        sb.AppendLine("---");
+        sb.AppendLine($"_Reply by approving or rejecting this design. Design session: {sessionId}_");
+        return sb.ToString();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/DesignEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/DesignEvents.cs
@@ -1,0 +1,82 @@
+namespace Tamma.Activities.Design;
+
+/// <summary>
+/// Story 3.7 (Design Proposal Workflow) — central catalogue of the <c>DESIGN.*</c> DCB
+/// event types emitted by the <c>design-proposal</c> sub-workflow via
+/// <see cref="EmitDesignEventActivity"/>. Type pattern follows the platform's
+/// <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors the sibling
+/// event catalogues (<see cref="Tamma.Activities.Clarify.ClarifyEvents"/>,
+/// <see cref="Tamma.Activities.Blocker.BlockerEvents"/>).
+///
+/// <para>The design-proposal workflow turns a complex requirement into a reviewed
+/// technical design: it asks the LLM (via the mediated <c>llm-call</c> path — the engine
+/// holds no LLM credential, TAMMA001) to generate a design proposal with alternatives +
+/// trade-off analysis, DELIVERS it to the issue / reviewer, SUSPENDS on a bookmark
+/// awaiting a human approve/reject decision, then RESUMES to finalise (approved →
+/// hand-off, rejected → feedback captured). Each transition is an auditable step so
+/// time-travel debugging and the Epic-32 learning loop can reconstruct WHAT was proposed,
+/// WHICH alternatives were weighed, and HOW the design decision was made — satisfying the
+/// Story-3.7 ACs "System tracks design decisions and maintains decision audit trail" +
+/// "Proposals are versioned and stored for future reference and learning".</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event
+/// drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern
+/// <see cref="Tamma.Activities.Clarify.EmitClarifyEventActivity"/> uses. No activity holds
+/// a DB / repository dependency of its own; the drain resolves the tenant from the
+/// workflow scope and each event carries a <c>tenantId</c> tag so per-tenant data stays
+/// tenant-scoped.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>DESIGN.PROPOSAL.GENERATED</c> — the LLM produced a design
+///     proposal (summary + alternatives + trade-off analysis) for the requirement.</description></item>
+///   <item><description><c>DESIGN.PROPOSAL.DELIVERED</c> — the proposal was posted to the
+///     issue / surfaced to the reviewer (carries channel).</description></item>
+///   <item><description><c>DESIGN.PROPOSAL.APPROVED</c> — terminal success: a human
+///     reviewer approved the design; it may proceed to implementation.</description></item>
+///   <item><description><c>DESIGN.PROPOSAL.REJECTED</c> — a human reviewer rejected the
+///     design (feedback captured). A real decision, NOT an error — recorded as a normal
+///     audit row so the rejection + its feedback feed the learning loop.</description></item>
+///   <item><description><c>DESIGN.PROPOSAL.FAILED</c> — LOUD (error-status): the
+///     generation <c>llm-call</c> failed or returned unparseable output; the workflow
+///     fails closed rather than proceeding with a fabricated design.</description></item>
+///   <item><description><c>DESIGN.REVIEW.TIMED_OUT</c> — LOUD (error-status): the review
+///     SLA expired with no human decision. A distinct, auditable terminal, NEVER a silent
+///     false approval.</description></item>
+/// </list>
+/// </summary>
+public static class DesignEvents
+{
+    public const string ProposalGenerated = "DESIGN.PROPOSAL.GENERATED";
+    public const string ProposalDelivered = "DESIGN.PROPOSAL.DELIVERED";
+    public const string ProposalApproved = "DESIGN.PROPOSAL.APPROVED";
+    public const string ProposalRejected = "DESIGN.PROPOSAL.REJECTED";
+
+    // LOUD (error-status) terminals — a fabricated / degraded / expired outcome must never
+    // be recorded as a false success.
+    public const string ProposalFailed = "DESIGN.PROPOSAL.FAILED";
+    public const string ReviewTimedOut = "DESIGN.REVIEW.TIMED_OUT";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (design events in
+    /// single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Clarify.ClarifyEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed generation and a review SLA expiry are LOUD
+    /// (error-status) audit rows; every other transition (generated, delivered, approved,
+    /// rejected) is a normal (success-status) row. A REJECTED proposal is a legitimate
+    /// human decision, not an error. Keeps a degraded/expired terminal from ever being
+    /// recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        ProposalFailed => "error",
+        ReviewTimedOut => "error",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/DesignParsing.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/DesignParsing.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using Tamma.Activities.Design.Models;
+
+namespace Tamma.Activities.Design;
+
+/// <summary>
+/// Story 3.7 — pure, context-free parser that recovers a <see cref="DesignProposal"/> from
+/// a mediated <c>llm-call</c> text response. Kept side-effect-free (no Elsa context) so the
+/// fail-closed behaviour is unit-testable without a live LLM. Mirrors the JSON-slice
+/// approach in <c>ClarifyParsing</c> / <c>AssessmentWorkflow</c>.
+///
+/// <para><b>Fail-closed:</b> unparseable / empty output — or output missing the
+/// load-bearing <c>summary</c> field — yields <c>null</c>, which the workflow routes to its
+/// <c>DESIGN.PROPOSAL.FAILED</c> error terminal. It NEVER fabricates a design a reviewer
+/// would then approve.</para>
+/// </summary>
+public static class DesignParsing
+{
+    /// <summary>
+    /// Extract the design proposal from an <c>llm-call</c> text response. Expects a JSON
+    /// object <c>{"summary":"...","alternatives":[{"name":"...","tradeoffs":"..."}],
+    /// "recommendation":"...","constraintEvaluation":"..."}</c>. Returns <c>null</c> when the
+    /// object or the required <c>summary</c> field is missing / empty (fail-closed) so the
+    /// workflow routes to its error terminal rather than delivering an empty design.
+    /// </summary>
+    public static DesignProposal? ParseProposal(string? llmText)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return null;
+
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart < 0 || objEnd <= objStart)
+            return null;
+
+        try
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+            if (element.ValueKind != JsonValueKind.Object)
+                return null;
+
+            var summary = ReadString(element, "summary");
+
+            // Fail-closed: the summary is the load-bearing field. Without it there is no
+            // design to review — never fabricate one.
+            if (string.IsNullOrWhiteSpace(summary))
+                return null;
+
+            return new DesignProposal
+            {
+                Summary = summary,
+                Recommendation = ReadString(element, "recommendation"),
+                ConstraintEvaluation = ReadString(element, "constraintEvaluation"),
+                Alternatives = ParseAlternatives(element),
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static List<DesignAlternative> ParseAlternatives(JsonElement element)
+    {
+        var result = new List<DesignAlternative>();
+        if (!element.TryGetProperty("alternatives", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                var name = item.GetString();
+                if (!string.IsNullOrWhiteSpace(name))
+                    result.Add(new DesignAlternative { Name = name!.Trim() });
+                continue;
+            }
+
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var altName = ReadString(item, "name");
+            var tradeoffs = ReadString(item, "tradeoffs");
+            if (string.IsNullOrWhiteSpace(altName) && string.IsNullOrWhiteSpace(tradeoffs))
+                continue;
+
+            result.Add(new DesignAlternative { Name = altName, Tradeoffs = tradeoffs });
+        }
+
+        return result;
+    }
+
+    private static string ReadString(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()?.Trim() ?? string.Empty
+            : string.Empty;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/EmitDesignEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/EmitDesignEventActivity.cs
@@ -1,0 +1,123 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Design;
+
+/// <summary>
+/// Story 3.7 — emits a <c>DESIGN.*</c> DCB event for the <c>design-proposal</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's
+/// <c>tamma:events</c> transient list via <see cref="TammaEventEmitter.Emit"/>. The merged
+/// engine event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that
+/// list <i>durably</i> to the tenant <c>domain_events</c> store — the same pattern
+/// <see cref="Tamma.Activities.Clarify.EmitClarifyEventActivity"/> and
+/// <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> use. No activity holds a DB /
+/// repository dependency of its own (none is registered in the Elsa engine — a directly
+/// injected repository would be inert and silently drop every event).
+/// </summary>
+[Activity(
+    "Tamma.Design",
+    "Emit Design Event",
+    "Emit a DESIGN.* DCB event for the design-proposal audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitDesignEventActivity : Activity
+{
+    private readonly ILogger<EmitDesignEventActivity>? _logger;
+
+    [Input(Description = "Event type — DESIGN.PROPOSAL.GENERATED / .DELIVERED / .APPROVED / .REJECTED / .FAILED / DESIGN.REVIEW.TIMED_OUT")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Design session id (unguessable Guid string)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id the design is for")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Delivery channel (issue-comment / api) for DELIVERED events")]
+    public Input<string?> Channel { get; set; } = new((string?)null);
+
+    [Input(Description = "Number of design alternatives weighed in the proposal")]
+    public Input<int> AlternativeCount { get; set; } = new(0);
+
+    [Input(Description = "Free-text detail for the audit payload (review feedback / failure reason)")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [Input(Description = "Reviewer identity for APPROVED / REJECTED decisions (non-repudiation)")]
+    public Input<string?> Reviewer { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitDesignEventActivity() { }
+
+    public EmitDesignEventActivity(ILogger<EmitDesignEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? DesignEvents.ProposalFailed;
+        var sessionId = SessionId.Get(context);
+        var issueId = IssueId.Get(context);
+        var tenantId = DesignEvents.ParseTenantId(TenantId.Get(context));
+        var channel = Channel.Get(context);
+        var alternativeCount = AlternativeCount.Get(context);
+        var detail = Detail.Get(context);
+        var reviewer = Reviewer.Get(context);
+
+        var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, channel, alternativeCount, detail, reviewer);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for design session {Session} issue {Issue} (alternatives={Count})",
+            type, sessionId, issueId, alternativeCount);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the design event inputs onto a <see cref="TammaEvent"/> expressed as the engine's
+    /// transient-list event so the merged drain persists it. Tags carry the queryable DCB
+    /// index keys (<c>sessionId</c>/<c>issueId</c>/<c>channel</c>/<c>tenantId</c>);
+    /// <c>Data</c> carries the per-transition payload (alternative count, detail, reviewer).
+    /// Status is driven off the event type (<see cref="DesignEvents.StatusForEvent"/>) so a
+    /// failed/timed-out terminal is a LOUD error row, never a false success. Pure (no Elsa
+    /// context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? issueId,
+        Guid? tenantId,
+        string? channel,
+        int alternativeCount,
+        string? detail,
+        string? reviewer)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (!string.IsNullOrWhiteSpace(channel)) tags["channel"] = channel;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (alternativeCount > 0) data["alternativeCount"] = alternativeCount;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+        if (!string.IsNullOrWhiteSpace(reviewer)) data["reviewer"] = reviewer;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = DesignEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/Models/DesignModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/Models/DesignModels.cs
@@ -1,0 +1,54 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.Design.Models;
+
+/// <summary>
+/// Story 3.7 — a technical design proposal produced (via the mediated <c>llm-call</c>)
+/// for a complex requirement. Parsed defensively from the generation <c>llm-call</c>
+/// output; the workflow fails closed (routes to the error terminal) if the load-bearing
+/// <see cref="Summary"/> cannot be recovered. Serialised into the workflow's
+/// <c>proposalJson</c> variable and surfaced to the reviewer by
+/// <see cref="Tamma.Activities.Design.DeliverDesignProposalActivity"/>.
+/// </summary>
+public sealed class DesignProposal
+{
+    /// <summary>The high-level summary of the recommended design (load-bearing field).</summary>
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>The candidate design alternatives with their trade-off analysis (AC 3).</summary>
+    [JsonPropertyName("alternatives")]
+    public List<DesignAlternative> Alternatives { get; set; } = new();
+
+    /// <summary>The recommended approach + rationale (why this alternative wins the trade-offs).</summary>
+    [JsonPropertyName("recommendation")]
+    public string Recommendation { get; set; } = string.Empty;
+
+    /// <summary>How the proposal was evaluated against the supplied technical / business
+    /// constraints (AC 4). Empty when the model returned none.</summary>
+    [JsonPropertyName("constraintEvaluation")]
+    public string ConstraintEvaluation { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// A single design alternative in a <see cref="DesignProposal"/>: a named option with the
+/// trade-offs a reviewer weighs before approving (AC 3 — "multiple design alternatives with
+/// trade-off analysis").
+/// </summary>
+public sealed class DesignAlternative
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("tradeoffs")]
+    public string Tradeoffs { get; set; } = string.Empty;
+}
+
+/// <summary>Outcome of delivering the design proposal to the reviewer / issue.</summary>
+public sealed class DesignDeliveryResult
+{
+    public bool Success { get; set; }
+    public string Channel { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public DateTime DeliveredAt { get; set; } = DateTime.UtcNow;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/WaitForDesignApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/WaitForDesignApprovalActivity.cs
@@ -1,0 +1,185 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Text.Json.Serialization;
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Design;
+
+/// <summary>
+/// Story 3.7 — bookmark-based human gate: suspend the <c>design-proposal</c> workflow until
+/// a reviewer approves or rejects the delivered design proposal, then surface the decision
+/// as a typed outcome the flowchart branches on (Story-3.7 AC "Design reviews are automated
+/// with stakeholder routing and feedback collection").
+///
+/// <para>Two resume paths are armed when the activity suspends:
+/// <list type="bullet">
+///   <item><description>an approval bookmark
+///   (<c>design-approval-{tenant}-{session}</c>, see <see cref="ApprovalBookmarkName"/>)
+///   resumed by the reviewer's decision via the secure resume endpoint → <c>Approved</c> or
+///   <c>Rejected</c> depending on the injected <c>Approved</c> flag;</description></item>
+///   <item><description>a DURABLE delay bookmark via
+///   <see cref="Elsa.Extensions.DelayActivityExecutionContextExtensions.DelayFor(ActivityExecutionContext, System.TimeSpan, ExecuteActivityDelegate)"/>
+///   at the review SLA (<c>Design:ReviewTimeoutMinutes</c>, default 4320 = 3 days) →
+///   <c>Timeout</c>.</description></item>
+/// </list>
+/// The Delay bookmark is EF-persisted and re-armed by <c>Elsa.Scheduling</c>'s startup task
+/// on rehydration, so a host restart mid-wait no longer drops the SLA (same hardening as
+/// <see cref="Tamma.Activities.Clarify.WaitForClarifyingAnswersActivity"/>). Whichever path
+/// resumes first completes the activity; Elsa burns the remaining bookmark, so there is no
+/// orphaned timer / stale double-resume.</para>
+///
+/// <para><b>SECURITY (IDOR)</b> — the bookmark name folds in the tenant id (the
+/// merge/deploy-gate posture, <see cref="WaitForMergeApprovalActivity.BookmarkName"/>). A
+/// resume caller scoped to tenant A computes a name keyed by tenant A, so it can NEVER
+/// resolve tenant B's gate; a cross-tenant attempt simply 404s (bookmark not found), it
+/// never acts. This is table-free (no design-proposal row is minted — Story 3.7 is a
+/// NON-MIGRATION change; the proposal lives in workflow state + DCB events) yet strictly
+/// cross-tenant-safe. The session id is itself an unguessable 128-bit Guid, so within a
+/// tenant the name is unguessable too.</para>
+/// </summary>
+[Activity(
+    "Tamma.Design",
+    "Wait For Design Approval",
+    "Suspend workflow until a reviewer approves/rejects the design proposal or the SLA expires",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Approved", "Rejected", "Timeout")]
+public class WaitForDesignApprovalActivity : Activity
+{
+    private readonly ILogger<WaitForDesignApprovalActivity>? _logger;
+    private readonly IConfiguration? _configuration;
+
+    [Input(Description = "Design session id (bookmark scoping)")]
+    public Input<Guid> SessionId { get; set; } = default!;
+
+    /// <summary>Tenant id (GUID string or empty for single-user). Folded into the bookmark
+    /// name so a cross-tenant resume can never resolve this gate.</summary>
+    [Input(Description = "Tenant id (bookmark scoping — prevents cross-tenant resume/IDOR)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    /// <summary>Whether the reviewer approved (set on bookmark resume).</summary>
+    [Output(Description = "Whether the reviewer approved the design")]
+    public Output<bool> Approved { get; set; } = default!;
+
+    /// <summary>The reviewer's feedback (set on bookmark resume).</summary>
+    [Output(Description = "Reviewer feedback text")]
+    public Output<string?> Feedback { get; set; } = default!;
+
+    /// <summary>Whether the review SLA expired with no decision (durable timeout).</summary>
+    [Output(Description = "Whether the review SLA expired with no decision")]
+    public Output<bool> TimedOut { get; set; } = default!;
+
+    [JsonConstructor]
+    public WaitForDesignApprovalActivity() { }
+
+    public WaitForDesignApprovalActivity(
+        ILogger<WaitForDesignApprovalActivity> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// The SINGLE canonical approval-bookmark name (<c>design-approval-{tenant}-{session}</c>).
+    /// Shared by the suspend side (<see cref="Execute"/>) and the resume side
+    /// (<c>DesignResumeEndpoint</c>) so the two match byte-for-byte — the same
+    /// suspend/resume-name-parity discipline as
+    /// <see cref="WaitForMergeApprovalActivity.BookmarkName"/>. The tenant segment is
+    /// normalised via the SAME <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/>
+    /// transform on both sides so the names always agree.
+    /// </summary>
+    public static string ApprovalBookmarkName(string? tenantId, Guid sessionId)
+    {
+        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
+        return $"design-approval-{tenant}-{sessionId}";
+    }
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var tenantId = TenantId.Get(context);
+        var bookmarkName = ApprovalBookmarkName(tenantId, sessionId);
+
+        _logger?.LogInformation(
+            "Waiting for design approval: bookmark={BookmarkName} for session {SessionId}",
+            bookmarkName, sessionId);
+
+        // 1) Approval bookmark — resumed by the reviewer via the secure resume endpoint.
+        context.CreateBookmark(new CreateBookmarkArgs
+        {
+            BookmarkName = bookmarkName,
+            Callback = OnDecisionReceivedAsync,
+            AutoBurn = true,
+            IncludeActivityInstanceId = false,
+        });
+
+        // 2) Durable review SLA — a DelayFor (Delay) bookmark that Elsa.Scheduling's startup
+        //    task re-arms after a host restart (EF-persisted, not an in-memory timer). A
+        //    never-reviewed proposal terminates as a real Timeout even across a VPS restart
+        //    inside the (default 3-day) SLA window.
+        var slaMinutes = _configuration?.GetValue<int?>("Design:ReviewTimeoutMinutes") ?? 4320;
+        context.DelayFor(TimeSpan.FromMinutes(Math.Max(1, slaMinutes)), OnTimeoutAsync);
+
+        _logger?.LogInformation(
+            "Design review wait armed; durable SLA timeout at +{SlaMinutes}min for session {SessionId}",
+            slaMinutes, sessionId);
+    }
+
+    /// <summary>External resume path: the reviewer decided. Reads the decision from the
+    /// resume input and completes with <c>Approved</c> or <c>Rejected</c> — Elsa burns the
+    /// still-armed SLA Delay bookmark on completion (no orphaned timer).</summary>
+    private async ValueTask OnDecisionReceivedAsync(ActivityExecutionContext context)
+    {
+        var (approved, feedback) = ReadDecision(context.WorkflowInput);
+
+        _logger?.LogInformation(
+            "Design review resumed (external): Approved={Approved}, feedbackLength={Length}",
+            approved, feedback?.Length ?? 0);
+
+        context.Set(Approved, approved);
+        context.Set(Feedback, feedback);
+        context.Set(TimedOut, false);
+
+        await context.CompleteActivityWithOutcomesAsync(approved ? "Approved" : "Rejected");
+    }
+
+    /// <summary>Durable timeout path: the review SLA elapsed with no decision. Flags
+    /// <see cref="TimedOut"/> (not <see cref="Approved"/>) so the workflow reports the real
+    /// Timeout terminal instead of suspending forever — NEVER a silent false approval.</summary>
+    private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        _logger?.LogWarning(
+            "Design review SLA expired (durable timeout) for session {SessionId} — taking the Timeout terminal",
+            sessionId);
+
+        context.Set(Approved, false);
+        context.Set(Feedback, null);
+        context.Set(TimedOut, true);
+
+        await context.CompleteActivityWithOutcomesAsync("Timeout");
+    }
+
+    /// <summary>
+    /// Pure read-back of the reviewer decision from the bookmark resume input (exposed for
+    /// unit testing). <c>Approved</c> is coerced via <see cref="ResumeInput.AsBool"/> so it
+    /// is correct whether the runtime delivers the flag as a boxed <see cref="bool"/>
+    /// (in-process) or as a <see cref="string"/> / <see cref="System.Text.Json.JsonElement"/>
+    /// (serializing dispatcher) — the #15/#437 lesson: never a bare <c>is true</c> on resume
+    /// input, which silently mis-branches (a rejection read as an approval) under
+    /// serialization while still returning HTTP 200. <c>Feedback</c> is read via
+    /// <c>.ToString()</c>, which is already serialization-tolerant.
+    /// </summary>
+    public static (bool Approved, string? Feedback) ReadDecision(IDictionary<string, object> input)
+    {
+        var approved = input.TryGetValue("Approved", out var a) && ResumeInput.AsBool(a);
+        var feedback = input.TryGetValue("Feedback", out var f) ? f?.ToString() : null;
+        return (approved, feedback);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AdlEndpoints.cs
@@ -420,6 +420,97 @@ public static class AdlEndpoints
         }
     }
 
+    // ================================================================
+    // Design-proposal human review gate (Story 3.7) —
+    // POST /api/adl/design/resume. Same RBAC (WorkflowsManage, enforced at the
+    // route group) + I2 (server-derived reviewer) posture as the merge/deploy
+    // gates. The cross-tenant guard uses the SAME mechanism as the merge gate:
+    // the caller's ambient tenant id is folded into the bookmark name by the
+    // engine, so a caller can only resume a gate in its OWN tenant (a cross-
+    // tenant/unknown session → 404). This is table-free — Story 3.7 mints no
+    // design-proposal row (NON-MIGRATION).
+    // ================================================================
+
+    /// <summary>The design review decisions accepted (case-insensitive). Anything else is
+    /// rejected with 400 up front so the caller never forwards an arbitrary string that
+    /// would silently route the gate.</summary>
+    private static readonly HashSet<string> AllowedDesignDecisions =
+        new(StringComparer.OrdinalIgnoreCase) { "approve", "reject" };
+
+    /// <summary>
+    /// Resume request for the design-proposal review gate. <c>Reviewer</c> is intentionally
+    /// absent — the acting identity is derived from the authenticated caller (I2), never
+    /// trusted from the client.
+    /// </summary>
+    public sealed record DesignReviewRequest(
+        Guid SessionId,
+        string Decision,       // "approve" | "reject"
+        string? Feedback);
+
+    /// <summary>
+    /// Resume the design-proposal workflow with a reviewer's approve/reject decision.
+    /// Route: <c>POST /api/adl/design/resume</c>.
+    /// </summary>
+    public static async Task<IResult> ResumeDesign(
+        [FromBody] DesignReviewRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.AdlEndpoints");
+
+        if (req.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+        if (string.IsNullOrWhiteSpace(req.Decision) || !AllowedDesignDecisions.Contains(req.Decision.Trim()))
+            return Results.BadRequest(new { error = "decision must be one of: approve, reject" });
+
+        var approved = string.Equals(req.Decision.Trim(), "approve", StringComparison.OrdinalIgnoreCase);
+
+        // SECURITY (IDOR) — scope the resume to the caller's ambient tenant. The engine folds
+        // this tenant id into the bookmark name, so a caller can only ever resolve a gate in
+        // its OWN tenant. (Ambient null = self-hosted single-user scope.)
+        var tenantId = tenantContext.TenantId?.ToString();
+
+        // I2 — the reviewer is the authenticated caller, derived server-side. A client-supplied
+        // reviewer is never honoured so the audit trail can't be forged.
+        var reviewer = ResolveApprover(principal);
+
+        try
+        {
+            var result = await elsa.ResumeDesignApprovalAsync(
+                req.SessionId, tenantId, approved, req.Feedback, reviewer);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No design-proposal review is currently suspended for this session.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove design gate for session {SessionId} with decision {Decision} (reviewer {Reviewer})",
+                req.SessionId, LogSanitizer.Clean(req.Decision), LogSanitizer.Clean(reviewer));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+                approved,
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "Failed to resume design gate for session {SessionId}", req.SessionId);
+            return Results.Problem(
+                detail: "Failed to resume the design-proposal review gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
     /// <summary>Map a case-insensitive level onto the workflow's exact PascalCase segment
     /// ("Hint"/"Guidance"/"Assistance"); null for anything else.</summary>
     internal static string? CanonicalBlockerLevel(string? level)

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2716,6 +2716,13 @@ adl.MapPost("/blocker/resume", AdlEndpoints.ResumeBlocker);
 // resolver derived server-side (I2). IDOR guard: the engine folds the caller's ambient
 // tenant id into the bookmark name, so a cross-tenant/unknown session → 404.
 adl.MapPost("/clarify/resume", AdlEndpoints.ResumeClarify);
+// Design-proposal review gate (Story 3.7). Resumes the tenant+session-scoped
+// design-approval-{tenant}-{session} bookmark with the reviewer's approve/reject
+// decision so the workflow can finalise (approved → implementation, rejected →
+// feedback captured). WorkflowsManage = tenant owner/admin (members 403); reviewer
+// derived server-side (I2). IDOR guard: the engine folds the caller's ambient tenant
+// id into the bookmark name, so a cross-tenant/unknown session → 404.
+adl.MapPost("/design/resume", AdlEndpoints.ResumeDesign);
 
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -511,6 +511,51 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
             WorkflowInstanceId: result?.WorkflowInstanceId);
     }
 
+    /// <summary>
+    /// Story 3.7 — forward a design-proposal review-gate resume to the engine's in-process
+    /// resume endpoint, which looks up the tenant+session-scoped
+    /// <c>design-approval-{tenant}-{session}</c> bookmark and runs the owning instance with
+    /// <c>{Approved, Feedback}</c> injected as input. A 404 (no gate waiting) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeDesignApprovalAsync(
+        Guid sessionId, string? tenantId, bool approved, string? feedback, string? reviewer)
+    {
+        _logger.LogInformation(
+            "Resuming design gate for session {SessionId} (approved={Approved})", sessionId, approved);
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            sessionId,
+            // Tenant scopes the engine's bookmark lookup (folded into the name).
+            tenantId,
+            approved,
+            feedback,
+            // I2 — server-derived acting identity, forwarded for the engine's audit log.
+            reviewer,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/adl/design/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No design gate waiting for session {SessionId}", sessionId);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
     private sealed class EngineResumeResponse
     {
         public bool Resumed { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -100,6 +100,23 @@ public interface IElsaWorkflowService
     /// </summary>
     Task<MergeApprovalResumeResult> ResumeClarifyingQuestionsAsync(
         Guid sessionId, string? tenantId, string answers, string? resolver);
+
+    /// <summary>
+    /// Story 3.7 — resume the design-proposal workflow's human review gate. Forwards to the
+    /// engine's in-process resume endpoint (which owns <c>IBookmarkStore</c>/
+    /// <c>IWorkflowRuntime</c>), which looks up the tenant+session-scoped
+    /// <c>design-approval-{tenant}-{session}</c> bookmark and runs the owning instance with
+    /// <c>{Approved, Feedback}</c> injected as input (the gate branches Approved/Rejected off
+    /// the flag). A 404 (no wait suspended) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    ///
+    /// <para>SECURITY — the bookmark name folds in <paramref name="tenantId"/> (the caller's
+    /// ambient tenant, derived server-side by <c>AdlEndpoints</c>), so a caller can only ever
+    /// resolve a gate in its OWN tenant (cross-tenant → 404). <paramref name="reviewer"/> is
+    /// the server-derived acting identity (I2), logged by the engine for the audit trail.</para>
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeDesignApprovalAsync(
+        Guid sessionId, string? tenantId, bool approved, string? feedback, string? reviewer);
 }
 
 /// <summary>Outcome of a merge-approval (or deploy-approval) gate resume.</summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DesignResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DesignResumeEndpoint.cs
@@ -1,0 +1,152 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.Design;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// Story 3.7 — in-process resume seam for the <c>design-proposal</c> workflow's human
+/// review gate. Mirrors <see cref="ClarifyResumeEndpoint"/> exactly.
+///
+/// <para>The gate (<see cref="WaitForDesignApprovalActivity"/>) suspends on the named
+/// bookmark <c>design-approval-{tenant}-{session}</c> (tenant folded in) and, on resume,
+/// reads <c>{Approved, Feedback}</c> from the workflow input. This endpoint looks the
+/// bookmark up by name, then runs the owning instance from that bookmark with the decision
+/// payload INJECTED as workflow input (<c>IWorkflowClient.RunInstanceAsync</c> with
+/// <c>RunWorkflowInstanceRequest.Input</c>, which lands in
+/// <c>ActivityExecutionContext.WorkflowInput</c> that the gate reads). The gate branches to
+/// its <c>Approved</c> or <c>Rejected</c> outcome off the injected <c>Approved</c> flag.</para>
+///
+/// <para>This lives in the engine process because <c>IBookmarkStore</c> /
+/// <c>IWorkflowRuntime</c> are in-process here. <c>Tamma.Api</c> exposes the RBAC-gated,
+/// tenant-scoped public surface (<c>POST /api/adl/design/resume</c>) and forwards to this
+/// engine endpoint.</para>
+///
+/// <para><b>SECURITY (mirrors the merge/deploy/clarify gate posture):</b>
+/// <list type="bullet">
+///   <item><description><b>No IDOR</b> — the bookmark name carries the tenant id that the
+///   (tenant-scoped) <c>Tamma.Api</c> caller supplies (derived server-side from the
+///   authenticated principal, never trusted from the client). A caller scoped to tenant A
+///   computes a name with tenant A, so it can NEVER resolve tenant B's gate: a cross-tenant
+///   attempt simply 404s (bookmark not found), it never acts. The session id is itself an
+///   unguessable 128-bit Guid, so within a tenant the name is unguessable too. This is
+///   table-free — Story 3.7 mints no design-proposal row (NON-MIGRATION) — yet strictly
+///   cross-tenant-safe, exactly like the merge gate.</description></item>
+///   <item><description><b>Collision refusal</b> — the name is globally unique (tenant +
+///   session); &gt;1 match is an integrity violation, so we REFUSE with 409 rather than
+///   resume an arbitrary <c>bookmarks[0]</c>.</description></item>
+///   <item><description><b>Engine-service-only</b> — the route is mapped with
+///   <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only the Tamma.Api→engine hop
+///   (presenting the Elsa admin API key) reaches it; anonymous public callers get 401. It is
+///   also excluded from the public nginx <c>/elsa/api/</c> block (internal hop only).
+///   </description></item>
+/// </list></para>
+/// </summary>
+public static class DesignResumeEndpoint
+{
+    public sealed record ResumeRequest(
+        Guid SessionId,
+        // Tenant scope — folded into the bookmark name so the lookup can only match a gate in
+        // the caller's own tenant. Supplied by the tenant-scoped Tamma.Api caller.
+        string? TenantId,
+        // The reviewer's decision: true = approve, false = reject.
+        bool Approved,
+        // The reviewer's feedback (optional; captured on the audit trail either way).
+        string? Feedback,
+        // Non-repudiation — the acting identity, derived server-side by Tamma.Api from the
+        // authenticated principal. Logged here for the audit trail; never trusted from a
+        // client (the public request record carries no reviewer field).
+        string? Reviewer);
+
+    /// <summary>Bookmark name the gate registers — delegates to the SINGLE canonical builder
+    /// shared with <see cref="WaitForDesignApprovalActivity"/> so suspend-side and resume-side
+    /// names match byte-for-byte.</summary>
+    public static string BookmarkName(ResumeRequest request)
+        => WaitForDesignApprovalActivity.ApprovalBookmarkName(request.TenantId, request.SessionId);
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.DesignResume");
+
+        if (request.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+
+        // The name carries the caller's tenant + session. A caller in tenant A produces a name
+        // keyed by tenant A and therefore can only ever resolve tenant A's gate.
+        var name = BookmarkName(request);
+
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended design bookmark {Bookmark} — gate not waiting (already decided/advanced, wrong session, wrong tenant, or timed out)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No design-proposal review is currently suspended for this session.",
+            });
+        }
+
+        // The name is unique per tenant+session; >1 match is an integrity violation, not a
+        // "pick the first" situation. REFUSE rather than resume an arbitrary instance.
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous design bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this design bookmark; refusing to resume an arbitrary one.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        // Inject the payload using the EXACT keys the suspend-side callback reads
+        // (WaitForDesignApprovalActivity.ReadDecision).
+        var input = new Dictionary<string, object>
+        {
+            ["Approved"] = request.Approved,
+            ["Feedback"] = request.Feedback ?? string.Empty,
+        };
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed design gate {Bookmark} (instance {InstanceId}) approved={Approved} by {Reviewer}",
+            name, bookmark.WorkflowInstanceId, request.Approved, request.Reviewer ?? "unknown");
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+            approved = request.Approved,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -427,6 +427,16 @@ app.MapPost("/elsa/api/adl/clarify/resume",
     Tamma.ElsaServer.Endpoints.ClarifyResumeEndpoint.Resume)
     .RequireAuthorization();
 
+// Story 3.7 — in-process resume seam for the design-proposal workflow's human review
+// gate. Tamma.Api's RBAC-gated, tenant-scoped POST /api/adl/design/resume forwards here;
+// this endpoint looks up the tenant+session-scoped design-approval-{tenant}-{session}
+// bookmark and runs the owning instance with the {Approved, Feedback} payload injected
+// (the gate branches Approved/Rejected off the flag). Same engine-control-surface /
+// RequireAuthorization rationale as the merge/deploy/blocker/clarify gates.
+app.MapPost("/elsa/api/adl/design/resume",
+    Tamma.ElsaServer.Endpoints.DesignResumeEndpoint.Resume)
+    .RequireAuthorization();
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs
@@ -1,0 +1,476 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using System.Text.Json;
+using Tamma.Activities;
+using Tamma.Activities.Design;
+using Tamma.Activities.Design.Models;
+using Tamma.Api.Services.Agents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 3.7 — Design Proposal sub-workflow. Given a complex requirement that needs a
+/// technical design it uses the LLM (via the MEDIATED <c>llm-call</c> path — the engine
+/// holds no LLM credential, TAMMA001) to generate a design PROPOSAL (summary + multiple
+/// alternatives with trade-off analysis + constraint evaluation), DELIVERS it to the issue,
+/// SUSPENDS on a bookmark awaiting a human approve/reject review decision, then RESUMES (via
+/// the secure <c>DesignResumeEndpoint</c>) and finalises — approved designs hand off to
+/// implementation, rejected designs capture the feedback.
+///
+/// Flow:
+///   1. Read inputs (issue/requirement + constraints + tenantId; mint a session id if none)
+///   2. Generate the design proposal via DispatchWorkflow("llm-call")
+///      role=architect / action=plan-system-design
+///   3. Deliver the proposal to the issue (mediated git seam) — emit DESIGN.PROPOSAL.DELIVERED
+///   4. Wait for the review decision (bookmark, durable SLA timeout)
+///   5a. On approve: emit DESIGN.PROPOSAL.APPROVED, set outputs (proceed to implementation)
+///   5b. On reject:  emit DESIGN.PROPOSAL.REJECTED (feedback captured), set outputs
+///   5c. On timeout: emit DESIGN.REVIEW.TIMED_OUT (LOUD), set outputs
+///
+/// Reuses the <see cref="ClarifyingQuestionsWorkflow"/> / <see cref="AssessmentWorkflow"/>
+/// skeleton (llm-call → deliver → bookmark-wait → resume, fail-closed gates + error
+/// terminal).
+///
+/// Fail-closed: if the generation <c>llm-call</c> returns success=false, or the JSON
+/// response cannot be parsed into a design with a load-bearing summary, the workflow emits a
+/// LOUD <c>DESIGN.PROPOSAL.FAILED</c> event and routes to the LlmCallError terminal — it
+/// NEVER proceeds with a fabricated design a reviewer would then approve. Prompt resolution
+/// is tenant→system→error (the <c>llm-call</c> registry never falls back to an empty/plain
+/// prompt).
+///
+/// DESIGN.* DCB events (AGGREGATE.ACTION.STATUS) are emitted at every transition so the
+/// design decision is fully auditable and feeds the Epic-32 learning loop (Story-3.7 AC
+/// "System tracks design decisions and maintains decision audit trail" + "Proposals are
+/// versioned and stored for future reference and learning").
+/// </summary>
+public class DesignProposalWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "DesignProposal";
+        builder.DefinitionId = "design-proposal";
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description = "Generate a reviewed technical design proposal for a complex requirement";
+
+        // ── Workflow variables ──────────────────────────────────────────
+        var sessionId    = builder.WithVariable<Guid>();
+        var issueId      = builder.WithVariable<string>();
+        var requirement  = builder.WithVariable<string>();
+        var repository   = builder.WithVariable<string>();
+        var issueNumber  = builder.WithVariable<int>();
+        var constraints  = builder.WithVariable<string>();
+        var conventions  = builder.WithVariable<string>();
+        var tenantId     = builder.WithVariable<string>("TenantId", "");
+
+        var proposalJson    = builder.WithVariable<string>();
+        var alternativeCount = builder.WithVariable<int>();
+        var feedback        = builder.WithVariable<string>();
+
+        // llm-call result container
+        var proposalLlm = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flag (fail-closed guard)
+        var proposalLlmOk = builder.WithVariable<bool>();
+
+        // Activity output capture
+        var deliveryResult = builder.WithVariable<DesignDeliveryResult>();
+        var waitApproved   = builder.WithVariable<bool>();
+        var waitFeedback   = builder.WithVariable<string>();
+        var waitTimedOut   = builder.WithVariable<bool>();
+        var proposalOutput = builder.WithVariable<DesignProposal>();
+
+        // Output variables (readable by a parent workflow)
+        var outputStatus       = builder.WithVariable<string>();
+        var outputProposalJson = builder.WithVariable<string>();
+        var outputApproved     = builder.WithVariable<bool>();
+
+        // ── Step 1: Read inputs ────────────────────────────────────────
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs",
+            Name = "Read Inputs",
+            Variable = sessionId,
+            Value = new(context =>
+            {
+                var sid = context.GetInput<Guid>("sessionId");
+                if (sid == Guid.Empty) sid = Guid.NewGuid();
+
+                issueId.Set(context, context.GetInput<string>("issueId") ?? string.Empty);
+                requirement.Set(context, context.GetInput<string>("requirement") ?? string.Empty);
+                repository.Set(context, context.GetInput<string>("repository") ?? string.Empty);
+                issueNumber.Set(context, context.GetInput<int>("issueNumber"));
+                constraints.Set(context, context.GetInput<string>("constraints") ?? string.Empty);
+                conventions.Set(context, context.GetInput<string>("conventions") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
+                return sid;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ── Step 2: Generate the design proposal via llm-call ──────────
+        var generateProposalLlm = new DispatchWorkflow
+        {
+            Id = "GenerateProposalLlm",
+            Name = "Generate Design Proposal (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["role"]     = AgentRole.Architect.ToWire(),
+                ["action"]   = AgentAction.PlanSystemDesign.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"]    = requirement.Get(ctx) ?? "",
+                    ["contextFindings"] = constraints.Get(ctx) ?? "",
+                    ["repository"]      = repository.Get(ctx) ?? "",
+                    ["conventions"]     = conventions.Get(ctx) ?? "",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(proposalLlm),
+        };
+        generateProposalLlm.SetDisplayText("Generate Design Proposal (LLM)");
+
+        // Parse llm-call response into a DesignProposal; set proposalLlmOk (fail-closed).
+        var parseProposal = new SetVariable
+        {
+            Id = "ParseProposal",
+            Name = "Parse Proposal",
+            Variable = proposalJson,
+            Value = new(ctx =>
+            {
+                var result = proposalLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    proposalLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var parsed = DesignParsing.ParseProposal(text);
+                if (parsed is null)
+                {
+                    // Fail-closed — no fabricated / empty design proposal.
+                    proposalLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                proposalLlmOk.Set(ctx, true);
+                proposalOutput.Set(ctx, parsed);
+                alternativeCount.Set(ctx, parsed.Alternatives.Count);
+                return JsonSerializer.Serialize(parsed);
+            })
+        };
+        parseProposal.SetDisplayText("Parse Proposal");
+
+        var proposalSuccessCheck = new FlowDecision(ctx => proposalLlmOk.Get(ctx))
+        { Id = "ProposalLlmOk", Name = "Proposal LLM OK?" };
+        proposalSuccessCheck.SetDisplayText("Proposal LLM OK?");
+
+        // ── Step 3: Emit GENERATED + deliver + emit DELIVERED ──────────
+        var emitProposalGenerated = new EmitDesignEventActivity
+        {
+            Id = "EmitProposalGenerated",
+            Name = "Emit Proposal Generated",
+            EventType = new(DesignEvents.ProposalGenerated),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            AlternativeCount = new(ctx => alternativeCount.Get(ctx)),
+        };
+        emitProposalGenerated.SetDisplayText("Emit Proposal Generated");
+
+        var deliverProposal = new DeliverDesignProposalActivity
+        {
+            Id = "DeliverDesignProposal",
+            Name = "Deliver Design Proposal",
+            SessionId = new(ctx => sessionId.Get(ctx)),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            Repository = new(ctx => repository.Get(ctx)),
+            IssueNumber = new(ctx => issueNumber.Get(ctx)),
+            ProposalJson = new(ctx => proposalJson.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Result = new(deliveryResult),
+        };
+        deliverProposal.SetDisplayText("Deliver Design Proposal");
+
+        var emitProposalDelivered = new EmitDesignEventActivity
+        {
+            Id = "EmitProposalDelivered",
+            Name = "Emit Proposal Delivered",
+            EventType = new(DesignEvents.ProposalDelivered),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Channel = new(ctx => deliveryResult.Get(ctx)?.Channel ?? "api"),
+            AlternativeCount = new(ctx => alternativeCount.Get(ctx)),
+        };
+        emitProposalDelivered.SetDisplayText("Emit Proposal Delivered");
+
+        // ── Step 4: Wait for the review decision (bookmark + durable SLA) ─
+        var waitForApproval = new WaitForDesignApprovalActivity
+        {
+            Id = "WaitForApproval",
+            Name = "Wait For Design Approval",
+            SessionId = new(ctx => sessionId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Approved = new(waitApproved),
+            Feedback = new(waitFeedback),
+            TimedOut = new(waitTimedOut),
+        };
+        waitForApproval.SetDisplayText("Wait For Design Approval");
+
+        // ── Step 5a: Approved path ─────────────────────────────────────
+        var storeApproved = new SetVariable
+        {
+            Id = "StoreApproved",
+            Name = "Store Approved",
+            Variable = feedback,
+            Value = new(ctx => waitFeedback.Get(ctx) ?? string.Empty)
+        };
+        storeApproved.SetDisplayText("Store Approved");
+
+        var emitProposalApproved = new EmitDesignEventActivity
+        {
+            Id = "EmitProposalApproved",
+            Name = "Emit Proposal Approved",
+            EventType = new(DesignEvents.ProposalApproved),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            AlternativeCount = new(ctx => alternativeCount.Get(ctx)),
+            Detail = new(ctx => feedback.Get(ctx)),
+        };
+        emitProposalApproved.SetDisplayText("Emit Proposal Approved");
+
+        var setApprovedResult = new SetVariable
+        {
+            Id = "SetApprovedResult",
+            Name = "Set Approved Result",
+            Variable = outputStatus,
+            Value = new(ctx =>
+            {
+                outputProposalJson.Set(ctx, proposalJson.Get(ctx) ?? "{}");
+                outputApproved.Set(ctx, true);
+                return "approved";
+            })
+        };
+        setApprovedResult.SetDisplayText("Set Approved Result");
+
+        var exposeApprovedOutput = new Sequence
+        {
+            Id = "ExposeApprovedOutput",
+            Name = "Expose Approved Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionIdApproved", Name = "Output Session Id (Approved)", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id (Approved)"),
+                WithLabel(new SetOutput { Id = "OutputStatusApproved", Name = "Output Status (Approved)", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status (Approved)"),
+                WithLabel(new SetOutput { Id = "OutputProposalApproved", Name = "Output Proposal (Approved)", OutputName = new("designProposal"), OutputValue = new(ctx => (object)(outputProposalJson.Get(ctx) ?? "{}")) }, "Output Proposal (Approved)"),
+                WithLabel(new SetOutput { Id = "OutputApprovedApproved", Name = "Output Approved (Approved)", OutputName = new("approved"), OutputValue = new(ctx => (object)outputApproved.Get(ctx)) }, "Output Approved (Approved)"),
+            }
+        };
+        exposeApprovedOutput.SetDisplayText("Expose Approved Output");
+
+        // ── Step 5b: Rejected path ─────────────────────────────────────
+        var storeRejected = new SetVariable
+        {
+            Id = "StoreRejected",
+            Name = "Store Rejected",
+            Variable = feedback,
+            Value = new(ctx => waitFeedback.Get(ctx) ?? string.Empty)
+        };
+        storeRejected.SetDisplayText("Store Rejected");
+
+        var emitProposalRejected = new EmitDesignEventActivity
+        {
+            Id = "EmitProposalRejected",
+            Name = "Emit Proposal Rejected",
+            EventType = new(DesignEvents.ProposalRejected),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            AlternativeCount = new(ctx => alternativeCount.Get(ctx)),
+            Detail = new(ctx => feedback.Get(ctx)),
+        };
+        emitProposalRejected.SetDisplayText("Emit Proposal Rejected");
+
+        var setRejectedResult = new SetVariable
+        {
+            Id = "SetRejectedResult",
+            Name = "Set Rejected Result",
+            Variable = outputStatus,
+            Value = new(ctx =>
+            {
+                outputProposalJson.Set(ctx, proposalJson.Get(ctx) ?? "{}");
+                outputApproved.Set(ctx, false);
+                return "rejected";
+            })
+        };
+        setRejectedResult.SetDisplayText("Set Rejected Result");
+
+        var exposeRejectedOutput = new Sequence
+        {
+            Id = "ExposeRejectedOutput",
+            Name = "Expose Rejected Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionIdRejected", Name = "Output Session Id (Rejected)", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id (Rejected)"),
+                WithLabel(new SetOutput { Id = "OutputStatusRejected", Name = "Output Status (Rejected)", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status (Rejected)"),
+                WithLabel(new SetOutput { Id = "OutputProposalRejected", Name = "Output Proposal (Rejected)", OutputName = new("designProposal"), OutputValue = new(ctx => (object)(outputProposalJson.Get(ctx) ?? "{}")) }, "Output Proposal (Rejected)"),
+                WithLabel(new SetOutput { Id = "OutputApprovedRejected", Name = "Output Approved (Rejected)", OutputName = new("approved"), OutputValue = new(ctx => (object)outputApproved.Get(ctx)) }, "Output Approved (Rejected)"),
+            }
+        };
+        exposeRejectedOutput.SetDisplayText("Expose Rejected Output");
+
+        // ── Step 5c: Timeout path ──────────────────────────────────────
+        var setTimeoutResult = new SetVariable
+        {
+            Id = "SetTimeoutResult",
+            Name = "Set Timeout Result",
+            Variable = outputStatus,
+            Value = new(ctx =>
+            {
+                outputProposalJson.Set(ctx, proposalJson.Get(ctx) ?? "{}");
+                outputApproved.Set(ctx, false);
+                return "timed_out";
+            })
+        };
+        setTimeoutResult.SetDisplayText("Set Timeout Result");
+
+        var emitReviewTimedOut = new EmitDesignEventActivity
+        {
+            Id = "EmitReviewTimedOut",
+            Name = "Emit Review Timed Out",
+            EventType = new(DesignEvents.ReviewTimedOut),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Design review SLA expired with no reviewer decision"),
+        };
+        emitReviewTimedOut.SetDisplayText("Emit Review Timed Out");
+
+        var exposeTimeoutOutput = new Sequence
+        {
+            Id = "ExposeTimeoutOutput",
+            Name = "Expose Timeout Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionIdTimeout", Name = "Output Session Id (Timeout)", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id (Timeout)"),
+                WithLabel(new SetOutput { Id = "OutputStatusTimeout", Name = "Output Status (Timeout)", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status (Timeout)"),
+                WithLabel(new SetOutput { Id = "OutputApprovedTimeout", Name = "Output Approved (Timeout)", OutputName = new("approved"), OutputValue = new(ctx => (object)outputApproved.Get(ctx)) }, "Output Approved (Timeout)"),
+            }
+        };
+        exposeTimeoutOutput.SetDisplayText("Expose Timeout Output");
+
+        // ── Fail-closed error terminal (LOUD event + Finish) ───────────
+        var emitProposalFailed = new EmitDesignEventActivity
+        {
+            Id = "EmitProposalFailed",
+            Name = "Emit Proposal Failed",
+            EventType = new(DesignEvents.ProposalFailed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for design-proposal generation failed or returned unparseable output"),
+        };
+        emitProposalFailed.SetDisplayText("Emit Proposal Failed");
+
+        var llmCallError = new Finish
+        {
+            Id = "LlmCallError",
+            Name = "LLM Call Error"
+        };
+        llmCallError.SetDisplayText("LLM Call Error");
+
+        // ── Build the flowchart ────────────────────────────────────────
+        builder.Root = new Flowchart
+        {
+            Id = "DesignProposalFlowchart",
+            Name = "Design Proposal Flowchart",
+            Activities =
+            {
+                readInputs,
+                generateProposalLlm,
+                parseProposal,
+                proposalSuccessCheck,
+                emitProposalGenerated,
+                deliverProposal,
+                emitProposalDelivered,
+                waitForApproval,
+
+                // Approved path
+                storeApproved,
+                emitProposalApproved,
+                setApprovedResult,
+                exposeApprovedOutput,
+
+                // Rejected path
+                storeRejected,
+                emitProposalRejected,
+                setRejectedResult,
+                exposeRejectedOutput,
+
+                // Timeout path
+                setTimeoutResult,
+                emitReviewTimedOut,
+                exposeTimeoutOutput,
+
+                // Fail-closed error terminal
+                emitProposalFailed,
+                llmCallError
+            },
+            Connections =
+            {
+                new(readInputs, generateProposalLlm),
+                new(generateProposalLlm, parseProposal),
+                new(parseProposal, proposalSuccessCheck),
+                new(new FlowEndpoint(proposalSuccessCheck, "True"),  new FlowEndpoint(emitProposalGenerated)),
+                new(new FlowEndpoint(proposalSuccessCheck, "False"), new FlowEndpoint(emitProposalFailed)),
+                new(emitProposalFailed, llmCallError),
+
+                new(emitProposalGenerated, deliverProposal),
+                new(deliverProposal, emitProposalDelivered),
+                new(emitProposalDelivered, waitForApproval),
+
+                // Approved path
+                new(new FlowEndpoint(waitForApproval, "Approved"), new FlowEndpoint(storeApproved)),
+                new(storeApproved, emitProposalApproved),
+                new(emitProposalApproved, setApprovedResult),
+                new(setApprovedResult, exposeApprovedOutput),
+
+                // Rejected path
+                new(new FlowEndpoint(waitForApproval, "Rejected"), new FlowEndpoint(storeRejected)),
+                new(storeRejected, emitProposalRejected),
+                new(emitProposalRejected, setRejectedResult),
+                new(setRejectedResult, exposeRejectedOutput),
+
+                // Timeout path
+                new(new FlowEndpoint(waitForApproval, "Timeout"), new FlowEndpoint(setTimeoutResult)),
+                new(setTimeoutResult, emitReviewTimedOut),
+                new(emitReviewTimedOut, exposeTimeoutOutput)
+            }
+        };
+    }
+
+    /// <summary>
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary. Returns
+    /// <c>false</c> if the dictionary is null, the key is absent, or the value is falsy —
+    /// fail-closed by design. Uses the tolerant <see cref="ResumeInput.AsBool"/> read (boxed
+    /// bool / string / JsonElement).
+    /// </summary>
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return ResumeInput.AsBool(s);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Design/DesignResumeReadBackTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Design/DesignResumeReadBackTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Design;
+
+namespace Tamma.Activities.Tests.Design;
+
+/// <summary>
+/// Story 3.7 — the design workflow's resume callback must read its control-flow boolean
+/// (<c>Approved</c>) tolerant of a SERIALIZING workflow runtime (the #15/#437 lesson): the
+/// in-process runtime keeps the resumed value a boxed <see cref="bool"/>, but a distributed
+/// dispatcher round-trips it to a <see cref="string"/> or a <see cref="JsonElement"/>. A bare
+/// <c>is true</c> pattern only matches the boxed-bool path — under serialization a rejection
+/// would silently be read as an approval, returning HTTP 200 while advancing the WRONG branch.
+/// These tests also cover the fail-closed <see cref="DesignParsing"/> helper, the canonical
+/// bookmark-name builder (suspend/resume parity + tenant folding), and the DESIGN.* event
+/// status mapping.
+/// </summary>
+[TestFixture]
+public class DesignResumeReadBackTests
+{
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    private static IDictionary<string, object> Input(params (string Key, object Value)[] entries)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
+    }
+
+    // ── ReadDecision — Approved coercion tolerant of serialization ─────────
+
+    [Test]
+    public void ReadDecision_BoxedBoolTrue_ReachesApproved()
+    {
+        var (approved, feedback) = WaitForDesignApprovalActivity.ReadDecision(
+            Input(("Approved", true), ("Feedback", "ship it")));
+        approved.Should().BeTrue();
+        feedback.Should().Be("ship it");
+    }
+
+    [Test]
+    public void ReadDecision_StringTrue_ReachesApproved()
+    {
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", "true"))).Approved.Should().BeTrue();
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", "True"))).Approved.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadDecision_JsonElementTrue_ReachesApproved()
+    {
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", JsonBool(true)))).Approved.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadDecision_FalseRepresentations_ReachRejected()
+    {
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", false))).Approved.Should().BeFalse();
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", "false"))).Approved.Should().BeFalse();
+        WaitForDesignApprovalActivity.ReadDecision(Input(("Approved", JsonBool(false)))).Approved.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadDecision_MissingKey_ReachesRejected_FailClosed()
+    {
+        var (approved, feedback) = WaitForDesignApprovalActivity.ReadDecision(Input(("Feedback", "n/a")));
+        approved.Should().BeFalse("a missing Approved flag must fail closed to a rejection, never a false approval");
+        feedback.Should().Be("n/a");
+    }
+
+    // ── Canonical bookmark name — suspend/resume parity + tenant folding ───
+
+    [Test]
+    public void ApprovalBookmarkName_IsDeterministic_AndFoldsTenant()
+    {
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+
+        var a1 = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenantA, session);
+        var a2 = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenantA, session);
+        var b1 = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenantB, session);
+
+        a1.Should().Be(a2, "the builder must be deterministic so suspend + resume names match byte-for-byte");
+        a1.Should().StartWith("design-approval-");
+        a1.Should().Contain(session.ToString());
+        a1.Should().NotBe(b1,
+            "folding the tenant into the name is the IDOR guard — a different tenant yields a " +
+            "different bookmark so a cross-tenant resume can never resolve this gate");
+    }
+
+    [Test]
+    public void ApprovalBookmarkName_NullTenant_UsesStablePlaceholder()
+    {
+        var session = Guid.NewGuid();
+        WaitForDesignApprovalActivity.ApprovalBookmarkName(null, session)
+            .Should().Be($"design-approval-none-{session}");
+    }
+
+    // ── DesignParsing.ParseProposal — tolerant + fail-closed ───────────────
+
+    [Test]
+    public void ParseProposal_FullObject_Parses()
+    {
+        var proposal = DesignParsing.ParseProposal(
+            "Here you go: {\"summary\":\"Event-sourced ledger\"," +
+            "\"alternatives\":[{\"name\":\"CQRS\",\"tradeoffs\":\"more moving parts\"}," +
+            "{\"name\":\"CRUD\",\"tradeoffs\":\"simpler, weaker audit\"}]," +
+            "\"recommendation\":\"CQRS\",\"constraintEvaluation\":\"meets SOC2\"} done");
+
+        proposal.Should().NotBeNull();
+        proposal!.Summary.Should().Be("Event-sourced ledger");
+        proposal.Alternatives.Should().HaveCount(2);
+        proposal.Alternatives[0].Name.Should().Be("CQRS");
+        proposal.Recommendation.Should().Be("CQRS");
+        proposal.ConstraintEvaluation.Should().Be("meets SOC2");
+    }
+
+    [Test]
+    public void ParseProposal_StringAlternatives_Parses()
+    {
+        var proposal = DesignParsing.ParseProposal(
+            "{\"summary\":\"S\",\"alternatives\":[\"Option A\",\"Option B\"]}");
+        proposal.Should().NotBeNull();
+        proposal!.Alternatives.Select(a => a.Name).Should().Equal("Option A", "Option B");
+    }
+
+    [Test]
+    public void ParseProposal_MissingSummary_IsNull_FailClosed()
+    {
+        DesignParsing.ParseProposal("{\"recommendation\":\"do X\"}").Should().BeNull();
+        DesignParsing.ParseProposal("{\"summary\":\"\"}").Should().BeNull();
+        DesignParsing.ParseProposal("not json").Should().BeNull();
+        DesignParsing.ParseProposal("").Should().BeNull();
+        DesignParsing.ParseProposal(null).Should().BeNull();
+    }
+
+    // ── DesignEvents.StatusForEvent — LOUD terminals are error rows ────────
+
+    [Test]
+    public void StatusForEvent_FailedAndTimedOut_AreErrorRows()
+    {
+        DesignEvents.StatusForEvent(DesignEvents.ProposalFailed).Should().Be("error");
+        DesignEvents.StatusForEvent(DesignEvents.ReviewTimedOut).Should().Be("error");
+    }
+
+    [Test]
+    public void StatusForEvent_NormalTransitions_AreSuccessRows()
+    {
+        DesignEvents.StatusForEvent(DesignEvents.ProposalGenerated).Should().Be("success");
+        DesignEvents.StatusForEvent(DesignEvents.ProposalDelivered).Should().Be("success");
+        DesignEvents.StatusForEvent(DesignEvents.ProposalApproved).Should().Be("success");
+        DesignEvents.StatusForEvent(DesignEvents.ProposalRejected).Should().Be("success",
+            "a rejection is a legitimate human decision, not an error");
+    }
+
+    // ── EmitDesignEventActivity.BuildTammaEvent — tag/data mapping ─────────
+
+    [Test]
+    public void BuildTammaEvent_MapsTagsAndStatus()
+    {
+        var tenant = Guid.NewGuid();
+        var evt = EmitDesignEventActivity.BuildTammaEvent(
+            DesignEvents.ProposalApproved, "sess-1", "issue-9", tenant, channel: null,
+            alternativeCount: 3, detail: "approved with nits", reviewer: "alice@x.test");
+
+        evt.EventType.Should().Be(DesignEvents.ProposalApproved);
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags!["issueId"].Should().Be("issue-9");
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+        evt.Data["alternativeCount"].Should().Be(3);
+        evt.Data["reviewer"].Should().Be("alice@x.test");
+    }
+
+    [Test]
+    public void BuildTammaEvent_FailedIsLoudErrorRow()
+    {
+        var evt = EmitDesignEventActivity.BuildTammaEvent(
+            DesignEvents.ProposalFailed, "sess-1", "issue-9", tenantId: null, channel: null,
+            alternativeCount: 0, detail: "llm-call failed", reviewer: null);
+
+        evt.Status.Should().Be("error", "a generation failure must be a LOUD error row, never a false success");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DesignResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DesignResumeEndpointTests.cs
@@ -1,0 +1,167 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Design;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// Story 3.7 — the engine-side design resume seam (<c>POST /elsa/api/adl/design/resume</c>).
+/// Verifies it:
+///   - computes the SAME tenant+session-scoped bookmark name as the suspend-side activity
+///     (<c>design-approval-{tenant}-{session}</c>) and resumes the matching (single) instance
+///     with the EXACT input keys the callback reads (<c>Approved</c> + <c>Feedback</c>);
+///   - is IDOR-safe: a caller scoped to a DIFFERENT tenant computes a different name and 404s
+///     (never resolves the victim's gate);
+///   - REFUSES with 409 when more than one instance matches a (unique) name rather than
+///     resuming an arbitrary <c>bookmarks[0]</c>;
+///   - 404s when no bookmark matches (already decided / advanced / timed out);
+///   - injects <c>Approved=false</c> on a reject decision (the gate branches off the flag);
+///   - 400s a malformed request (empty session).
+/// </summary>
+[TestFixture]
+public class DesignResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static DesignResumeEndpoint.ResumeRequest Req(
+        Guid session, string? tenant, bool approved = true, string? feedback = "looks good") =>
+        new(session, tenant, approved, feedback, Reviewer: "who@x.test");
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    private Task<IResult> Invoke(DesignResumeEndpoint.ResumeRequest req)
+        => DesignResumeEndpoint.Resume(
+            req, _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Test]
+    public async Task Resume_ValidApprove_UsesCanonicalBookmarkName_InjectsApprovedAndFeedback_ResumesMatch()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenant, session);
+        SetupFind(expected, Bookmark(expected, "wf-d1"));
+
+        var result = await Invoke(Req(session, tenant, approved: true, feedback: "ship it"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (bool)r.Input!["Approved"] == true
+                && (string)r.Input!["Feedback"] == "ship it"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _runtime.Verify(r => r.CreateClientAsync("wf-d1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_ValidReject_InjectsApprovedFalse()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenant, session);
+        SetupFind(expected, Bookmark(expected, "wf-d2"));
+
+        var result = await Invoke(Req(session, tenant, approved: false, feedback: "revise the data model"));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (bool)r.Input!["Approved"] == false
+                && (string)r.Input!["Feedback"] == "revise the data model"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_CrossTenant_DifferentName_Returns404_NeverResumes()
+    {
+        // IDOR — the gate was armed under tenant A. A caller scoped to tenant B computes a
+        // DIFFERENT bookmark name, so the store returns zero matches for B's name; the victim's
+        // (A's) gate is never touched. We arm ONLY tenant A's name and resume as tenant B.
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+        var nameA = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenantA, session);
+        var nameB = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenantB, session);
+        SetupFind(nameA, Bookmark(nameA, "wf-victim")); // A's gate is live
+        SetupFind(nameB /* zero matches for B */);
+
+        var result = await Invoke(Req(session, tenantB));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant caller computes a different bookmark name and must 404, never resolving the victim's gate");
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Resume_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenant, session);
+        SetupFind(name /* zero matches */);
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "a miss must never resume any instance");
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForDesignApprovalActivity.ApprovalBookmarkName(tenant, session);
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptySession_Returns400()
+    {
+        var result = await Invoke(Req(Guid.Empty, Guid.NewGuid().ToString()));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DesignProposalWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DesignProposalWorkflowStructureTests.cs
@@ -1,0 +1,145 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Design;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 3.7 — structural verification for <see cref="DesignProposalWorkflow"/>.
+///
+/// Asserts the workflow:
+/// 1. Builds and has DefinitionId "design-proposal".
+/// 2. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts
+///    (resolution is tenant→system→error — never empty/plain) for role=architect /
+///    action=plan-system-design.
+/// 3. Generates the design proposal via <c>DispatchWorkflow("llm-call")</c> (mediated —
+///    the engine holds no LLM credential, TAMMA001) rather than any in-engine provider call.
+/// 4. Delivers the proposal to the reviewer via <see cref="DeliverDesignProposalActivity"/>.
+/// 5. Suspends on the <see cref="WaitForDesignApprovalActivity"/> bookmark awaiting the
+///    human review decision (approval gate).
+/// 6. Is fail-closed: an <c>LlmCallError</c> terminal exists and a <c>FlowDecision</c> gate
+///    checks LLM-call success before proceeding (never a fabricated design).
+/// 7. Emits the required DESIGN.* DCB events (generated / delivered / approved / rejected /
+///    failed / review timed out) via <see cref="EmitDesignEventActivity"/> nodes.
+/// </summary>
+[TestFixture]
+public class DesignProposalWorkflowStructureTests
+{
+    private static Flowchart Flowchart()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DesignProposalWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithoutError()
+    {
+        var act = () => WorkflowTestHelper.BuildWorkflow(new DesignProposalWorkflow());
+        act.Should().NotThrow("DesignProposalWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void Workflow_HasCorrectDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DesignProposalWorkflow());
+        builder.Object.DefinitionId.Should().Be("design-proposal");
+    }
+
+    [Test]
+    public void Workflow_ThreadsTenantId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DesignProposalWorkflow());
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "the workflow must thread TenantId so llm-call resolves tenant-scoped prompts " +
+                "(tenant→system→error) for architect/plan-system-design");
+    }
+
+    [Test]
+    public void Workflow_DispatchesLlmCallForProposalGeneration()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "GenerateProposalLlm",
+                "the design proposal must be generated via the mediated llm-call (engine holds no LLM credential)");
+    }
+
+    [Test]
+    public void Workflow_DeliversProposal()
+    {
+        Flowchart().Activities
+            .OfType<DeliverDesignProposalActivity>()
+            .Should().ContainSingle(a => a.Id == "DeliverDesignProposal",
+                "the workflow must deliver the design proposal to the reviewer");
+    }
+
+    [Test]
+    public void Workflow_SuspendsOnApprovalBookmark()
+    {
+        Flowchart().Activities
+            .OfType<WaitForDesignApprovalActivity>()
+            .Should().ContainSingle(a => a.Id == "WaitForApproval",
+                "the workflow must suspend on the WaitForDesignApprovalActivity bookmark " +
+                "awaiting the human review decision");
+    }
+
+    [Test]
+    public void Workflow_HasFailClosedErrorTerminal()
+    {
+        Flowchart().Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "LlmCallError",
+                "a fail-closed LlmCallError terminal must exist — an LLM-call failure routes there, " +
+                "never proceeding with a fabricated design");
+    }
+
+    [Test]
+    public void Workflow_HasSuccessGateForGeneration()
+    {
+        Flowchart().Activities.OfType<FlowDecision>().Select(d => d.Id)
+            .Should().Contain("ProposalLlmOk",
+                "proposal delivery must be gated behind a ProposalLlmOk decision (fail-closed)");
+    }
+
+    [Test]
+    public void Workflow_EmitsRequiredDesignEvents()
+    {
+        var emitIds = Flowchart().Activities
+            .OfType<EmitDesignEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitProposalGenerated",
+            "must emit DESIGN.PROPOSAL.GENERATED when the proposal is produced");
+        emitIds.Should().Contain("EmitProposalDelivered",
+            "must emit DESIGN.PROPOSAL.DELIVERED when the proposal is delivered");
+        emitIds.Should().Contain("EmitProposalApproved",
+            "must emit DESIGN.PROPOSAL.APPROVED when the reviewer approves");
+        emitIds.Should().Contain("EmitProposalRejected",
+            "must emit DESIGN.PROPOSAL.REJECTED when the reviewer rejects");
+        emitIds.Should().Contain("EmitProposalFailed",
+            "must emit a LOUD DESIGN.PROPOSAL.FAILED on the fail-closed path");
+        emitIds.Should().Contain("EmitReviewTimedOut",
+            "must emit a LOUD DESIGN.REVIEW.TIMED_OUT when the review SLA expires");
+    }
+
+    [Test]
+    public void Workflow_ApprovalGate_HasApprovedRejectedTimeoutBranches()
+    {
+        var flow = Flowchart();
+
+        var outcomes = flow.Connections
+            .Where(c => c.Source.Activity.Id == "WaitForApproval")
+            .Select(c => c.Source.Port)
+            .ToList();
+
+        outcomes.Should().Contain("Approved", "the gate must branch on an approve decision");
+        outcomes.Should().Contain("Rejected", "the gate must branch on a reject decision");
+        outcomes.Should().Contain("Timeout", "the gate must branch on the durable review-SLA timeout");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/DesignResumeApiTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/DesignResumeApiTests.cs
@@ -1,0 +1,177 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// Story 3.7 — the RBAC-gated design resume surface (<c>POST /api/adl/design/resume</c>).
+/// Verifies the handler:
+///   - forwards a well-formed approve/reject to the engine with the caller's AMBIENT tenant id
+///     so the engine can only resolve THIS tenant's gate (IDOR guard via tenant-in-bookmark-name);
+///   - maps "approve"/"reject" to the boolean the engine expects and validates the decision;
+///   - derives the reviewer from the authenticated principal (a client-supplied reviewer is
+///     impossible — the request type carries none);
+///   - validates the session + decision and rejects junk with 400 before forwarding;
+///   - maps a "no gate waiting" engine response (incl. a cross-tenant miss) to 404.
+///
+/// The route group applies <c>WorkflowsManage</c> (tenant owner/admin; member SaaS callers hit
+/// 403 at the policy) — the same posture as the merge/deploy/clarify resume routes.
+/// </summary>
+[TestFixture]
+public class DesignResumeApiTests
+{
+    private Mock<IElsaWorkflowService> _elsa = null!;
+    private readonly NullLoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    [SetUp]
+    public void SetUp() => _elsa = new Mock<IElsaWorkflowService>();
+
+    private static ITenantContext TenantContext(Guid? tenantId)
+    {
+        var ctx = new Mock<ITenantContext>();
+        ctx.SetupGet(c => c.TenantId).Returns(tenantId);
+        return ctx.Object;
+    }
+
+    private static ClaimsPrincipal Principal(string email)
+        => new(new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Email, email) }, "test"));
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Test]
+    public async Task ResumeDesign_ValidApprove_ForwardsAmbientTenantApprovedTrueAndDerivedReviewer_Returns200()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDesignApprovalAsync(
+                session, tenant.ToString(), true, "ship it", "alice@example.com"))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-d1"));
+
+        var req = new AdlEndpoints.DesignReviewRequest(session, "approve", "ship it");
+
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(tenant), Principal("alice@example.com"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _elsa.Verify(s => s.ResumeDesignApprovalAsync(
+            session, tenant.ToString(), true, "ship it", "alice@example.com"), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeDesign_ValidReject_ForwardsApprovedFalse()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDesignApprovalAsync(
+                session, tenant.ToString(), false, "revise", It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-d2"));
+
+        var req = new AdlEndpoints.DesignReviewRequest(session, "reject", "revise");
+
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(tenant), Principal("bob@corp.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _elsa.Verify(s => s.ResumeDesignApprovalAsync(
+            session, tenant.ToString(), false, "revise", It.IsAny<string?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeDesign_ReviewerDerivedFromPrincipal_NotForgeable()
+    {
+        var tenant = Guid.NewGuid();
+        string? capturedReviewer = null;
+        _elsa
+            .Setup(s => s.ResumeDesignApprovalAsync(
+                It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, bool, string?, string?>((_, _, _, _, reviewer) => capturedReviewer = reviewer)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-9"));
+
+        var req = new AdlEndpoints.DesignReviewRequest(Guid.NewGuid(), "approve", null);
+
+        await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(tenant), Principal("bob@corp.test"), _loggerFactory);
+
+        capturedReviewer.Should().Be("bob@corp.test",
+            "the reviewer must be derived from the authenticated principal for non-repudiation");
+    }
+
+    [Test]
+    public async Task ResumeDesign_CrossTenantGate_Returns404_NeverActs()
+    {
+        // The victim's gate lives under a different bookmark name (keyed by the victim's tenant),
+        // so the engine reports GateNotFound for the caller's ambient tenant. The handler must
+        // surface 404 and forward the CALLER's tenant id, never the victim's.
+        var callerTenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDesignApprovalAsync(
+                session, callerTenant.ToString(), true, It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.DesignReviewRequest(session, "approve", "sneaky");
+
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(callerTenant), Principal("attacker@evil.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant resume must be a not-found, never an action on the victim's gate");
+        _elsa.Verify(s => s.ResumeDesignApprovalAsync(
+            session, callerTenant.ToString(), true, It.IsAny<string?>(), It.IsAny<string?>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ResumeDesign_GateNotWaiting_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDesignApprovalAsync(
+                session, It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new AdlEndpoints.DesignReviewRequest(session, "approve", null);
+
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(tenant), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task ResumeDesign_EmptySession_Returns400_NoForward()
+    {
+        var req = new AdlEndpoints.DesignReviewRequest(Guid.Empty, "approve", null);
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeDesignApprovalAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("maybe")]
+    public async Task ResumeDesign_InvalidDecision_Returns400_NoForward(string decision)
+    {
+        var req = new AdlEndpoints.DesignReviewRequest(Guid.NewGuid(), decision, null);
+        var result = await AdlEndpoints.ResumeDesign(
+            req, _elsa.Object, TenantContext(Guid.NewGuid()), Principal("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeDesignApprovalAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<bool>(), It.IsAny<string?>(), It.IsAny<string?>()), Times.Never);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
@@ -176,5 +176,7 @@ public sealed class RotationTriggerServiceTests
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
         public Task<MergeApprovalResumeResult> ResumeClarifyingQuestionsAsync(Guid sid, string? t, string answers, string? resolver) =>
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+        public Task<MergeApprovalResumeResult> ResumeDesignApprovalAsync(Guid sid, string? t, bool approved, string? feedback, string? reviewer) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
     }
 }


### PR DESCRIPTION
## What

Story 3.7 — `DesignProposalWorkflow` (`design-proposal`) on the Assessment/3.5 skeleton: generate a design proposal (mediated LLM, role `architect`/action `plan-system-design` — the existing PlanGeneration pair, resolves to the system Plan template) → deliver to the issue → suspend on a human review bookmark → resume (Approved / Rejected / Timeout). `DESIGN.PROPOSAL.GENERATED/DELIVERED/APPROVED/REJECTED` + loud `DESIGN.PROPOSAL.FAILED` / `DESIGN.REVIEW.TIMED_OUT`.

- **Secure resume** (`AdlEndpoints.ResumeDesign` → engine `DesignResumeEndpoint`) mirrors 3.5 exactly: `WorkflowsManage` (member 403); one canonical `ApprovalBookmarkName` builder on suspend+resume; tenant **server-derived** + folded into the bookmark name → cross-tenant = 404; 0→404 / >1→409; reviewer non-forgeable; `Approved` read via tolerant `ResumeInput.AsBool` (a rejection can't be mis-read as approval under serialization).
- **Mediated LLM** + mediated git delivery (TAMMA001 clean). **Non-migration** (DCB events + workflow state; both `has-pending-model-changes` "No changes"). No workflow-registration Program.cs line (assembly sweep) — only 2 additive `adl` design/resume routes.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Tests: Activities 134 (33 design incl. approval-gate branches) + Api 64 (9 DesignResume: cross-tenant→404, 0→404/>1→409, approve/reject injection, tolerant read, I2 reviewer). No ACs deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)