### PR TITLE
feat(epic-23-1): System Health overview page

### DIFF
--- a/packages/dashboard/src/hooks/monitoring/useSystemHealth.ts
+++ b/packages/dashboard/src/hooks/monitoring/useSystemHealth.ts
@@ -1,0 +1,371 @@
+/**
+ * useSystemHealth — data hook for the System Health overview (Story 23-1).
+ *
+ * The Epic-23 monitoring LANDING page composes existing, read-only sources —
+ * it adds NO new health infrastructure. Four sources are fetched in parallel
+ * and merged into a single at-a-glance summary; each source is fetched
+ * independently (`Promise.allSettled`) so one unavailable source degrades to a
+ * red service card rather than blanking the whole page:
+ *
+ *   • `GET /api/health` — API process liveness (`{ status, version }`). Public.
+ *   • `GET /api/providers/health` — per-provider circuit-breaker state
+ *     (tenant-scoped, settings:view). Drives the provider status cards + the
+ *     healthy/total roll-up.
+ *   • `GET /api/providers/diagnostics/deep?from&to` — the Story 23-6 tenant
+ *     aggregation. Only its `totalCalls` / `totalErrors` are read here for
+ *     throughput + error-rate; cost/token economics are intentionally NOT
+ *     surfaced on this overview (health/status only — no cost leak).
+ *   • `GET /api/engine/events/query?from&to` — the Story 4-7 tenant-scoped DCB
+ *     event query. Drives the recent-events/errors table, the active-run count
+ *     (distinct correlation ids) and the recent-error count.
+ *
+ * Every source is tenant-scoped server-side; a null tenant on the tenant-scoped
+ * routes fails closed there (404 / empty page) — this hook never fans out.
+ * Responses arrive with ASP.NET Core's camelCase policy.
+ */
+
+import { useCallback, useState } from 'react';
+import type { StatusKind } from '../../components/monitoring/StatusBadge.js';
+
+/** Health of one composed data source, rendered as a service status card. */
+export interface ServiceStatus {
+  key: string;
+  label: string;
+  kind: StatusKind;
+  detail: string;
+}
+
+/** A single provider's live circuit-breaker health. */
+export interface ProviderHealthRow {
+  providerKey: string;
+  kind: StatusKind;
+  label: string;
+  failureCount: number;
+  lastFailure: string | null;
+}
+
+/** A recent DCB event projected for the overview table. */
+export interface RecentEventRow {
+  id: string;
+  type: string;
+  isError: boolean;
+  correlationId: string | null;
+  issueNumber: number | null;
+  createdAt: string;
+}
+
+export interface SystemHealthSummary {
+  services: ServiceStatus[];
+  providers: ProviderHealthRow[];
+  providerHealthy: number;
+  providerTotal: number;
+  recentEvents: RecentEventRow[];
+  recentEventTotal: number | null;
+  recentErrorCount: number;
+  activeRuns: number;
+  totalCalls: number;
+  totalErrors: number;
+  errorRate: number;
+  diagnosticsAvailable: boolean;
+}
+
+export interface UseSystemHealthResult {
+  summary: SystemHealthSummary | null;
+  loading: boolean;
+  /** Set only when EVERY source failed (catastrophic). Per-source failures
+   *  surface as a `down` service card, not a page-level error. */
+  error: string | null;
+  lastUpdated: Date | null;
+  load: (range: { start: Date; end: Date }) => Promise<void>;
+}
+
+// ── Wire shapes (subset of each endpoint's response) ────────────────────────
+
+interface HealthResponse {
+  status?: string;
+  version?: string;
+}
+
+interface ProviderHealthWire {
+  providerKey: string;
+  state?: string;
+  status?: string;
+  failureCount?: number;
+  lastFailure?: string | null;
+}
+
+interface ProviderHealthResponse {
+  providers?: ProviderHealthWire[];
+}
+
+interface DeepReportWire {
+  totalCalls?: number;
+  totalErrors?: number;
+}
+
+interface EventWire {
+  id: string;
+  type: string;
+  tags: unknown;
+  createdAt: string;
+  issueNumber: number | null;
+}
+
+interface EventQueryResponse {
+  events?: EventWire[];
+  total?: number | null;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+/** Events whose type marks a failure/rejection — drives the "error" flag. */
+const ERROR_TYPE_PATTERN = /(FAIL|ERROR|REJECT|TIMEOUT|DENIED|EXHAUST)/i;
+
+const RECENT_EVENT_LIMIT = 100;
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // keep the default status message
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as T;
+}
+
+/** Map the circuit-breaker `status` string to a badge kind + label. */
+function providerKind(status: string | undefined): { kind: StatusKind; label: string } {
+  switch (status) {
+    case 'healthy':
+      return { kind: 'healthy', label: 'Healthy' };
+    case 'degraded':
+      return { kind: 'degraded', label: 'Half-open' };
+    case 'down':
+      return { kind: 'down', label: 'Circuit open' };
+    default:
+      return { kind: 'unknown', label: 'Unknown' };
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Pull a string tag out of the (possibly null) parsed tag bag. */
+function stringTag(tags: unknown, key: string): string | null {
+  if (!isRecord(tags)) return null;
+  const v = tags[key];
+  return typeof v === 'string' && v.length > 0 ? v : null;
+}
+
+function isErrorEvent(e: EventWire): boolean {
+  if (ERROR_TYPE_PATTERN.test(e.type)) return true;
+  return stringTag(e.tags, 'status')?.toLowerCase() === 'failed';
+}
+
+export function useSystemHealth(): UseSystemHealthResult {
+  const [summary, setSummary] = useState<SystemHealthSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const load = useCallback(async (range: { start: Date; end: Date }): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams({
+      from: range.start.toISOString(),
+      to: range.end.toISOString(),
+    });
+    const eventParams = new URLSearchParams(params);
+    eventParams.set('limit', String(RECENT_EVENT_LIMIT));
+    eventParams.set('includeTotal', 'true');
+
+    const [healthRes, providersRes, deepRes, eventsRes] = await Promise.allSettled([
+      fetchJson<HealthResponse>(`${API_BASE}/api/health`),
+      fetchJson<ProviderHealthResponse>(`${API_BASE}/api/providers/health`),
+      fetchJson<DeepReportWire>(
+        `${API_BASE}/api/providers/diagnostics/deep?${params.toString()}`,
+      ),
+      fetchJson<EventQueryResponse>(
+        `${API_BASE}/api/engine/events/query?${eventParams.toString()}`,
+      ),
+    ]);
+
+    // Catastrophic: nothing responded (e.g. network down / logged out).
+    if (
+      healthRes.status === 'rejected' &&
+      providersRes.status === 'rejected' &&
+      deepRes.status === 'rejected' &&
+      eventsRes.status === 'rejected'
+    ) {
+      setError(
+        healthRes.reason instanceof Error
+          ? healthRes.reason.message
+          : 'Failed to load system health',
+      );
+      setLoading(false);
+      return;
+    }
+
+    const services: ServiceStatus[] = [];
+
+    // ── API process ──
+    if (healthRes.status === 'fulfilled') {
+      const ok = (healthRes.value.status ?? '').toLowerCase() === 'ok';
+      services.push({
+        key: 'api',
+        label: 'API',
+        kind: ok ? 'healthy' : 'degraded',
+        detail: healthRes.value.version
+          ? `v${healthRes.value.version}`
+          : ok
+            ? 'Operational'
+            : 'Unexpected status',
+      });
+    } else {
+      services.push({ key: 'api', label: 'API', kind: 'down', detail: 'Unreachable' });
+    }
+
+    // ── AI providers (circuit-breaker roll-up) ──
+    let providers: ProviderHealthRow[] = [];
+    let providerHealthy = 0;
+    if (providersRes.status === 'fulfilled') {
+      providers = (providersRes.value.providers ?? []).map((p) => {
+        const { kind, label } = providerKind(p.status);
+        return {
+          providerKey: p.providerKey,
+          kind,
+          label,
+          failureCount: p.failureCount ?? 0,
+          lastFailure: p.lastFailure ?? null,
+        };
+      });
+      providerHealthy = providers.filter((p) => p.kind === 'healthy').length;
+      const anyDown = providers.some((p) => p.kind === 'down');
+      const anyDegraded = providers.some((p) => p.kind === 'degraded');
+      services.push({
+        key: 'providers',
+        label: 'AI providers',
+        kind:
+          providers.length === 0
+            ? 'unknown'
+            : anyDown
+              ? 'down'
+              : anyDegraded
+                ? 'degraded'
+                : 'healthy',
+        detail:
+          providers.length === 0
+            ? 'None tracked'
+            : `${providerHealthy}/${providers.length} healthy`,
+      });
+    } else {
+      services.push({
+        key: 'providers',
+        label: 'AI providers',
+        kind: 'down',
+        detail: 'Health unavailable',
+      });
+    }
+
+    // ── Provider diagnostics (throughput + error-rate source) ──
+    let totalCalls = 0;
+    let totalErrors = 0;
+    const diagnosticsAvailable = deepRes.status === 'fulfilled';
+    if (deepRes.status === 'fulfilled') {
+      totalCalls = deepRes.value.totalCalls ?? 0;
+      totalErrors = deepRes.value.totalErrors ?? 0;
+      const errRate = totalCalls > 0 ? totalErrors / totalCalls : 0;
+      services.push({
+        key: 'diagnostics',
+        label: 'Diagnostics',
+        kind:
+          totalCalls === 0
+            ? 'unknown'
+            : errRate === 0
+              ? 'healthy'
+              : errRate < 0.5
+                ? 'degraded'
+                : 'down',
+        detail: totalCalls === 0 ? 'No calls in window' : `${totalCalls.toLocaleString()} calls`,
+      });
+    } else {
+      services.push({
+        key: 'diagnostics',
+        label: 'Diagnostics',
+        kind: 'down',
+        detail: 'Report unavailable',
+      });
+    }
+
+    // ── Event store (recent events / active runs / recent errors source) ──
+    let recentEvents: RecentEventRow[] = [];
+    let recentEventTotal: number | null = null;
+    let recentErrorCount = 0;
+    let activeRuns = 0;
+    if (eventsRes.status === 'fulfilled') {
+      const rows = eventsRes.value.events ?? [];
+      const correlationIds = new Set<string>();
+      recentEvents = rows.map((e) => {
+        const correlationId = stringTag(e.tags, 'correlationId');
+        if (correlationId) correlationIds.add(correlationId);
+        const isError = isErrorEvent(e);
+        if (isError) recentErrorCount += 1;
+        return {
+          id: e.id,
+          type: e.type,
+          isError,
+          correlationId,
+          issueNumber: e.issueNumber,
+          createdAt: e.createdAt,
+        };
+      });
+      activeRuns = correlationIds.size;
+      recentEventTotal = eventsRes.value.total ?? null;
+      services.push({
+        key: 'events',
+        label: 'Event store',
+        kind: 'healthy',
+        detail:
+          recentEventTotal != null
+            ? `${recentEventTotal.toLocaleString()} in window`
+            : `${rows.length} recent`,
+      });
+    } else {
+      services.push({
+        key: 'events',
+        label: 'Event store',
+        kind: 'down',
+        detail: 'Query unavailable',
+      });
+    }
+
+    setSummary({
+      services,
+      providers,
+      providerHealthy,
+      providerTotal: providers.length,
+      recentEvents,
+      recentEventTotal,
+      recentErrorCount,
+      activeRuns,
+      totalCalls,
+      totalErrors,
+      errorRate: totalCalls > 0 ? totalErrors / totalCalls : 0,
+      diagnosticsAvailable,
+    });
+    setLastUpdated(new Date());
+    setLoading(false);
+  }, []);
+
+  return { summary, loading, error, lastUpdated, load };
+}

--- a/packages/dashboard/src/pages/monitoring/SystemHealthPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/SystemHealthPage.tsx
@@ -1,21 +1,322 @@
 /**
- * System Health monitoring page. Scaffold from Story 23-12; full dashboard
- * arrives in Story 23-1.
+ * System Health — Story 23-1.
+ *
+ * The Epic-23 monitoring LANDING page: an at-a-glance operator overview of
+ * system health. It COMPOSES existing read-only sources (no new health
+ * infrastructure) via {@link useSystemHealth}:
+ *   • `GET /api/health` — API process liveness.
+ *   • `GET /api/providers/health` — provider circuit-breaker state.
+ *   • `GET /api/providers/diagnostics/deep` — throughput + error-rate (Story 23-6).
+ *   • `GET /api/engine/events/query` — recent events, active runs, recent errors
+ *     (Story 4-7).
+ *
+ * Deliberately health/status ONLY — no cost/token/margin figures are surfaced
+ * here (those live behind Provider Diagnostics). The page links out to the
+ * detail sections (Provider Diagnostics, Event Explorer) via the monitoring-nav
+ * manifest.
+ *
+ * Built entirely on the Story 23-12 monitoring primitives (MonitoringLayout,
+ * MetricGrid/MetricCard, StatusBadge, DataTable, EmptyState, ErrorBanner) and
+ * hooks (useTimeRange, useAutoRefresh). The route is already `AdminGuard`-gated
+ * + lazy-mounted by Story 23-12; this module only supplies the page body.
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useCallback, useEffect, useMemo, useRef, type JSX } from 'react';
+import { Link } from 'react-router-dom';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import { MetricGrid } from '../../components/monitoring/MetricGrid.js';
+import { MetricCard } from '../../components/monitoring/MetricCard.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { DataTable, type DataTableColumn } from '../../components/monitoring/DataTable.js';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import { useTimeRange } from '../../hooks/monitoring/useTimeRange.js';
+import {
+  useSystemHealth,
+  type ProviderHealthRow,
+  type RecentEventRow,
+  type ServiceStatus,
+} from '../../hooks/monitoring/useSystemHealth.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/health');
+const PROVIDERS_NAV = getMonitoringNavItem('/monitoring/providers');
+const EVENTS_NAV = getMonitoringNavItem('/monitoring/events');
+
+const DETAIL_LINK_CLASS =
+  'text-xs font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300';
+
+function formatInt(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatPct(fraction: number): string {
+  return `${(fraction * 100).toFixed(1)}%`;
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+/** A single composed-source health tile. */
+function ServiceCard({ service }: { service: ServiceStatus }): JSX.Element {
+  return (
+    <div
+      data-testid="service-card"
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {service.label}
+        </span>
+        <StatusBadge status={service.kind}>{service.kind}</StatusBadge>
+      </div>
+      <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">{service.detail}</p>
+    </div>
+  );
+}
+
+const PROVIDER_COLUMNS: DataTableColumn<ProviderHealthRow>[] = [
+  {
+    key: 'providerKey',
+    header: 'Provider',
+    accessor: (r) => r.providerKey,
+    sortable: true,
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    accessor: (r) => r.label,
+    render: (r) => <StatusBadge status={r.kind}>{r.label}</StatusBadge>,
+    sortable: true,
+  },
+  {
+    key: 'failureCount',
+    header: 'Failures',
+    accessor: (r) => r.failureCount,
+    align: 'right',
+    sortable: true,
+  },
+  {
+    key: 'lastFailure',
+    header: 'Last failure',
+    accessor: (r) => r.lastFailure ?? '',
+    render: (r) => (r.lastFailure ? formatTime(r.lastFailure) : '—'),
+    sortable: true,
+  },
+];
+
+const EVENT_COLUMNS: DataTableColumn<RecentEventRow>[] = [
+  {
+    key: 'createdAt',
+    header: 'Time',
+    accessor: (r) => r.createdAt,
+    render: (r) => <span className="whitespace-nowrap">{formatTime(r.createdAt)}</span>,
+    sortable: true,
+  },
+  {
+    key: 'type',
+    header: 'Event',
+    accessor: (r) => r.type,
+    render: (r) => (
+      <span className="inline-flex items-center gap-2">
+        {r.isError && <StatusBadge status="down" showDot={false}>error</StatusBadge>}
+        <code className="text-xs">{r.type}</code>
+      </span>
+    ),
+    sortable: true,
+  },
+  {
+    key: 'correlationId',
+    header: 'Correlation',
+    accessor: (r) => r.correlationId ?? '',
+    render: (r) =>
+      r.correlationId ? <code className="text-xs">{r.correlationId}</code> : '—',
+    sortable: true,
+  },
+  {
+    key: 'issueNumber',
+    header: 'Issue',
+    accessor: (r) => r.issueNumber ?? '',
+    render: (r) => (r.issueNumber != null ? `#${r.issueNumber}` : '—'),
+    align: 'right',
+    sortable: true,
+  },
+];
 
 export function SystemHealthPage(): JSX.Element {
+  const { preset, range, setPreset } = useTimeRange('24h');
+  const { summary, loading, error, lastUpdated, load } = useSystemHealth();
+
+  // Stable trigger that always reads the latest time-range window, so the
+  // interval timer / manual refresh / preset change reuse it without re-arming.
+  const loadRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    loadRef.current = () => {
+      void load({ start: range.start, end: range.end });
+    };
+  }, [load, range]);
+  const trigger = useCallback(() => loadRef.current(), []);
+
+  const autoRefresh = useAutoRefresh(trigger, {
+    storageKey: NAV.storageKey,
+    defaultInterval: null,
+  });
+
+  // Run on mount and whenever the time-range preset changes.
+  useEffect(() => {
+    trigger();
+  }, [trigger, preset]);
+
+  const services = summary?.services ?? [];
+  const providers = summary?.providers ?? [];
+  const recentEvents = summary?.recentEvents ?? [];
+
+  const errorRateTone = useMemo(() => {
+    if (!summary || summary.totalCalls === 0) return undefined;
+    return summary.totalErrors > 0 ? ('red' as const) : ('green' as const);
+  }, [summary]);
+
   return (
-    <MonitoringPlaceholder
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="At-a-glance operator overview — service status, AI-provider health, active runs, error rate and recent events for your tenant."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={trigger}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      timeRange={preset}
+      onTimeRangeChange={setPreset}
+      showTimeRange
+      actions={
+        <div className="flex items-center gap-3">
+          <Link to={PROVIDERS_NAV.to} className={DETAIL_LINK_CLASS}>
+            Provider diagnostics →
+          </Link>
+          <Link to={EVENTS_NAV.to} className={DETAIL_LINK_CLASS}>
+            Event explorer →
+          </Link>
+        </div>
+      }
+    >
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={trigger} />
+        </div>
+      )}
+
+      {/* Services / provider status roll-up */}
+      <section className="mb-6" aria-label="Service status">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">Services</h2>
+        {services.length === 0 && !loading ? (
+          <EmptyState title="No status yet" description="Health sources have not reported." />
+        ) : (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {services.map((service) => (
+              <ServiceCard key={service.key} service={service} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Key metrics */}
+      {summary && (
+        <MetricGrid columns={4} className="mb-6">
+          <MetricCard
+            label="Active runs"
+            value={formatInt(summary.activeRuns)}
+            hint="distinct correlation IDs (window)"
+          />
+          <MetricCard
+            label="Error rate"
+            value={summary.diagnosticsAvailable ? formatPct(summary.errorRate) : '—'}
+            hint={
+              summary.diagnosticsAvailable
+                ? `${formatInt(summary.totalErrors)} of ${formatInt(summary.totalCalls)} provider calls`
+                : 'diagnostics unavailable'
+            }
+            {...(errorRateTone ? { tone: errorRateTone } : {})}
+          />
+          <MetricCard
+            label="Throughput"
+            value={summary.diagnosticsAvailable ? formatInt(summary.totalCalls) : '—'}
+            hint="provider calls in window"
+            {...(summary.diagnosticsAvailable ? { unit: 'calls' } : {})}
+          />
+          <MetricCard
+            label="Recent errors"
+            value={formatInt(summary.recentErrorCount)}
+            tone={summary.recentErrorCount > 0 ? 'red' : 'green'}
+            hint={
+              summary.recentEventTotal != null
+                ? `${formatInt(summary.recentEventTotal)} events in window`
+                : `in ${formatInt(recentEvents.length)} recent events`
+            }
+          />
+        </MetricGrid>
+      )}
+
+      {/* Provider health detail */}
+      <section className="mb-6" aria-label="Provider health">
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200">
+            AI providers
+            {summary && summary.providerTotal > 0 && (
+              <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">
+                {summary.providerHealthy}/{summary.providerTotal} healthy
+              </span>
+            )}
+          </h2>
+          <Link to={PROVIDERS_NAV.to} className={DETAIL_LINK_CLASS}>
+            View diagnostics →
+          </Link>
+        </div>
+        {providers.length === 0 ? (
+          <EmptyState
+            title="No providers tracked"
+            description="No AI-provider circuit-breaker state has been recorded for this tenant."
+          />
+        ) : (
+          <DataTable
+            columns={PROVIDER_COLUMNS}
+            rows={providers}
+            getRowId={(r) => r.providerKey}
+            pageSize={10}
+            filterable={false}
+            initialSort={{ key: 'providerKey', direction: 'asc' }}
+            emptyTitle="No providers tracked"
+          />
+        )}
+      </section>
+
+      {/* Recent events / errors */}
+      <section aria-label="Recent events">
+        <div className="mb-2 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-gray-700 dark:text-gray-200">Recent events</h2>
+          <Link to={EVENTS_NAV.to} className={DETAIL_LINK_CLASS}>
+            Open event explorer →
+          </Link>
+        </div>
+        {recentEvents.length === 0 ? (
+          <EmptyState
+            title="No recent events"
+            description="No audit events were recorded in the selected time range."
+          />
+        ) : (
+          <DataTable
+            columns={EVENT_COLUMNS}
+            rows={recentEvents}
+            getRowId={(r) => r.id}
+            pageSize={10}
+            filterPlaceholder="Filter events…"
+            initialSort={{ key: 'createdAt', direction: 'desc' }}
+            emptyTitle="No recent events"
+          />
+        )}
+      </section>
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/monitoring-pages.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/monitoring-pages.test.tsx
@@ -12,6 +12,10 @@ vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
   useCurrentUser: () => mockUseCurrentUser(),
 }));
 
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
 function renderInRouter(node: React.ReactNode, path = '/monitoring/health') {
   return render(<MemoryRouter initialEntries={[path]}>{node}</MemoryRouter>);
 }
@@ -40,9 +44,20 @@ describe('MonitoringOverviewPage', () => {
 });
 
 describe('monitoring page RBAC (mirrors the route AdminGuard)', () => {
-  afterEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    // System Health composes existing endpoints on mount — stub fetch so the
+    // page renders without hitting the network.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(okResponse({}))),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
 
-  it('renders the page + scaffold empty-state for an admin', () => {
+  it('renders the System Health overview for an admin', () => {
     mockUseCurrentUser.mockReturnValue({
       user: { id: 'u1', role: 'admin' },
       loading: false,
@@ -54,7 +69,8 @@ describe('monitoring page RBAC (mirrors the route AdminGuard)', () => {
       </AdminGuard>,
     );
     expect(screen.getByRole('heading', { name: 'System Health' })).toBeInTheDocument();
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    // The overview renders its composed sections, not the scaffold placeholder.
+    expect(screen.getByRole('heading', { name: 'Services' })).toBeInTheDocument();
   });
 
   it('does NOT render the page for a non-admin member', () => {

--- a/packages/dashboard/src/pages/monitoring/__tests__/system-health-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/system-health-page.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { SystemHealthPage } from '../SystemHealthPage.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function errResponse(status: number, body: unknown): Response {
+  return { ok: false, status, json: async () => body } as unknown as Response;
+}
+
+const healthResponse = { status: 'ok', timestamp: '2026-07-05T12:00:00Z', version: '2.0.0' };
+
+const providerHealthResponse = {
+  providers: [
+    {
+      providerKey: 'anthropic-claude',
+      state: 'Closed',
+      status: 'healthy',
+      failureCount: 0,
+      lastFailure: null,
+    },
+    {
+      providerKey: 'openai',
+      state: 'Open',
+      status: 'down',
+      failureCount: 5,
+      lastFailure: '2026-07-05T10:00:00Z',
+    },
+  ],
+  byKey: {},
+};
+
+const deepResponse = {
+  from: '2026-07-04T12:00:00Z',
+  to: '2026-07-05T12:00:00Z',
+  totalCalls: 10,
+  totalErrors: 2,
+  totalTokens: 0,
+  totalCost: 0,
+  providers: [],
+};
+
+const eventsResponse = {
+  events: [
+    {
+      id: 'e1',
+      type: 'CODE.GENERATED.SUCCESS',
+      tags: { correlationId: 'run-1' },
+      data: {},
+      createdAt: '2026-07-05T11:59:00Z',
+      issueNumber: 42,
+      sequenceNumber: 2,
+    },
+    {
+      id: 'e2',
+      type: 'CODE.GENERATED.FAILED',
+      tags: { correlationId: 'run-2', status: 'failed' },
+      data: {},
+      createdAt: '2026-07-05T11:58:00Z',
+      issueNumber: 42,
+      sequenceNumber: 1,
+    },
+  ],
+  total: 2,
+  limit: 100,
+  nextCursor: null,
+  hasMore: false,
+};
+
+const fetchMock = vi.fn();
+
+/** Route by URL; per-source overrides let a test fail one source in isolation. */
+function routeFetch(
+  over: Partial<{ health: Response; providers: Response; deep: Response; events: Response }> = {},
+): void {
+  fetchMock.mockImplementation((url: string) => {
+    const u = String(url);
+    if (u.includes('/api/providers/diagnostics/deep'))
+      return Promise.resolve(over.deep ?? okResponse(deepResponse));
+    if (u.includes('/api/providers/health'))
+      return Promise.resolve(over.providers ?? okResponse(providerHealthResponse));
+    if (u.includes('/api/engine/events/query'))
+      return Promise.resolve(over.events ?? okResponse(eventsResponse));
+    if (u.includes('/api/health')) return Promise.resolve(over.health ?? okResponse(healthResponse));
+    return Promise.resolve(okResponse({}));
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  routeFetch();
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/health']}>
+      <SystemHealthPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('SystemHealthPage', () => {
+  it('composes the four health/diagnostics/event sources into one overview', async () => {
+    renderPage();
+
+    // Service status cards (one per composed source).
+    expect(await screen.findByText('AI providers')).toBeInTheDocument();
+    expect(screen.getByText('API')).toBeInTheDocument();
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument();
+    expect(screen.getByText('Event store')).toBeInTheDocument();
+
+    // Provider health roll-up (anthropic healthy, openai down → 1/2 healthy).
+    expect(screen.getAllByText('1/2 healthy').length).toBeGreaterThan(0);
+
+    // Key metrics.
+    expect(screen.getByText('Active runs')).toBeInTheDocument();
+    expect(screen.getByText('Error rate')).toBeInTheDocument();
+    expect(screen.getByText('20.0%')).toBeInTheDocument(); // 2 / 10 provider calls
+    expect(screen.getByText('Throughput')).toBeInTheDocument();
+
+    // Provider detail table + circuit-breaker badges.
+    expect(screen.getByText('anthropic-claude')).toBeInTheDocument();
+    expect(screen.getByText('openai')).toBeInTheDocument();
+    expect(screen.getByText('Circuit open')).toBeInTheDocument();
+
+    // Recent-events table with an error-flagged row.
+    expect(screen.getByText('CODE.GENERATED.SUCCESS')).toBeInTheDocument();
+    expect(screen.getByText('CODE.GENERATED.FAILED')).toBeInTheDocument();
+
+    // All four existing sources were queried.
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes('/api/health'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/providers/health'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/providers/diagnostics/deep'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/engine/events/query'))).toBe(true);
+    });
+  });
+
+  it('links out to the Provider Diagnostics and Event Explorer detail pages', async () => {
+    renderPage();
+    await screen.findByText('AI providers');
+
+    const providerLinks = screen.getAllByRole('link', { name: /provider diagnostics|view diagnostics/i });
+    expect(providerLinks.some((a) => a.getAttribute('href') === '/monitoring/providers')).toBe(true);
+
+    const eventLinks = screen.getAllByRole('link', { name: /event explorer/i });
+    expect(eventLinks.some((a) => a.getAttribute('href') === '/monitoring/events')).toBe(true);
+  });
+
+  it('degrades a single unavailable source to a down service card (fail-soft)', async () => {
+    routeFetch({ events: errResponse(500, { error: 'boom' }) });
+    renderPage();
+
+    // The rest of the overview still renders…
+    expect(await screen.findByText('AI providers')).toBeInTheDocument();
+    // …and the failed source shows its down detail instead of blanking the page.
+    expect(screen.getByText('Query unavailable')).toBeInTheDocument();
+    // No page-level error banner for a partial failure.
+    expect(screen.queryByTestId('error-banner')).not.toBeInTheDocument();
+  });
+
+  it('shows a page-level error banner only when every source fails', async () => {
+    fetchMock.mockImplementation(() => Promise.reject(new Error('network down')));
+    renderPage();
+    expect(await screen.findByTestId('error-banner')).toHaveTextContent('network down');
+  });
+});
+
+describe('SystemHealthPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/health']}>
+        <AdminGuard>
+          <SystemHealthPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'System Health' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/health']}>
+        <AdminGuard>
+          <SystemHealthPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'System Health' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Story 23.1 — the monitoring overview landing page. **Pure frontend** — composes existing read-only endpoints, no backend/endpoint/migration.

- `useSystemHealth` hook aggregates 4 existing sources via `Promise.allSettled` (each fail-soft): `/api/health` (liveness), `/api/providers/health` (circuit state), `/api/providers/diagnostics/deep` (reads only totalCalls/totalErrors for throughput/error-rate), `/api/engine/events/query` (recent events, active-run count, recent errors).
- `SystemHealthPage` (replaces the #289 stub): service status cards, key-metrics grid (active runs, error rate, throughput), provider-health + recent-events tables, links to Provider Diagnostics / Event Explorer. `AdminGuard`-gated, time-range + auto-refresh.

## Safety

Health/status only — the deep report's `totalCost`/`totalTokens` are deliberately **not** read/rendered (no economics leak). Null-tenant fail-closed is inherited from the #283 server guards. **Queue depth intentionally omitted** — its only source is cross-tenant `PlatformOwnerAccess`; surfaced tenant-scoped "active runs" instead (honest labeling, no fabricated agent count).

## Verification

- `pnpm --filter @tamma/dashboard test` → 384 passed (6 new: compose/links/fail-soft/RBAC). Build clean. Typecheck 0 errors in changed files. **No backend change** → both `has-pending-model-changes` trivially "No changes".

Deferred (need infra-metrics that don't exist yet — Story 23-8): dependency graph, per-service CPU/mem/uptime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)