### PR TITLE
feat(epic-4-8): black-box replay — point-in-time state reconstruction over the DCB slice

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs
@@ -2,10 +2,12 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using System.Globalization;
 using Tamma.Api.Auth;
 using Tamma.Api.Dtos.Engine;
 using Tamma.Api.Services.Engine;
 using Tamma.Api.Services.Engine.Lifecycle;
+using Tamma.Api.Services.Engine.Replay;
 using Tamma.Data;
 using Tamma.Data.Abstractions;
 using Tamma.Data.Entities;
@@ -248,6 +250,112 @@ public static class EngineEndpoints
             nextCursor,
             hasMore = nextCursor is not null,
         });
+    }
+
+    /// <summary>
+    /// Story 4-8 (black-box replay for debugging) — the RECONSTRUCTION half Story
+    /// 4-7 deferred. Reconstructs a run's point-in-time state by folding its ordered
+    /// DCB event slice (from Story 4-7's
+    /// <see cref="IEventRepository.ListByCorrelationIdAsync"/>) into a read-only
+    /// <see cref="ReplayResult"/> — a pure, deterministic left-fold over recorded
+    /// events. It re-executes nothing and mutates nothing (no Elsa runtime, no
+    /// writes): time-travel for debugging, not re-run.
+    ///
+    /// <para>Route: <c>GET /api/engine/runs/{correlationId}/replay?upTo={seq|timestamp}&amp;from={seq}</c>.</para>
+    ///
+    /// <para>Query parameters:
+    /// <list type="bullet">
+    ///   <item><c>upTo</c> — the point-in-time marker. Either a positive
+    ///     <c>SequenceNumber</c> (replay up to and including that event) OR an
+    ///     ISO-8601 timestamp (replay up to and including that instant). Omitted =
+    ///     replay the whole run. A value that is neither → <c>400</c>; a
+    ///     non-positive sequence → <c>400</c>.</item>
+    ///   <item><c>from</c> — optional positive <c>SequenceNumber</c>; when supplied
+    ///     the result carries a <see cref="ReplayDelta"/> diff of everything after
+    ///     that point up to <c>upTo</c> (AC6). A non-positive value → <c>400</c>.</item>
+    /// </list></para>
+    ///
+    /// <para><b>Tenant-scoped, null-tenant fail-closed.</b> The read is bound to
+    /// <see cref="ITenantContext.TenantId"/>; a request with no resolved tenant is a
+    /// <c>404</c> (the run is not visible) — never another tenant's run. A run whose
+    /// correlationId this tenant does not own returns no events → <c>404</c>. So a
+    /// tenant can only replay THEIR OWN run (no IDOR).</para>
+    ///
+    /// <para>Point-in-time semantics: an <c>upTo</c> before the run began returns a
+    /// known-but-empty state (<c>200</c>, <c>eventsReplayed = 0</c>); an <c>upTo</c>
+    /// beyond the last event returns the full state. Determinism: the same slice
+    /// always folds to the same result.</para>
+    /// </summary>
+    public static async Task<IResult> ReplayRun(
+        string correlationId,
+        IReplayService replay,
+        ITenantContext tc,
+        string? upTo,
+        string? from)
+    {
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            return Results.BadRequest(new { error = "correlationId is required" });
+        }
+
+        // Parse upTo — a positive sequenceNumber OR an ISO-8601 timestamp. Fail loud
+        // on anything else rather than silently replaying the whole run.
+        long? upToSeq = null;
+        DateTimeOffset? upToTs = null;
+        if (!string.IsNullOrWhiteSpace(upTo))
+        {
+            if (long.TryParse(upTo, NumberStyles.Integer, CultureInfo.InvariantCulture, out var seq))
+            {
+                if (seq < 1)
+                {
+                    return Results.BadRequest(new
+                    {
+                        error = "invalid upTo: a sequenceNumber must be a positive integer",
+                    });
+                }
+                upToSeq = seq;
+            }
+            else if (DateTimeOffset.TryParse(
+                         upTo, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var ts))
+            {
+                upToTs = ts;
+            }
+            else
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid upTo: expected a positive sequenceNumber or an ISO-8601 timestamp",
+                });
+            }
+        }
+
+        long? fromSeq = null;
+        if (!string.IsNullOrWhiteSpace(from))
+        {
+            if (!long.TryParse(from, NumberStyles.Integer, CultureInfo.InvariantCulture, out var f) || f < 1)
+            {
+                return Results.BadRequest(new
+                {
+                    error = "invalid from: a sequenceNumber must be a positive integer",
+                });
+            }
+            fromSeq = f;
+        }
+
+        // Null-tenant fail-closed: no resolved tenant → the run is not visible to the
+        // caller → 404. Never a cross-tenant read (mirrors 4-7 + the #283 fix).
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "run not found", correlationId });
+        }
+
+        var result = await replay.ReplayAsync(tenantId, correlationId, upToSeq, upToTs, fromSeq);
+        if (result is null)
+        {
+            return Results.NotFound(new { error = "run not found", correlationId });
+        }
+
+        return Results.Ok(result);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -874,6 +874,11 @@ builder.Services.AddSingleton<Tamma.Api.Services.Engine.IContextStore,
     Tamma.Api.Services.Engine.InMemoryContextStore>();
 builder.Services.AddScoped<Tamma.Api.Services.Engine.IExecuteTaskService,
     Tamma.Api.Services.Engine.ExecuteTaskService>();
+// Story 4-8 — black-box replay: tenant-scoped point-in-time state reconstruction
+// (a pure read-fold over the DCB domain_events store via the 4-7 event query API).
+// Scoped: reads through the request-scoped tenant EventRepository.
+builder.Services.AddScoped<Tamma.Api.Services.Engine.Replay.IReplayService,
+    Tamma.Api.Services.Engine.Replay.ReplayService>();
 if (builder.Configuration.GetValue<long?>("GitHub:AppId") is long appId && appId > 0
     && !string.IsNullOrWhiteSpace(builder.Configuration["GitHub:PrivateKey"]))
 {
@@ -2649,6 +2654,12 @@ engine.MapGet("/history", EngineEndpoints.GetHistory);
 // domain_events with time-range / correlationId / actor / type (exact|prefix)
 // filters. Inherits WorkflowsView (read-only, tenant-scoped) from the group.
 engine.MapGet("/events/query", EngineEndpoints.QueryEvents);
+// Story 4-8 — black-box replay: reconstruct a run's point-in-time state by folding
+// its ordered DCB event slice (a pure, read-only fold over domain_events; no Elsa
+// re-run). Inherits WorkflowsView (read-only, tenant-scoped) from the group;
+// null-tenant fails closed (404). ?upTo={seq|timestamp} = as-of point; ?from={seq}
+// adds a diff (AC6).
+engine.MapGet("/runs/{correlationId}/replay", EngineEndpoints.ReplayRun);
 engine.MapGet("/events/state", EngineEndpoints.GetEventsState);
 engine.MapGet("/events/logs", EngineEndpoints.GetEventsLogs);
 engine.MapPost("/store-context", EngineEndpoints.StoreContext).RequireAuthorization("WorkflowsManage");

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/IReplayService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/IReplayService.cs
@@ -1,0 +1,38 @@
+namespace Tamma.Api.Services.Engine.Replay;
+
+/// <summary>
+/// Story 4-8 — reconstructs a run's point-in-time state by folding its ordered DCB
+/// event slice. The RECONSTRUCTION half that Story 4-7 deferred.
+///
+/// <para>READ-ONLY by construction: the only data access is
+/// <see cref="Tamma.Data.Repositories.IEventRepository.ListByCorrelationIdAsync"/>
+/// (a tenant-scoped read); the fold
+/// (<see cref="ReplayReconstructor.Reconstruct"/>) re-executes no activity and
+/// mutates nothing. Tenant-scoped: an empty tenant fails closed (returns
+/// <c>null</c> — the run is not visible), never a cross-tenant read.</para>
+/// </summary>
+public interface IReplayService
+{
+    /// <summary>
+    /// Reconstruct the state of run <paramref name="correlationId"/> within
+    /// <paramref name="tenantId"/> as of the chosen point.
+    /// </summary>
+    /// <param name="tenantId">The tenant that owns the run. <see cref="Guid.Empty"/>
+    /// fails closed (returns <c>null</c>).</param>
+    /// <param name="correlationId">The run / workflow-instance correlation id.</param>
+    /// <param name="upToSequence">Replay up to and including this
+    /// <c>SequenceNumber</c> (point-in-time). Null replays the whole run.</param>
+    /// <param name="upToTimestamp">Replay up to and including this timestamp
+    /// (point-in-time). Null replays the whole run.</param>
+    /// <param name="fromSequence">When set, the result carries a
+    /// <see cref="ReplayDelta"/> diff of everything after this point up to the
+    /// replay point (AC6).</param>
+    /// <returns>The reconstructed <see cref="ReplayResult"/>, or <c>null</c> when the
+    /// run is unknown to this tenant (no events) — the endpoint maps that to 404.</returns>
+    Task<ReplayResult?> ReplayAsync(
+        Guid tenantId,
+        string correlationId,
+        long? upToSequence,
+        DateTimeOffset? upToTimestamp,
+        long? fromSequence);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayModels.cs
@@ -1,0 +1,123 @@
+namespace Tamma.Api.Services.Engine.Replay;
+
+/// <summary>
+/// Story 4-8 (black-box replay) — the point-in-time state view reconstructed by
+/// folding a run's ordered DCB event slice. This is the RECONSTRUCTION half that
+/// Story 4-7 (the event query API) deferred: 4-7 filters/pages the raw
+/// <c>domain_events</c> stream; 4-8 folds one run's ordered slice into the
+/// workflow/issue state as of a chosen point (a sequence number or timestamp).
+///
+/// <para>The fold is a PURE, deterministic left-fold over recorded events
+/// (<see cref="ReplayReconstructor.Reconstruct"/>) — it re-executes nothing and
+/// mutates nothing, so the same event slice always yields the same
+/// <see cref="ReplayResult"/>.</para>
+///
+/// <para>AC3 shape — the reconstructed view surfaces: issue context
+/// (<see cref="IssueNumber"/>/<see cref="Repository"/>), AI provider decisions
+/// (<see cref="AiDecisions"/>), code changes (<see cref="CodeChanges"/>),
+/// approval points (<see cref="Approvals"/>), and errors
+/// (<see cref="Errors"/>) — plus the step reached (<see cref="StepReached"/>) and
+/// a derived <see cref="Status"/>.</para>
+/// </summary>
+/// <param name="CorrelationId">The run / workflow-instance correlation id replayed.</param>
+/// <param name="EventsReplayed">Number of events in the folded slice (up to the
+/// chosen point).</param>
+/// <param name="TotalEvents">Total events recorded for the run (all sequence
+/// numbers), so a caller can tell whether the slice is the full run.</param>
+/// <param name="ReplayedToEnd"><c>true</c> when the slice reached the last recorded
+/// event (an <c>upTo</c> beyond the final event, or no <c>upTo</c> at all).</param>
+/// <param name="AtSequenceNumber">The
+/// <see cref="Tamma.Data.Entities.DomainEvent.SequenceNumber"/> of the last event in
+/// the slice — the point-in-time marker. Null for an empty slice (a point before
+/// the run began).</param>
+/// <param name="AtTimestamp">The <c>CreatedAt</c> of the last event in the slice.</param>
+/// <param name="StepReached">The event type of the last event in the slice — the
+/// furthest-along step reconstructed. Null for an empty slice.</param>
+/// <param name="Status">Derived terminal status: <c>running</c> until a terminal
+/// event is folded, then <c>completed</c> / <c>failed</c> / <c>cancelled</c>.</param>
+/// <param name="IssueNumber">The issue the run is scoped to (last non-null across
+/// the slice), or null.</param>
+/// <param name="Repository">The repository (from event tags/data), or null.</param>
+/// <param name="Timeline">Every event in the slice as a lightweight ordered entry
+/// (the black-box trail).</param>
+/// <param name="AiDecisions">AI provider decisions (LLM/agent/research/design/
+/// ambiguity events) in order.</param>
+/// <param name="CodeChanges">Code-change and git artifacts (CODE/GIT/PR events) in
+/// order.</param>
+/// <param name="Approvals">Approval / quality-gate points in order.</param>
+/// <param name="Errors">Failure events (cross-cutting: a failed AI call appears in
+/// both <see cref="AiDecisions"/> and here) in order.</param>
+/// <param name="Delta">Populated only when a <c>from</c> marker was supplied — the
+/// pure diff between the fold-to-<c>from</c> and the fold-to-<c>upTo</c> (AC6).</param>
+public sealed record ReplayResult(
+    string CorrelationId,
+    int EventsReplayed,
+    int TotalEvents,
+    bool ReplayedToEnd,
+    long? AtSequenceNumber,
+    DateTime? AtTimestamp,
+    string? StepReached,
+    string Status,
+    int? IssueNumber,
+    string? Repository,
+    IReadOnlyList<ReplayTimelineEntry> Timeline,
+    IReadOnlyList<ReplayDecision> AiDecisions,
+    IReadOnlyList<ReplayArtifact> CodeChanges,
+    IReadOnlyList<ReplayApproval> Approvals,
+    IReadOnlyList<ReplayError> Errors,
+    ReplayDelta? Delta);
+
+/// <summary>One event in the reconstructed timeline (the ordered black-box trail).</summary>
+/// <param name="Category">Domain bucket: <c>ai</c> | <c>code</c> | <c>approval</c> |
+/// <c>issue</c> | <c>workflow</c> | <c>other</c>.</param>
+public sealed record ReplayTimelineEntry(
+    long SequenceNumber,
+    string Type,
+    DateTime CreatedAt,
+    int? IssueNumber,
+    string Category);
+
+/// <summary>An AI provider decision (LLM call / agent task / research / design proposal).</summary>
+public sealed record ReplayDecision(
+    long SequenceNumber,
+    string Type,
+    DateTime CreatedAt,
+    string? Provider,
+    string? Model,
+    string? Role,
+    string? Outcome);
+
+/// <summary>A code-change or git artifact produced during the run.</summary>
+public sealed record ReplayArtifact(
+    long SequenceNumber,
+    string Type,
+    DateTime CreatedAt,
+    string? Detail);
+
+/// <summary>An approval / quality-gate point.</summary>
+public sealed record ReplayApproval(
+    long SequenceNumber,
+    string Type,
+    DateTime CreatedAt,
+    string? Decision);
+
+/// <summary>A failure event encountered during the run.</summary>
+public sealed record ReplayError(
+    long SequenceNumber,
+    string Type,
+    DateTime CreatedAt,
+    string? Message);
+
+/// <summary>
+/// AC6 — the diff between two folds of the SAME run: everything that happened
+/// strictly after <see cref="FromSequenceNumber"/> up to the replay point. A pure
+/// comparison of two prefix folds (see <see cref="ReplayReconstructor.Diff"/>).
+/// </summary>
+public sealed record ReplayDelta(
+    long FromSequenceNumber,
+    int AddedEventCount,
+    int AddedDecisions,
+    int AddedCodeChanges,
+    int AddedApprovals,
+    int AddedErrors,
+    IReadOnlyList<ReplayTimelineEntry> AddedEvents);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayReconstructor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayReconstructor.cs
@@ -1,0 +1,338 @@
+using System.Text.Json;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Engine.Replay;
+
+/// <summary>
+/// Story 4-8 — the PURE, deterministic core of black-box replay. Given a run's
+/// ordered DCB event slice it folds the events (left-to-right) into a
+/// <see cref="ReplayResult"/> point-in-time state view. No I/O, no clock, no
+/// randomness, no side effects: the same input slice always yields an equal
+/// result (determinism), and nothing is re-executed or mutated (read-only by
+/// construction — this class never touches the Elsa runtime, a repository, or a
+/// DbContext).
+///
+/// <para>The event source is Story 4-7's
+/// <see cref="Tamma.Data.Repositories.IEventRepository.ListByCorrelationIdAsync"/>
+/// (all of a run's events, ordered by
+/// <see cref="DomainEvent.SequenceNumber"/>); this class only transforms that
+/// already-fetched, already-ordered list.</para>
+/// </summary>
+public static class ReplayReconstructor
+{
+    /// <summary>
+    /// Slice an ordered (ascending <see cref="DomainEvent.SequenceNumber"/>) run to
+    /// the events at or before the chosen point. <paramref name="upToSequence"/>
+    /// keeps events with <c>SequenceNumber &lt;= upToSequence</c>;
+    /// <paramref name="upToTimestamp"/> keeps events with
+    /// <c>CreatedAt &lt;= upToTimestamp</c>. When neither is supplied the full run
+    /// is returned. A point before the run began yields an empty slice (the run is
+    /// still known — that is a valid as-of view, not a 404).
+    /// </summary>
+    public static IReadOnlyList<DomainEvent> SliceUpTo(
+        IReadOnlyList<DomainEvent> ordered,
+        long? upToSequence,
+        DateTimeOffset? upToTimestamp)
+    {
+        ArgumentNullException.ThrowIfNull(ordered);
+
+        IEnumerable<DomainEvent> slice = ordered;
+        if (upToSequence is { } seq)
+        {
+            slice = slice.Where(e => e.SequenceNumber <= seq);
+        }
+        if (upToTimestamp is { } ts)
+        {
+            var tsUtc = ts.UtcDateTime;
+            slice = slice.Where(e => e.CreatedAt <= tsUtc);
+        }
+        return slice.ToList();
+    }
+
+    /// <summary>
+    /// Fold an ordered event <paramref name="slice"/> into the reconstructed
+    /// point-in-time state. <paramref name="totalEvents"/> is the full run's event
+    /// count (so the result reports whether the slice reached the end).
+    /// </summary>
+    public static ReplayResult Reconstruct(
+        string correlationId,
+        IReadOnlyList<DomainEvent> slice,
+        int totalEvents,
+        ReplayDelta? delta = null)
+    {
+        ArgumentNullException.ThrowIfNull(correlationId);
+        ArgumentNullException.ThrowIfNull(slice);
+
+        var timeline = new List<ReplayTimelineEntry>(slice.Count);
+        var decisions = new List<ReplayDecision>();
+        var artifacts = new List<ReplayArtifact>();
+        var approvals = new List<ReplayApproval>();
+        var errors = new List<ReplayError>();
+
+        int? issueNumber = null;
+        string? repository = null;
+        var status = "running";
+
+        // Left-fold: apply each recorded event to the accumulating state, in order.
+        foreach (var e in slice)
+        {
+            var tags = SafeJsonToStringMap(e.Tags);
+            var data = SafeParse(e.Data);
+            var category = Categorize(e.Type);
+
+            timeline.Add(new ReplayTimelineEntry(
+                e.SequenceNumber, e.Type, e.CreatedAt, e.IssueNumber, category));
+
+            if (e.IssueNumber is int n)
+            {
+                issueNumber = n;
+            }
+            var repo = ReadString(tags, "repository") ?? ReadJsonString(data, "repository");
+            if (!string.IsNullOrEmpty(repo))
+            {
+                repository = repo;
+            }
+
+            if (IsAiDecision(e.Type))
+            {
+                decisions.Add(new ReplayDecision(
+                    e.SequenceNumber, e.Type, e.CreatedAt,
+                    Provider: ReadString(tags, "provider") ?? ReadJsonString(data, "provider"),
+                    Model: ReadString(tags, "model") ?? ReadJsonString(data, "model"),
+                    Role: ReadString(tags, "role") ?? ReadJsonString(data, "role"),
+                    Outcome: DecisionOutcome(e.Type)));
+            }
+
+            if (IsCodeChange(e.Type))
+            {
+                artifacts.Add(new ReplayArtifact(
+                    e.SequenceNumber, e.Type, e.CreatedAt,
+                    Detail: ArtifactDetail(data)));
+            }
+
+            if (IsApproval(e.Type))
+            {
+                approvals.Add(new ReplayApproval(
+                    e.SequenceNumber, e.Type, e.CreatedAt,
+                    Decision: ApprovalDecision(e.Type, tags, data)));
+            }
+
+            if (IsError(e.Type))
+            {
+                errors.Add(new ReplayError(
+                    e.SequenceNumber, e.Type, e.CreatedAt,
+                    Message: ErrorMessage(e, tags, data)));
+            }
+
+            // Terminal-status transitions — the LAST terminal event folded wins.
+            var terminal = TerminalStatus(e.Type);
+            if (terminal is not null)
+            {
+                status = terminal;
+            }
+        }
+
+        var last = slice.Count > 0 ? slice[^1] : null;
+
+        return new ReplayResult(
+            CorrelationId: correlationId,
+            EventsReplayed: slice.Count,
+            TotalEvents: totalEvents,
+            ReplayedToEnd: slice.Count >= totalEvents,
+            AtSequenceNumber: last?.SequenceNumber,
+            AtTimestamp: last?.CreatedAt,
+            StepReached: last?.Type,
+            Status: status,
+            IssueNumber: issueNumber,
+            Repository: repository,
+            Timeline: timeline,
+            AiDecisions: decisions,
+            CodeChanges: artifacts,
+            Approvals: approvals,
+            Errors: errors,
+            Delta: delta);
+    }
+
+    /// <summary>
+    /// AC6 — the pure diff between two prefix folds of the SAME run. Both
+    /// <paramref name="older"/> and <paramref name="newer"/> come from
+    /// <see cref="Reconstruct"/> over prefix slices, so <paramref name="newer"/>'s
+    /// timeline is a superset of <paramref name="older"/>'s; the delta is the set of
+    /// events with a sequence number not present in the older fold — i.e. everything
+    /// that happened between the two points. No new events are computed — this is a
+    /// comparison of two already-folded states.
+    /// </summary>
+    public static ReplayDelta Diff(ReplayResult older, ReplayResult newer)
+    {
+        ArgumentNullException.ThrowIfNull(older);
+        ArgumentNullException.ThrowIfNull(newer);
+
+        var olderSeqs = older.Timeline.Select(t => t.SequenceNumber).ToHashSet();
+        var added = newer.Timeline.Where(t => !olderSeqs.Contains(t.SequenceNumber)).ToList();
+        var addedSeqs = added.Select(a => a.SequenceNumber).ToHashSet();
+
+        var fromSeq = older.AtSequenceNumber ?? 0L;
+
+        return new ReplayDelta(
+            FromSequenceNumber: fromSeq,
+            AddedEventCount: added.Count,
+            AddedDecisions: newer.AiDecisions.Count(d => addedSeqs.Contains(d.SequenceNumber)),
+            AddedCodeChanges: newer.CodeChanges.Count(c => addedSeqs.Contains(c.SequenceNumber)),
+            AddedApprovals: newer.Approvals.Count(a => addedSeqs.Contains(a.SequenceNumber)),
+            AddedErrors: newer.Errors.Count(x => addedSeqs.Contains(x.SequenceNumber)),
+            AddedEvents: added);
+    }
+
+    // ─── categorization (pure, type-driven) ───────────────────────────────────
+
+    /// <summary>Single domain bucket for the timeline. Approval &gt; code &gt; ai
+    /// &gt; issue &gt; workflow &gt; other. A failure is a cross-cut (see
+    /// <see cref="IsError"/>), not a timeline category, so a failed AI call still
+    /// reads as an <c>ai</c> step on the timeline while also appearing in
+    /// <see cref="ReplayResult.Errors"/>.</summary>
+    internal static string Categorize(string type)
+    {
+        if (IsApproval(type)) return "approval";
+        if (IsCodeChange(type)) return "code";
+        if (IsAiDecision(type)) return "ai";
+        if (type.StartsWith("ISSUE.", StringComparison.Ordinal)) return "issue";
+        if (IsWorkflowStep(type)) return "workflow";
+        return "other";
+    }
+
+    internal static bool IsAiDecision(string type) =>
+        type.StartsWith("LLM.CALL", StringComparison.Ordinal)
+        || type.StartsWith("AGENT.TASK", StringComparison.Ordinal)
+        || type.StartsWith("AGENT.RUN", StringComparison.Ordinal)
+        || type.StartsWith("AGENT.TOOL_CALL", StringComparison.Ordinal)
+        || type.StartsWith("AGENT.RESULTS", StringComparison.Ordinal)
+        || type.StartsWith("AGENT.ITERATION", StringComparison.Ordinal)
+        || type.StartsWith("RESEARCH.", StringComparison.Ordinal)
+        || type.StartsWith("DESIGN.PROPOSAL", StringComparison.Ordinal)
+        || type.StartsWith("AMBIGUITY.", StringComparison.Ordinal);
+
+    internal static bool IsCodeChange(string type) =>
+        type.StartsWith("CODE.", StringComparison.Ordinal)
+        || type.StartsWith("GIT.", StringComparison.Ordinal)
+        || type.StartsWith("PR.", StringComparison.Ordinal);
+
+    internal static bool IsApproval(string type) =>
+        type.StartsWith("APPROVAL", StringComparison.Ordinal)
+        || type.StartsWith("GATE.", StringComparison.Ordinal)
+        || type.Contains(".APPROVAL", StringComparison.Ordinal)
+        || type.EndsWith(".APPROVED", StringComparison.Ordinal)
+        || type.EndsWith(".REJECTED", StringComparison.Ordinal)
+        || type.Contains("APPROVAL_REQUESTED", StringComparison.Ordinal);
+
+    internal static bool IsError(string type) =>
+        type.EndsWith(".FAILED", StringComparison.Ordinal)
+        || type.EndsWith(".ERROR", StringComparison.Ordinal)
+        || type.Contains(".STEP_FAILED", StringComparison.Ordinal)
+        || type.Contains(".RETRY_EXCEEDED", StringComparison.Ordinal)
+        || type.Contains(".TIMED_OUT", StringComparison.Ordinal);
+
+    internal static bool IsWorkflowStep(string type) =>
+        type.StartsWith("WORKFLOW.", StringComparison.Ordinal)
+        || type.StartsWith("CYCLE.", StringComparison.Ordinal)
+        || type.StartsWith("ADL.", StringComparison.Ordinal);
+
+    /// <summary>Map an event type to a terminal run status, or null if not terminal.</summary>
+    internal static string? TerminalStatus(string type) => type switch
+    {
+        "WORKFLOW.COMPLETED" or "CYCLE.COMPLETED" => "completed",
+        "WORKFLOW.FAILED" or "CYCLE.FAILED" or "WORKFLOW.RETRY_EXCEEDED" => "failed",
+        "WORKFLOW.CANCELLED" => "cancelled",
+        _ => null,
+    };
+
+    private static string? DecisionOutcome(string type)
+    {
+        if (type.EndsWith(".SUCCESS", StringComparison.Ordinal)) return "success";
+        if (type.EndsWith(".FAILED", StringComparison.Ordinal)) return "failed";
+        if (type.EndsWith(".PARTIAL", StringComparison.Ordinal)) return "partial";
+        return null;
+    }
+
+    private static string? ApprovalDecision(
+        string type, IReadOnlyDictionary<string, string?> tags, JsonElement? data)
+    {
+        if (type.EndsWith(".APPROVED", StringComparison.Ordinal)) return "approved";
+        if (type.EndsWith(".REJECTED", StringComparison.Ordinal)) return "rejected";
+        if (type.Contains("APPROVAL_REQUESTED", StringComparison.Ordinal)
+            || type.Contains(".WAIT", StringComparison.Ordinal)) return "pending";
+        return ReadString(tags, "decision")
+            ?? ReadString(tags, "status")
+            ?? ReadJsonString(data, "decision");
+    }
+
+    private static string? ArtifactDetail(JsonElement? data)
+    {
+        // Best-effort human-readable artifact detail — never throws, null when absent.
+        return ReadJsonString(data, "pullRequestUrl")
+            ?? ReadJsonString(data, "prUrl")
+            ?? ReadJsonString(data, "htmlUrl")
+            ?? ReadJsonString(data, "branch")
+            ?? ReadJsonString(data, "branchName")
+            ?? ReadJsonString(data, "sha")
+            ?? ReadJsonString(data, "commitSha");
+    }
+
+    private static string? ErrorMessage(
+        DomainEvent e, IReadOnlyDictionary<string, string?> tags, JsonElement? data)
+    {
+        // Metadata.error is where the engine append path records the failure reason.
+        var meta = SafeParse(e.Metadata);
+        return ReadJsonString(meta, "error")
+            ?? ReadJsonString(data, "error")
+            ?? ReadString(tags, "error")
+            ?? ReadJsonString(data, "exitReason");
+    }
+
+    // ─── JSON helpers (safe, never throw) ─────────────────────────────────────
+
+    private static JsonElement? SafeParse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(raw);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static Dictionary<string, string?> SafeJsonToStringMap(string? raw)
+    {
+        var map = new Dictionary<string, string?>(StringComparer.Ordinal);
+        var el = SafeParse(raw);
+        if (el is not { ValueKind: JsonValueKind.Object } obj) return map;
+        foreach (var prop in obj.EnumerateObject())
+        {
+            map[prop.Name] = prop.Value.ValueKind == JsonValueKind.String
+                ? prop.Value.GetString()
+                : prop.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined
+                    ? null
+                    : prop.Value.GetRawText();
+        }
+        return map;
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, string?> map, string key) =>
+        map.TryGetValue(key, out var v) && !string.IsNullOrEmpty(v) ? v : null;
+
+    private static string? ReadJsonString(JsonElement? element, string key)
+    {
+        if (element is not { ValueKind: JsonValueKind.Object } obj) return null;
+        if (!obj.TryGetProperty(key, out var prop)) return null;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.String => prop.GetString(),
+            JsonValueKind.Number => prop.GetRawText(),
+            JsonValueKind.True or JsonValueKind.False => prop.GetRawText(),
+            _ => null,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayService.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Logging;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Engine.Replay;
+
+/// <summary>
+/// Story 4-8 — the default <see cref="IReplayService"/>. Reuses Story 4-7's
+/// tenant-scoped, parameterized
+/// <see cref="IEventRepository.ListByCorrelationIdAsync"/> as the event source
+/// (all of a run's events, ordered by <c>SequenceNumber</c>, served by
+/// <c>ix_domain_events_tags_correlationid</c>), then folds the ordered slice into a
+/// <see cref="ReplayResult"/> via the pure
+/// <see cref="ReplayReconstructor"/>.
+///
+/// <para>No new storage, no migration: replay is a read over the existing DCB
+/// <c>domain_events</c> store. No Elsa runtime, no external credential — a pure
+/// event fold.</para>
+/// </summary>
+public sealed class ReplayService(
+    IEventRepository events,
+    ILogger<ReplayService> logger) : IReplayService
+{
+    public async Task<ReplayResult?> ReplayAsync(
+        Guid tenantId,
+        string correlationId,
+        long? upToSequence,
+        DateTimeOffset? upToTimestamp,
+        long? fromSequence)
+    {
+        // Fail closed on a missing tenant — never a cross-tenant read. The endpoint
+        // already 404s a null tenant; this is defence-in-depth for internal callers.
+        if (tenantId == Guid.Empty || string.IsNullOrWhiteSpace(correlationId))
+        {
+            return null;
+        }
+
+        // Story 4-7 event source: ALL of the run's events, tenant-scoped, ordered
+        // oldest-first by SequenceNumber. A read — nothing is executed or written.
+        var all = await events.ListByCorrelationIdAsync(tenantId, correlationId);
+        if (all.Count == 0)
+        {
+            // Unknown run for this tenant (or another tenant's run — the tenant-scoped
+            // read simply returns nothing). The endpoint maps null → 404.
+            logger.LogInformation(
+                "Replay requested for unknown run {CorrelationId} (tenant {TenantId}); no events.",
+                correlationId, tenantId);
+            return null;
+        }
+
+        // Pure fold to the chosen point (point-in-time). SliceUpTo + Reconstruct are
+        // deterministic and side-effect-free.
+        var slice = ReplayReconstructor.SliceUpTo(all, upToSequence, upToTimestamp);
+
+        ReplayDelta? delta = null;
+        if (fromSequence is { } fromSeq)
+        {
+            // AC6 — the diff is a pure comparison of two prefix folds of the same run.
+            var fromSlice = ReplayReconstructor.SliceUpTo(all, fromSeq, null);
+            var fromResult = ReplayReconstructor.Reconstruct(correlationId, fromSlice, all.Count);
+            var toResult = ReplayReconstructor.Reconstruct(correlationId, slice, all.Count);
+            delta = ReplayReconstructor.Diff(fromResult, toResult);
+        }
+
+        var result = ReplayReconstructor.Reconstruct(correlationId, slice, all.Count, delta);
+
+        logger.LogInformation(
+            "Replay reconstructed run {CorrelationId} (tenant {TenantId}): {Replayed}/{Total} events, step {Step}, status {Status}.",
+            correlationId, tenantId, result.EventsReplayed, result.TotalEvents,
+            result.StepReached, result.Status);
+
+        return result;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/ReplayEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/ReplayEndpointTests.cs
@@ -1,0 +1,362 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Engine.Replay;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Engine;
+
+/// <summary>
+/// Story 4-8 (black-box replay) — endpoint coverage for
+/// <see cref="EngineEndpoints.ReplayRun"/> against the fixture's tenant Postgres so
+/// the correlationId JSONB lookup + BIGSERIAL sequence exercise the real
+/// EF/Postgres path (like <see cref="EventQueryEndpointTests"/>).
+///
+/// <para>Proves: a run reconstructs its full state; an <c>upTo</c> sequence /
+/// timestamp returns the as-of-then state (not the final); tenant isolation (a
+/// tenant can only replay THEIR OWN run — another tenant's correlationId is a 404,
+/// no IDOR); null-tenant fails closed (404); an unknown run is a 404; bad
+/// <c>upTo</c>/<c>from</c> are 400; the diff (<c>from</c>) is present; and replay is
+/// READ-ONLY (the tenant event count is unchanged — no writes, no activity
+/// execution).</para>
+/// </summary>
+[TestFixture]
+public class ReplayEndpointTests
+{
+    private IServiceScope _scope = null!;
+    private IEventRepository _events = null!;
+    private IReplayService _replay = null!;
+    private ITenantDbContextFactory _factory = null!;
+
+    private static readonly DateTime Base = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await ApiTestFixture.ResetDatabaseAsync();
+        _scope = ApiTestFixture.Factory.Services.CreateScope();
+        _events = _scope.ServiceProvider.GetRequiredService<IEventRepository>();
+        _replay = _scope.ServiceProvider.GetRequiredService<IReplayService>();
+        _factory = _scope.ServiceProvider.GetRequiredService<ITenantDbContextFactory>();
+    }
+
+    [TearDown]
+    public void TearDown() => _scope?.Dispose();
+
+    // ── full run ────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_FullRun_ReconstructsState()
+    {
+        var tenantId = Guid.NewGuid();
+        await SeedRunAsync(tenantId, "run-full", new[]
+        {
+            "WORKFLOW.STEP_STARTED",
+            "LLM.CALL.SUCCESS",
+            "CODE.GENERATED.SUCCESS",
+            "GIT.PR_OPENED.SUCCESS",
+            "WORKFLOW.COMPLETED",
+        }, issueNumber: 7);
+
+        var doc = await CallOkAsync(tenantId, "run-full");
+
+        doc.GetProperty("eventsReplayed").GetInt32().Should().Be(5);
+        doc.GetProperty("totalEvents").GetInt32().Should().Be(5);
+        doc.GetProperty("replayedToEnd").GetBoolean().Should().BeTrue();
+        doc.GetProperty("status").GetString().Should().Be("completed");
+        doc.GetProperty("stepReached").GetString().Should().Be("WORKFLOW.COMPLETED");
+        doc.GetProperty("issueNumber").GetInt32().Should().Be(7);
+        doc.GetProperty("aiDecisions").GetArrayLength().Should().Be(1);
+        doc.GetProperty("codeChanges").GetArrayLength().Should().Be(2);
+    }
+
+    // ── point-in-time: upTo sequence ──────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_UpToMidSequence_ReturnsAsOfThen_NotFinal()
+    {
+        var tenantId = Guid.NewGuid();
+        await SeedRunAsync(tenantId, "run-seq", new[]
+        {
+            "WORKFLOW.STEP_STARTED",   // index 0
+            "LLM.CALL.SUCCESS",        // index 1
+            "CODE.GENERATED.SUCCESS",  // index 2  ← replay up to here
+            "GIT.PR_OPENED.SUCCESS",   // index 3
+            "WORKFLOW.COMPLETED",      // index 4
+        });
+
+        // The real BIGSERIAL sequences, oldest-first.
+        var seqs = (await _events.ListByCorrelationIdAsync(tenantId, "run-seq"))
+            .Select(e => e.SequenceNumber).ToList();
+        var mid = seqs[2];
+
+        var doc = await CallOkAsync(tenantId, "run-seq", upTo: mid.ToString());
+
+        doc.GetProperty("eventsReplayed").GetInt32().Should().Be(3);
+        doc.GetProperty("replayedToEnd").GetBoolean().Should().BeFalse();
+        doc.GetProperty("stepReached").GetString().Should().Be("CODE.GENERATED.SUCCESS");
+        doc.GetProperty("status").GetString().Should().Be("running",
+            "the terminal WORKFLOW.COMPLETED is after the replay point");
+        doc.GetProperty("atSequenceNumber").GetInt64().Should().Be(mid);
+    }
+
+    // ── point-in-time: upTo timestamp ─────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_UpToTimestamp_ReturnsAsOfThen()
+    {
+        var tenantId = Guid.NewGuid();
+        // Insertion order == chronological order, so SequenceNumber tracks CreatedAt.
+        await SeedRunAsync(tenantId, "run-ts", new[]
+        {
+            ("A.ONE", Base),
+            ("A.TWO", Base.AddHours(1)),
+            ("A.THREE", Base.AddHours(2)),
+        });
+
+        // Cut at Base+1h — only the first two events qualify (half-inclusive at the cut).
+        var cut = new DateTimeOffset(Base.AddHours(1)).ToString("O");
+        var doc = await CallOkAsync(tenantId, "run-ts", upTo: cut);
+
+        doc.GetProperty("eventsReplayed").GetInt32().Should().Be(2);
+        doc.GetProperty("stepReached").GetString().Should().Be("A.TWO");
+    }
+
+    // ── diff (from) ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_WithFrom_IncludesDelta()
+    {
+        var tenantId = Guid.NewGuid();
+        await SeedRunAsync(tenantId, "run-diff", new[]
+        {
+            "WORKFLOW.STEP_STARTED",
+            "LLM.CALL.SUCCESS",
+            "GIT.PR_OPENED.SUCCESS",
+            "WORKFLOW.COMPLETED",
+        });
+        var seqs = (await _events.ListByCorrelationIdAsync(tenantId, "run-diff"))
+            .Select(e => e.SequenceNumber).ToList();
+
+        // from = seq[1] (the LLM call); upTo = end → delta is seq[2], seq[3].
+        var doc = await CallOkAsync(tenantId, "run-diff", from: seqs[1].ToString());
+
+        var delta = doc.GetProperty("delta");
+        delta.ValueKind.Should().Be(JsonValueKind.Object);
+        delta.GetProperty("fromSequenceNumber").GetInt64().Should().Be(seqs[1]);
+        delta.GetProperty("addedEventCount").GetInt32().Should().Be(2);
+        delta.GetProperty("addedCodeChanges").GetInt32().Should().Be(1);
+    }
+
+    // ── tenant isolation (no IDOR) ────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_TenantIsolation_SeesOnlyOwnRun_SameCorrelationId()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        // Both tenants stamp the IDENTICAL correlationId — a leak would surface here.
+        await SeedRunAsync(tenantA, "shared", new[] { "A.ONE", "A.TWO" });
+        await SeedRunAsync(tenantB, "shared", new[] { "B.ONE", "B.TWO", "B.THREE" });
+
+        var docA = await CallOkAsync(tenantA, "shared");
+        docA.GetProperty("eventsReplayed").GetInt32().Should().Be(2,
+            "tenant A must replay only tenant A's events, even for a shared correlationId");
+        docA.GetProperty("totalEvents").GetInt32().Should().Be(2);
+
+        var docB = await CallOkAsync(tenantB, "shared");
+        docB.GetProperty("eventsReplayed").GetInt32().Should().Be(3);
+    }
+
+    [Test]
+    public async Task Replay_OtherTenantsRun_Returns404()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        // Only tenant B owns "b-only".
+        await SeedRunAsync(tenantB, "b-only", new[] { "B.ONE" });
+        await EnsureTenantProvisionedAsync(tenantA); // A exists but owns nothing here
+
+        var (status, _) = await CallAsync(tenantA, "b-only");
+        status.Should().Be(StatusCodes.Status404NotFound,
+            "a tenant cannot replay another tenant's run (no IDOR)");
+    }
+
+    // ── null-tenant fail-closed ───────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_NullTenant_FailsClosed_404()
+    {
+        var otherTenant = Guid.NewGuid();
+        await SeedRunAsync(otherTenant, "private-run", new[] { "X.ONE" });
+
+        var (status, _) = await CallAsync(tenantId: null, correlationId: "private-run");
+        status.Should().Be(StatusCodes.Status404NotFound,
+            "no resolved tenant must never surface another tenant's run");
+    }
+
+    // ── unknown run ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_UnknownRun_Returns404()
+    {
+        var tenantId = Guid.NewGuid();
+        await EnsureTenantProvisionedAsync(tenantId);
+
+        var (status, _) = await CallAsync(tenantId, "does-not-exist");
+        status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    // ── fail-loud 400s ────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task Replay_BadUpTo_Returns400()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var (garbage, _) = await CallAsync(tenantId, "run", upTo: "not-a-seq-or-date");
+        garbage.Should().Be(StatusCodes.Status400BadRequest);
+
+        var (zero, _) = await CallAsync(tenantId, "run", upTo: "0");
+        zero.Should().Be(StatusCodes.Status400BadRequest);
+
+        var (neg, _) = await CallAsync(tenantId, "run", upTo: "-3");
+        neg.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Test]
+    public async Task Replay_BadFrom_Returns400()
+    {
+        var tenantId = Guid.NewGuid();
+
+        var (bad, _) = await CallAsync(tenantId, "run", from: "0");
+        bad.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ── read-only (no writes / no activity execution) ─────────────────────────
+
+    [Test]
+    public async Task Replay_IsReadOnly_DoesNotWriteOrExecute()
+    {
+        var tenantId = Guid.NewGuid();
+        await SeedRunAsync(tenantId, "run-ro", new[]
+        {
+            "WORKFLOW.STEP_STARTED", "LLM.CALL.SUCCESS", "WORKFLOW.COMPLETED",
+        });
+
+        var before = await CountEventsAsync(tenantId);
+
+        // Replay a few times (full + point-in-time + diff) — a pure fold must not
+        // append, mutate, or re-execute anything.
+        await CallOkAsync(tenantId, "run-ro");
+        await CallOkAsync(tenantId, "run-ro", upTo: "1");
+        await CallOkAsync(tenantId, "run-ro", from: "1");
+
+        var after = await CountEventsAsync(tenantId);
+        after.Should().Be(before, "replay is a read-only fold — it writes no events");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private async Task<int> CountEventsAsync(Guid tenantId)
+    {
+        await using var db = await _factory.CreateAsync(tenantId);
+        return await db.DomainEvents.IgnoreQueryFilters()
+            .CountAsync(e => e.TenantId == tenantId);
+    }
+
+    private async Task EnsureTenantProvisionedAsync(Guid tenantId)
+    {
+        var cp = _scope.ServiceProvider.GetRequiredService<ControlPlaneDbContext>();
+        if (!await cp.Tenants.IgnoreQueryFilters().AnyAsync(t => t.Id == tenantId))
+        {
+            cp.Tenants.Add(new Tenant
+            {
+                Id = tenantId,
+                Name = $"Test {tenantId:N}",
+                Slug = $"t-{tenantId:N}",
+                Plan = "free"
+            });
+            await cp.SaveChangesAsync();
+        }
+        await ApiTestFixture.ProvisionTenantAsync(tenantId);
+    }
+
+    private Task SeedRunAsync(Guid tenantId, string correlationId, string[] types, int? issueNumber = null)
+        => SeedRunAsync(tenantId, correlationId,
+            types.Select(t => (t, (DateTime?)null)).ToArray(), issueNumber);
+
+    private Task SeedRunAsync(Guid tenantId, string correlationId, (string Type, DateTime At)[] events)
+        => SeedRunAsync(tenantId, correlationId,
+            events.Select(e => (e.Type, (DateTime?)e.At)).ToArray(), null);
+
+    /// <summary>
+    /// Insert a run's events one-by-one (so BIGSERIAL sequence tracks insertion
+    /// order) with the correlationId stamped into Tags — the same shape
+    /// <see cref="IEventRepository.ListByCorrelationIdAsync"/> filters on.
+    /// </summary>
+    private async Task SeedRunAsync(
+        Guid tenantId, string correlationId,
+        (string Type, DateTime? At)[] events, int? issueNumber)
+    {
+        await EnsureTenantProvisionedAsync(tenantId);
+
+        var tags = JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["correlationId"] = correlationId,
+        });
+
+        var i = 0;
+        foreach (var (type, at) in events)
+        {
+            await using var db = await _factory.CreateAsync(tenantId);
+            db.DomainEvents.Add(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = type,
+                TenantId = tenantId,
+                IssueNumber = issueNumber,
+                Tags = tags,
+                Metadata = "{\"workflowVersion\":\"1.0.0\",\"eventSource\":\"system\"}",
+                Data = "{}",
+                CreatedAt = at ?? Base.AddSeconds(i),
+            });
+            await db.SaveChangesAsync();
+            i++;
+        }
+    }
+
+    private async Task<(int Status, JsonElement Body)> CallAsync(
+        Guid? tenantId, string correlationId, string? upTo = null, string? from = null)
+    {
+        var tc = new TenantContext();
+        if (tenantId is Guid tid) tc.SetTenantId(tid);
+
+        var result = await EngineEndpoints.ReplayRun(correlationId, _replay, tc, upTo, from);
+
+        var ctx = new DefaultHttpContext { RequestServices = ApiTestFixture.Factory.Services };
+        ctx.Response.Body = new MemoryStream();
+        await result.ExecuteAsync(ctx);
+
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = ctx.Response.Body.Length == 0
+            ? default
+            : JsonDocument.Parse(ctx.Response.Body).RootElement.Clone();
+        return (ctx.Response.StatusCode, body);
+    }
+
+    private async Task<JsonElement> CallOkAsync(
+        Guid? tenantId, string correlationId, string? upTo = null, string? from = null)
+    {
+        var (status, body) = await CallAsync(tenantId, correlationId, upTo, from);
+        status.Should().Be(StatusCodes.Status200OK);
+        return body;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/ReplayReconstructorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Engine/ReplayReconstructorTests.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Engine.Replay;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Engine;
+
+/// <summary>
+/// Story 4-8 (black-box replay) — unit coverage for the PURE fold
+/// (<see cref="ReplayReconstructor"/>). No DB, no clock, no I/O: these prove the
+/// reconstruction is a deterministic left-fold over an in-memory ordered slice —
+/// a known slice folds to the expected state, an <c>upTo</c> point returns the
+/// as-of-then state (not the final), the same slice always yields the same result,
+/// and the diff between two folds is a pure comparison.
+/// </summary>
+[TestFixture]
+public class ReplayReconstructorTests
+{
+    private static readonly DateTime Base = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private static DomainEvent Ev(
+        long seq, string type,
+        int? issue = null,
+        DateTime? at = null,
+        string? tags = null,
+        string? data = null,
+        string? metadata = null) => new()
+    {
+        Id = Guid.NewGuid(),
+        Type = type,
+        SequenceNumber = seq,
+        IssueNumber = issue,
+        CreatedAt = at ?? Base.AddSeconds(seq),
+        Tags = tags ?? "{}",
+        Data = data ?? "{}",
+        Metadata = metadata ?? "{}",
+    };
+
+    /// <summary>A representative run: issue context, an LLM decision, code + git
+    /// artifacts, a gate/approval, a failed call, and a terminal completion.</summary>
+    private static List<DomainEvent> SampleRun() => new()
+    {
+        Ev(10, "WORKFLOW.STEP_STARTED", issue: 42),
+        Ev(11, "LLM.CALL.SUCCESS", issue: 42,
+            tags: "{\"correlationId\":\"run-1\",\"provider\":\"anthropic\",\"model\":\"claude\",\"role\":\"developer\"}"),
+        Ev(12, "CODE.GENERATED.SUCCESS", issue: 42,
+            data: "{\"repository\":\"acme/app\"}"),
+        Ev(13, "GIT.PR_OPENED.SUCCESS", issue: 42,
+            data: "{\"pullRequestUrl\":\"https://github.com/acme/app/pull/7\"}"),
+        Ev(14, "GATE.EVALUATED.SUCCESS", issue: 42),
+        Ev(15, "APPROVAL.GATE", issue: 42, data: "{\"decision\":\"approved\"}"),
+        Ev(16, "LLM.CALL.FAILED", issue: 42,
+            metadata: "{\"error\":\"rate limited\"}"),
+        Ev(17, "WORKFLOW.COMPLETED", issue: 42),
+    };
+
+    [Test]
+    public void Reconstruct_FoldsKnownSlice_IntoExpectedState()
+    {
+        var run = SampleRun();
+
+        var state = ReplayReconstructor.Reconstruct("run-1", run, run.Count);
+
+        state.CorrelationId.Should().Be("run-1");
+        state.EventsReplayed.Should().Be(8);
+        state.TotalEvents.Should().Be(8);
+        state.ReplayedToEnd.Should().BeTrue();
+        state.AtSequenceNumber.Should().Be(17);
+        state.StepReached.Should().Be("WORKFLOW.COMPLETED");
+        state.Status.Should().Be("completed");
+        state.IssueNumber.Should().Be(42);
+        state.Repository.Should().Be("acme/app");
+
+        // AI decisions: the two LLM calls (success + failed).
+        state.AiDecisions.Select(d => d.Type).Should()
+            .BeEquivalentTo(new[] { "LLM.CALL.SUCCESS", "LLM.CALL.FAILED" });
+        var ok = state.AiDecisions.Single(d => d.Type == "LLM.CALL.SUCCESS");
+        ok.Provider.Should().Be("anthropic");
+        ok.Model.Should().Be("claude");
+        ok.Role.Should().Be("developer");
+        ok.Outcome.Should().Be("success");
+
+        // Code changes: CODE + GIT + PR events (PR here is none; CODE + GIT = 2).
+        state.CodeChanges.Select(c => c.Type).Should()
+            .BeEquivalentTo(new[] { "CODE.GENERATED.SUCCESS", "GIT.PR_OPENED.SUCCESS" });
+        state.CodeChanges.Single(c => c.Type == "GIT.PR_OPENED.SUCCESS").Detail
+            .Should().Be("https://github.com/acme/app/pull/7");
+
+        // Approvals: the gate + the approval point.
+        state.Approvals.Select(a => a.Type).Should()
+            .BeEquivalentTo(new[] { "GATE.EVALUATED.SUCCESS", "APPROVAL.GATE" });
+        state.Approvals.Single(a => a.Type == "APPROVAL.GATE").Decision.Should().Be("approved");
+
+        // Errors (cross-cut): the failed LLM call, with its metadata.error message.
+        state.Errors.Should().ContainSingle().Which.Type.Should().Be("LLM.CALL.FAILED");
+        state.Errors.Single().Message.Should().Be("rate limited");
+
+        // Timeline is the full ordered slice.
+        state.Timeline.Select(t => t.SequenceNumber).Should()
+            .Equal(10, 11, 12, 13, 14, 15, 16, 17);
+        state.Timeline.Single(t => t.SequenceNumber == 11).Category.Should().Be("ai");
+        state.Timeline.Single(t => t.SequenceNumber == 12).Category.Should().Be("code");
+        state.Timeline.Single(t => t.SequenceNumber == 15).Category.Should().Be("approval");
+    }
+
+    [Test]
+    public void SliceUpTo_BySequence_ReturnsAsOfThen_NotFinal()
+    {
+        var run = SampleRun();
+
+        // Replay up to seq 13 (the PR-opened event) — mid-run.
+        var slice = ReplayReconstructor.SliceUpTo(run, upToSequence: 13, upToTimestamp: null);
+        var state = ReplayReconstructor.Reconstruct("run-1", slice, run.Count);
+
+        state.EventsReplayed.Should().Be(4, "events 10..13 are at or before seq 13");
+        state.TotalEvents.Should().Be(8);
+        state.ReplayedToEnd.Should().BeFalse();
+        state.AtSequenceNumber.Should().Be(13);
+        state.StepReached.Should().Be("GIT.PR_OPENED.SUCCESS");
+        state.Status.Should().Be("running", "the terminal WORKFLOW.COMPLETED (seq 17) is not in the slice");
+        state.Errors.Should().BeEmpty("the failed call at seq 16 is after the replay point");
+        state.Approvals.Should().BeEmpty("the gate/approval at seq 14/15 is after the replay point");
+    }
+
+    [Test]
+    public void SliceUpTo_ByTimestamp_ReturnsAsOfThen()
+    {
+        var run = SampleRun();
+        // Each event's CreatedAt is Base + seq seconds. Cut at seq 12's instant.
+        var cut = new DateTimeOffset(Base.AddSeconds(12));
+
+        var slice = ReplayReconstructor.SliceUpTo(run, upToSequence: null, upToTimestamp: cut);
+        var state = ReplayReconstructor.Reconstruct("run-1", slice, run.Count);
+
+        state.EventsReplayed.Should().Be(3, "events at <= Base+12s are seq 10,11,12");
+        state.StepReached.Should().Be("CODE.GENERATED.SUCCESS");
+        state.ReplayedToEnd.Should().BeFalse();
+    }
+
+    [Test]
+    public void SliceUpTo_BeyondLastEvent_ReturnsFullState()
+    {
+        var run = SampleRun();
+
+        var slice = ReplayReconstructor.SliceUpTo(run, upToSequence: 9999, upToTimestamp: null);
+        var state = ReplayReconstructor.Reconstruct("run-1", slice, run.Count);
+
+        state.EventsReplayed.Should().Be(8);
+        state.ReplayedToEnd.Should().BeTrue();
+        state.Status.Should().Be("completed");
+    }
+
+    [Test]
+    public void SliceUpTo_BeforeRun_ReturnsEmptyButKnownState()
+    {
+        var run = SampleRun();
+
+        // A point before the first event (seq 10) — the run is known, the as-of view
+        // is empty (NOT a 404 — that distinction is the service/endpoint's).
+        var slice = ReplayReconstructor.SliceUpTo(run, upToSequence: 5, upToTimestamp: null);
+        var state = ReplayReconstructor.Reconstruct("run-1", slice, run.Count);
+
+        state.EventsReplayed.Should().Be(0);
+        state.TotalEvents.Should().Be(8);
+        state.ReplayedToEnd.Should().BeFalse();
+        state.AtSequenceNumber.Should().BeNull();
+        state.StepReached.Should().BeNull();
+        state.Status.Should().Be("running");
+        state.Timeline.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Reconstruct_IsDeterministic_SameSliceSameState()
+    {
+        var run = SampleRun();
+
+        var a = ReplayReconstructor.Reconstruct("run-1", run, run.Count);
+        var b = ReplayReconstructor.Reconstruct("run-1", run, run.Count);
+
+        // A pure fold: identical input → byte-identical serialized output.
+        JsonSerializer.Serialize(a).Should().Be(JsonSerializer.Serialize(b));
+    }
+
+    [Test]
+    public void Diff_BetweenTwoFolds_ShowsOnlyEventsAfterFrom()
+    {
+        var run = SampleRun();
+
+        var fromSlice = ReplayReconstructor.SliceUpTo(run, 13, null);   // seq 10..13
+        var toSlice = ReplayReconstructor.SliceUpTo(run, 17, null);     // seq 10..17
+        var from = ReplayReconstructor.Reconstruct("run-1", fromSlice, run.Count);
+        var to = ReplayReconstructor.Reconstruct("run-1", toSlice, run.Count);
+
+        var delta = ReplayReconstructor.Diff(from, to);
+
+        delta.FromSequenceNumber.Should().Be(13);
+        delta.AddedEventCount.Should().Be(4, "seq 14,15,16,17 are new");
+        delta.AddedEvents.Select(e => e.SequenceNumber).Should().Equal(14, 15, 16, 17);
+        delta.AddedApprovals.Should().Be(2, "the gate + approval (seq 14,15)");
+        delta.AddedErrors.Should().Be(1, "the failed call (seq 16)");
+        delta.AddedDecisions.Should().Be(1, "the failed LLM call is an AI decision too (seq 16)");
+    }
+
+    [Test]
+    public void Reconstruct_TolerantOfMalformedJson_NeverThrows()
+    {
+        var run = new List<DomainEvent>
+        {
+            Ev(1, "LLM.CALL.SUCCESS", tags: "not json", data: "{bad", metadata: "]"),
+        };
+
+        var act = () => ReplayReconstructor.Reconstruct("run-x", run, run.Count);
+
+        act.Should().NotThrow();
+        var state = act();
+        state.AiDecisions.Should().ContainSingle();
+        state.AiDecisions.Single().Provider.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## What

Story 4-8 — the reconstruction half 4-7 deferred. `GET /api/engine/runs/{correlationId}/replay?upTo={seq|timestamp}&from={seq}` (`WorkflowsView`) reconstructs a run's point-in-time state by a **pure deterministic left-fold** over its ordered DCB event slice. Re-executes nothing, mutates nothing, never touches the Elsa runtime.

- **Reuses 4-7:** event source is the tenant-scoped, parameterized `ListByCorrelationIdAsync` (served by the existing `correlationId` expression index) — the replay layer only transforms the already-fetched, already-ordered list. **No migration.**
- **State shape:** `EventsReplayed/TotalEvents/ReplayedToEnd`, `StepReached`, derived `Status`, `Timeline`, categorized `AiDecisions/CodeChanges/Approvals/Errors`, optional `Delta` (AC6 diff of two prefix folds).
- **Guarantees:** point-in-time (`upTo` seq or ISO instant); determinism (fold twice → byte-equal); **read-only by construction** (asserted: tenant event-count unchanged across replays); **tenant isolation** (another tenant's correlationId → no events → 404; shared-correlationId cross-tenant test); **null-tenant fail-closed** (→ 404, mirrors #283); fail-loud (bad `upTo`/`from` → 400).

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes" (reuses the existing index). Tests: Replay 29 + full engine filter 126.

Deferred (CLI/TS surface): AC1 `tamma replay` CLI, AC4 interactive step-through, AC5 HTML export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)