### PR TITLE
feat(epic-4-5): DCB event coverage for code changes & git operations

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/ApplyRefactoringActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/ApplyRefactoringActivity.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Tamma.Activities.Core;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.TDD.Models;
 
@@ -99,17 +100,31 @@ public class ApplyRefactoringActivity : CodeActivity<RefactoringResult>
                 "TDD REFACTOR phase: Applied refactoring to {FileCount} files for session {SessionId}",
                 result.FilesChanged.Count, sessionId);
 
+            // Story 4-5 (AC1) — the REFACTOR phase modified implementation code;
+            // capture it as a DCB event (CODE.REFACTORED.*) so refactors are audited
+            // alongside test/implementation generation.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildRefactored(result.Success, storyId, sessionId,
+                    result.FilesChanged, result.ErrorMessage));
+
             context.SetResult(result);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "TDD REFACTOR phase: Error applying refactoring for session {SessionId}", sessionId);
 
-            context.SetResult(new RefactoringResult
+            var failed = new RefactoringResult
             {
                 Success = false,
                 ErrorMessage = $"Refactoring failed: {ex.Message}"
-            });
+            };
+
+            // Story 4-5 (AC1) — loud, error-status failure edge.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildRefactored(success: false, storyId, sessionId,
+                    failed.FilesChanged, failed.ErrorMessage));
+
+            context.SetResult(failed);
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/CodeEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/CodeEvents.cs
@@ -1,0 +1,134 @@
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.TDD;
+
+/// <summary>
+/// Story 4-5 (AC1 — <c>CodeFileWrittenEvent</c>) — central catalogue of the
+/// <c>CODE.*</c> DCB event types emitted by the code-producing steps of the
+/// red-green-refactor TDD cycle: <see cref="WriteTestsActivity"/> (RED, test
+/// authoring), <see cref="WriteImplementationActivity"/> (GREEN, implementation),
+/// and <see cref="ApplyRefactoringActivity"/> (REFACTOR). Every code change the
+/// autonomous loop makes is therefore observable on the DCB audit stream
+/// (<c>domain_events</c>), satisfying the "every code/git op observable" audit rule.
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern <see cref="Tamma.Activities.ADL.EmitBranchEventActivity"/> uses. No
+/// activity holds a DB / repository dependency of its own (a directly-injected
+/// <c>IEventRepository</c> would be inert inside the Elsa engine and silently drop
+/// every event). The drain resolves the tenant from the workflow's <c>TenantId</c>
+/// variable, so a SaaS caller's code events carry the tenant column while a
+/// single-user run is platform-scope (TenantId null) — never a throw.</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention (<c>CLAUDE.md</c>: <c>CODE.GENERATED.SUCCESS</c>). The FAILED types
+/// ALWAYS fire on the failure edge (loud, error-status) so the loop never records a
+/// silent false success. <c>CODE.GENERATED.FAILED</c> matches the
+/// <c>SensitiveActionCatalog</c> code of the same name (this is the emitter that
+/// fulfils that catalogue's <c>MapsExistingEmitter</c> claim).</para>
+///
+/// <list type="bullet">
+///   <item><description><c>CODE.GENERATED.SUCCESS</c> / <c>CODE.GENERATED.FAILED</c>
+///     — an LLM produced test or implementation code (RED / GREEN). The
+///     <c>operation</c> tag/data distinguishes <c>testing</c> from
+///     <c>implementation</c>.</description></item>
+///   <item><description><c>CODE.REFACTORED.SUCCESS</c> / <c>CODE.REFACTORED.FAILED</c>
+///     — the REFACTOR phase applied refactoring suggestions to the
+///     implementation.</description></item>
+/// </list>
+/// </summary>
+public static class CodeEvents
+{
+    public const string GeneratedSuccess = "CODE.GENERATED.SUCCESS";
+    public const string GeneratedFailed = "CODE.GENERATED.FAILED";
+    public const string RefactoredSuccess = "CODE.REFACTORED.SUCCESS";
+    public const string RefactoredFailed = "CODE.REFACTORED.FAILED";
+
+    /// <summary>The <c>operation</c> discriminators (mirrors the story's
+    /// <c>operation</c> enum: generation / modification / refactoring / testing /
+    /// documentation). The two generation phases share <c>CODE.GENERATED.*</c> and
+    /// are told apart by this value.</summary>
+    public const string OperationImplementation = "implementation";
+    public const string OperationTesting = "testing";
+    public const string OperationRefactoring = "refactoring";
+
+    /// <summary>True for the loud (error-status) FAILED types — used by tests /
+    /// callers to assert a failure was recorded as a failure, never a false
+    /// success.</summary>
+    public static bool IsFailureType(string type)
+        => type == GeneratedFailed || type == RefactoredFailed;
+
+    /// <summary>
+    /// Build a <c>CODE.GENERATED.*</c> event for a code-generation step (RED test
+    /// authoring or GREEN implementation). Tags carry the queryable DCB index keys
+    /// (<c>storyId</c>/<c>sessionId</c>/<c>operation</c>); <c>Data</c> carries the
+    /// files-changed payload (<c>files</c>/<c>fileCount</c>, optional
+    /// <c>testCount</c>). Pure (no Elsa context) — exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildGenerated(
+        bool success,
+        string? storyId,
+        Guid sessionId,
+        string operation,
+        IReadOnlyList<string>? files,
+        int? testCount,
+        string? error)
+        => Build(
+            success ? GeneratedSuccess : GeneratedFailed,
+            success, storyId, sessionId, operation, files, testCount, error);
+
+    /// <summary>
+    /// Build a <c>CODE.REFACTORED.*</c> event for the REFACTOR phase. Same tag /
+    /// data shape as <see cref="BuildGenerated"/> with <c>operation=refactoring</c>.
+    /// Pure — exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildRefactored(
+        bool success,
+        string? storyId,
+        Guid sessionId,
+        IReadOnlyList<string>? files,
+        string? error)
+        => Build(
+            success ? RefactoredSuccess : RefactoredFailed,
+            success, storyId, sessionId, OperationRefactoring, files, testCount: null, error);
+
+    private static TammaEvent Build(
+        string type,
+        bool success,
+        string? storyId,
+        Guid sessionId,
+        string operation,
+        IReadOnlyList<string>? files,
+        int? testCount,
+        string? error)
+    {
+        var fileList = (files ?? Array.Empty<string>()).ToList();
+
+        var tags = new Dictionary<string, object?>
+        {
+            ["operation"] = operation,
+        };
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (sessionId != Guid.Empty) tags["sessionId"] = sessionId.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["operation"] = operation,
+            ["source"] = "ai_generated",
+            ["fileCount"] = fileList.Count,
+            ["files"] = fileList,
+        };
+        if (testCount is not null) data["testCount"] = testCount.Value;
+        if (!success && !string.IsNullOrWhiteSpace(error)) data["reason"] = error;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = success ? "success" : "error",
+            Error = success ? null : error,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/CommitChangesActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/CommitChangesActivity.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Tamma.Activities.Core;
 using Tamma.Activities.TDD.Models;
 
 namespace Tamma.Activities.TDD;
@@ -97,6 +98,13 @@ public class CommitChangesActivity : CodeActivity<CommitResult>
                 _logger?.LogWarning(
                     "TDD Commit: No files to commit for session {SessionId}", sessionId);
 
+                // Story 4-5 (AC2) — an empty change set is a loud COMMIT.CREATED.FAILED
+                // (no commit happened; never a silent non-event).
+                TammaEventEmitter.Emit(context, this, _logger,
+                    CommitEvents.BuildCreated(success: false, storyId, sessionId,
+                        sha: null, commitMessage, branchName, repositoryUrl, allFiles,
+                        error: "No files to commit"));
+
                 context.SetResult(new CommitResult
                 {
                     Success = false,
@@ -127,11 +135,25 @@ public class CommitChangesActivity : CodeActivity<CommitResult>
                 "TDD Commit: {Status} for session {SessionId}. SHA={Sha}, Message=\"{Message}\"",
                 result.Success ? "Committed" : "Failed", sessionId, result.CommitSha, result.CommitMessage);
 
+            // Story 4-5 (AC2) — capture the commit as a DCB event
+            // (COMMIT.CREATED.SUCCESS/FAILED) carrying sha / message / branch /
+            // file-count so every commit is on the audit stream.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CommitEvents.BuildCreated(result.Success, storyId, sessionId,
+                    result.CommitSha, result.CommitMessage, branchName, repositoryUrl,
+                    result.FilesCommitted, result.ErrorMessage));
+
             context.SetResult(result);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "TDD Commit: Error creating commit for session {SessionId}", sessionId);
+
+            // Story 4-5 (AC2) — loud, error-status failure edge.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CommitEvents.BuildCreated(success: false, storyId, sessionId,
+                    sha: null, commitMessage, branchName, repositoryUrl, allFiles,
+                    error: $"Commit failed: {ex.Message}"));
 
             context.SetResult(new CommitResult
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/CommitEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/CommitEvents.cs
@@ -1,0 +1,88 @@
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.TDD;
+
+/// <summary>
+/// Story 4-5 (AC2 — <c>CommitCreatedEvent</c>) — central catalogue of the
+/// <c>COMMIT.*</c> DCB event types emitted by <see cref="CommitChangesActivity"/>,
+/// the atomic TDD commit step (tests + implementation) at the tail of the
+/// red-green-refactor cycle. Every commit the autonomous loop creates is therefore
+/// observable on the DCB audit stream (<c>domain_events</c>) with its SHA, message,
+/// branch, and file count — satisfying the "every code/git op observable" audit
+/// rule.
+///
+/// <para>Emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine
+/// event drain (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same
+/// pattern the branch / PR / merge ADL activities use. No activity holds a DB /
+/// repository dependency of its own. The drain resolves the tenant from the
+/// workflow's <c>TenantId</c> variable (single-user run → platform-scope, TenantId
+/// null — never a throw).</para>
+///
+/// <para>Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c>
+/// convention. The FAILED type ALWAYS fires on the failure edge (no files to
+/// commit, engine-callback failure, exception) as a loud (error-status) row so a
+/// non-commit is never recorded as a silent false success.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>COMMIT.CREATED.SUCCESS</c> — an atomic commit landed
+///     (carries <c>sha</c>/<c>message</c>/<c>branch</c>/<c>fileCount</c>).</description></item>
+///   <item><description><c>COMMIT.CREATED.FAILED</c> — the commit did not happen
+///     (empty change set / callback failure / exception). Loud, error-status.</description></item>
+/// </list>
+/// </summary>
+public static class CommitEvents
+{
+    public const string CreatedSuccess = "COMMIT.CREATED.SUCCESS";
+    public const string CreatedFailed = "COMMIT.CREATED.FAILED";
+
+    /// <summary>True for the loud (error-status) FAILED type.</summary>
+    public static bool IsFailureType(string type) => type == CreatedFailed;
+
+    /// <summary>
+    /// Build a <c>COMMIT.CREATED.*</c> event. Tags carry the queryable DCB index
+    /// keys (<c>storyId</c>/<c>sessionId</c>/<c>branch</c>/<c>repository</c>, plus
+    /// <c>sha</c> on success); <c>Data</c> carries the commit payload
+    /// (<c>sha</c>/<c>message</c>/<c>branch</c>/<c>fileCount</c>/<c>files</c>) or the
+    /// failure <c>reason</c>. Pure (no Elsa context) — exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildCreated(
+        bool success,
+        string? storyId,
+        Guid sessionId,
+        string? sha,
+        string? message,
+        string? branch,
+        string? repository,
+        IReadOnlyList<string>? files,
+        string? error)
+    {
+        var fileList = (files ?? Array.Empty<string>()).ToList();
+
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(storyId)) tags["storyId"] = storyId;
+        if (sessionId != Guid.Empty) tags["sessionId"] = sessionId.ToString("D");
+        if (!string.IsNullOrWhiteSpace(branch)) tags["branch"] = branch;
+        if (!string.IsNullOrWhiteSpace(repository)) tags["repository"] = repository;
+        if (success && !string.IsNullOrWhiteSpace(sha)) tags["sha"] = sha;
+
+        var data = new Dictionary<string, object?>
+        {
+            ["fileCount"] = fileList.Count,
+            ["files"] = fileList,
+        };
+        if (!string.IsNullOrWhiteSpace(message)) data["message"] = message;
+        if (!string.IsNullOrWhiteSpace(branch)) data["branch"] = branch;
+        if (success && !string.IsNullOrWhiteSpace(sha)) data["sha"] = sha;
+        if (!success && !string.IsNullOrWhiteSpace(error)) data["reason"] = error;
+
+        return new TammaEvent
+        {
+            EventType = success ? CreatedSuccess : CreatedFailed,
+            Status = success ? "success" : "error",
+            Error = success ? null : error,
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteImplementationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteImplementationActivity.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Tamma.Activities.Core;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.TDD.Models;
 
@@ -103,17 +104,35 @@ public class WriteImplementationActivity : CodeActivity<ImplementationResult>
                 "TDD GREEN phase: Generated implementation across {FileCount} files for session {SessionId}",
                 result.ImplementationFiles.Count, sessionId);
 
+            // Story 4-5 (AC1) — capture the code-file write as a DCB event. The
+            // GREEN phase produced implementation code; emit CODE.GENERATED.SUCCESS
+            // (or the loud CODE.GENERATED.FAILED when generation yielded no code) so
+            // every code change is on the audit stream.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildGenerated(result.Success, storyId, sessionId,
+                    CodeEvents.OperationImplementation, result.ImplementationFiles,
+                    testCount: null, result.ErrorMessage));
+
             context.SetResult(result);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "TDD GREEN phase: Error generating implementation for session {SessionId}", sessionId);
 
-            context.SetResult(new ImplementationResult
+            var failed = new ImplementationResult
             {
                 Success = false,
                 ErrorMessage = $"Implementation generation failed: {ex.Message}"
-            });
+            };
+
+            // Story 4-5 (AC1) — the failure edge is auditable too (loud, error-status);
+            // a failed code generation is never a silent non-event.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildGenerated(success: false, storyId, sessionId,
+                    CodeEvents.OperationImplementation, failed.ImplementationFiles,
+                    testCount: null, failed.ErrorMessage));
+
+            context.SetResult(failed);
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteTestsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteTestsActivity.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Tamma.Activities.Core;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.TDD.Models;
 
@@ -110,17 +111,33 @@ public class WriteTestsActivity : CodeActivity<TestGenerationResult>
                 "TDD RED phase: Generated {TestCount} tests across {FileCount} files for session {SessionId}",
                 result.TestCount, result.TestFiles.Count, sessionId);
 
+            // Story 4-5 (AC1) — the RED phase authored test files; capture the code
+            // write as a DCB event (CODE.GENERATED.* with operation=testing) so test
+            // authoring is on the audit stream alongside implementation.
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildGenerated(result.Success, storyId, sessionId,
+                    CodeEvents.OperationTesting, result.TestFiles,
+                    testCount: result.TestCount, result.ErrorMessage));
+
             context.SetResult(result);
         }
         catch (Exception ex)
         {
             _logger?.LogError(ex, "TDD RED phase: Error generating tests for session {SessionId}", sessionId);
 
-            context.SetResult(new TestGenerationResult
+            var failed = new TestGenerationResult
             {
                 Success = false,
                 ErrorMessage = $"Test generation failed: {ex.Message}"
-            });
+            };
+
+            // Story 4-5 (AC1) — loud, error-status failure edge (never a silent non-event).
+            TammaEventEmitter.Emit(context, this, _logger,
+                CodeEvents.BuildGenerated(success: false, storyId, sessionId,
+                    CodeEvents.OperationTesting, failed.TestFiles,
+                    testCount: failed.TestCount, failed.ErrorMessage));
+
+            context.SetResult(failed);
         }
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/TDD/CodeGitEventTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/TDD/CodeGitEventTests.cs
@@ -1,0 +1,208 @@
+using System.Reflection;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.TDD;
+using Tamma.Core.Interfaces;
+
+namespace Tamma.Activities.Tests.TDD;
+
+/// <summary>
+/// Story 4-5 (AC1 <c>CodeFileWrittenEvent</c> / AC2 <c>CommitCreatedEvent</c>) —
+/// the code-change + commit DCB event-capture coverage. Asserts the pure event
+/// builders (<see cref="CodeEvents"/> / <see cref="CommitEvents"/>) that the RED /
+/// GREEN / REFACTOR / commit activities emit through <c>TammaEventEmitter</c>:
+/// correct <c>AGGREGATE.ACTION.STATUS</c> type, status, tags (issue/story/session/
+/// branch/repo/sha), and files-changed data — plus the loud FAILED edge and the
+/// null-tenant single-user path (no throw). Also the TAMMA001 cutover proof: the
+/// coverage adds NO credential-holding integration-service injection.
+/// </summary>
+[TestFixture]
+public class CodeGitEventTests
+{
+    private static readonly Guid Session = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    // ===================================================================
+    // CODE.GENERATED.* (AC1 — RED test authoring + GREEN implementation)
+    // ===================================================================
+
+    [Test]
+    public void BuildGenerated_ImplementationSuccess_Emits_CodeGeneratedSuccess_WithTagsAndFiles()
+    {
+        var files = new[] { "src/foo.ts", "src/bar.ts" };
+        var evt = CodeEvents.BuildGenerated(
+            success: true, storyId: "story-4-5", sessionId: Session,
+            operation: CodeEvents.OperationImplementation, files: files,
+            testCount: null, error: null);
+
+        evt.EventType.Should().Be(CodeEvents.GeneratedSuccess);
+        evt.Status.Should().Be("success");
+        evt.Error.Should().BeNull();
+        evt.Tags.Should().ContainKey("storyId").WhoseValue.Should().Be("story-4-5");
+        evt.Tags.Should().ContainKey("sessionId").WhoseValue.Should().Be(Session.ToString("D"));
+        evt.Tags.Should().ContainKey("operation").WhoseValue.Should().Be("implementation");
+        evt.Data.Should().ContainKey("fileCount").WhoseValue.Should().Be(2);
+        evt.Data.Should().ContainKey("source").WhoseValue.Should().Be("ai_generated");
+        evt.Data["files"].Should().BeEquivalentTo(files);
+        CodeEvents.IsFailureType(evt.EventType).Should().BeFalse();
+    }
+
+    [Test]
+    public void BuildGenerated_TestingSuccess_CarriesTestCount_AndTestingOperation()
+    {
+        var evt = CodeEvents.BuildGenerated(
+            success: true, storyId: "story-4-5", sessionId: Session,
+            operation: CodeEvents.OperationTesting, files: new[] { "src/foo.test.ts" },
+            testCount: 7, error: null);
+
+        evt.EventType.Should().Be(CodeEvents.GeneratedSuccess);
+        evt.Tags.Should().ContainKey("operation").WhoseValue.Should().Be("testing");
+        evt.Data.Should().ContainKey("operation").WhoseValue.Should().Be("testing");
+        evt.Data.Should().ContainKey("testCount").WhoseValue.Should().Be(7);
+    }
+
+    [Test]
+    public void BuildGenerated_Failure_Emits_CodeGeneratedFailed_LoudWithReason()
+    {
+        var evt = CodeEvents.BuildGenerated(
+            success: false, storyId: "story-4-5", sessionId: Session,
+            operation: CodeEvents.OperationImplementation, files: null,
+            testCount: null, error: "LLM returned empty code");
+
+        evt.EventType.Should().Be(CodeEvents.GeneratedFailed);
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("LLM returned empty code");
+        evt.Data.Should().ContainKey("reason").WhoseValue.Should().Be("LLM returned empty code");
+        evt.Data.Should().ContainKey("fileCount").WhoseValue.Should().Be(0);
+        CodeEvents.IsFailureType(evt.EventType).Should().BeTrue(
+            "a failed code generation is a loud error-status audit row, never a silent success");
+    }
+
+    // ===================================================================
+    // CODE.REFACTORED.* (AC1 — REFACTOR phase)
+    // ===================================================================
+
+    [Test]
+    public void BuildRefactored_Success_Emits_CodeRefactoredSuccess_WithRefactoringOperation()
+    {
+        var evt = CodeEvents.BuildRefactored(
+            success: true, storyId: "story-4-5", sessionId: Session,
+            files: new[] { "src/foo.ts" }, error: null);
+
+        evt.EventType.Should().Be(CodeEvents.RefactoredSuccess);
+        evt.Status.Should().Be("success");
+        evt.Tags.Should().ContainKey("operation").WhoseValue.Should().Be("refactoring");
+        evt.Data.Should().ContainKey("operation").WhoseValue.Should().Be("refactoring");
+        evt.Data.Should().ContainKey("fileCount").WhoseValue.Should().Be(1);
+    }
+
+    [Test]
+    public void BuildRefactored_Failure_Emits_CodeRefactoredFailed_Loud()
+    {
+        var evt = CodeEvents.BuildRefactored(
+            success: false, storyId: "story-4-5", sessionId: Session,
+            files: null, error: "refactor broke tests");
+
+        evt.EventType.Should().Be(CodeEvents.RefactoredFailed);
+        evt.Status.Should().Be("error");
+        evt.Data.Should().ContainKey("reason").WhoseValue.Should().Be("refactor broke tests");
+        CodeEvents.IsFailureType(evt.EventType).Should().BeTrue();
+    }
+
+    // ===================================================================
+    // Null-tenant / single-user path — no story/session must not throw and
+    // must simply omit those tags (platform-scope).
+    // ===================================================================
+
+    [Test]
+    public void BuildGenerated_NoStoryOrSession_OmitsThoseTags_NoThrow()
+    {
+        var evt = CodeEvents.BuildGenerated(
+            success: true, storyId: null, sessionId: Guid.Empty,
+            operation: CodeEvents.OperationImplementation, files: Array.Empty<string>(),
+            testCount: null, error: null);
+
+        evt.EventType.Should().Be(CodeEvents.GeneratedSuccess);
+        evt.Tags.Should().NotContainKey("storyId");
+        evt.Tags.Should().NotContainKey("sessionId");
+        evt.Tags.Should().ContainKey("operation");
+    }
+
+    // ===================================================================
+    // COMMIT.CREATED.* (AC2)
+    // ===================================================================
+
+    [Test]
+    public void BuildCreated_Success_Emits_CommitCreatedSuccess_WithShaBranchAndFileCount()
+    {
+        var files = new[] { "src/foo.ts", "src/foo.test.ts" };
+        var evt = CommitEvents.BuildCreated(
+            success: true, storyId: "story-4-5", sessionId: Session,
+            sha: "abc1234def", message: "feat(story-4-5): task [TDD]",
+            branch: "feature/story-4-5", repository: "acme/widgets",
+            files: files, error: null);
+
+        evt.EventType.Should().Be(CommitEvents.CreatedSuccess);
+        evt.Status.Should().Be("success");
+        evt.Error.Should().BeNull();
+        evt.Tags.Should().ContainKey("sha").WhoseValue.Should().Be("abc1234def");
+        evt.Tags.Should().ContainKey("branch").WhoseValue.Should().Be("feature/story-4-5");
+        evt.Tags.Should().ContainKey("repository").WhoseValue.Should().Be("acme/widgets");
+        evt.Tags.Should().ContainKey("storyId").WhoseValue.Should().Be("story-4-5");
+        evt.Tags.Should().ContainKey("sessionId").WhoseValue.Should().Be(Session.ToString("D"));
+        evt.Data.Should().ContainKey("sha").WhoseValue.Should().Be("abc1234def");
+        evt.Data.Should().ContainKey("message").WhoseValue.Should().Be("feat(story-4-5): task [TDD]");
+        evt.Data.Should().ContainKey("branch").WhoseValue.Should().Be("feature/story-4-5");
+        evt.Data.Should().ContainKey("fileCount").WhoseValue.Should().Be(2);
+        evt.Data["files"].Should().BeEquivalentTo(files);
+    }
+
+    [Test]
+    public void BuildCreated_Failure_Emits_CommitCreatedFailed_LoudWithReason_NoShaTag()
+    {
+        var evt = CommitEvents.BuildCreated(
+            success: false, storyId: "story-4-5", sessionId: Session,
+            sha: null, message: "feat(story-4-5): task [TDD]",
+            branch: "feature/story-4-5", repository: "acme/widgets",
+            files: Array.Empty<string>(), error: "No files to commit");
+
+        evt.EventType.Should().Be(CommitEvents.CreatedFailed);
+        evt.Status.Should().Be("error");
+        evt.Error.Should().Be("No files to commit");
+        evt.Tags.Should().NotContainKey("sha", "a failed commit has no SHA to index");
+        evt.Data.Should().ContainKey("reason").WhoseValue.Should().Be("No files to commit");
+        evt.Data.Should().ContainKey("fileCount").WhoseValue.Should().Be(0);
+        CommitEvents.IsFailureType(evt.EventType).Should().BeTrue();
+    }
+
+    // ===================================================================
+    // Cutover proof (TAMMA001) — the coverage pass injects NO
+    // credential-holding vendor/git integration service into any engine
+    // activity it touches. Emissions go through the transient-list drain only.
+    // ===================================================================
+
+    [Test]
+    public void TouchedActivities_InjectNoCredentialHoldingIntegrationService()
+    {
+        foreach (var type in new[]
+        {
+            typeof(WriteTestsActivity),
+            typeof(WriteImplementationActivity),
+            typeof(ApplyRefactoringActivity),
+            typeof(CommitChangesActivity),
+        })
+        {
+            foreach (var ctor in type.GetConstructors())
+            {
+                ctor.GetParameters()
+                    .Any(p => typeof(IGitHubIntegrationService).IsAssignableFrom(p.ParameterType)
+                              || typeof(IIntegrationService).IsAssignableFrom(p.ParameterType))
+                    .Should().BeFalse($"{type.Name} must not inject a credential-holding integration service");
+            }
+
+            type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Any(f => typeof(IGitHubIntegrationService).IsAssignableFrom(f.FieldType)
+                          || typeof(IIntegrationService).IsAssignableFrom(f.FieldType))
+                .Should().BeFalse($"{type.Name} must hold no credential-holding integration-service field");
+        }
+    }
+}


### PR DESCRIPTION
## What

Story 4-5 — coverage pass (like #446/4-6) ensuring every code-change + git op emits a DCB audit event. Audited all flows; branch/PR-create/merge/release + the mediated `GitMediationService` (`GIT.*`) were already covered. Filled the AC1/AC2 gaps (previously silent):

| Activity | Added event |
|---|---|
| `WriteTestsActivity` (TDD RED) | `CODE.GENERATED.SUCCESS/FAILED` (operation=testing) |
| `WriteImplementationActivity` (GREEN) | `CODE.GENERATED.*` (operation=implementation) |
| `ApplyRefactoringActivity` | `CODE.REFACTORED.*` |
| `CommitChangesActivity` | `COMMIT.CREATED.*` (sha/branch/files) |

New `CodeEvents`/`CommitEvents` catalogs; both success + loud error edges captured (no silent false success). All via the existing `TammaEventEmitter` (tenant from workflow `TenantId`, single-user = platform-scope, never throws). `CODE.GENERATED.FAILED` fulfils the string `SensitiveActionCatalog` had reserved.

## Verification

- Build 0 errors, no TAMMA001 (reflection test proves the 4 activities inject no git-credential type). Both `has-pending-model-changes` → "No changes" (JSONB appends). **No Program.cs touch.** Tests: new 9 + Activities TDD 173 + Api git/code/PR/merge/release 269 — all green.

Deferred: AC6 (diff blobs — no blob store to reuse), AC7 richer who-triggered attribution (CODE events tag `source=ai_generated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)