### PR TITLE
feat(epic-21-4): Repos & Workflow Runs dashboard pages

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/ReposRunsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/ReposRunsEndpoints.cs
@@ -1,0 +1,340 @@
+using System.Text.Json;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 21-4 — the tenant-facing user-dashboard read surface behind the
+/// SPA's <c>/repos</c> and <c>/runs</c> destinations. Three thin, read-only,
+/// tenant-scoped projections over data that already exists:
+/// <list type="bullet">
+///   <item><c>GET /api/v1/repos</c> — the tenant's connected platform
+///     installations (<see cref="ITenantPlatformInstallationRepository"/>).</item>
+///   <item><c>GET /api/v1/runs</c> — the tenant's workflow runs
+///     (<see cref="IWorkflowRepository.ListInstancesAsync"/>).</item>
+///   <item><c>GET /api/v1/runs/{runId}</c> — a single run's DCB event/log
+///     timeline + the tenant's OWN recorded per-run cost
+///     (<see cref="IEventRepository.ListByCorrelationIdAsync"/>).</item>
+/// </list>
+///
+/// <para><b>Tenant is resolved strictly from
+/// <see cref="ITenantContext"/></b> (populated per-request by
+/// <c>TenantContextMiddleware</c> from the caller's principal) — never from a
+/// body/route value, so there is no IDOR surface. A null / empty ambient
+/// tenant <b>FAILS CLOSED</b> with <c>404 no_active_tenant</c> BEFORE any
+/// repository call, mirroring the Story 23-6 (#283) diagnostics fix: a
+/// tenant-scoped read must never fan out across every tenant's data.</para>
+///
+/// <para><b>No economics leak.</b> The per-run cost is summed from the run's
+/// OWN <c>Data.costUsd</c> event fields (the tenant's recorded spend) — it
+/// never reads a <c>MarginPolicy</c> or any platform price/markup. A member
+/// sees only their tenant's repos/runs and their tenant's own cost.</para>
+/// </summary>
+public static class ReposRunsEndpoints
+{
+    private const int DefaultRunLimit = 25;
+    private const int MaxRunLimit = 100;
+
+    // ─── GET /api/v1/repos ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Connected repositories / platform installations for the caller's
+    /// tenant, newest-first. Backs the <c>/repos</c> page.
+    /// </summary>
+    public static async Task<IResult> ListRepos(
+        ITenantPlatformInstallationRepository installations,
+        ITenantContext tc,
+        HttpContext http)
+    {
+        // Fail closed (Story 23-6 / #283): a null-or-empty ambient tenant on
+        // this tenant-scoped route must NOT enumerate every tenant's
+        // installations. Reject before touching the repository.
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        var rows = await installations
+            .ListByTenantAsync(tenantId, http.RequestAborted)
+            .ConfigureAwait(false);
+
+        var repos = rows.Select(r => new
+        {
+            id = r.Id,
+            name = DisplayName(r),
+            platform = r.PlatformKind,
+            baseUrl = r.BaseUrl,
+            externalId = r.InstallationExternalId,
+            status = r.Status,
+            isPrimary = r.IsPrimary,
+            connectedAt = r.CreatedAt,
+            updatedAt = r.UpdatedAt,
+        }).ToList();
+
+        return Results.Ok(new { tenantId, repos, count = repos.Count });
+    }
+
+    // ─── GET /api/v1/runs ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Workflow runs for the caller's tenant, newest-first, offset-paginated.
+    /// Backs the <c>/runs</c> list. Reuses the same tenant-scoped
+    /// <see cref="IWorkflowRepository.ListInstancesAsync"/> read as the
+    /// existing dashboard "recent runs" widget.
+    /// </summary>
+    public static async Task<IResult> ListRuns(
+        IWorkflowRepository workflows,
+        ITenantContext tc,
+        int? limit,
+        int? page)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        var pageSize = Math.Clamp(limit ?? DefaultRunLimit, 1, MaxRunLimit);
+        var pageNumber = Math.Max(page ?? 1, 1);
+
+        var (instances, total) = await workflows
+            .ListInstancesAsync(definitionId: null, tenantId: tenantId, page: pageNumber, pageSize: pageSize)
+            .ConfigureAwait(false);
+
+        var runs = instances.Select(ToRunSummary).ToList();
+
+        return Results.Ok(new
+        {
+            tenantId,
+            total,
+            page = pageNumber,
+            pageSize,
+            runs,
+        });
+    }
+
+    // ─── GET /api/v1/runs/{runId} ─────────────────────────────────────────
+
+    /// <summary>
+    /// One run's detail: the workflow-instance metadata plus its full DCB
+    /// event timeline (correlationId = the run id), a derived log stream, and
+    /// the tenant's OWN recorded total cost. Returns <c>404 run_not_found</c>
+    /// when the run does not belong to the caller's tenant (defence-in-depth
+    /// on top of the structurally tenant-scoped reads).
+    /// </summary>
+    public static async Task<IResult> GetRunDetail(
+        Guid runId,
+        IWorkflowRepository workflows,
+        IEventRepository events,
+        ITenantContext tc)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+        if (runId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "run_not_found" });
+        }
+
+        // GetInstanceAsync is physically scoped to the ambient tenant's schema;
+        // the explicit TenantId equality below is defence-in-depth so a bare-id
+        // read can never surface another tenant's run.
+        var instance = await workflows.GetInstanceAsync(runId).ConfigureAwait(false);
+        if (instance is null || instance.TenantId != tenantId)
+        {
+            return Results.NotFound(new { error = "run_not_found" });
+        }
+
+        // Full run timeline from the DCB store. ListByCorrelationIdAsync is
+        // structurally tenant-scoped (it throws on an empty tenant) and matches
+        // Tags->>'correlationId' == runId, oldest-first.
+        var timeline = await events
+            .ListByCorrelationIdAsync(tenantId, runId.ToString())
+            .ConfigureAwait(false);
+
+        decimal totalCostUsd = 0m;
+        string? provider = null;
+        string? repository = null;
+        int? issueNumber = null;
+        string? prUrl = null;
+        var filesChanged = new List<string>();
+        var eventDtos = new List<object>(timeline.Count);
+        var logs = new List<string>(timeline.Count);
+
+        foreach (var e in timeline)
+        {
+            var tags = ParseObject(e.Tags);
+            var data = ParseObject(e.Data);
+
+            // Per-run cost = the tenant's OWN recorded spend, summed from the
+            // run's own events. NEVER a platform margin (no MarginPolicy read).
+            if (DataDecimal(data, "costUsd") is decimal cost)
+            {
+                totalCostUsd += cost;
+            }
+
+            provider ??= TagString(tags, "provider");
+            repository ??= TagString(tags, "repository") ?? DataString(data, "repository");
+            prUrl ??= DataString(data, "prUrl")
+                ?? DataString(data, "pullRequestUrl")
+                ?? DataString(data, "htmlUrl");
+            issueNumber ??= e.IssueNumber;
+
+            CollectFilesChanged(data, filesChanged);
+
+            eventDtos.Add(new
+            {
+                id = e.Id,
+                type = e.Type,
+                tags = SafeElement(e.Tags),
+                data = SafeElement(e.Data),
+                createdAt = e.CreatedAt,
+                sequenceNumber = e.SequenceNumber,
+            });
+
+            logs.Add(FormatLogLine(e, data));
+        }
+
+        return Results.Ok(new
+        {
+            id = instance.Id,
+            definitionId = instance.DefinitionId,
+            status = instance.Status,
+            currentActivity = instance.CurrentActivity,
+            createdAt = instance.CreatedAt,
+            startedAt = instance.StartedAt,
+            completedAt = instance.CompletedAt,
+            durationMs = DurationMs(instance),
+            provider,
+            issueNumber,
+            repository,
+            prUrl,
+            filesChanged,
+            totalCostUsd,
+            eventCount = timeline.Count,
+            events = eventDtos,
+            logs,
+        });
+    }
+
+    // ─── Projections / helpers ────────────────────────────────────────────
+
+    private static object ToRunSummary(WorkflowInstance i) => new
+    {
+        id = i.Id,
+        definitionId = i.DefinitionId,
+        status = i.Status,
+        currentActivity = i.CurrentActivity,
+        createdAt = i.CreatedAt,
+        startedAt = i.StartedAt,
+        completedAt = i.CompletedAt,
+        durationMs = DurationMs(i),
+    };
+
+    private static double? DurationMs(WorkflowInstance i)
+        => i.StartedAt is null || i.CompletedAt is null
+            ? null
+            : (i.CompletedAt.Value - i.StartedAt.Value).TotalMilliseconds;
+
+    /// <summary>
+    /// Best-effort human label for a connected installation. Prefers a
+    /// metadata "name"/"fullName"/"account" field; falls back to the external
+    /// id or the base URL host.
+    /// </summary>
+    private static string DisplayName(TenantPlatformInstallation r)
+    {
+        var meta = ParseObject(r.MetadataJson);
+        var fromMeta = DataString(meta, "name")
+            ?? DataString(meta, "fullName")
+            ?? DataString(meta, "account")
+            ?? DataString(meta, "login");
+        if (!string.IsNullOrWhiteSpace(fromMeta)) return fromMeta;
+        if (!string.IsNullOrWhiteSpace(r.InstallationExternalId))
+            return $"{r.PlatformKind}:{r.InstallationExternalId}";
+        return string.IsNullOrWhiteSpace(r.BaseUrl) ? r.PlatformKind : r.BaseUrl;
+    }
+
+    private static string FormatLogLine(DomainEvent e, JsonElement data)
+    {
+        var message = DataString(data, "message")
+            ?? DataString(data, "error")
+            ?? DataString(data, "reason")
+            ?? DataString(data, "activityName")
+            ?? string.Empty;
+        var stamp = e.CreatedAt.ToUniversalTime().ToString("O");
+        return string.IsNullOrEmpty(message)
+            ? $"{stamp}  {e.Type}"
+            : $"{stamp}  {e.Type}  {message}";
+    }
+
+    private static void CollectFilesChanged(JsonElement data, List<string> sink)
+    {
+        if (data.ValueKind != JsonValueKind.Object) return;
+        if (!data.TryGetProperty("filesChanged", out var files)) return;
+        if (files.ValueKind != JsonValueKind.Array) return;
+        foreach (var f in files.EnumerateArray())
+        {
+            if (f.ValueKind == JsonValueKind.String)
+            {
+                var value = f.GetString();
+                if (!string.IsNullOrWhiteSpace(value) && !sink.Contains(value))
+                    sink.Add(value);
+            }
+        }
+    }
+
+    private static JsonElement ParseObject(string? json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(json) ? "{}" : json);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            using var doc = JsonDocument.Parse("{}");
+            return doc.RootElement.Clone();
+        }
+    }
+
+    /// <summary>Parse a JSONB string for wire emission; invalid → null literal.</summary>
+    private static JsonElement SafeElement(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return JsonDocument.Parse("null").RootElement.Clone();
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return JsonDocument.Parse("null").RootElement.Clone();
+        }
+    }
+
+    private static string? TagString(JsonElement tags, string key)
+        => tags.ValueKind == JsonValueKind.Object
+           && tags.TryGetProperty(key, out var v)
+            ? (v.ValueKind == JsonValueKind.String ? v.GetString()
+                : v.ValueKind == JsonValueKind.Null ? null
+                : v.ToString())
+            : null;
+
+    private static string? DataString(JsonElement data, string key)
+        => data.ValueKind == JsonValueKind.Object
+           && data.TryGetProperty(key, out var v)
+           && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static decimal? DataDecimal(JsonElement data, string key)
+        => data.ValueKind == JsonValueKind.Object
+           && data.TryGetProperty(key, out var v)
+           && v.ValueKind == JsonValueKind.Number
+           && v.TryGetDecimal(out var d)
+            ? d
+            : null;
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2681,6 +2681,19 @@ engine.MapPost("/platform-events", EngineEndpoints.AppendPlatformEvents)
 // from the TS contract.
 engine.MapGet("/agent-available", EngineEndpoints.AgentAvailable);
 
+// ── User dashboard: Repos & Workflow Runs (Story 21-4) ──
+// Tenant-facing read surface behind the SPA's /repos + /runs destinations.
+// Tenant is resolved strictly from ITenantContext inside each handler (no
+// path/body tenant → no IDOR); a null/empty tenant fails closed with
+// 404 no_active_tenant (mirrors the Story 23-6 / #283 diagnostics fix). All
+// three are member-level reads over data that already exists (connected
+// installations + the DCB run event stream); per-run cost is the tenant's OWN
+// recorded spend (no platform margin). Kept out of the health region so the
+// concurrent System Health work (#277) does not conflict.
+app.MapGet("/api/v1/repos", ReposRunsEndpoints.ListRepos).RequireAuthorization("MemberAccess");
+app.MapGet("/api/v1/runs", ReposRunsEndpoints.ListRuns).RequireAuthorization("MemberAccess");
+app.MapGet("/api/v1/runs/{runId:guid}", ReposRunsEndpoints.GetRunDetail).RequireAuthorization("MemberAccess");
+
 // ── Workflows ──
 var workflows = app.MapGroup("/api/workflows").RequireAuthorization("WorkflowsView");
 workflows.MapPost("/definitions", WorkflowEndpoints.CreateDefinition).RequireAuthorization("WorkflowsManage");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Dashboard/ReposRunsEndpointsGuardTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Dashboard/ReposRunsEndpointsGuardTests.cs
@@ -1,0 +1,388 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Dashboard;
+
+/// <summary>
+/// Story 21-4 — guards + projections on the tenant-facing Repos &amp; Workflow
+/// Runs read endpoints (<see cref="ReposRunsEndpoints"/>). Handlers are called
+/// directly with fake repositories + a fake <see cref="ITenantContext"/> so the
+/// in-handler invariants are verified without an HTTP round-trip (same pattern
+/// as <see cref="Tamma.Api.Tests.Diagnostics.ProviderDiagnosticsGuardTests"/>).
+///
+/// <para>Coverage:
+/// <list type="bullet">
+///   <item><b>Fail-closed</b> — a null / empty ambient tenant returns
+///     <c>404 no_active_tenant</c> BEFORE any repository call (no cross-tenant
+///     fan-out).</item>
+///   <item><b>Tenant-scoping</b> — a run owned by another tenant is
+///     <c>404 run_not_found</c> even though the id is valid.</item>
+///   <item><b>No economics leak</b> — per-run cost is summed from the run's OWN
+///     recorded <c>Data.costUsd</c> events, never a platform margin.</item>
+/// </list></para>
+/// </summary>
+[TestFixture]
+public class ReposRunsEndpointsGuardTests
+{
+    // ── /api/v1/repos ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ListRepos_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingInstallationRepo();
+
+        var result = await ReposRunsEndpoints.ListRepos(
+            repo, new FakeTenantContext(null), NewHttpContext());
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.Called.Should().BeFalse("the guard must reject before enumerating installations");
+    }
+
+    [Test]
+    public async Task ListRepos_EmptyTenant_FailsClosed()
+    {
+        var repo = new RecordingInstallationRepo();
+
+        var result = await ReposRunsEndpoints.ListRepos(
+            repo, new FakeTenantContext(Guid.Empty), NewHttpContext());
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.Called.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task ListRepos_ConcreteTenant_ReturnsOnlyThatTenantsInstallations()
+    {
+        var tenant = Guid.NewGuid();
+        var repo = new RecordingInstallationRepo
+        {
+            Rows =
+            {
+                new TenantPlatformInstallation
+                {
+                    Id = Guid.NewGuid(), TenantId = tenant, PlatformKind = "github",
+                    BaseUrl = "https://api.github.com", InstallationExternalId = "42",
+                    Status = "connected", IsPrimary = true,
+                    MetadataJson = "{\"name\":\"acme/widgets\"}",
+                    CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+                },
+            },
+        };
+
+        var result = await ReposRunsEndpoints.ListRepos(
+            repo, new FakeTenantContext(tenant), NewHttpContext());
+
+        StatusOf(result).Should().Be(200);
+        repo.RequestedTenant.Should().Be(tenant);
+        var root = await CaptureJson(result);
+        root.GetProperty("count").GetInt32().Should().Be(1);
+        var first = root.GetProperty("repos")[0];
+        first.GetProperty("name").GetString().Should().Be("acme/widgets");
+        first.GetProperty("platform").GetString().Should().Be("github");
+        first.GetProperty("status").GetString().Should().Be("connected");
+    }
+
+    // ── /api/v1/runs ──────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ListRuns_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingWorkflowRepo();
+
+        var result = await ReposRunsEndpoints.ListRuns(
+            repo, new FakeTenantContext(null), limit: null, page: null);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.ListCalled.Should().BeFalse("the guard must reject before listing instances");
+    }
+
+    [Test]
+    public async Task ListRuns_ConcreteTenant_ProjectsRunSummaries()
+    {
+        var tenant = Guid.NewGuid();
+        var started = new DateTime(2026, 4, 16, 12, 0, 0, DateTimeKind.Utc);
+        var repo = new RecordingWorkflowRepo
+        {
+            Instances =
+            {
+                new WorkflowInstance
+                {
+                    Id = Guid.NewGuid(), DefinitionId = Guid.NewGuid(), TenantId = tenant,
+                    Status = "completed", CurrentActivity = "done",
+                    CreatedAt = started, StartedAt = started, CompletedAt = started.AddMinutes(2),
+                },
+            },
+        };
+
+        var result = await ReposRunsEndpoints.ListRuns(
+            repo, new FakeTenantContext(tenant), limit: null, page: null);
+
+        StatusOf(result).Should().Be(200);
+        repo.RequestedTenant.Should().Be(tenant);
+        var root = await CaptureJson(result);
+        root.GetProperty("total").GetInt32().Should().Be(1);
+        var run = root.GetProperty("runs")[0];
+        run.GetProperty("status").GetString().Should().Be("completed");
+        run.GetProperty("durationMs").GetDouble().Should().Be(TimeSpan.FromMinutes(2).TotalMilliseconds);
+    }
+
+    [Test]
+    public async Task ListRuns_ClampsLimitTo100()
+    {
+        var tenant = Guid.NewGuid();
+        var repo = new RecordingWorkflowRepo();
+
+        await ReposRunsEndpoints.ListRuns(repo, new FakeTenantContext(tenant), limit: 500, page: 3);
+
+        repo.RequestedPageSize.Should().Be(100);
+        repo.RequestedPage.Should().Be(3);
+    }
+
+    // ── /api/v1/runs/{runId} ──────────────────────────────────────────────
+
+    [Test]
+    public async Task GetRunDetail_NullTenant_FailsClosed_WithoutCallingRepos()
+    {
+        var workflows = new RecordingWorkflowRepo();
+        var events = new RecordingEventRepo();
+
+        var result = await ReposRunsEndpoints.GetRunDetail(
+            Guid.NewGuid(), workflows, events, new FakeTenantContext(null));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        workflows.GetCalled.Should().BeFalse();
+        events.Called.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetRunDetail_ForeignTenantInstance_Returns404_WithoutReadingEvents()
+    {
+        var tenant = Guid.NewGuid();
+        var foreign = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var workflows = new RecordingWorkflowRepo
+        {
+            // The bare-id read surfaces an instance owned by ANOTHER tenant.
+            InstanceById = new WorkflowInstance
+            {
+                Id = runId, DefinitionId = Guid.NewGuid(), TenantId = foreign, Status = "completed",
+            },
+        };
+        var events = new RecordingEventRepo();
+
+        var result = await ReposRunsEndpoints.GetRunDetail(
+            runId, workflows, events, new FakeTenantContext(tenant));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("run_not_found");
+        events.Called.Should().BeFalse("a cross-tenant run must never read the event timeline");
+    }
+
+    [Test]
+    public async Task GetRunDetail_UnknownRun_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var workflows = new RecordingWorkflowRepo { InstanceById = null };
+        var events = new RecordingEventRepo();
+
+        var result = await ReposRunsEndpoints.GetRunDetail(
+            Guid.NewGuid(), workflows, events, new FakeTenantContext(tenant));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("run_not_found");
+    }
+
+    [Test]
+    public async Task GetRunDetail_OwnedRun_SumsOwnCostAndBuildsTimeline()
+    {
+        var tenant = Guid.NewGuid();
+        var runId = Guid.NewGuid();
+        var t = new DateTime(2026, 4, 16, 12, 0, 0, DateTimeKind.Utc);
+        var workflows = new RecordingWorkflowRepo
+        {
+            InstanceById = new WorkflowInstance
+            {
+                Id = runId, DefinitionId = Guid.NewGuid(), TenantId = tenant,
+                Status = "completed", CreatedAt = t, StartedAt = t, CompletedAt = t.AddMinutes(3),
+            },
+        };
+        var events = new RecordingEventRepo
+        {
+            Timeline =
+            {
+                Event(runId, tenant, "AGENT.TASK.STARTED", t, provider: "anthropic-claude", costUsd: null),
+                Event(runId, tenant, "AGENT.TASK.SUCCESS", t.AddMinutes(1),
+                    provider: "anthropic-claude", costUsd: 1.25m, prUrl: "https://github.com/acme/w/pull/7"),
+                Event(runId, tenant, "AGENT.TASK.SUCCESS", t.AddMinutes(2),
+                    provider: "anthropic-claude", costUsd: 0.75m),
+            },
+        };
+
+        var result = await ReposRunsEndpoints.GetRunDetail(
+            runId, workflows, events, new FakeTenantContext(tenant));
+
+        StatusOf(result).Should().Be(200);
+        events.RequestedTenant.Should().Be(tenant);
+        events.RequestedCorrelationId.Should().Be(runId.ToString());
+
+        var root = await CaptureJson(result);
+        root.GetProperty("id").GetGuid().Should().Be(runId);
+        root.GetProperty("totalCostUsd").GetDecimal().Should().Be(2.0m); // tenant's OWN 1.25 + 0.75
+        root.GetProperty("provider").GetString().Should().Be("anthropic-claude");
+        root.GetProperty("prUrl").GetString().Should().Be("https://github.com/acme/w/pull/7");
+        root.GetProperty("eventCount").GetInt32().Should().Be(3);
+        root.GetProperty("events").GetArrayLength().Should().Be(3);
+        root.GetProperty("logs").GetArrayLength().Should().Be(3);
+        root.GetProperty("durationMs").GetDouble().Should().Be(TimeSpan.FromMinutes(3).TotalMilliseconds);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static HttpContext NewHttpContext() => new DefaultHttpContext();
+
+    private static int? StatusOf(IResult result) => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    private static string? ErrorOf(IResult result)
+    {
+        var value = (result as IValueHttpResult)?.Value;
+        return value?.GetType().GetProperty("error")?.GetValue(value) as string;
+    }
+
+    private static async Task<JsonElement> CaptureJson(IResult result)
+    {
+        await using var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var ctx = new DefaultHttpContext { RequestServices = services };
+        using var stream = new MemoryStream();
+        ctx.Response.Body = stream;
+        await result.ExecuteAsync(ctx);
+        stream.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    private static DomainEvent Event(
+        Guid runId, Guid tenant, string type, DateTime createdAt,
+        string? provider = null, decimal? costUsd = null, string? prUrl = null)
+    {
+        var tags = new Dictionary<string, object?> { ["correlationId"] = runId.ToString() };
+        if (provider is not null) tags["provider"] = provider;
+        var data = new Dictionary<string, object?>();
+        if (costUsd is decimal c) data["costUsd"] = c;
+        if (prUrl is not null) data["prUrl"] = prUrl;
+        return new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenant,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = "{}",
+            Data = JsonSerializer.Serialize(data),
+            CreatedAt = createdAt,
+            SequenceNumber = createdAt.Ticks,
+        };
+    }
+
+    // ── Test doubles ──────────────────────────────────────────────────────
+
+    private sealed class FakeTenantContext(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class RecordingInstallationRepo : ITenantPlatformInstallationRepository
+    {
+        public bool Called { get; private set; }
+        public Guid? RequestedTenant { get; private set; }
+        public List<TenantPlatformInstallation> Rows { get; } = new();
+
+        public Task<IReadOnlyList<TenantPlatformInstallation>> ListByTenantAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            Called = true;
+            RequestedTenant = tenantId;
+            return Task.FromResult<IReadOnlyList<TenantPlatformInstallation>>(
+                Rows.Where(r => r.TenantId == tenantId).ToList());
+        }
+
+        public Task<TenantPlatformInstallation?> GetByTenantPrimaryAsync(Guid tenantId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<TenantPlatformInstallation?> GetByTenantKindAsync(Guid tenantId, string platformKind, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<TenantPlatformInstallation?> GetByIdAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<TenantPlatformInstallation?> GetByExternalIdAsync(string platformKind, string installationExternalId, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<TenantPlatformInstallation> CreateAsync(TenantPlatformInstallation row, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task<TenantPlatformInstallation> UpdateAsync(TenantPlatformInstallation row, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task SoftDeleteAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+        public Task RestoreAsync(Guid id, CancellationToken ct = default) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingWorkflowRepo : IWorkflowRepository
+    {
+        public bool ListCalled { get; private set; }
+        public bool GetCalled { get; private set; }
+        public Guid? RequestedTenant { get; private set; }
+        public int RequestedPage { get; private set; }
+        public int RequestedPageSize { get; private set; }
+        public List<WorkflowInstance> Instances { get; } = new();
+        public WorkflowInstance? InstanceById { get; set; }
+
+        public Task<(List<WorkflowInstance> Instances, int Total)> ListInstancesAsync(
+            Guid? definitionId, Guid? tenantId, int page, int pageSize)
+        {
+            ListCalled = true;
+            RequestedTenant = tenantId;
+            RequestedPage = page;
+            RequestedPageSize = pageSize;
+            return Task.FromResult((Instances.ToList(), Instances.Count));
+        }
+
+        public Task<WorkflowInstance?> GetInstanceAsync(Guid id)
+        {
+            GetCalled = true;
+            return Task.FromResult(InstanceById);
+        }
+
+        public Task<WorkflowDefinition> UpsertDefinitionAsync(WorkflowDefinition def) => throw new NotSupportedException();
+        public Task<WorkflowDefinition?> GetDefinitionAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<WorkflowDefinition>> ListDefinitionsAsync() => throw new NotSupportedException();
+        public Task<WorkflowInstance> CreateInstanceAsync(WorkflowInstance instance) => throw new NotSupportedException();
+        public Task<WorkflowInstance?> UpdateInstanceAsync(Guid id, Action<WorkflowInstance> update) => throw new NotSupportedException();
+        public Task<bool> DeleteInstanceAsync(Guid id) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingEventRepo : IEventRepository
+    {
+        public bool Called { get; private set; }
+        public Guid? RequestedTenant { get; private set; }
+        public string? RequestedCorrelationId { get; private set; }
+        public List<DomainEvent> Timeline { get; } = new();
+
+        public Task<IReadOnlyList<DomainEvent>> ListByCorrelationIdAsync(Guid tenantId, string correlationId)
+        {
+            Called = true;
+            RequestedTenant = tenantId;
+            RequestedCorrelationId = correlationId;
+            return Task.FromResult<IReadOnlyList<DomainEvent>>(Timeline.ToList());
+        }
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+}

--- a/packages/dashboard/src/components/layout/Sidebar.tsx
+++ b/packages/dashboard/src/components/layout/Sidebar.tsx
@@ -30,6 +30,15 @@ const MEMBER_NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
+    // Story 21-4: tenant-facing Repos & Workflow Runs. Member-visible — the
+    // API scopes every read to the caller's tenant.
+    label: 'Workspace',
+    items: [
+      { to: '/repos', label: 'Repositories' },
+      { to: '/runs', label: 'Workflow Runs' },
+    ],
+  },
+  {
     // Story 18-8: tenant-admin user-mgmt UI. Visible to all members; the
     // TenantAdminGuard renders a friendly 403 if the user lacks admin/
     // owner role inside their active tenant.

--- a/packages/dashboard/src/pages/repos/ReposPage.tsx
+++ b/packages/dashboard/src/pages/repos/ReposPage.tsx
@@ -1,0 +1,170 @@
+/**
+ * Repos page (Story 21-4) — the tenant's connected repositories / platform
+ * installations behind the SPA's `/repos` destination.
+ *
+ * Read-only: lists what the tenant has connected (from
+ * `GET /api/v1/repos`) with connection status. Connecting a new repository
+ * reuses the existing onboarding flow (`/onboarding`) rather than a bespoke
+ * add-dialog, so there is no new write surface here. The route is already
+ * behind `AuthGuard` (applied at the AppLayout level); the API scopes every
+ * row to the caller's tenant.
+ */
+
+import { useCallback, useEffect, useState, type JSX } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { StatusBadge, type StatusKind } from '../../components/monitoring/StatusBadge.js';
+import { reposApi, type ConnectedRepo } from '../../services/repos/repos-api-client.js';
+
+function statusKind(status: string): StatusKind {
+  switch (status.toLowerCase()) {
+    case 'connected':
+      return 'healthy';
+    case 'suspended':
+      return 'degraded';
+    case 'disconnected':
+      return 'down';
+    default:
+      return 'unknown';
+  }
+}
+
+function platformLabel(platform: string): string {
+  switch (platform) {
+    case 'github':
+      return 'GitHub';
+    case 'gitlab':
+      return 'GitLab';
+    case 'gitea':
+      return 'Gitea';
+    case 'forgejo':
+      return 'Forgejo';
+    case 'bitbucket':
+      return 'Bitbucket';
+    case 'azure_devops':
+      return 'Azure DevOps';
+    default:
+      return platform;
+  }
+}
+
+function RepoCard({ repo }: { repo: ConnectedRepo }): JSX.Element {
+  return (
+    <div
+      data-testid="repo-card"
+      className="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-semibold text-gray-900 dark:text-gray-100">
+            {repo.name}
+          </h2>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {platformLabel(repo.platform)}
+            {repo.isPrimary && (
+              <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-[10px] font-medium text-blue-800 dark:bg-blue-900/40 dark:text-blue-300">
+                Primary
+              </span>
+            )}
+          </p>
+        </div>
+        <StatusBadge status={statusKind(repo.status)}>{repo.status}</StatusBadge>
+      </div>
+
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-xs">
+        <dt className="text-gray-500 dark:text-gray-400">Base URL</dt>
+        <dd className="truncate text-gray-700 dark:text-gray-300">{repo.baseUrl || '—'}</dd>
+        {repo.externalId && (
+          <>
+            <dt className="text-gray-500 dark:text-gray-400">Account</dt>
+            <dd className="truncate text-gray-700 dark:text-gray-300">{repo.externalId}</dd>
+          </>
+        )}
+        <dt className="text-gray-500 dark:text-gray-400">Connected</dt>
+        <dd className="text-gray-700 dark:text-gray-300">
+          {new Date(repo.connectedAt).toLocaleDateString()}
+        </dd>
+      </dl>
+    </div>
+  );
+}
+
+export function ReposPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [repos, setRepos] = useState<ConnectedRepo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await reposApi.list();
+      setRepos(res.repos);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load repositories');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Repositories</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Git platforms connected to your account.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Refresh
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/onboarding')}
+            className="rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
+          >
+            Add repository
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={() => void load()} />
+        </div>
+      )}
+
+      {loading && repos.length === 0 && !error && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading repositories…</p>
+      )}
+
+      {!loading && repos.length === 0 && !error && (
+        <EmptyState
+          title="No repositories connected yet"
+          description="Connect a GitHub, GitLab, or Gitea repository to let Tamma start working on your issues."
+          action={{ label: 'Add repository', onClick: () => navigate('/onboarding') }}
+        />
+      )}
+
+      {repos.length > 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {repos.map((repo) => (
+            <RepoCard key={repo.id} repo={repo} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/repos/__tests__/repos-page.test.tsx
+++ b/packages/dashboard/src/pages/repos/__tests__/repos-page.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ReposPage } from '../ReposPage.js';
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/repos']}>
+      <ReposPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ReposPage', () => {
+  it('renders connected repositories from /api/v1/repos', async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({
+        tenantId: 't1',
+        count: 2,
+        repos: [
+          {
+            id: 'r1',
+            name: 'acme/widgets',
+            platform: 'github',
+            baseUrl: 'https://api.github.com',
+            externalId: '42',
+            status: 'connected',
+            isPrimary: true,
+            connectedAt: '2026-04-16T12:00:00.000Z',
+            updatedAt: '2026-04-16T12:00:00.000Z',
+          },
+          {
+            id: 'r2',
+            name: 'gitlab:99',
+            platform: 'gitlab',
+            baseUrl: 'https://gitlab.example.com',
+            externalId: '99',
+            status: 'suspended',
+            isPrimary: false,
+            connectedAt: '2026-04-15T12:00:00.000Z',
+            updatedAt: '2026-04-16T12:00:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByRole('heading', { name: 'acme/widgets' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'gitlab:99' })).toBeInTheDocument();
+    expect(screen.getAllByTestId('repo-card')).toHaveLength(2);
+    // The request scopes to the caller's tenant — no tenant id in the URL.
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/v1/repos'))).toBe(true);
+  });
+
+  it('shows an empty state with a connect CTA when no repos are connected', async () => {
+    fetchMock.mockResolvedValue(okResponse({ tenantId: 't1', count: 0, repos: [] }));
+    renderPage();
+    expect(await screen.findByTestId('empty-state')).toHaveTextContent(
+      'No repositories connected yet',
+    );
+  });
+
+  it('surfaces an error banner when the request fails (e.g. no_active_tenant)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'no_active_tenant' }),
+    } as unknown as Response);
+    renderPage();
+    expect(await screen.findByTestId('error-banner')).toHaveTextContent('no_active_tenant');
+  });
+});

--- a/packages/dashboard/src/pages/runs/RunDetailPage.tsx
+++ b/packages/dashboard/src/pages/runs/RunDetailPage.tsx
@@ -1,0 +1,212 @@
+/**
+ * Run detail page (Story 21-4) — one workflow run's event/log timeline behind
+ * `/runs/:runId`.
+ *
+ * Lazily loads the run's DCB event timeline, derived log stream, files changed,
+ * PR link, and the tenant's OWN recorded total cost from
+ * `GET /api/v1/runs/:runId`. A run owned by another tenant (or a null tenant)
+ * comes back 404 and renders a friendly "not found" banner — never another
+ * tenant's data. The cost shown is the tenant's own spend, never a platform
+ * margin.
+ */
+
+import { useCallback, useEffect, useState, type JSX } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { runsApi, type RunEvent, type WorkflowRunDetail } from '../../services/runs/runs-api-client.js';
+import { formatCost, formatDuration, formatTimestamp, runStatusKind } from './run-format.js';
+
+function eventKind(type: string): 'healthy' | 'down' | 'info' | 'unknown' {
+  const upper = type.toUpperCase();
+  if (upper.includes('SUCCESS') || upper.includes('COMPLETED')) return 'healthy';
+  if (upper.includes('FAIL') || upper.includes('ERROR')) return 'down';
+  if (upper.includes('STARTED') || upper.includes('STEP')) return 'info';
+  return 'unknown';
+}
+
+function RunStat({ label, value }: { label: string; value: JSX.Element | string }): JSX.Element {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-semibold text-gray-900 dark:text-gray-100">{value}</div>
+    </div>
+  );
+}
+
+function TimelineRow({ event }: { event: RunEvent }): JSX.Element {
+  const hasData = event.data != null && Object.keys(event.data).length > 0;
+  return (
+    <li className="flex gap-3 py-2">
+      <div className="mt-1.5 shrink-0">
+        <StatusBadge status={eventKind(event.type)} showDot label="" className="!px-1.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <code className="text-xs font-semibold text-gray-800 dark:text-gray-200">
+            {event.type}
+          </code>
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {formatTimestamp(event.createdAt)}
+          </span>
+        </div>
+        {hasData && (
+          <details className="mt-1">
+            <summary className="cursor-pointer text-xs text-blue-600 hover:underline dark:text-blue-400">
+              details
+            </summary>
+            <pre className="mt-1 overflow-x-auto rounded bg-gray-50 p-2 text-[11px] text-gray-700 dark:bg-gray-900 dark:text-gray-300">
+              {JSON.stringify(event.data, null, 2)}
+            </pre>
+          </details>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export function RunDetailPage(): JSX.Element {
+  const { runId } = useParams<{ runId: string }>();
+  const [detail, setDetail] = useState<WorkflowRunDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!runId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setDetail(await runsApi.getDetail(runId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load run');
+    } finally {
+      setLoading(false);
+    }
+  }, [runId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const notFound = error === 'run_not_found' || error === 'no_active_tenant';
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-4">
+        <Link to="/runs" className="text-sm text-blue-600 hover:underline dark:text-blue-400">
+          ← Back to runs
+        </Link>
+      </div>
+
+      {error && !notFound && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={() => void load()} />
+        </div>
+      )}
+
+      {notFound && (
+        <EmptyState
+          title="Run not found"
+          description="This run does not exist, or it belongs to a different account."
+        />
+      )}
+
+      {loading && detail === null && !error && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading run…</p>
+      )}
+
+      {detail && (
+        <>
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                Run <code className="text-lg">{detail.id.slice(0, 8)}</code>
+              </h1>
+              <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {detail.repository ?? 'Workflow run'}
+                {detail.issueNumber != null && ` · issue #${detail.issueNumber}`}
+              </p>
+            </div>
+            <StatusBadge status={runStatusKind(detail.status)}>{detail.status}</StatusBadge>
+          </div>
+
+          <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+            <RunStat label="Provider" value={detail.provider ?? '—'} />
+            <RunStat label="Started" value={formatTimestamp(detail.startedAt)} />
+            <RunStat label="Duration" value={formatDuration(detail.durationMs)} />
+            <RunStat label="Cost" value={formatCost(detail.totalCostUsd)} />
+            <RunStat label="Events" value={String(detail.eventCount)} />
+          </div>
+
+          {(detail.prUrl || detail.filesChanged.length > 0) && (
+            <div className="mb-6 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              {detail.prUrl && (
+                <div className="mb-2 text-sm">
+                  <span className="font-medium text-gray-500 dark:text-gray-400">Pull request: </span>
+                  <a
+                    href={detail.prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-blue-600 hover:underline dark:text-blue-400"
+                  >
+                    {detail.prUrl}
+                  </a>
+                </div>
+              )}
+              {detail.filesChanged.length > 0 && (
+                <div className="text-sm">
+                  <span className="font-medium text-gray-500 dark:text-gray-400">
+                    Files changed ({detail.filesChanged.length}):
+                  </span>
+                  <ul className="mt-1 list-inside list-disc text-gray-700 dark:text-gray-300">
+                    {detail.filesChanged.map((f) => (
+                      <li key={f}>
+                        <code className="text-xs">{f}</code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <section>
+              <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+                Event timeline
+              </h2>
+              {detail.events.length === 0 ? (
+                <EmptyState title="No events" description="This run has not recorded any events." />
+              ) : (
+                <ul className="divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white px-4 dark:divide-gray-800 dark:border-gray-700 dark:bg-gray-800">
+                  {detail.events.map((e) => (
+                    <TimelineRow key={e.id} event={e} />
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">Logs</h2>
+              {detail.logs.length === 0 ? (
+                <EmptyState title="No logs" description="This run produced no log output." />
+              ) : (
+                <pre
+                  data-testid="run-logs"
+                  className="max-h-[28rem] overflow-auto rounded-lg border border-gray-200 bg-gray-900 p-3 font-mono text-xs leading-relaxed text-gray-100 dark:border-gray-700"
+                >
+                  {detail.logs.map((line, i) => (
+                    <div key={i}>{line}</div>
+                  ))}
+                </pre>
+              )}
+            </section>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/runs/RunsPage.tsx
+++ b/packages/dashboard/src/pages/runs/RunsPage.tsx
@@ -1,0 +1,168 @@
+/**
+ * Runs page (Story 21-4) — the tenant's workflow-run history behind the SPA's
+ * `/runs` destination.
+ *
+ * Read-only list from `GET /api/v1/runs` (tenant-scoped WorkflowInstance rows).
+ * Reuses the shared monitoring `DataTable` for client-side sort/filter/paging
+ * (AC6/AC7) and adds a status filter. Clicking a row opens the run detail
+ * (`/runs/:runId`). The route is behind `AuthGuard`; the API scopes rows to the
+ * caller's tenant.
+ */
+
+import { useCallback, useEffect, useMemo, useState, type JSX } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { DataTable, type DataTableColumn } from '../../components/monitoring/DataTable.js';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { runsApi, type WorkflowRunSummary } from '../../services/runs/runs-api-client.js';
+import { formatDuration, formatTimestamp, runStatusKind, shortId } from './run-format.js';
+
+const SELECT_CLASS =
+  'rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200';
+
+export function RunsPage(): JSX.Element {
+  const navigate = useNavigate();
+  const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState('all');
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await runsApi.list({ limit: 100 });
+      setRuns(res.runs);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load workflow runs');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const statuses = useMemo(
+    () => Array.from(new Set(runs.map((r) => r.status))).sort(),
+    [runs],
+  );
+
+  const visibleRuns = useMemo(
+    () => (statusFilter === 'all' ? runs : runs.filter((r) => r.status === statusFilter)),
+    [runs, statusFilter],
+  );
+
+  const columns = useMemo<DataTableColumn<WorkflowRunSummary>[]>(
+    () => [
+      {
+        key: 'id',
+        header: 'Run',
+        accessor: (r) => r.id,
+        render: (r) => <code className="text-xs">{shortId(r.id)}</code>,
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        accessor: (r) => r.status,
+        render: (r) => <StatusBadge status={runStatusKind(r.status)}>{r.status}</StatusBadge>,
+        sortable: true,
+      },
+      {
+        key: 'activity',
+        header: 'Current activity',
+        accessor: (r) => r.currentActivity ?? '',
+        render: (r) => r.currentActivity ?? '—',
+      },
+      {
+        key: 'startedAt',
+        header: 'Started',
+        accessor: (r) => r.startedAt ?? r.createdAt,
+        render: (r) => formatTimestamp(r.startedAt ?? r.createdAt),
+        sortable: true,
+      },
+      {
+        key: 'duration',
+        header: 'Duration',
+        accessor: (r) => r.durationMs ?? -1,
+        render: (r) => formatDuration(r.durationMs),
+        sortable: true,
+        align: 'right',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6 flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Workflow Runs</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            History of what Tamma has run on your behalf.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {statuses.length > 0 && (
+            <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+              <span className="sr-only">Status</span>
+              <select
+                aria-label="Status filter"
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                <option value="all">All statuses</option>
+                {statuses.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={() => void load()} />
+        </div>
+      )}
+
+      {loading && runs.length === 0 && !error && (
+        <p className="text-sm text-gray-500 dark:text-gray-400">Loading workflow runs…</p>
+      )}
+
+      {!loading && runs.length === 0 && !error && (
+        <EmptyState
+          title="No workflow runs yet"
+          description="Once Tamma picks up an issue on one of your repositories, its runs will appear here."
+        />
+      )}
+
+      {runs.length > 0 && (
+        <DataTable
+          columns={columns}
+          rows={visibleRuns}
+          getRowId={(r) => r.id}
+          pageSize={20}
+          initialSort={{ key: 'startedAt', direction: 'desc' }}
+          filterPlaceholder="Filter runs…"
+          onRowClick={(r) => navigate(`/runs/${r.id}`)}
+          emptyTitle="No matching runs"
+          emptyMessage="No runs match the current filters."
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/runs/__tests__/run-detail-page.test.tsx
+++ b/packages/dashboard/src/pages/runs/__tests__/run-detail-page.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { RunDetailPage } from '../RunDetailPage.js';
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const RUN_ID = '11111111-aaaa-bbbb-cccc-000000000001';
+
+const DETAIL = {
+  id: RUN_ID,
+  definitionId: 'def1',
+  status: 'completed',
+  currentActivity: null,
+  createdAt: '2026-04-16T12:00:00.000Z',
+  startedAt: '2026-04-16T12:00:00.000Z',
+  completedAt: '2026-04-16T12:03:00.000Z',
+  durationMs: 180000,
+  provider: 'anthropic-claude',
+  issueNumber: 258,
+  repository: 'acme/widgets',
+  prUrl: 'https://github.com/acme/widgets/pull/7',
+  filesChanged: ['src/foo.ts', 'src/bar.ts'],
+  totalCostUsd: 2.0,
+  eventCount: 2,
+  events: [
+    {
+      id: 'e1',
+      type: 'AGENT.TASK.STARTED',
+      tags: { correlationId: RUN_ID, provider: 'anthropic-claude' },
+      data: {},
+      createdAt: '2026-04-16T12:00:00.000Z',
+      sequenceNumber: 1,
+    },
+    {
+      id: 'e2',
+      type: 'AGENT.TASK.SUCCESS',
+      tags: { correlationId: RUN_ID },
+      data: { costUsd: 2.0 },
+      createdAt: '2026-04-16T12:03:00.000Z',
+      sequenceNumber: 2,
+    },
+  ],
+  logs: ['2026-04-16T12:00:00.000Z  AGENT.TASK.STARTED', '2026-04-16T12:03:00.000Z  AGENT.TASK.SUCCESS'],
+};
+
+function renderPage(entry = `/runs/${RUN_ID}`): void {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/runs/:runId" element={<RunDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RunDetailPage', () => {
+  it('renders run stats, cost, timeline and logs', async () => {
+    fetchMock.mockResolvedValue(okResponse(DETAIL));
+    renderPage();
+
+    expect(await screen.findByText('acme/widgets · issue #258')).toBeInTheDocument();
+    // Tenant's OWN recorded cost (never a platform margin).
+    expect(screen.getByText('$2.00')).toBeInTheDocument();
+    expect(screen.getByText('anthropic-claude')).toBeInTheDocument();
+    expect(screen.getByText('AGENT.TASK.SUCCESS')).toBeInTheDocument();
+    expect(screen.getByTestId('run-logs')).toHaveTextContent('AGENT.TASK.STARTED');
+    // PR link + files changed.
+    expect(screen.getByRole('link', { name: /pull\/7/ })).toBeInTheDocument();
+    expect(screen.getByText('src/foo.ts')).toBeInTheDocument();
+    // The detail request targets the run id, tenant resolved server-side.
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes(`/api/v1/runs/${RUN_ID}`))).toBe(true);
+  });
+
+  it('renders a friendly not-found state on a 404 run_not_found', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'run_not_found' }),
+    } as unknown as Response);
+    renderPage();
+    expect(await screen.findByTestId('empty-state')).toHaveTextContent('Run not found');
+  });
+
+  it('surfaces an error banner on a non-404 failure', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    } as unknown as Response);
+    renderPage();
+    expect(await screen.findByTestId('error-banner')).toHaveTextContent('boom');
+  });
+});

--- a/packages/dashboard/src/pages/runs/__tests__/runs-page.test.tsx
+++ b/packages/dashboard/src/pages/runs/__tests__/runs-page.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { RunsPage } from '../RunsPage.js';
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+const RUNS = {
+  tenantId: 't1',
+  total: 2,
+  page: 1,
+  pageSize: 100,
+  runs: [
+    {
+      id: '11111111-aaaa-bbbb-cccc-000000000001',
+      definitionId: 'def1',
+      status: 'completed',
+      currentActivity: 'done',
+      createdAt: '2026-04-16T12:00:00.000Z',
+      startedAt: '2026-04-16T12:00:00.000Z',
+      completedAt: '2026-04-16T12:02:00.000Z',
+      durationMs: 120000,
+    },
+    {
+      id: '22222222-aaaa-bbbb-cccc-000000000002',
+      definitionId: 'def1',
+      status: 'failed',
+      currentActivity: null,
+      createdAt: '2026-04-16T11:00:00.000Z',
+      startedAt: '2026-04-16T11:00:00.000Z',
+      completedAt: '2026-04-16T11:01:00.000Z',
+      durationMs: 60000,
+    },
+  ],
+};
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/runs']}>
+      <Routes>
+        <Route path="/runs" element={<RunsPage />} />
+        <Route path="/runs/:runId" element={<div>run detail opened</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('RunsPage', () => {
+  it('renders the run list with status + duration', async () => {
+    fetchMock.mockResolvedValue(okResponse(RUNS));
+    renderPage();
+
+    expect(await screen.findByTestId('data-table')).toBeInTheDocument();
+    expect(screen.getByText('11111111')).toBeInTheDocument();
+    // "completed" appears both in the status filter <option> and the row badge.
+    expect(screen.getAllByText('completed').length).toBeGreaterThan(0);
+    expect(screen.getByText('2m 0s')).toBeInTheDocument();
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/v1/runs'))).toBe(true);
+  });
+
+  it('filters runs by status', async () => {
+    fetchMock.mockResolvedValue(okResponse(RUNS));
+    renderPage();
+    await screen.findByTestId('data-table');
+
+    await userEvent.selectOptions(screen.getByLabelText('Status filter'), 'failed');
+
+    expect(screen.queryByText('11111111')).not.toBeInTheDocument();
+    expect(screen.getByText('22222222')).toBeInTheDocument();
+  });
+
+  it('navigates to the run detail on row click', async () => {
+    fetchMock.mockResolvedValue(okResponse(RUNS));
+    renderPage();
+    await screen.findByTestId('data-table');
+
+    await userEvent.click(screen.getByText('11111111'));
+    expect(await screen.findByText('run detail opened')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no runs', async () => {
+    fetchMock.mockResolvedValue(okResponse({ tenantId: 't1', total: 0, page: 1, pageSize: 100, runs: [] }));
+    renderPage();
+    expect(await screen.findByTestId('empty-state')).toHaveTextContent('No workflow runs yet');
+  });
+
+  it('surfaces an error banner when the request fails', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: 'boom' }),
+    } as unknown as Response);
+    renderPage();
+    expect(await screen.findByTestId('error-banner')).toHaveTextContent('boom');
+  });
+});

--- a/packages/dashboard/src/pages/runs/run-format.ts
+++ b/packages/dashboard/src/pages/runs/run-format.ts
@@ -1,0 +1,60 @@
+/**
+ * Small formatting helpers shared by the Runs list + Run detail pages
+ * (Story 21-4). Dependency-free (no dayjs in the dashboard bundle).
+ */
+
+import type { StatusKind } from '../../components/monitoring/StatusBadge.js';
+
+/** Human-readable run status → StatusBadge tone. */
+export function runStatusKind(status: string): StatusKind {
+  switch (status.toLowerCase()) {
+    case 'completed':
+    case 'succeeded':
+    case 'success':
+      return 'healthy';
+    case 'running':
+    case 'pending':
+    case 'queued':
+      return 'info';
+    case 'failed':
+    case 'error':
+      return 'down';
+    case 'cancelled':
+    case 'canceled':
+      return 'unknown';
+    default:
+      return 'unknown';
+  }
+}
+
+/** "2m 34s" / "1h 12m" / "540ms" / "—" (null). */
+export function formatDuration(ms: number | null | undefined): string {
+  if (ms == null) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+/** USD cost with adaptive precision ("$0.0000" for sub-dollar, "$12.34" else). */
+export function formatCost(usd: number | null | undefined): string {
+  if (usd == null) return '$0.00';
+  if (usd === 0) return '$0.00';
+  return `$${usd.toFixed(usd < 1 ? 4 : 2)}`;
+}
+
+/** Locale timestamp; falls back to the raw string when unparseable. */
+export function formatTimestamp(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+/** Short run id for dense table cells (first 8 chars of the GUID). */
+export function shortId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}

--- a/packages/dashboard/src/router.tsx
+++ b/packages/dashboard/src/router.tsx
@@ -28,6 +28,10 @@ import { LoadingSpinner } from './components/common/LoadingSpinner.js';
 import { LoginPage } from './pages/LoginPage.js';
 import { AccountPage } from './pages/AccountPage.js';
 import { MyApiKeysPage } from './pages/MyApiKeysPage.js';
+// Story 21-4 — tenant-facing Repos & Workflow Runs dashboard pages.
+import { ReposPage } from './pages/repos/ReposPage.js';
+import { RunsPage } from './pages/runs/RunsPage.js';
+import { RunDetailPage } from './pages/runs/RunDetailPage.js';
 import { OrganizationLayout } from './pages/organization/OrganizationLayout.js';
 import { TenantAdminGuard } from './guards/TenantAdminGuard.js';
 // Story 18-4: onboarding wizard. Lives outside AppLayout because new
@@ -95,6 +99,12 @@ export const router = createBrowserRouter([
       { path: '/', element: <Navigate to="/account" replace /> },
       { path: '/account', element: <AccountPage /> },
       { path: '/keys', element: <MyApiKeysPage /> },
+      // Story 21-4 — member-level Repos & Workflow Runs pages. AuthGuard is
+      // applied at the layout above; the API scopes every read to the caller's
+      // tenant (null tenant fails closed 404), so no in-route role guard.
+      { path: '/repos', element: <ReposPage /> },
+      { path: '/runs', element: <RunsPage /> },
+      { path: '/runs/:runId', element: <RunDetailPage /> },
       // Tenant-admin routes (Story 18-8) — gated by TenantAdminGuard which
       // reads the caller's role inside their currently-active tenant from
       // /auth/me, NOT the platform role.

--- a/packages/dashboard/src/services/repos/repos-api-client.ts
+++ b/packages/dashboard/src/services/repos/repos-api-client.ts
@@ -1,0 +1,55 @@
+/**
+ * Repos API client (Story 21-4).
+ *
+ * Typed HTTP client for the tenant-facing connected-repositories read
+ * endpoint. Cookie-session authenticated (`credentials: 'include'`); the
+ * server resolves the tenant from the caller's principal, so no tenant id is
+ * ever sent from the browser (no IDOR surface). A null tenant fails closed
+ * with 404 `no_active_tenant`.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${url}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({ error: response.statusText }))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** A connected git-platform installation for the current tenant. */
+export interface ConnectedRepo {
+  id: string;
+  /** Human label — "owner/repo" when metadata carries it, else kind:externalId. */
+  name: string;
+  /** github | gitea | forgejo | gitlab | bitbucket | azure_devops */
+  platform: string;
+  baseUrl: string;
+  externalId: string | null;
+  /** connected | suspended | disconnected */
+  status: string;
+  isPrimary: boolean;
+  connectedAt: string;
+  updatedAt: string;
+}
+
+export interface ReposListResponse {
+  tenantId: string;
+  repos: ConnectedRepo[];
+  count: number;
+}
+
+export const reposApi = {
+  /** List the current tenant's connected repositories / installations. */
+  list: (): Promise<ReposListResponse> => fetchJSON<ReposListResponse>('/api/v1/repos'),
+};

--- a/packages/dashboard/src/services/runs/runs-api-client.ts
+++ b/packages/dashboard/src/services/runs/runs-api-client.ts
@@ -1,0 +1,99 @@
+/**
+ * Runs API client (Story 21-4).
+ *
+ * Typed HTTP client for the tenant-facing workflow-runs read endpoints:
+ *   • GET /api/v1/runs            — paginated run list (WorkflowInstance rows)
+ *   • GET /api/v1/runs/{runId}    — one run's DCB event/log timeline + the
+ *                                   tenant's OWN recorded cost.
+ *
+ * Cookie-session authenticated; the server resolves the tenant from the
+ * caller's principal (no tenant id sent from the browser). A null tenant, or a
+ * run owned by another tenant, fails closed with 404.
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${url}`, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    ...options,
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({ error: response.statusText }))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `HTTP ${response.status}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** One workflow run as shown in the /runs list. */
+export interface WorkflowRunSummary {
+  id: string;
+  definitionId: string;
+  /** pending | running | completed | failed | cancelled (+ any engine status) */
+  status: string;
+  currentActivity: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+}
+
+export interface RunsListResponse {
+  tenantId: string;
+  total: number;
+  page: number;
+  pageSize: number;
+  runs: WorkflowRunSummary[];
+}
+
+/** A single DCB event on a run's timeline. */
+export interface RunEvent {
+  id: string;
+  type: string;
+  tags: Record<string, unknown> | null;
+  data: Record<string, unknown> | null;
+  createdAt: string;
+  sequenceNumber: number;
+}
+
+/** Full run detail: instance metadata + timeline + the tenant's OWN cost. */
+export interface WorkflowRunDetail {
+  id: string;
+  definitionId: string;
+  status: string;
+  currentActivity: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+  provider: string | null;
+  issueNumber: number | null;
+  repository: string | null;
+  prUrl: string | null;
+  filesChanged: string[];
+  /** The tenant's OWN recorded spend for this run (never a platform margin). */
+  totalCostUsd: number;
+  eventCount: number;
+  events: RunEvent[];
+  logs: string[];
+}
+
+export const runsApi = {
+  /** List the current tenant's workflow runs (newest first). */
+  list: (params?: { limit?: number; page?: number }): Promise<RunsListResponse> => {
+    const search = new URLSearchParams();
+    if (params?.limit !== undefined) search.set('limit', String(params.limit));
+    if (params?.page !== undefined) search.set('page', String(params.page));
+    const qs = search.toString();
+    return fetchJSON<RunsListResponse>(`/api/v1/runs${qs ? `?${qs}` : ''}`);
+  },
+
+  /** Get one run's detail (event timeline, logs, files changed, cost). */
+  getDetail: (runId: string): Promise<WorkflowRunDetail> =>
+    fetchJSON<WorkflowRunDetail>(`/api/v1/runs/${encodeURIComponent(runId)}`),
+};


### PR DESCRIPTION
## What

Story 21.4 — fills the `AppLayout`-advertised `/repos` + `/runs` destinations (were 404).

- **Frontend:** `/repos` (connected-repo cards + status), `/runs` (run list, sortable/filterable `DataTable`), `/runs/:runId` (event timeline, derived logs, files-changed, PR link, provider, duration, cost). New "Workspace" member nav group; reuses the shared monitoring primitives.
- **Backend (thin, read-only):** `GET /api/v1/repos`, `/api/v1/runs`, `/api/v1/runs/{runId}` (`MemberAccess`) over `TenantPlatformInstallationRepository`, `WorkflowRepository.ListInstancesAsync`, and `EventRepository.ListByCorrelationIdAsync` (correlationId = run).

## Safety

Tenant strictly from `ITenantContext` (no path/body tenant → no IDOR); **null/empty tenant → 404 `no_active_tenant` before any repo call** (mirrors the #283 fix); a foreign-tenant run → 404 (explicit `instance.TenantId == tenantId` on top of schema-scoped reads). Per-run cost = sum of the run's own `Data.costUsd` events — never reads `MarginPolicy` or platform price (no economics leak). Non-migration.

## Verification

- Backend build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Backend tests 482 (10 new guards: null/empty-tenant fail-closed, foreign-tenant 404, unknown-run 404, own-cost sum, limit clamp). Frontend 389 (11 new page tests), build clean.

Deferred (need write endpoints / SSE beyond this read-only story): AC2 pause/resume/disconnect, AC3 bespoke add-repo dialog (reuses `/onboarding`), AC8 live SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)