### PR TITLE
feat(epic-3-4): add research action + template — ResearchWorkflow emits real findings

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
@@ -239,6 +239,10 @@ public static class SystemPrompts
         AgentAction.GenerateAssessmentQuestions => GenerateAssessmentQuestionsBody,
         AgentAction.AnalyzeAssessmentResponse => AnalyzeAssessmentResponseBody,
 
+        // ── research (Story 3.4 — real per-cell body producing the ranked-findings JSON
+        //    ResearchParsing recovers; NOT a transitional family) ──
+        AgentAction.Research => ResearchBody,
+
         // ── summarize / documentation / write-ups → Summarize ──
         AgentAction.SummarizeStakeholder => Summarize,
         AgentAction.SummarizeTechnical => Summarize,
@@ -251,8 +255,8 @@ public static class SystemPrompts
         AgentAction.WriteRunbook => Summarize,
         AgentAction.UpdateChangelog => Summarize,
 
-        // Exhaustive over the 72-token AgentAction enum. A newly-added token with
-        // no arm here is a hard failure rather than a silent default — keeps the
+        // Exhaustive over the AgentAction enum. A newly-added token with no arm
+        // here is a hard failure rather than a silent default — keeps the
         // transitional mapping honest until 27-16 replaces it.
         _ => throw new TammaError(
             "PROMPT.SEED.NO_BODY_FAMILY",
@@ -716,6 +720,77 @@ public static class SystemPrompts
         Variables: ["storyContext", "questions", "response", "skillLevel"],
         EnableTools: false,
         MaxTokens: 2048);
+
+    // -----------------------------------------------------------------------
+    // Research-specific body builder (Story 3.4)
+    //
+    // Purpose-written for the ResearchWorkflow llm-call dispatch
+    // (Tamma.ElsaServer/Workflows/ResearchWorkflow.cs). It synthesises the
+    // codebase / prior-art context already gathered by the context-gathering
+    // sub-workflow into a RANKED, confidence-scored research report and returns
+    // the EXACT JSON object ResearchParsing.ParseReport recovers:
+    //   { "topic", "summary", "findings":[{ "title","summary","relevance",
+    //     "confidence","citations":[...] }], "overallConfidence" }
+    // The parser fails closed on a missing summary or zero usable findings, so the
+    // template is explicit that both are load-bearing (resolution is
+    // tenant→system→error — this body is never empty/plain).
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Prompt for <c>(product_owner, research)</c>: investigate the given work item
+    /// using the gathered context and emit a ranked, confidence-scored research
+    /// report as the structured JSON <see cref="Tamma.Activities.Research.ResearchParsing"/>
+    /// parses. Variables: <c>workItemJson</c> (the topic / issue under investigation)
+    /// and <c>findings</c> (the codebase / prior-art context from context-gathering).
+    /// </summary>
+    private static PromptTemplate ResearchBody(string role, string action) => new(
+        Role: role,
+        Action: action,
+        Template:
+            "You are a {{role}} investigating a work item to produce a ranked, " +
+            "confidence-scored research report for the engineering team.\n\n" +
+            "## Work Item / Topic\n{{workItemJson}}\n\n" +
+            "## Gathered Context (codebase / prior art)\n{{findings}}\n\n" +
+            "## Conventions\n{{conventions}}\n\n" +
+            "## Instructions\n\n" +
+            "<thinking>\n" +
+            "1. Identify the concrete question(s) the work item raises that research must answer\n" +
+            "2. Mine the gathered context for evidence — relevant files, existing patterns, prior decisions, gaps\n" +
+            "3. Distil each piece of evidence into a discrete finding: what was learned and why it matters\n" +
+            "4. Score each finding for RELEVANCE (how directly it bears on the topic) and CONFIDENCE " +
+            "(how well the gathered context supports it), each a decimal in [0,1]\n" +
+            "5. Attach citations (file paths, URLs, or doc references from the context) that back each finding\n" +
+            "6. Rank findings most-relevant-first, then compute an overall confidence across them\n" +
+            "</thinking>\n\n" +
+            "Base every finding on the gathered context — do NOT invent findings or citations that the " +
+            "context does not support. If the context is thin, return only the findings it genuinely supports.\n\n" +
+            "Return ONLY a single JSON object (no markdown fences, no prose outside it) of this EXACT shape:\n" +
+            "```json\n" +
+            "{\n" +
+            "  \"topic\": \"the question / topic investigated\",\n" +
+            "  \"summary\": \"1-3 sentence overview of what the research concluded\",\n" +
+            "  \"findings\": [\n" +
+            "    {\n" +
+            "      \"title\": \"short headline for the finding\",\n" +
+            "      \"summary\": \"what was learned and why it matters\",\n" +
+            "      \"relevance\": 0.0,\n" +
+            "      \"confidence\": 0.0,\n" +
+            "      \"citations\": [\"path/to/file.cs\", \"https://...\"]\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"overallConfidence\": 0.0\n" +
+            "}\n" +
+            "```\n\n" +
+            "Requirements (the downstream parser fails closed if these are not met):\n" +
+            "- `summary` MUST be a non-empty overview — it is load-bearing.\n" +
+            "- `findings` MUST contain at least one real finding, each with a non-empty `title` or `summary`.\n" +
+            "- `relevance` and `confidence` are decimals between 0.0 and 1.0.\n" +
+            "- Order `findings` by `relevance` descending, then `confidence` descending.\n" +
+            "- `overallConfidence` is a decimal in [0,1] reflecting confidence across the findings.",
+        SystemPrompt: SystemFor(role),
+        Variables: ["role", "workItemJson", "findings", "conventions"],
+        EnableTools: false,
+        MaxTokens: 4096);
 
     // -----------------------------------------------------------------------
     // Role-specific review lenses (inlined in plan-review / code-review bodies)

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
@@ -30,6 +30,7 @@ public enum AgentAction
     [Wire("review-scope")] ReviewScope,
     [Wire("generate-assessment-questions")] GenerateAssessmentQuestions,
     [Wire("analyze-assessment-response")] AnalyzeAssessmentResponse,
+    [Wire("research")] Research,
 
     // architect
     [Wire("triage-technical")] TriageTechnical,

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
@@ -56,7 +56,8 @@ public static class RolePhaseMap
                 AgentAction.ReviewAcceptance,
                 AgentAction.ReviewScope,
                 AgentAction.GenerateAssessmentQuestions,
-                AgentAction.AnalyzeAssessmentResponse),
+                AgentAction.AnalyzeAssessmentResponse,
+                AgentAction.Research),
 
             // architect — system design, technical strategy
             [AgentRole.Architect] = FreezeSet(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
@@ -30,7 +30,7 @@ namespace Tamma.ElsaServer.Workflows;
 ///      (Story 7-1F multi-role scan) — same reuse as <see cref="AssessmentWorkflow"/>
 ///   4. Emit RESEARCH.CONTEXT_GATHERED
 ///   5. Synthesize a ranked research report via DispatchWorkflow("llm-call")
-///      role=product_owner / action=summarize-stakeholder
+///      role=product_owner / action=research
 ///   6. Parse the synthesis fail-closed (empty/unparseable → error terminal)
 ///   7a. On success: emit RESEARCH.COMPLETED, set outputs (report, confidence, findings)
 ///   7b. On failure: emit RESEARCH.FAILED (LOUD) and route to the ResearchError terminal
@@ -46,13 +46,13 @@ namespace Tamma.ElsaServer.Workflows;
 /// proceeds with a fabricated report. Prompt resolution is tenant→system→error (the
 /// <c>llm-call</c> registry never falls back to an empty/plain prompt).
 ///
-/// NOTE (taxonomy): Tamma's action taxonomy has no dedicated <c>research</c>/<c>investigate</c>
-/// action (the legacy TS <c>researcher</c> role maps onto <c>product_owner</c> in
-/// <c>RolePhaseMap.LegacyRoleAliases</c>). The synthesis therefore dispatches the closest
-/// eligible pair, <c>product_owner</c> / <c>summarize-stakeholder</c>, so the workflow is
-/// taxonomy-drift-clean and prompt resolution works. A future story that adds a dedicated
-/// research action + a structured-findings prompt template (a cross-cutting taxonomy change)
-/// only needs to swap the action constant below.
+/// NOTE (taxonomy): the synthesis dispatches the dedicated <c>(product_owner, research)</c>
+/// pair (Story 3.4). The <c>research</c> action is a first-class member of the
+/// <see cref="AgentAction"/> taxonomy and is eligible for <c>product_owner</c> in
+/// <c>RolePhaseMap</c> (consistent with the legacy TS <c>researcher</c> role aliasing onto
+/// <c>product_owner</c>). Its system-default prompt template (<c>SystemPrompts.ResearchBody</c>)
+/// emits the ranked-findings JSON <see cref="ResearchParsing"/> parses, so the happy path
+/// produces a real <c>RESEARCH.COMPLETED</c> report rather than failing closed.
 /// </summary>
 public class ResearchWorkflow : WorkflowBase
 {
@@ -182,16 +182,16 @@ public class ResearchWorkflow : WorkflowBase
             WorkflowDefinitionId = new("llm-call"),
             Input = new(ctx => new Dictionary<string, object>
             {
-                // No dedicated research action exists; product_owner/summarize-stakeholder
-                // is the closest eligible pair (see class remarks). tenant→system→error.
+                // Dedicated research action (Story 3.4): (product_owner, research) resolves the
+                // structured-findings prompt template that yields the ranked-findings JSON
+                // ResearchParsing recovers. Prompt resolution is tenant→system→error.
                 ["role"]     = AgentRole.ProductOwner.ToWire(),
-                ["action"]   = AgentAction.SummarizeStakeholder.ToWire(),
+                ["action"]   = AgentAction.Research.ToWire(),
                 ["tenantId"] = tenantId.Get(ctx),
                 ["variables"] = new Dictionary<string, object>
                 {
                     ["workItemJson"] = BuildWorkItem(topic.Get(ctx), workItemJson.Get(ctx), issueId.Get(ctx)),
                     ["findings"]     = researchContext.Get(ctx) ?? "",
-                    ["audience"]     = "engineering-team",
                 },
                 ["enableTools"] = false,
             }),

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/ResearchParsingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Research/ResearchParsingTests.cs
@@ -99,6 +99,40 @@ public class ResearchParsingTests
             "empty-shell findings (no title and no summary) must be dropped, not admitted blank");
     }
 
+    /// <summary>
+    /// A sample matching the EXACT shape the (product_owner, research) system-default
+    /// prompt template (SystemPrompts.ResearchBody, Story 3.4) instructs the LLM to
+    /// emit. Proves the template's documented output is parseable end-to-end, so the
+    /// ResearchWorkflow happy path emits a real RESEARCH.COMPLETED report.
+    /// </summary>
+    private const string TemplateShapedReport =
+        """
+        {
+          "topic": "per-tenant rate limiting",
+          "summary": "No rate limiter exists; requests are unbounded per tenant. A token-bucket middleware keyed by tenant id is the lowest-risk introduction.",
+          "findings": [
+            { "title": "No existing limiter", "summary": "The API pipeline has no rate-limiting middleware today.", "relevance": 0.95, "confidence": 0.9, "citations": ["src/Tamma.Api/Program.cs"] },
+            { "title": "Tenant id already on context", "summary": "Every request already resolves a tenant id that a limiter can key on.", "relevance": 0.8, "confidence": 0.85, "citations": ["src/Tamma.Api/Auth/TenantContext.cs"] }
+          ],
+          "overallConfidence": 0.88
+        }
+        """;
+
+    [Test]
+    public void ParseReport_TemplateShapedOutput_RecoversRankedReport()
+    {
+        var report = ResearchParsing.ParseReport(TemplateShapedReport, topic: "fallback");
+
+        report.Should().NotBeNull(
+            "the (product_owner, research) template's documented JSON shape must parse into a real report");
+        report!.Topic.Should().Be("per-tenant rate limiting");
+        report.Summary.Should().NotBeNullOrWhiteSpace();
+        report.Findings.Should().HaveCount(2);
+        report.OverallConfidence.Should().Be(0.88m);
+        report.Findings[0].Title.Should().Be("No existing limiter", "ranked by relevance descending");
+        report.Findings[0].Citations.Should().Contain("src/Tamma.Api/Program.cs");
+    }
+
     // ── Fail-closed cases (all → null) ─────────────────────────────────
     [TestCase(null)]
     [TestCase("")]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -112,6 +112,7 @@ public class TaxonomyDriftBuildTests
         "PlanGenerationWorkflow",
         "PlanReviewWorkflow",
         "PullRequestWorkflow",
+        "ResearchWorkflow",             // Story 3.4: dispatches the dedicated (product_owner, research) synthesis pair
         "ReviewFixWorkflow",
         "TaskCreationWorkflow",
         "TaskReviewWorkflow",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
@@ -25,13 +25,15 @@ public class AgentActionTests
     public void Has_the_expected_token_count()
     {
         // 72 original + 2 assessment actions (generate-assessment-questions,
-        // analyze-assessment-response) added in assessment P0.
-        Enum.GetValues<AgentAction>().Length.Should().Be(74);
+        // analyze-assessment-response) added in assessment P0 + 1 research action
+        // (Story 3.4 — dedicated research/investigate token under product_owner).
+        Enum.GetValues<AgentAction>().Length.Should().Be(75);
     }
 
     [TestCase("context-scan", AgentAction.ContextScan)]
     [TestCase("implement-feature", AgentAction.ImplementFeature)]
     [TestCase("code-review-security", AgentAction.CodeReviewSecurity)]
+    [TestCase("research", AgentAction.Research)]
     public void Parse_resolves_canonical_wire(string wire, AgentAction expected)
     {
         AgentActionExtensions.Parse(wire).Should().Be(expected);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
@@ -11,9 +11,10 @@ namespace Tamma.Api.Tests.Agents;
 /// The 8 roles: developer, tester, security, devops, architect, product_owner,
 /// senior_developer, tech_writer.
 ///
-/// The 74 actions are the union of the per-role action sets in SPEC §4
+/// The 75 actions are the union of the per-role action sets in SPEC §4
 /// (72 original + 2 assessment actions: generate-assessment-questions,
-/// analyze-assessment-response under product_owner — added in assessment P0).
+/// analyze-assessment-response under product_owner — added in assessment P0 —
+/// + 1 research action under product_owner, Story 3.4).
 /// Which (role, action) pairs are valid is the per-role eligibility matrix.
 /// </summary>
 [TestFixture]
@@ -41,11 +42,12 @@ public class RolePhaseMapTests
     }
 
     [Test]
-    public void ValidActions_Should_Contain_Seventy_Four_Actions()
+    public void ValidActions_Should_Contain_Seventy_Five_Actions()
     {
         // 72 original actions + 2 assessment actions added in assessment P0
-        // (generate-assessment-questions, analyze-assessment-response under product_owner).
-        RolePhaseMap.ValidActions.Should().HaveCount(74);
+        // (generate-assessment-questions, analyze-assessment-response under product_owner)
+        // + 1 research action (Story 3.4 — dedicated research token under product_owner).
+        RolePhaseMap.ValidActions.Should().HaveCount(75);
     }
 
     [Test]
@@ -340,6 +342,39 @@ public class RolePhaseMapTests
         RolePhaseMap.ValidActions.Should().Contain("review-testability");
         RolePhaseMap.ValidActions.Should().Contain("review-operability");
         RolePhaseMap.ValidActions.Should().Contain("review-scope");
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 3.4 — dedicated research action (product_owner-eligible)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void ValidActions_Contains_Research()
+    {
+        RolePhaseMap.ValidActions.Should().Contain("research");
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_Research_ProductOwner_Returns_True()
+    {
+        // The legacy 'researcher' role aliases onto product_owner, so the dedicated
+        // research action is eligible for product_owner (Story 3.4 — ResearchWorkflow
+        // dispatches (product_owner, research)).
+        RolePhaseMap.IsRoleEligibleForPhase("research", "product_owner").Should().BeTrue();
+    }
+
+    [Test]
+    public void GetEligibleRolesForPhase_Research_Is_ProductOwner_Only()
+    {
+        RolePhaseMap.GetEligibleRolesForPhase("research")
+            .Should().BeEquivalentTo(new[] { "product_owner" });
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_Research_Developer_Returns_False()
+    {
+        // research is a product_owner-only action; a developer must not be eligible.
+        RolePhaseMap.IsRoleEligibleForPhase("research", "developer").Should().BeFalse();
     }
 
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
@@ -202,6 +202,47 @@ public class SystemPromptsTests
     }
 
     // ------------------------------------------------------------------
+    // Story 3.4 — the research cell under product_owner. The ResearchWorkflow
+    // dispatches (product_owner, research); resolution is tenant→system→error, so
+    // the system default MUST be a real, non-empty body that instructs the exact
+    // ranked-findings JSON schema ResearchParsing.ParseReport recovers.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void ResearchAction_ExistsInTaxonomy_ProductOwner()
+    {
+        var research = SystemPrompts.GetRoleAction("product_owner", "research");
+
+        research.Should().NotBeNull(
+            "research must be in product_owner's RolePhaseMap action set with a non-empty " +
+            "SystemPrompts template (Story 3.4 taxonomy)");
+
+        research!.Template.Should().NotBeNullOrWhiteSpace(
+            "research template must not be empty (resolution is tenant→system→error)");
+
+        research.Variables.Should().Contain("workItemJson")
+            .And.Contain("findings",
+                "research must declare the variables ResearchWorkflow passes in the llm-call dispatch");
+    }
+
+    [Test]
+    public void ResearchAction_Template_DocumentsTheParserSchema()
+    {
+        // The body must instruct the EXACT JSON keys ResearchParsing.ParseReport reads:
+        // summary + findings[] {title, summary, relevance, confidence, citations} + overallConfidence.
+        var research = SystemPrompts.GetRoleAction("product_owner", "research");
+
+        research.Should().NotBeNull();
+        var body = research!.Template;
+        body.Should().Contain("\"summary\"");
+        body.Should().Contain("\"findings\"");
+        body.Should().Contain("\"relevance\"");
+        body.Should().Contain("\"confidence\"");
+        body.Should().Contain("\"citations\"");
+        body.Should().Contain("\"overallConfidence\"");
+    }
+
+    // ------------------------------------------------------------------
     // Audit prompts/001 — role-tailored review-lens shape is retained on the
     // review-family cells. The PlanReview body is used by the per-role
     // plan-review lens actions; CodeReview by the code-review lens actions.


### PR DESCRIPTION
## What

Completes Story 3.4 — adds the dedicated `research` action so `ResearchWorkflow` produces real ranked findings instead of failing loud on a borrowed action.

- **Taxonomy (74→75), 3 coupled source places** (the rest derive automatically from `RolePhaseMap.EligibleActions`): `AgentAction.cs` (`[Wire("research")] Research`), `RolePhaseMap.cs` (`research` eligible for `product_owner`, mirroring the legacy `researcher` alias), `SystemPrompts.cs` (`ResearchBody` template + exhaustive-switch case).
- **`ResearchBody` template** matches `ResearchParsing`'s schema exactly (`{topic, summary, findings[{title,summary,relevance,confidence,citations}], overallConfidence}`), states the parser's fail-closed invariants, and forbids fabricating findings/citations.
- **`ResearchWorkflow`** dispatch swapped `product_owner/summarize-stakeholder` → `product_owner/research` (structure untouched → structure test stays green).

## Verification

- Build 0 errors, no TAMMA001. **Non-migration** — taxonomy + system defaults are code; both `has-pending-model-changes` → "No changes" (`prompt_overrides` table untouched). Tests: Api 225 + Activities 39 (count asserts 74→75, new eligibility/coverage/parse tests, TaxonomyDrift accepts the new `(product_owner, research)` pair — the drift keysets stay set-equal). No new `AgentRole` needed (still 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)