### PR TITLE
feat(epic-3-6): ambiguity scoring workflow (+score-ambiguity action, AMBIGUITY.* events)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityEvents.cs
@@ -1,0 +1,77 @@
+namespace Tamma.Activities.Ambiguity;
+
+/// <summary>
+/// Story 3.6 (Ambiguity Scoring) — central catalogue of the <c>AMBIGUITY.*</c> DCB event
+/// types emitted by the <c>ambiguity-scoring</c> sub-workflow via
+/// <see cref="EmitAmbiguityEventActivity"/>. Type pattern follows the platform's
+/// <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors the sibling event
+/// catalogues (<see cref="Tamma.Activities.Research.ResearchEvents"/>,
+/// <see cref="Tamma.Activities.Clarify.ClarifyEvents"/>).
+///
+/// <para>The scoring workflow quantifies how ambiguous / underspecified a requirement is
+/// (a 0..1 score + a typed, itemised breakdown) by asking the LLM via the mediated
+/// <c>llm-call</c> path — the engine holds no LLM credential. The score is then compared to a
+/// caller-supplied threshold: above it, the requirement is routed to the sibling
+/// <c>ClarifyingQuestionsWorkflow</c> (Story 3.5) before implementation proceeds; below it, the
+/// requirement proceeds as-is. Each transition — start, scored, and the threshold DECISION —
+/// is an auditable step so time-travel debugging and the Epic-32 learning loop can reconstruct
+/// WHAT was scored, HOW ambiguous it was, and WHETHER clarification was triggered (Story 3.6
+/// ACs). Without these events the scoring decision is invisible to the audit trail.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern the sibling
+/// catalogues use. No activity holds a DB / repository dependency of its own; the drain
+/// resolves the tenant from the workflow scope and each event carries a <c>tenantId</c> tag so
+/// per-tenant data stays tenant-scoped.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>AMBIGUITY.STARTED</c> — the scorer began analysing the
+///     requirement.</description></item>
+///   <item><description><c>AMBIGUITY.SCORED</c> — terminal success: the LLM returned a valid
+///     score + rationale; the assessment is recorded.</description></item>
+///   <item><description><c>AMBIGUITY.CLARIFICATION_TRIGGERED</c> — threshold DECISION: the score
+///     met/exceeded the threshold, so clarification is triggered before proceeding (AC6).</description></item>
+///   <item><description><c>AMBIGUITY.BELOW_THRESHOLD</c> — threshold DECISION: the score was
+///     below the threshold, so the requirement proceeds as-is (no clarification).</description></item>
+///   <item><description><c>AMBIGUITY.FAILED</c> — LOUD (error-status): the scoring
+///     <c>llm-call</c> failed or returned unparseable / out-of-range output; the workflow fails
+///     closed rather than emitting a fabricated score.</description></item>
+/// </list>
+/// </summary>
+public static class AmbiguityEvents
+{
+    public const string Started = "AMBIGUITY.STARTED";
+    public const string Scored = "AMBIGUITY.SCORED";
+
+    // Threshold-decision transitions (AC6). Both are normal (success-status) audit rows —
+    // the decision itself is not an error; only a failed scoring is.
+    public const string ClarificationTriggered = "AMBIGUITY.CLARIFICATION_TRIGGERED";
+    public const string BelowThreshold = "AMBIGUITY.BELOW_THRESHOLD";
+
+    // LOUD (error-status) terminal — a fabricated / degraded score must never be recorded as a
+    // false success.
+    public const string Failed = "AMBIGUITY.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs.
+    /// Returns <c>null</c> for empty / single-user / unparseable values (ambiguity events in
+    /// single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Research.ResearchEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed scoring is a LOUD (error-status) audit row; the start
+    /// transition is an informational (started) row; every other transition (scored + both
+    /// threshold decisions) is a normal (success-status) row. Keeps a degraded terminal from
+    /// ever being recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        Failed => "error",
+        Started => "started",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityParsing.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityParsing.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using Tamma.Activities.Ambiguity.Models;
+
+namespace Tamma.Activities.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — pure, context-free parser that recovers the structured
+/// <see cref="AmbiguityAssessment"/> from a mediated <c>llm-call</c> scoring response. Kept
+/// side-effect-free (no Elsa context) so the fail-closed behaviour is unit-testable without a
+/// live LLM. Mirrors the JSON-slice approach in <c>ResearchParsing</c> / <c>ClarifyParsing</c>
+/// / <c>AssessmentWorkflow</c>.
+///
+/// <para>The parser is <b>fail-closed</b>: an empty response, a response with no JSON object, a
+/// response whose <c>score</c> is missing / non-numeric / outside [0,1], or a response with no
+/// non-empty <c>rationale</c> all yield <c>null</c>. The workflow routes a <c>null</c> parse to
+/// its <c>AMBIGUITY.FAILED</c> error terminal — it NEVER fabricates a score, a rationale, or an
+/// ambiguity item the downstream would act on. A <b>valid</b> assessment with an empty
+/// <c>ambiguities</c> list is legitimate (a genuinely clear requirement scored near 0), so an
+/// empty breakdown is NOT a failure.</para>
+/// </summary>
+public static class AmbiguityParsing
+{
+    /// <summary>
+    /// Extract the ambiguity assessment from an <c>llm-call</c> text response. Expects a JSON
+    /// object of the shape
+    /// <c>{"score":0.72,"confidence":0.8,"rationale":"...","ambiguities":[{"type":"vague",
+    /// "description":"...","severity":"high","recommendation":"..."}]}</c>.
+    ///
+    /// <para>The <c>score</c> and <c>rationale</c> are load-bearing: the score is the whole
+    /// point of the workflow, and a score with no rationale is not auditable/actionable.
+    /// Ambiguity item <c>type</c> / <c>severity</c> labels are normalised onto the canonical
+    /// buckets (<see cref="AmbiguityTypes"/> / <see cref="AmbiguitySeverities"/>); items with
+    /// no <c>description</c> are dropped as empty shells (item-level fail-closed) but do not
+    /// fail the whole parse.</para>
+    ///
+    /// <para>Returns <c>null</c> (fail-closed) when the text is empty, carries no JSON object,
+    /// has a missing / non-numeric / out-of-range <c>score</c>, or has no non-empty
+    /// <c>rationale</c>.</para>
+    /// </summary>
+    /// <param name="llmText">The raw LLM scoring response.</param>
+    public static AmbiguityAssessment? ParseAssessment(string? llmText)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return null;
+
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart < 0 || objEnd <= objStart)
+            return null;
+
+        try
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+
+            // Fail-closed: the score is the whole point — it must be a number in [0,1].
+            if (!element.TryGetProperty("score", out var sv) || sv.ValueKind != JsonValueKind.Number)
+                return null;
+
+            var score = (decimal)sv.GetDouble();
+            if (score < 0m || score > 1m)
+                return null;
+
+            var rationale = ReadString(element, "rationale");
+
+            // Fail-closed: a score with no rationale is not auditable/actionable.
+            if (string.IsNullOrWhiteSpace(rationale))
+                return null;
+
+            var confidence = element.TryGetProperty("confidence", out var cv) && cv.ValueKind == JsonValueKind.Number
+                ? ClampConfidence((decimal)cv.GetDouble())
+                : 0m;
+
+            return new AmbiguityAssessment
+            {
+                Score = score,
+                Rationale = rationale,
+                Confidence = confidence,
+                Ambiguities = ParseAmbiguities(element),
+            };
+        }
+        catch
+        {
+            // Malformed JSON → fail closed.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Recover the itemised ambiguity breakdown. Each item must carry a non-empty
+    /// <c>description</c> — empty shells are dropped. Type / severity labels are normalised
+    /// onto the canonical buckets.
+    /// </summary>
+    private static List<AmbiguityItem> ParseAmbiguities(JsonElement element)
+    {
+        if (!element.TryGetProperty("ambiguities", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<AmbiguityItem>();
+
+        var items = new List<AmbiguityItem>();
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var description = ReadString(item, "description");
+
+            // An item with no description is an empty shell — skip it rather than admit a
+            // fabricated blank ambiguity.
+            if (string.IsNullOrWhiteSpace(description))
+                continue;
+
+            items.Add(new AmbiguityItem
+            {
+                Type = AmbiguityTypes.Normalize(ReadString(item, "type")),
+                Description = description,
+                Severity = AmbiguitySeverities.Normalize(ReadString(item, "severity")),
+                Recommendation = ReadString(item, "recommendation"),
+            });
+        }
+
+        return items;
+    }
+
+    private static string ReadString(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static decimal ClampConfidence(decimal value)
+        => value < 0m ? 0m : value > 1m ? 1m : value;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityThresholds.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/AmbiguityThresholds.cs
@@ -1,0 +1,39 @@
+namespace Tamma.Activities.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — the threshold policy that turns a quantitative ambiguity score into a routing
+/// DECISION (Story 3.6 AC6 — "ambiguity thresholds trigger appropriate workflows"). Pure and
+/// side-effect-free so the decision boundary is unit-testable without a live LLM. The
+/// <c>AmbiguityScoringWorkflow</c> reads a caller-supplied threshold, clamps it, and routes
+/// score ≥ threshold to the sibling <c>ClarifyingQuestionsWorkflow</c> (Story 3.5) before
+/// implementation proceeds.
+/// </summary>
+public static class AmbiguityThresholds
+{
+    /// <summary>
+    /// Default clarify threshold used when the caller supplies none (or a non-positive value).
+    /// A score at or above this routes the requirement to clarification. 0.5 is the neutral
+    /// midpoint — a requirement judged more ambiguous than clear gets clarified first.
+    /// </summary>
+    public const decimal DefaultClarify = 0.5m;
+
+    /// <summary>
+    /// Resolve the effective threshold: a positive caller value (clamped to [0,1]) wins;
+    /// anything ≤ 0 (i.e. "not supplied") falls back to <see cref="DefaultClarify"/>. A
+    /// threshold of exactly 0 is rejected as "unset" because it would make every requirement —
+    /// including a perfectly clear one scored 0 — trigger clarification, which is never useful.
+    /// </summary>
+    public static decimal Resolve(decimal requested)
+        => requested <= 0m ? DefaultClarify : Clamp01(requested);
+
+    /// <summary>
+    /// The routing decision: <c>true</c> ⇒ score met/exceeded the threshold ⇒ trigger
+    /// clarification; <c>false</c> ⇒ below threshold ⇒ proceed as-is.
+    /// </summary>
+    public static bool ShouldClarify(decimal score, decimal threshold)
+        => score >= threshold;
+
+    /// <summary>Clamp a value into [0,1]. Pure.</summary>
+    public static decimal Clamp01(decimal value)
+        => value < 0m ? 0m : value > 1m ? 1m : value;
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/EmitAmbiguityEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/EmitAmbiguityEventActivity.cs
@@ -1,0 +1,135 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — emits an <c>AMBIGUITY.*</c> DCB event for the <c>ambiguity-scoring</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c>
+/// transient list via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list <i>durably</i> to
+/// the tenant <c>domain_events</c> store — the same pattern
+/// <see cref="Tamma.Activities.Research.EmitResearchEventActivity"/> and
+/// <see cref="Tamma.Activities.Clarify.EmitClarifyEventActivity"/> use. No activity holds a
+/// DB / repository dependency of its own (none is registered in the Elsa engine — a directly
+/// injected repository would be inert and silently drop every event).
+/// </summary>
+[Activity(
+    "Tamma.Ambiguity",
+    "Emit Ambiguity Event",
+    "Emit an AMBIGUITY.* DCB event for the ambiguity-scoring workflow audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitAmbiguityEventActivity : Activity
+{
+    private readonly ILogger<EmitAmbiguityEventActivity>? _logger;
+
+    [Input(Description = "Event type — AMBIGUITY.STARTED / .SCORED / .CLARIFICATION_TRIGGERED / .BELOW_THRESHOLD / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Scoring session id (unguessable Guid string)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id being scored")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Ambiguity score (0..1); null when not yet computed (started / failed)")]
+    public Input<double?> Score { get; set; } = new((double?)null);
+
+    [Input(Description = "Number of itemised ambiguities detected")]
+    public Input<int> AmbiguityCount { get; set; } = new(0);
+
+    [Input(Description = "Scorer confidence (0..1) in the assessment")]
+    public Input<double> Confidence { get; set; } = new(0d);
+
+    [Input(Description = "Clarify threshold (0..1) the score was compared against (decision events)")]
+    public Input<double> Threshold { get; set; } = new(0d);
+
+    [Input(Description = "Free-text detail for the audit payload")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitAmbiguityEventActivity() { }
+
+    public EmitAmbiguityEventActivity(ILogger<EmitAmbiguityEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? AmbiguityEvents.Failed;
+        var sessionId = SessionId.Get(context);
+        var issueId = IssueId.Get(context);
+        var tenantId = AmbiguityEvents.ParseTenantId(TenantId.Get(context));
+        var score = Score.Get(context);
+        var ambiguityCount = AmbiguityCount.Get(context);
+        var confidence = Confidence.Get(context);
+        var threshold = Threshold.Get(context);
+        var detail = Detail.Get(context);
+
+        var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, score, ambiguityCount, confidence, threshold, detail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for ambiguity session {Session} issue {Issue} (score={Score})",
+            type, sessionId, issueId, score);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the ambiguity event inputs onto a <see cref="TammaEvent"/> expressed as the engine's
+    /// transient-list event so the merged drain persists it. Tags carry the queryable DCB index
+    /// keys (<c>sessionId</c>/<c>issueId</c>/<c>tenantId</c>); <c>Data</c> carries the
+    /// per-transition payload (<c>score</c>/<c>ambiguityCount</c>/<c>confidence</c>/
+    /// <c>threshold</c>/<c>detail</c>). Status is driven off the event type
+    /// (<see cref="AmbiguityEvents.StatusForEvent"/>) so a failed terminal is a LOUD error row,
+    /// never a false success.
+    ///
+    /// <para><c>score</c> is a NULLABLE input so a genuine score of <c>0.0</c> (a perfectly
+    /// clear requirement) is still recorded, while a not-yet-computed score (started / failed)
+    /// is omitted — a plain <c>&gt; 0</c> guard could not tell those apart.</para>
+    ///
+    /// Pure (no Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? issueId,
+        Guid? tenantId,
+        double? score,
+        int ambiguityCount,
+        double confidence,
+        double threshold,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (score is not null) data["score"] = score.Value;
+        if (ambiguityCount > 0) data["ambiguityCount"] = ambiguityCount;
+        if (confidence > 0d) data["confidence"] = confidence;
+        if (threshold > 0d) data["threshold"] = threshold;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = AmbiguityEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/Models/AmbiguityModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/Models/AmbiguityModels.cs
@@ -1,0 +1,142 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.Ambiguity.Models;
+
+/// <summary>
+/// Story 3.6 — the canonical ambiguity <b>types</b> the scorer classifies a requirement's
+/// problems into (Story 3.6 AC2 — "identifies different types of ambiguity (vague, missing,
+/// contradictory, implicit)"). Kept as a small closed set so a drifting LLM label
+/// (<c>"unclear"</c>, <c>"Vague."</c>) is normalised onto a known bucket rather than leaking
+/// an arbitrary string downstream. An unrecognised / empty label normalises to
+/// <see cref="Unspecified"/> — the item is still kept (its description carries the signal),
+/// it is just not force-fit into a specific bucket.
+/// </summary>
+public static class AmbiguityTypes
+{
+    public const string Vague = "vague";
+    public const string Missing = "missing";
+    public const string Contradictory = "contradictory";
+    public const string Implicit = "implicit";
+    public const string Unspecified = "unspecified";
+
+    private static readonly IReadOnlySet<string> Canonical = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Vague, Missing, Contradictory, Implicit,
+    };
+
+    /// <summary>
+    /// Normalise a raw LLM type label onto the canonical set: trimmed + lower-cased, with a
+    /// couple of common synonyms folded in. Anything unrecognised → <see cref="Unspecified"/>.
+    /// Pure; exposed for unit testing.
+    /// </summary>
+    public static string Normalize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return Unspecified;
+
+        var t = raw.Trim().TrimEnd('.').ToLowerInvariant();
+        if (Canonical.Contains(t)) return t;
+
+        return t switch
+        {
+            "unclear" or "ambiguous" or "imprecise" => Vague,
+            "incomplete" or "underspecified" or "absent" => Missing,
+            "conflicting" or "contradiction" or "inconsistent" => Contradictory,
+            "assumed" or "implied" or "unstated" => Implicit,
+            _ => Unspecified,
+        };
+    }
+}
+
+/// <summary>
+/// Story 3.6 — the canonical severity buckets for a single detected ambiguity. Normalised the
+/// same way as <see cref="AmbiguityTypes"/> so a drifting label folds onto a known bucket;
+/// an unrecognised / empty label defaults to <see cref="Medium"/> (a neutral middle, never
+/// silently dropped).
+/// </summary>
+public static class AmbiguitySeverities
+{
+    public const string Low = "low";
+    public const string Medium = "medium";
+    public const string High = "high";
+
+    private static readonly IReadOnlySet<string> Canonical = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Low, Medium, High,
+    };
+
+    /// <summary>Normalise a raw severity label; unrecognised → <see cref="Medium"/>. Pure.</summary>
+    public static string Normalize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return Medium;
+
+        var s = raw.Trim().TrimEnd('.').ToLowerInvariant();
+        if (Canonical.Contains(s)) return s;
+
+        return s switch
+        {
+            "critical" or "blocker" or "severe" => High,
+            "minor" or "trivial" or "info" => Low,
+            _ => Medium,
+        };
+    }
+}
+
+/// <summary>
+/// Story 3.6 — one detected ambiguity within a requirement: its classified
+/// <see cref="Type"/> (Story 3.6 AC2), a human-readable <see cref="Description"/> of what is
+/// unclear, a <see cref="Severity"/>, and a specific <see cref="Recommendation"/> for
+/// resolving it (Story 3.6 AC4 — "detailed ambiguity breakdown with specific
+/// recommendations"). Parsed defensively by <see cref="AmbiguityParsing.ParseAssessment"/>;
+/// items with no description are dropped as empty shells rather than admitted blank.
+/// </summary>
+public sealed class AmbiguityItem
+{
+    /// <summary>The ambiguity type — one of the <see cref="AmbiguityTypes"/> buckets.</summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = AmbiguityTypes.Unspecified;
+
+    /// <summary>What is unclear / missing / contradictory / implicit about the requirement.</summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Severity — one of the <see cref="AmbiguitySeverities"/> buckets.</summary>
+    [JsonPropertyName("severity")]
+    public string Severity { get; set; } = AmbiguitySeverities.Medium;
+
+    /// <summary>A specific recommendation for resolving this ambiguity (AC4).</summary>
+    [JsonPropertyName("recommendation")]
+    public string Recommendation { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Story 3.6 — the structured ambiguity assessment for a requirement: a quantitative
+/// <see cref="Score"/> in [0,1] (Story 3.6 AC1 — higher = more ambiguous / underspecified),
+/// a <see cref="Rationale"/> explaining the score, the scorer's <see cref="Confidence"/>, and
+/// the itemised <see cref="Ambiguities"/> breakdown. Serialised into the workflow's
+/// <c>assessmentJson</c> output and carried onto the <c>AMBIGUITY.SCORED</c> DCB event so the
+/// score and its reasons are fully auditable and feed the Epic-32 learning loop.
+///
+/// <para>A high score above the caller's threshold routes the requirement to the sibling
+/// <c>ClarifyingQuestionsWorkflow</c> (Story 3.5) before implementation proceeds (Story 3.6
+/// AC6 — "ambiguity thresholds trigger appropriate workflows"). The parser fails closed on a
+/// missing / out-of-range score or a missing rationale, so a fabricated score is never acted
+/// on.</para>
+/// </summary>
+public sealed class AmbiguityAssessment
+{
+    /// <summary>Overall ambiguity score in [0,1]; higher = more ambiguous / underspecified.</summary>
+    [JsonPropertyName("score")]
+    public decimal Score { get; set; }
+
+    /// <summary>Overview rationale explaining the score — load-bearing (fail-closed if empty).</summary>
+    [JsonPropertyName("rationale")]
+    public string Rationale { get; set; } = string.Empty;
+
+    /// <summary>The scorer's confidence in the assessment, in [0,1].</summary>
+    [JsonPropertyName("confidence")]
+    public decimal Confidence { get; set; }
+
+    /// <summary>The itemised ambiguity breakdown (may be empty for a genuinely clear requirement).</summary>
+    [JsonPropertyName("ambiguities")]
+    public List<AmbiguityItem> Ambiguities { get; set; } = new();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
@@ -243,6 +243,10 @@ public static class SystemPrompts
         //    ResearchParsing recovers; NOT a transitional family) ──
         AgentAction.Research => ResearchBody,
 
+        // ── score-ambiguity (Story 3.6 — real per-cell body producing the structured score
+        //    JSON AmbiguityParsing recovers; NOT a transitional family) ──
+        AgentAction.ScoreAmbiguity => ScoreAmbiguityBody,
+
         // ── summarize / documentation / write-ups → Summarize ──
         AgentAction.SummarizeStakeholder => Summarize,
         AgentAction.SummarizeTechnical => Summarize,
@@ -791,6 +795,81 @@ public static class SystemPrompts
         Variables: ["role", "workItemJson", "findings", "conventions"],
         EnableTools: false,
         MaxTokens: 4096);
+
+    // -----------------------------------------------------------------------
+    // Ambiguity-scoring body builder (Story 3.6)
+    //
+    // Purpose-written for the AmbiguityScoringWorkflow llm-call dispatch
+    // (Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs). It scores how
+    // ambiguous / underspecified a requirement is and returns the EXACT JSON object
+    // AmbiguityParsing.ParseAssessment recovers:
+    //   { "score", "confidence", "rationale", "ambiguities":[{ "type","description",
+    //     "severity","recommendation" }] }
+    // The parser fails closed on a missing / out-of-range score or a missing
+    // rationale, so the template is explicit that both are load-bearing (resolution
+    // is tenant→system→error — this body is never empty/plain).
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Prompt for <c>(product_owner, score-ambiguity)</c>: score how ambiguous /
+    /// underspecified the given requirement is and emit a structured assessment as the JSON
+    /// <see cref="Tamma.Activities.Ambiguity.AmbiguityParsing"/> parses. Variables:
+    /// <c>workItemJson</c> (the requirement under assessment) and <c>contextFindings</c>
+    /// (any domain / codebase context that informs the scoring).
+    /// </summary>
+    private static PromptTemplate ScoreAmbiguityBody(string role, string action) => new(
+        Role: role,
+        Action: action,
+        Template:
+            "You are a {{role}} scoring how ambiguous or underspecified a requirement is, so the " +
+            "team can decide whether to ask clarifying questions before implementation begins.\n\n" +
+            "## Requirement / Work Item\n{{workItemJson}}\n\n" +
+            "## Context (domain / codebase / prior decisions)\n{{contextFindings}}\n\n" +
+            "## Conventions\n{{conventions}}\n\n" +
+            "## Instructions\n\n" +
+            "<thinking>\n" +
+            "1. Read the requirement and identify every place where it is unclear, incomplete, " +
+            "self-contradictory, or relies on unstated assumptions\n" +
+            "2. Classify each problem by TYPE: `vague` (imprecise wording), `missing` (required " +
+            "information absent), `contradictory` (conflicting statements), or `implicit` (unstated " +
+            "assumptions / constraints)\n" +
+            "3. Weigh each problem by how much it would impact development if left unresolved " +
+            "(severity: `low` / `medium` / `high`), considering the context above\n" +
+            "4. For each problem, write a specific, actionable recommendation for resolving it\n" +
+            "5. Aggregate into a single overall ambiguity SCORE in [0,1] — 0.0 = crystal clear and " +
+            "fully specified, 1.0 = so ambiguous it cannot be implemented as written\n" +
+            "6. State your confidence in the assessment\n" +
+            "</thinking>\n\n" +
+            "Base the assessment on the requirement and context provided — do NOT invent problems " +
+            "that are not there. A genuinely clear requirement should score near 0 with an empty " +
+            "`ambiguities` list; do not manufacture ambiguities to justify a higher score.\n\n" +
+            "Return ONLY a single JSON object (no markdown fences, no prose outside it) of this EXACT shape:\n" +
+            "```json\n" +
+            "{\n" +
+            "  \"score\": 0.0,\n" +
+            "  \"confidence\": 0.0,\n" +
+            "  \"rationale\": \"1-3 sentence explanation of the overall score\",\n" +
+            "  \"ambiguities\": [\n" +
+            "    {\n" +
+            "      \"type\": \"vague|missing|contradictory|implicit\",\n" +
+            "      \"description\": \"what is unclear / missing / contradictory / implicit\",\n" +
+            "      \"severity\": \"low|medium|high\",\n" +
+            "      \"recommendation\": \"a specific action to resolve this ambiguity\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n" +
+            "```\n\n" +
+            "Requirements (the downstream parser fails closed if these are not met):\n" +
+            "- `score` MUST be a decimal between 0.0 and 1.0 — it is load-bearing.\n" +
+            "- `rationale` MUST be a non-empty explanation of the score — it is load-bearing.\n" +
+            "- `confidence` is a decimal between 0.0 and 1.0.\n" +
+            "- `ambiguities` MAY be empty when the requirement is genuinely clear; otherwise each " +
+            "item MUST carry a non-empty `description`.\n" +
+            "- `type` MUST be one of: `vague`, `missing`, `contradictory`, `implicit`.",
+        SystemPrompt: SystemFor(role),
+        Variables: ["role", "workItemJson", "contextFindings", "conventions"],
+        EnableTools: false,
+        MaxTokens: 2048);
 
     // -----------------------------------------------------------------------
     // Role-specific review lenses (inlined in plan-review / code-review bodies)

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
@@ -31,6 +31,7 @@ public enum AgentAction
     [Wire("generate-assessment-questions")] GenerateAssessmentQuestions,
     [Wire("analyze-assessment-response")] AnalyzeAssessmentResponse,
     [Wire("research")] Research,
+    [Wire("score-ambiguity")] ScoreAmbiguity,
 
     // architect
     [Wire("triage-technical")] TriageTechnical,

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
@@ -57,7 +57,8 @@ public static class RolePhaseMap
                 AgentAction.ReviewScope,
                 AgentAction.GenerateAssessmentQuestions,
                 AgentAction.AnalyzeAssessmentResponse,
-                AgentAction.Research),
+                AgentAction.Research,
+                AgentAction.ScoreAmbiguity),
 
             // architect — system design, technical strategy
             [AgentRole.Architect] = FreezeSet(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs
@@ -1,0 +1,377 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using System.Text.Json;
+using Tamma.Activities;
+using Tamma.Activities.Ambiguity;
+using Tamma.Activities.Ambiguity.Models;
+using Tamma.Api.Services.Agents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 3.6 — Ambiguity Scoring sub-workflow. Given an issue / requirement it uses the LLM
+/// (via the MEDIATED <c>llm-call</c> path — the engine holds no LLM credential, TAMMA001) to
+/// score how ambiguous / underspecified the requirement is (a 0..1 score + a typed, itemised
+/// breakdown with specific recommendations), then compares the score to a caller-supplied
+/// threshold to DECIDE whether to trigger clarification before proceeding. Every transition is
+/// emitted as an <c>AMBIGUITY.*</c> DCB event.
+///
+/// Flow:
+///   1. Read inputs (issue/requirement + optional context + tenantId + threshold; mint a
+///      session id if none)
+///   2. Emit AMBIGUITY.STARTED
+///   3. Score the requirement via DispatchWorkflow("llm-call")
+///      role=product_owner / action=score-ambiguity
+///   4. Parse the response fail-closed (empty/unparseable/out-of-range score → error terminal)
+///   5a. On success: emit AMBIGUITY.SCORED, then apply the threshold policy:
+///        - score ≥ threshold → emit AMBIGUITY.CLARIFICATION_TRIGGERED (decision="clarify")
+///        - score &lt; threshold → emit AMBIGUITY.BELOW_THRESHOLD (decision="proceed")
+///       and set outputs (score, breakdown, decision).
+///   5b. On failure: emit AMBIGUITY.FAILED (LOUD) and route to the AmbiguityError terminal.
+///
+/// Reuses the <see cref="ResearchWorkflow"/> / <see cref="AssessmentWorkflow"/> skeleton
+/// (llm-call → parse → fail-closed gate + error terminal). The scoring is AUTONOMOUS — there is
+/// no human gate / bookmark; the clarification it can trigger is handled by the sibling
+/// <see cref="ClarifyingQuestionsWorkflow"/> (Story 3.5), which a parent flow dispatches on the
+/// <c>decision="clarify"</c> output.
+///
+/// Fail-closed: if the scoring <c>llm-call</c> returns success=false, or the response cannot be
+/// parsed into a valid in-range score with a rationale, the workflow emits a LOUD
+/// <c>AMBIGUITY.FAILED</c> event and routes to the AmbiguityError terminal — it NEVER proceeds
+/// with a fabricated score. Prompt resolution is tenant→system→error (the <c>llm-call</c>
+/// registry never falls back to an empty/plain prompt).
+///
+/// NOTE (taxonomy): the scoring dispatches the dedicated <c>(product_owner, score-ambiguity)</c>
+/// pair (Story 3.6). The <c>score-ambiguity</c> action is a first-class member of the
+/// <see cref="AgentAction"/> taxonomy and is eligible for <c>product_owner</c> in
+/// <c>RolePhaseMap</c> (requirement clarity is a product_owner concern, consistent with
+/// <c>clarify-requirements</c> and <c>research</c>). Its system-default prompt template
+/// (<c>SystemPrompts.ScoreAmbiguityBody</c>) emits the structured JSON
+/// <see cref="AmbiguityParsing"/> parses, so the happy path produces a real
+/// <c>AMBIGUITY.SCORED</c> assessment rather than failing closed.
+/// </summary>
+public class AmbiguityScoringWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "AmbiguityScoring";
+        builder.DefinitionId = "ambiguity-scoring";
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description = "Score how ambiguous/underspecified a requirement is via the mediated LLM and decide whether to trigger clarification";
+
+        // ── Workflow variables ──────────────────────────────────────────
+        var sessionId        = builder.WithVariable<Guid>();
+        var issueId          = builder.WithVariable<string>();
+        var requirement      = builder.WithVariable<string>();
+        var ambiguityContext = builder.WithVariable<string>();
+        var tenantId         = builder.WithVariable<string>("TenantId", "");
+        var threshold        = builder.WithVariable<double>();
+
+        var assessmentJson   = builder.WithVariable<string>();
+        var score            = builder.WithVariable<double>();
+        var ambiguityCount   = builder.WithVariable<int>();
+        var confidence       = builder.WithVariable<double>();
+        var decision         = builder.WithVariable<string>();
+
+        // llm-call result container
+        var scoreLlm         = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flag (fail-closed guard) + threshold decision
+        var ambiguityLlmOk   = builder.WithVariable<bool>();
+        var shouldClarify    = builder.WithVariable<bool>();
+
+        // Captured parse output
+        var assessment       = builder.WithVariable<AmbiguityAssessment>();
+
+        // Output variable (readable by a parent workflow)
+        var outputStatus     = builder.WithVariable<string>();
+
+        // ── Step 1: Read inputs ────────────────────────────────────────
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs",
+            Name = "Read Inputs",
+            Variable = sessionId,
+            Value = new(context =>
+            {
+                var sid = context.GetInput<Guid>("sessionId");
+                if (sid == Guid.Empty) sid = Guid.NewGuid();
+
+                issueId.Set(context, context.GetInput<string>("issueId") ?? string.Empty);
+                requirement.Set(context, context.GetInput<string>("requirement") ?? string.Empty);
+                ambiguityContext.Set(context, context.GetInput<string>("context") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
+
+                // Resolve the effective clarify threshold (caller value clamped to [0,1];
+                // ≤ 0 / unset → default). Kept in decimal by the pure policy, exposed as double
+                // to the workflow variables.
+                var requested = (decimal)context.GetInput<double>("threshold");
+                threshold.Set(context, (double)AmbiguityThresholds.Resolve(requested));
+                return sid;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ── Step 2: Emit AMBIGUITY.STARTED ─────────────────────────────
+        var emitStarted = new EmitAmbiguityEventActivity
+        {
+            Id = "EmitAmbiguityStarted",
+            Name = "Emit Ambiguity Started",
+            EventType = new(AmbiguityEvents.Started),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Ambiguity scoring started"),
+        };
+        emitStarted.SetDisplayText("Emit Ambiguity Started");
+
+        // ── Step 3: Score the requirement via llm-call ─────────────────
+        var scoreAmbiguityLlm = new DispatchWorkflow
+        {
+            Id = "ScoreAmbiguityLlm",
+            Name = "Score Ambiguity (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                // Dedicated scoring action (Story 3.6): (product_owner, score-ambiguity) resolves
+                // the structured-score prompt template that yields the JSON AmbiguityParsing
+                // recovers. Prompt resolution is tenant→system→error.
+                ["role"]     = AgentRole.ProductOwner.ToWire(),
+                ["action"]   = AgentAction.ScoreAmbiguity.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"]    = requirement.Get(ctx) ?? "",
+                    ["contextFindings"] = ambiguityContext.Get(ctx) ?? "",
+                    ["conventions"]     = "",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(scoreLlm),
+        };
+        scoreAmbiguityLlm.SetDisplayText("Score Ambiguity (LLM)");
+
+        // ── Step 4: Parse the response (fail-closed) ───────────────────
+        var parseAmbiguity = new SetVariable
+        {
+            Id = "ParseAmbiguity",
+            Name = "Parse Ambiguity",
+            Variable = assessmentJson,
+            Value = new(ctx =>
+            {
+                var result = scoreLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    ambiguityLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var parsed = AmbiguityParsing.ParseAssessment(text);
+                if (parsed is null)
+                {
+                    // Fail-closed — no fabricated score.
+                    ambiguityLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                ambiguityLlmOk.Set(ctx, true);
+                assessment.Set(ctx, parsed);
+                score.Set(ctx, (double)parsed.Score);
+                ambiguityCount.Set(ctx, parsed.Ambiguities.Count);
+                confidence.Set(ctx, (double)parsed.Confidence);
+                return JsonSerializer.Serialize(parsed);
+            })
+        };
+        parseAmbiguity.SetDisplayText("Parse Ambiguity");
+
+        // Fail-closed gate: route to error terminal if scoring failed / unparseable.
+        var ambiguitySuccessCheck = new FlowDecision(ctx => ambiguityLlmOk.Get(ctx))
+        { Id = "AmbiguityLlmOk", Name = "Ambiguity LLM OK?" };
+        ambiguitySuccessCheck.SetDisplayText("Ambiguity LLM OK?");
+
+        // ── Step 5a: Success path — emit SCORED, then apply threshold ──
+        var emitScored = new EmitAmbiguityEventActivity
+        {
+            Id = "EmitAmbiguityScored",
+            Name = "Emit Ambiguity Scored",
+            EventType = new(AmbiguityEvents.Scored),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Score = new(ctx => (double?)score.Get(ctx)),
+            AmbiguityCount = new(ctx => ambiguityCount.Get(ctx)),
+            Confidence = new(ctx => confidence.Get(ctx)),
+            Detail = new("Ambiguity score computed"),
+        };
+        emitScored.SetDisplayText("Emit Ambiguity Scored");
+
+        var computeDecision = new SetVariable
+        {
+            Id = "ComputeDecision",
+            Name = "Compute Decision",
+            Variable = shouldClarify,
+            Value = new(ctx =>
+            {
+                var clarify = AmbiguityThresholds.ShouldClarify(
+                    (decimal)score.Get(ctx), (decimal)threshold.Get(ctx));
+                decision.Set(ctx, clarify ? "clarify" : "proceed");
+                return clarify;
+            })
+        };
+        computeDecision.SetDisplayText("Compute Decision");
+
+        var shouldClarifyCheck = new FlowDecision(ctx => shouldClarify.Get(ctx))
+        { Id = "ShouldClarify", Name = "Should Clarify?" };
+        shouldClarifyCheck.SetDisplayText("Should Clarify?");
+
+        // ── Step 5a-i: above threshold → trigger clarification ─────────
+        var emitClarificationTriggered = new EmitAmbiguityEventActivity
+        {
+            Id = "EmitClarificationTriggered",
+            Name = "Emit Clarification Triggered",
+            EventType = new(AmbiguityEvents.ClarificationTriggered),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Score = new(ctx => (double?)score.Get(ctx)),
+            Threshold = new(ctx => threshold.Get(ctx)),
+            Detail = new("Score met/exceeded the clarify threshold — routing to clarifying questions"),
+        };
+        emitClarificationTriggered.SetDisplayText("Emit Clarification Triggered");
+
+        // ── Step 5a-ii: below threshold → proceed as-is ────────────────
+        var emitBelowThreshold = new EmitAmbiguityEventActivity
+        {
+            Id = "EmitBelowThreshold",
+            Name = "Emit Below Threshold",
+            EventType = new(AmbiguityEvents.BelowThreshold),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Score = new(ctx => (double?)score.Get(ctx)),
+            Threshold = new(ctx => threshold.Get(ctx)),
+            Detail = new("Score below the clarify threshold — proceeding without clarification"),
+        };
+        emitBelowThreshold.SetDisplayText("Emit Below Threshold");
+
+        var setOutputResult = new SetVariable
+        {
+            Id = "SetOutputResult",
+            Name = "Set Output Result",
+            Variable = outputStatus,
+            Value = new(_ => "scored")
+        };
+        setOutputResult.SetDisplayText("Set Output Result");
+
+        var exposeOutput = new Sequence
+        {
+            Id = "ExposeOutput",
+            Name = "Expose Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionId", Name = "Output Session Id", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id"),
+                WithLabel(new SetOutput { Id = "OutputStatus", Name = "Output Status", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status"),
+                WithLabel(new SetOutput { Id = "OutputScore", Name = "Output Score", OutputName = new("score"), OutputValue = new(ctx => (object)score.Get(ctx)) }, "Output Score"),
+                WithLabel(new SetOutput { Id = "OutputAmbiguityCount", Name = "Output Ambiguity Count", OutputName = new("ambiguityCount"), OutputValue = new(ctx => (object)ambiguityCount.Get(ctx)) }, "Output Ambiguity Count"),
+                WithLabel(new SetOutput { Id = "OutputConfidence", Name = "Output Confidence", OutputName = new("confidence"), OutputValue = new(ctx => (object)confidence.Get(ctx)) }, "Output Confidence"),
+                WithLabel(new SetOutput { Id = "OutputThreshold", Name = "Output Threshold", OutputName = new("threshold"), OutputValue = new(ctx => (object)threshold.Get(ctx)) }, "Output Threshold"),
+                WithLabel(new SetOutput { Id = "OutputDecision", Name = "Output Decision", OutputName = new("decision"), OutputValue = new(ctx => (object)(decision.Get(ctx) ?? "")) }, "Output Decision"),
+                WithLabel(new SetOutput { Id = "OutputAssessment", Name = "Output Assessment", OutputName = new("assessment"), OutputValue = new(ctx => (object)(assessmentJson.Get(ctx) ?? "{}")) }, "Output Assessment"),
+            }
+        };
+        exposeOutput.SetDisplayText("Expose Output");
+
+        // ── Step 5b: Fail-closed error terminal (LOUD event + Finish) ──
+        var emitAmbiguityFailed = new EmitAmbiguityEventActivity
+        {
+            Id = "EmitAmbiguityFailed",
+            Name = "Emit Ambiguity Failed",
+            EventType = new(AmbiguityEvents.Failed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for ambiguity scoring failed or returned unparseable/out-of-range output"),
+        };
+        emitAmbiguityFailed.SetDisplayText("Emit Ambiguity Failed");
+
+        var ambiguityError = new Finish
+        {
+            Id = "AmbiguityError",
+            Name = "Ambiguity Error"
+        };
+        ambiguityError.SetDisplayText("Ambiguity Error");
+
+        // ── Build the flowchart ────────────────────────────────────────
+        builder.Root = new Flowchart
+        {
+            Id = "AmbiguityScoringFlowchart",
+            Name = "Ambiguity Scoring Flowchart",
+            Start = readInputs,
+            Activities =
+            {
+                readInputs,
+                emitStarted,
+                scoreAmbiguityLlm,
+                parseAmbiguity,
+                ambiguitySuccessCheck,
+
+                // Success path
+                emitScored,
+                computeDecision,
+                shouldClarifyCheck,
+                emitClarificationTriggered,
+                emitBelowThreshold,
+                setOutputResult,
+                exposeOutput,
+
+                // Fail-closed error terminal
+                emitAmbiguityFailed,
+                ambiguityError,
+            },
+            Connections =
+            {
+                new(readInputs, emitStarted),
+                new(emitStarted, scoreAmbiguityLlm),
+                new(scoreAmbiguityLlm, parseAmbiguity),
+                new(parseAmbiguity, ambiguitySuccessCheck),
+
+                // Success path
+                new(new FlowEndpoint(ambiguitySuccessCheck, "True"),  new FlowEndpoint(emitScored)),
+                new(emitScored, computeDecision),
+                new(computeDecision, shouldClarifyCheck),
+                new(new FlowEndpoint(shouldClarifyCheck, "True"),  new FlowEndpoint(emitClarificationTriggered)),
+                new(new FlowEndpoint(shouldClarifyCheck, "False"), new FlowEndpoint(emitBelowThreshold)),
+                new(emitClarificationTriggered, setOutputResult),
+                new(emitBelowThreshold, setOutputResult),
+                new(setOutputResult, exposeOutput),
+
+                // Fail-closed error path
+                new(new FlowEndpoint(ambiguitySuccessCheck, "False"), new FlowEndpoint(emitAmbiguityFailed)),
+                new(emitAmbiguityFailed, ambiguityError),
+            }
+        };
+    }
+
+    /// <summary>
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary. Returns
+    /// <c>false</c> if the dictionary is null, the key is absent, or the value is falsy —
+    /// fail-closed by design. Uses the tolerant <see cref="ResumeInput.AsBool"/> read (boxed
+    /// bool / string / JsonElement).
+    /// </summary>
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return ResumeInput.AsBool(s);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/AmbiguityParsingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/AmbiguityParsingTests.cs
@@ -1,0 +1,191 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+using Tamma.Activities.Ambiguity.Models;
+
+namespace Tamma.Activities.Tests.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — unit coverage for <see cref="AmbiguityParsing.ParseAssessment"/>. Proves the
+/// parser recovers the structured assessment on a well-formed scoring response, NORMALISES the
+/// ambiguity type / severity labels, keeps a valid empty-breakdown ("clear requirement")
+/// result, and FAILS CLOSED (returns null) on every degraded / empty / malformed / out-of-range
+/// input so the workflow routes to AMBIGUITY.FAILED rather than fabricating a score.
+/// </summary>
+[TestFixture]
+public class AmbiguityParsingTests
+{
+    private const string ValidAssessment =
+        """
+        Here is the ambiguity assessment:
+        {
+          "score": 0.72,
+          "confidence": 0.8,
+          "rationale": "The requirement is missing acceptance criteria and uses vague wording.",
+          "ambiguities": [
+            { "type": "missing", "description": "No acceptance criteria", "severity": "high", "recommendation": "Ask for measurable ACs" },
+            { "type": "Vague.", "description": "\"fast\" is not quantified", "severity": "medium", "recommendation": "Define a latency target" }
+          ]
+        }
+        """;
+
+    [Test]
+    public void ParseAssessment_ValidResponse_RecoversAssessment()
+    {
+        var a = AmbiguityParsing.ParseAssessment(ValidAssessment);
+
+        a.Should().NotBeNull();
+        a!.Score.Should().Be(0.72m);
+        a.Confidence.Should().Be(0.8m);
+        a.Rationale.Should().Contain("missing acceptance criteria");
+        a.Ambiguities.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void ParseAssessment_NormalisesTypeAndSeverityLabels()
+    {
+        var a = AmbiguityParsing.ParseAssessment(ValidAssessment);
+
+        // "Vague." → canonical "vague" (trimmed, lower-cased, trailing dot removed).
+        a!.Ambiguities.Select(x => x.Type).Should().Contain(AmbiguityTypes.Vague);
+        a.Ambiguities.Select(x => x.Type).Should().Contain(AmbiguityTypes.Missing);
+        a.Ambiguities.Select(x => x.Severity).Should().OnlyContain(
+            s => s == AmbiguitySeverities.High || s == AmbiguitySeverities.Medium);
+    }
+
+    [Test]
+    public void ParseAssessment_ClearRequirement_EmptyBreakdown_IsValid()
+    {
+        const string clear =
+            """{ "score": 0.05, "confidence": 0.9, "rationale": "Fully specified with clear ACs.", "ambiguities": [] }""";
+
+        var a = AmbiguityParsing.ParseAssessment(clear);
+
+        a.Should().NotBeNull(
+            "a genuinely clear requirement scores near 0 with an empty breakdown — that is a " +
+            "valid assessment, not a failure");
+        a!.Score.Should().Be(0.05m);
+        a.Ambiguities.Should().BeEmpty();
+    }
+
+    [Test]
+    public void ParseAssessment_ScoreZero_IsValid()
+    {
+        const string zero = """{ "score": 0.0, "rationale": "Crystal clear." }""";
+
+        var a = AmbiguityParsing.ParseAssessment(zero);
+
+        a.Should().NotBeNull("a score of exactly 0.0 is a valid 'perfectly clear' result");
+        a!.Score.Should().Be(0m);
+    }
+
+    [Test]
+    public void ParseAssessment_MissingConfidence_DefaultsToZero()
+    {
+        const string noConf = """{ "score": 0.4, "rationale": "Some gaps." }""";
+
+        var a = AmbiguityParsing.ParseAssessment(noConf);
+
+        a!.Confidence.Should().Be(0m, "absent confidence is not fabricated — defaults to 0");
+    }
+
+    [Test]
+    public void ParseAssessment_DropsEmptyShellAmbiguities()
+    {
+        const string withShell =
+            """
+            { "score": 0.6, "rationale": "r", "ambiguities": [
+              { "type": "vague", "description": "" },
+              { "type": "missing", "description": "real gap" }
+            ] }
+            """;
+
+        var a = AmbiguityParsing.ParseAssessment(withShell);
+
+        a!.Ambiguities.Should().ContainSingle(x => x.Description == "real gap",
+            "empty-shell ambiguities (no description) must be dropped, not admitted blank");
+    }
+
+    /// <summary>
+    /// A sample matching the EXACT shape the (product_owner, score-ambiguity) system-default
+    /// prompt template (SystemPrompts.ScoreAmbiguityBody, Story 3.6) instructs the LLM to emit.
+    /// Proves the template's documented output is parseable end-to-end, so the
+    /// AmbiguityScoringWorkflow happy path emits a real AMBIGUITY.SCORED assessment.
+    /// </summary>
+    private const string TemplateShapedAssessment =
+        """
+        {
+          "score": 0.65,
+          "confidence": 0.75,
+          "rationale": "The feature request omits the target platform and contradicts itself on auth.",
+          "ambiguities": [
+            { "type": "missing", "description": "Target platform (web vs mobile) is unstated.", "severity": "high", "recommendation": "Confirm the platform with the stakeholder." },
+            { "type": "contradictory", "description": "Says 'no login' but also 'per-user history'.", "severity": "high", "recommendation": "Resolve whether accounts are required." },
+            { "type": "implicit", "description": "Assumes English-only content.", "severity": "low", "recommendation": "Confirm i18n scope." }
+          ]
+        }
+        """;
+
+    [Test]
+    public void ParseAssessment_TemplateShapedOutput_RecoversAssessment()
+    {
+        var a = AmbiguityParsing.ParseAssessment(TemplateShapedAssessment);
+
+        a.Should().NotBeNull(
+            "the (product_owner, score-ambiguity) template's documented JSON shape must parse " +
+            "into a real assessment");
+        a!.Score.Should().Be(0.65m);
+        a.Rationale.Should().NotBeNullOrWhiteSpace();
+        a.Ambiguities.Should().HaveCount(3);
+        a.Ambiguities.Select(x => x.Type).Should().Contain(new[]
+        {
+            AmbiguityTypes.Missing, AmbiguityTypes.Contradictory, AmbiguityTypes.Implicit,
+        });
+    }
+
+    // ── Fail-closed cases (all → null) ─────────────────────────────────
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("no json here at all")]
+    [TestCase("{ not valid json")]
+    public void ParseAssessment_DegradedInput_FailsClosed(string? input)
+    {
+        AmbiguityParsing.ParseAssessment(input).Should().BeNull(
+            "degraded/empty/malformed scoring output must fail closed (no fabricated score)");
+    }
+
+    [Test]
+    public void ParseAssessment_MissingScore_FailsClosed()
+    {
+        const string noScore = """{ "rationale": "r", "ambiguities": [] }""";
+        AmbiguityParsing.ParseAssessment(noScore).Should().BeNull(
+            "the score is the whole point — an assessment without it must fail closed");
+    }
+
+    [Test]
+    public void ParseAssessment_NonNumericScore_FailsClosed()
+    {
+        const string badScore = """{ "score": "high", "rationale": "r" }""";
+        AmbiguityParsing.ParseAssessment(badScore).Should().BeNull(
+            "a non-numeric score cannot be acted on — fail closed");
+    }
+
+    [TestCase("1.5")]
+    [TestCase("-0.2")]
+    [TestCase("42")]
+    public void ParseAssessment_OutOfRangeScore_FailsClosed(string raw)
+    {
+        var outOfRange = $$"""{ "score": {{raw}}, "rationale": "r" }""";
+        AmbiguityParsing.ParseAssessment(outOfRange).Should().BeNull(
+            "a score outside [0,1] is nonsensical — fail closed rather than clamp a fabricated value");
+    }
+
+    [Test]
+    public void ParseAssessment_MissingRationale_FailsClosed()
+    {
+        const string noRationale = """{ "score": 0.5, "ambiguities": [] }""";
+        AmbiguityParsing.ParseAssessment(noRationale).Should().BeNull(
+            "a score with no rationale is not auditable/actionable — fail closed");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/AmbiguityThresholdsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/AmbiguityThresholdsTests.cs
@@ -1,0 +1,73 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+using Tamma.Activities.Ambiguity.Models;
+
+namespace Tamma.Activities.Tests.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — unit coverage for the threshold policy (<see cref="AmbiguityThresholds"/>) that
+/// turns a quantitative score into the clarify / proceed routing DECISION (AC6), plus the
+/// type / severity label normalisation (<see cref="AmbiguityTypes"/> / <see cref="AmbiguitySeverities"/>).
+/// </summary>
+[TestFixture]
+public class AmbiguityThresholdsTests
+{
+    [Test]
+    public void Resolve_NonPositive_FallsBackToDefault()
+    {
+        AmbiguityThresholds.Resolve(0m).Should().Be(AmbiguityThresholds.DefaultClarify);
+        AmbiguityThresholds.Resolve(-1m).Should().Be(AmbiguityThresholds.DefaultClarify,
+            "a threshold of 0 would clarify even a perfectly-clear (score 0) requirement, so " +
+            "≤ 0 is treated as 'unset' and falls back to the default");
+    }
+
+    [Test]
+    public void Resolve_PositiveValue_IsClampedIntoRange()
+    {
+        AmbiguityThresholds.Resolve(0.3m).Should().Be(0.3m);
+        AmbiguityThresholds.Resolve(2m).Should().Be(1m, "a threshold above 1 is clamped to 1");
+    }
+
+    [TestCase(0.5, 0.5, true)]   // at threshold → clarify
+    [TestCase(0.9, 0.5, true)]   // above threshold → clarify
+    [TestCase(0.49, 0.5, false)] // below threshold → proceed
+    [TestCase(0.0, 0.5, false)]  // clear requirement → proceed
+    public void ShouldClarify_DecidesOnThreshold(double score, double threshold, bool expected)
+    {
+        AmbiguityThresholds.ShouldClarify((decimal)score, (decimal)threshold)
+            .Should().Be(expected);
+    }
+
+    [Test]
+    public void Clamp01_BoundsValues()
+    {
+        AmbiguityThresholds.Clamp01(-0.5m).Should().Be(0m);
+        AmbiguityThresholds.Clamp01(1.5m).Should().Be(1m);
+        AmbiguityThresholds.Clamp01(0.4m).Should().Be(0.4m);
+    }
+
+    [TestCase("vague", AmbiguityTypes.Vague)]
+    [TestCase("MISSING", AmbiguityTypes.Missing)]
+    [TestCase(" Contradictory. ", AmbiguityTypes.Contradictory)]
+    [TestCase("implied", AmbiguityTypes.Implicit)]   // synonym fold
+    [TestCase("unclear", AmbiguityTypes.Vague)]       // synonym fold
+    [TestCase("incomplete", AmbiguityTypes.Missing)]  // synonym fold
+    [TestCase("", AmbiguityTypes.Unspecified)]
+    [TestCase("gibberish", AmbiguityTypes.Unspecified)]
+    public void AmbiguityTypes_Normalize(string raw, string expected)
+    {
+        AmbiguityTypes.Normalize(raw).Should().Be(expected);
+    }
+
+    [TestCase("high", AmbiguitySeverities.High)]
+    [TestCase("LOW", AmbiguitySeverities.Low)]
+    [TestCase("critical", AmbiguitySeverities.High)] // synonym fold
+    [TestCase("trivial", AmbiguitySeverities.Low)]   // synonym fold
+    [TestCase("", AmbiguitySeverities.Medium)]        // default
+    [TestCase("weird", AmbiguitySeverities.Medium)]   // default
+    public void AmbiguitySeverities_Normalize(string raw, string expected)
+    {
+        AmbiguitySeverities.Normalize(raw).Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/EmitAmbiguityEventActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Ambiguity/EmitAmbiguityEventActivityTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+
+namespace Tamma.Activities.Tests.Ambiguity;
+
+/// <summary>
+/// Story 3.6 — unit coverage for the AMBIGUITY.* event mapping
+/// (<see cref="EmitAmbiguityEventActivity.BuildTammaEvent"/> +
+/// <see cref="AmbiguityEvents.StatusForEvent"/>). Verifies the queryable DCB tags, the
+/// per-transition data payload (including that a genuine score of 0.0 is still recorded), and —
+/// critically — that the failed terminal is a LOUD error-status row (never a false success).
+/// </summary>
+[TestFixture]
+public class EmitAmbiguityEventActivityTests
+{
+    private static readonly Guid Tenant = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Test]
+    public void BuildTammaEvent_Scored_CarriesTagsAndData()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.Scored, "sess-1", "issue-9", Tenant,
+            score: 0.72, ambiguityCount: 3, confidence: 0.8, threshold: 0d, detail: "done");
+
+        evt.EventType.Should().Be("AMBIGUITY.SCORED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags["issueId"].Should().Be("issue-9");
+        evt.Tags["tenantId"].Should().Be(Tenant.ToString("D"));
+        evt.Data["score"].Should().Be(0.72);
+        evt.Data["ambiguityCount"].Should().Be(3);
+        evt.Data["confidence"].Should().Be(0.8);
+        evt.Data["detail"].Should().Be("done");
+        evt.Data.Should().NotContainKey("threshold", "threshold 0 is omitted on the scored event");
+    }
+
+    [Test]
+    public void BuildTammaEvent_ScoreZero_IsStillRecorded()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.Scored, "sess-1", "issue-9", Tenant,
+            score: 0.0, ambiguityCount: 0, confidence: 0d, threshold: 0d, detail: null);
+
+        evt.Data.Should().ContainKey("score",
+            "a genuine score of 0.0 (perfectly clear) must still be recorded — a nullable input " +
+            "distinguishes it from 'not yet computed'");
+        evt.Data["score"].Should().Be(0.0);
+        evt.Data.Should().NotContainKey("ambiguityCount", "0 ambiguities is omitted");
+    }
+
+    [Test]
+    public void BuildTammaEvent_ClarificationTriggered_CarriesThreshold()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.ClarificationTriggered, "sess-1", "issue-9", Tenant,
+            score: 0.8, ambiguityCount: 2, confidence: 0d, threshold: 0.5, detail: null);
+
+        evt.EventType.Should().Be("AMBIGUITY.CLARIFICATION_TRIGGERED");
+        evt.Status.Should().Be("success", "a threshold decision is a normal audit row, not an error");
+        evt.Data["threshold"].Should().Be(0.5);
+        evt.Data["score"].Should().Be(0.8);
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_IsLoudErrorStatus()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.Failed, "sess-1", "issue-9", Tenant,
+            score: null, ambiguityCount: 0, confidence: 0d, threshold: 0d, detail: "boom");
+
+        evt.Status.Should().Be("error",
+            "a failed scoring must be a LOUD error-status row, never a false success");
+        evt.Data.Should().NotContainKey("score", "no score was computed on failure (null omitted)");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Started_IsStartedStatus_AndOmitsScore()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.Started, "sess-1", "issue-9", Tenant,
+            score: null, ambiguityCount: 0, confidence: 0d, threshold: 0d, detail: null);
+
+        evt.Status.Should().Be("started");
+        evt.Data.Should().NotContainKey("score", "no score yet at start (null omitted)");
+        evt.Data.Should().NotContainKey("detail", "a null detail is omitted");
+    }
+
+    [Test]
+    public void BuildTammaEvent_NullTenant_OmitsTenantTag()
+    {
+        var evt = EmitAmbiguityEventActivity.BuildTammaEvent(
+            AmbiguityEvents.Scored, "sess-1", "issue-9", tenantId: null,
+            score: 0.5, ambiguityCount: 1, confidence: 0.5, threshold: 0d, detail: null);
+
+        evt.Tags.Should().NotContainKey("tenantId",
+            "single-user / platform-scope ambiguity events carry no tenantId tag");
+    }
+
+    [Test]
+    public void ParseTenantId_RoundTrips_AndRejectsGarbage()
+    {
+        AmbiguityEvents.ParseTenantId(Tenant.ToString()).Should().Be(Tenant);
+        AmbiguityEvents.ParseTenantId("").Should().BeNull();
+        AmbiguityEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    [TestCase("AMBIGUITY.STARTED", "started")]
+    [TestCase("AMBIGUITY.SCORED", "success")]
+    [TestCase("AMBIGUITY.CLARIFICATION_TRIGGERED", "success")]
+    [TestCase("AMBIGUITY.BELOW_THRESHOLD", "success")]
+    [TestCase("AMBIGUITY.FAILED", "error")]
+    public void StatusForEvent_MapsCorrectly(string type, string expected)
+    {
+        AmbiguityEvents.StatusForEvent(type).Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AmbiguityScoringWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AmbiguityScoringWorkflowStructureTests.cs
@@ -1,0 +1,151 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 3.6 — structural verification for <see cref="AmbiguityScoringWorkflow"/>.
+///
+/// Asserts the workflow:
+/// 1. Builds and has DefinitionId "ambiguity-scoring".
+/// 2. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts
+///    (resolution is tenant→system→error — never empty/plain).
+/// 3. Scores the requirement via <c>DispatchWorkflow("llm-call")</c> (mediated — the engine
+///    holds no LLM credential, TAMMA001) and dispatches NOTHING else (no direct provider call).
+/// 4. Is fail-closed: an <c>AmbiguityError</c> terminal exists and a <c>FlowDecision</c> gate
+///    checks LLM-call success before proceeding.
+/// 5. Applies the threshold policy via a <c>ShouldClarify</c> decision (AC6).
+/// 6. Emits the required AMBIGUITY.* DCB events (started / scored / clarification-triggered /
+///    below-threshold / failed) via <see cref="EmitAmbiguityEventActivity"/> nodes.
+/// 7. Is AUTONOMOUS — no human gate / bookmark (no suspend activity in the graph).
+/// </summary>
+[TestFixture]
+public class AmbiguityScoringWorkflowStructureTests
+{
+    private static Flowchart Flowchart()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new AmbiguityScoringWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithoutError()
+    {
+        var act = () => WorkflowTestHelper.BuildWorkflow(new AmbiguityScoringWorkflow());
+        act.Should().NotThrow("AmbiguityScoringWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void Workflow_HasCorrectDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new AmbiguityScoringWorkflow());
+        builder.Object.DefinitionId.Should().Be("ambiguity-scoring");
+    }
+
+    [Test]
+    public void Workflow_ThreadsTenantId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new AmbiguityScoringWorkflow());
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "the workflow must thread TenantId so llm-call resolves tenant-scoped prompts " +
+                "(tenant→system→error) for the ambiguity scoring");
+    }
+
+    [Test]
+    public void Workflow_ScoresViaMediatedLlmCall()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "ScoreAmbiguityLlm",
+                "the ambiguity score must be produced via the mediated llm-call " +
+                "(engine holds no LLM credential, TAMMA001)");
+    }
+
+    [Test]
+    public void Workflow_OnlyDispatchesTheLlmCall()
+    {
+        var dispatchIds = Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Select(d => d.Id)
+            .OrderBy(x => x)
+            .ToList();
+
+        dispatchIds.Should().BeEquivalentTo(new[] { "ScoreAmbiguityLlm" },
+            "scoring is a single mediated llm-call — no other dispatch and, crucially, no direct " +
+            "in-engine provider call");
+    }
+
+    [Test]
+    public void Workflow_HasFailClosedErrorTerminal()
+    {
+        Flowchart().Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "AmbiguityError",
+                "a fail-closed AmbiguityError terminal must exist — scoring failures route there, " +
+                "never proceeding with a fabricated score");
+    }
+
+    [Test]
+    public void Workflow_HasSuccessGateForScoring()
+    {
+        Flowchart().Activities
+            .OfType<FlowDecision>()
+            .Select(d => d.Id)
+            .Should().Contain("AmbiguityLlmOk",
+                "the assessment must be gated behind an AmbiguityLlmOk decision (fail-closed)");
+    }
+
+    [Test]
+    public void Workflow_HasThresholdDecision()
+    {
+        Flowchart().Activities
+            .OfType<FlowDecision>()
+            .Select(d => d.Id)
+            .Should().Contain("ShouldClarify",
+                "the clarify/proceed routing must go through a ShouldClarify threshold decision (AC6)");
+    }
+
+    [Test]
+    public void Workflow_EmitsRequiredAmbiguityEvents()
+    {
+        var emitIds = Flowchart().Activities
+            .OfType<EmitAmbiguityEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitAmbiguityStarted",
+            "must emit AMBIGUITY.STARTED when scoring begins");
+        emitIds.Should().Contain("EmitAmbiguityScored",
+            "must emit AMBIGUITY.SCORED when a valid score is produced");
+        emitIds.Should().Contain("EmitClarificationTriggered",
+            "must emit AMBIGUITY.CLARIFICATION_TRIGGERED when the score meets the threshold");
+        emitIds.Should().Contain("EmitBelowThreshold",
+            "must emit AMBIGUITY.BELOW_THRESHOLD when the score is below the threshold");
+        emitIds.Should().Contain("EmitAmbiguityFailed",
+            "must emit a LOUD AMBIGUITY.FAILED when scoring fails / is unparseable");
+    }
+
+    [Test]
+    public void Workflow_IsAutonomous_NoHumanBookmark()
+    {
+        // Ambiguity scoring is autonomous: unlike ClarifyingQuestionsWorkflow (which suspends on a
+        // WaitForClarifyingAnswersActivity bookmark awaiting human answers) it has no human gate.
+        // Assert no bookmark-style "Wait*" activity is present in the graph.
+        var waitActivities = Flowchart().Activities
+            .Where(a => a.GetType().Name.StartsWith("Wait", StringComparison.Ordinal))
+            .Select(a => a.GetType().Name)
+            .ToList();
+
+        waitActivities.Should().BeEmpty(
+            "the ambiguity-scoring workflow is autonomous — it must not suspend on a human " +
+            "bookmark (no Wait* activity); the clarification it can trigger is the sibling " +
+            "ClarifyingQuestionsWorkflow's job");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -102,6 +102,7 @@ public class TaxonomyDriftBuildTests
     /// </summary>
     private static readonly IReadOnlySet<string> ExpectedContributingWorkflows = new HashSet<string>
     {
+        "AmbiguityScoringWorkflow",     // Story 3.6: dispatches the dedicated (product_owner, score-ambiguity) scoring pair
         "AssessmentWorkflow",           // P0 fix 2026-06-30: dispatches generate-assessment-questions + analyze-assessment-response
         "BlockerDiagnosisWorkflow",
         "ClarifyingQuestionsWorkflow",  // Story 3.5: dispatches clarify-requirements (generate questions + incorporate answers)

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
@@ -26,14 +26,17 @@ public class AgentActionTests
     {
         // 72 original + 2 assessment actions (generate-assessment-questions,
         // analyze-assessment-response) added in assessment P0 + 1 research action
-        // (Story 3.4 — dedicated research/investigate token under product_owner).
-        Enum.GetValues<AgentAction>().Length.Should().Be(75);
+        // (Story 3.4 — dedicated research/investigate token under product_owner)
+        // + 1 score-ambiguity action (Story 3.6 — dedicated ambiguity-scoring token
+        // under product_owner).
+        Enum.GetValues<AgentAction>().Length.Should().Be(76);
     }
 
     [TestCase("context-scan", AgentAction.ContextScan)]
     [TestCase("implement-feature", AgentAction.ImplementFeature)]
     [TestCase("code-review-security", AgentAction.CodeReviewSecurity)]
     [TestCase("research", AgentAction.Research)]
+    [TestCase("score-ambiguity", AgentAction.ScoreAmbiguity)]
     public void Parse_resolves_canonical_wire(string wire, AgentAction expected)
     {
         AgentActionExtensions.Parse(wire).Should().Be(expected);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
@@ -11,10 +11,11 @@ namespace Tamma.Api.Tests.Agents;
 /// The 8 roles: developer, tester, security, devops, architect, product_owner,
 /// senior_developer, tech_writer.
 ///
-/// The 75 actions are the union of the per-role action sets in SPEC §4
+/// The 76 actions are the union of the per-role action sets in SPEC §4
 /// (72 original + 2 assessment actions: generate-assessment-questions,
 /// analyze-assessment-response under product_owner — added in assessment P0 —
-/// + 1 research action under product_owner, Story 3.4).
+/// + 1 research action under product_owner, Story 3.4
+/// + 1 score-ambiguity action under product_owner, Story 3.6).
 /// Which (role, action) pairs are valid is the per-role eligibility matrix.
 /// </summary>
 [TestFixture]
@@ -42,12 +43,14 @@ public class RolePhaseMapTests
     }
 
     [Test]
-    public void ValidActions_Should_Contain_Seventy_Five_Actions()
+    public void ValidActions_Should_Contain_Seventy_Six_Actions()
     {
         // 72 original actions + 2 assessment actions added in assessment P0
         // (generate-assessment-questions, analyze-assessment-response under product_owner)
-        // + 1 research action (Story 3.4 — dedicated research token under product_owner).
-        RolePhaseMap.ValidActions.Should().HaveCount(75);
+        // + 1 research action (Story 3.4 — dedicated research token under product_owner)
+        // + 1 score-ambiguity action (Story 3.6 — dedicated ambiguity-scoring token
+        // under product_owner).
+        RolePhaseMap.ValidActions.Should().HaveCount(76);
     }
 
     [Test]
@@ -375,6 +378,39 @@ public class RolePhaseMapTests
     {
         // research is a product_owner-only action; a developer must not be eligible.
         RolePhaseMap.IsRoleEligibleForPhase("research", "developer").Should().BeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 3.6 — dedicated score-ambiguity action (product_owner-eligible)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void ValidActions_Contains_ScoreAmbiguity()
+    {
+        RolePhaseMap.ValidActions.Should().Contain("score-ambiguity");
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_ScoreAmbiguity_ProductOwner_Returns_True()
+    {
+        // Requirement clarity is a product_owner concern (consistent with clarify-requirements
+        // and research), so the dedicated score-ambiguity action is eligible for product_owner
+        // (Story 3.6 — AmbiguityScoringWorkflow dispatches (product_owner, score-ambiguity)).
+        RolePhaseMap.IsRoleEligibleForPhase("score-ambiguity", "product_owner").Should().BeTrue();
+    }
+
+    [Test]
+    public void GetEligibleRolesForPhase_ScoreAmbiguity_Is_ProductOwner_Only()
+    {
+        RolePhaseMap.GetEligibleRolesForPhase("score-ambiguity")
+            .Should().BeEquivalentTo(new[] { "product_owner" });
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_ScoreAmbiguity_Developer_Returns_False()
+    {
+        // score-ambiguity is a product_owner-only action; a developer must not be eligible.
+        RolePhaseMap.IsRoleEligibleForPhase("score-ambiguity", "developer").Should().BeFalse();
     }
 
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/SystemPromptsTests.cs
@@ -243,6 +243,51 @@ public class SystemPromptsTests
     }
 
     // ------------------------------------------------------------------
+    // Story 3.6 — the score-ambiguity cell under product_owner. The
+    // AmbiguityScoringWorkflow dispatches (product_owner, score-ambiguity);
+    // resolution is tenant→system→error, so the system default MUST be a real,
+    // non-empty body that instructs the exact structured-score JSON schema
+    // AmbiguityParsing.ParseAssessment recovers.
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void ScoreAmbiguityAction_ExistsInTaxonomy_ProductOwner()
+    {
+        var score = SystemPrompts.GetRoleAction("product_owner", "score-ambiguity");
+
+        score.Should().NotBeNull(
+            "score-ambiguity must be in product_owner's RolePhaseMap action set with a " +
+            "non-empty SystemPrompts template (Story 3.6 taxonomy)");
+
+        score!.Template.Should().NotBeNullOrWhiteSpace(
+            "score-ambiguity template must not be empty (resolution is tenant→system→error)");
+
+        score.Variables.Should().Contain("workItemJson")
+            .And.Contain("contextFindings",
+                "score-ambiguity must declare the variables AmbiguityScoringWorkflow passes " +
+                "in the llm-call dispatch");
+    }
+
+    [Test]
+    public void ScoreAmbiguityAction_Template_DocumentsTheParserSchema()
+    {
+        // The body must instruct the EXACT JSON keys AmbiguityParsing.ParseAssessment reads:
+        // score + confidence + rationale + ambiguities[] {type, description, severity, recommendation}.
+        var score = SystemPrompts.GetRoleAction("product_owner", "score-ambiguity");
+
+        score.Should().NotBeNull();
+        var body = score!.Template;
+        body.Should().Contain("\"score\"");
+        body.Should().Contain("\"rationale\"");
+        body.Should().Contain("\"confidence\"");
+        body.Should().Contain("\"ambiguities\"");
+        body.Should().Contain("\"type\"");
+        body.Should().Contain("\"description\"");
+        body.Should().Contain("\"severity\"");
+        body.Should().Contain("\"recommendation\"");
+    }
+
+    // ------------------------------------------------------------------
     // Audit prompts/001 — role-tailored review-lens shape is retained on the
     // review-family cells. The PlanReview body is used by the per-role
     // plan-review lens actions; CodeReview by the code-review lens actions.


### PR DESCRIPTION
## What

Story 3.6 — `AmbiguityScoringWorkflow` (`ambiguity-scoring`), an autonomous sub-workflow that scores a requirement's ambiguity (0..1 + typed breakdown) via the mediated LLM and applies a threshold to decide **clarify vs proceed** (exposes a `decision` output a parent flow routes into the 3.5 ClarifyingQuestions workflow). Same Research/Clarify skeleton (llm-call → fail-closed parse → gate).

- **Taxonomy 75→76:** added `[Wire("score-ambiguity")] ScoreAmbiguity` across the coupled places (`AgentAction`, `RolePhaseMap` product_owner, `SystemPrompts` `ScoreAmbiguityBody` template emitting the exact parser JSON) — count asserts + TaxonomyDrift updated (ConventionSeed derives automatically).
- Scoring schema `{score, confidence, rationale, ambiguities[{type,severity,recommendation}]}`, strict fail-closed parser (never fabricates a score; empty breakdown + score≈0 = valid "clear"). `AMBIGUITY.STARTED/SCORED/CLARIFICATION_TRIGGERED/BELOW_THRESHOLD` + loud `FAILED`.
- No Program.cs (auto-swept). **Non-migration** (score in DCB events + workflow state; both `has-pending-model-changes` "No changes"). Mediated LLM — no TAMMA001.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` "No changes". Tests: Activities 92 + Api 233 (count 75→76, eligibility, SystemPrompts schema, ConventionSeedDrift, fail-closed parse, workflow structure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)