### PR TITLE
feat(epic-18-4): onboarding non-migration slices — repo activate/deactivate + ONBOARDING.COMPLETED

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/OnboardingEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/OnboardingEndpoints.cs
@@ -1,7 +1,10 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
+using Tamma.Data;
+using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
 namespace Tamma.Api.Endpoints;
@@ -19,13 +22,20 @@ namespace Tamma.Api.Endpoints;
 /// non-empty <c>installations</c> array on its next poll and advances
 /// to the success step.
 ///
-/// We deliberately keep this endpoint surface tight — a single status read
-/// + a single install-redirect — so the bulk of the install flow stays in
+/// The read + redirect stay tight — the bulk of the install flow lives in
 /// <see cref="Services.GitHub.InstallationRouterService"/> (already
-/// implemented). The full install plan in
+/// implemented). Two NON-MIGRATION write slices land here on top of that:
+/// <list type="bullet">
+///   <item><see cref="SetRepoActive"/> (AC4) — flip the EXISTING
+///     <c>IsActive</c> flag on one connected repo (activate / deactivate).</item>
+///   <item><see cref="CompleteOnboarding"/> (AC6/AC7) — record the
+///     onboarding-complete milestone by emitting the
+///     <c>ONBOARDING.COMPLETED.SUCCESS</c> DCB event.</item>
+/// </list>
+/// The remaining wider surface in
 /// <c>docs/stories/epic-18/18-4-github-app-installation-onboarding-impl-plan.md</c>
-/// describes a much wider surface (per-repo activation, settings,
-/// first-run workflow); those land in follow-up stories.
+/// (installation settings persisted on a jsonb column, the live first-run
+/// test workflow) is the SEPARATE settings-column migration lane.
 /// </summary>
 public static class OnboardingEndpoints
 {
@@ -152,6 +162,241 @@ public static class OnboardingEndpoints
         return Results.Redirect(redirect);
     }
 
+    // ─── Repo activate / deactivate (Story 18-4 AC4) ─────────────────────────
+
+    /// <summary>
+    /// Flip the <c>IsActive</c> flag on ONE repo connected through a GitHub
+    /// App installation. Active repos are the ones Tamma watches for issues
+    /// and runs workflows on — GitHub App permission grants access; this
+    /// endpoint decides which of the granted repos Tamma actually monitors.
+    /// The WRITE counterpart to the Story 21-4 <c>GET /api/v1/repos</c> read.
+    ///
+    /// <para><b>Tenant is resolved strictly from
+    /// <see cref="ITenantContext"/></b> (populated per-request from the
+    /// caller's principal), never from a route/body value — no IDOR surface.
+    /// A null / empty ambient tenant <b>FAILS CLOSED</b> with
+    /// <c>404 no_active_tenant</c> BEFORE any repository call, mirroring the
+    /// Story 23-6 (#283) fix. An installation that does not belong to the
+    /// caller's OWN tenant returns <c>404 installation_not_found</c> — a
+    /// foreign installation is indistinguishable from a non-existent one.</para>
+    ///
+    /// <para><b>Idempotent.</b> We only FLIP an EXISTING repo row's flag; we
+    /// never create a schema column or a repo row here. Re-issuing the same
+    /// state is a no-op (<c>changed:false</c>, no duplicate DCB event). A
+    /// state change emits <c>REPO.ACTIVATED.SUCCESS</c> /
+    /// <c>REPO.DEACTIVATED.SUCCESS</c> for the audit trail.</para>
+    /// </summary>
+    public static async Task<IResult> SetRepoActive(
+        long installationId,
+        long repoId,
+        SetRepoActiveRequest? request,
+        IInstallationRepository installations,
+        IEventRepository events,
+        ITenantContext tenantContext,
+        ClaimsPrincipal principal)
+    {
+        // Fail closed (Story 23-6 / #283): a null-or-empty ambient tenant on
+        // this tenant-scoped write must NOT touch another tenant's installs.
+        if (tenantContext.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        if (request is null)
+        {
+            return Results.BadRequest(new { error = "missing_body" });
+        }
+        var active = request.Active;
+
+        // A foreign / unknown installation is a 404 — never leak that a given
+        // installation id exists under a different tenant.
+        var install = await installations.GetByInstallationIdAsync(installationId);
+        if (install is null || install.TenantId != tenantId)
+        {
+            return Results.NotFound(new { error = "installation_not_found" });
+        }
+
+        // We FLIP the flag on a repo that is ALREADY connected through this
+        // installation — we do not synthesize new repo rows from a bare id.
+        var repo = install.Repos.FirstOrDefault(r => r.RepoId == repoId);
+        if (repo is null)
+        {
+            return Results.NotFound(new { error = "repo_not_found" });
+        }
+
+        var changed = repo.IsActive != active;
+        if (changed)
+        {
+            if (active)
+            {
+                // AddRepoAsync reactivates the existing row (IsActive = true);
+                // idempotent and preserves the stored full name.
+                await installations.AddRepoAsync(install.Id, repoId, repo.RepoFullName);
+            }
+            else
+            {
+                // RemoveRepoAsync is a soft-flip to IsActive = false.
+                await installations.RemoveRepoAsync(install.Id, repoId);
+            }
+
+            await EmitRepoStateEvent(
+                events,
+                tenantId,
+                ResolveUserId(principal),
+                active ? "REPO.ACTIVATED.SUCCESS" : "REPO.DEACTIVATED.SUCCESS",
+                installationId,
+                repoId,
+                repo.RepoFullName,
+                active);
+        }
+
+        return Results.Ok(new
+        {
+            installationId,
+            repoId,
+            repoFullName = repo.RepoFullName,
+            active,
+            changed,
+        });
+    }
+
+    // ─── First-run / onboarding-complete (Story 18-4 AC6/AC7) ────────────────
+
+    /// <summary>
+    /// Record that the caller's tenant has finished onboarding and emit the
+    /// <c>ONBOARDING.COMPLETED.SUCCESS</c> DCB event (AC7). There is NO
+    /// persisted "onboarding complete" column — the append-only event stream
+    /// IS the record of the milestone (non-migration slice). The event's
+    /// <c>data</c> captures what was set up (linked installation + active-repo
+    /// counts) so the audit trail explains the completion.
+    ///
+    /// <para><b>Tenant from <see cref="ITenantContext"/></b>; a null / empty
+    /// ambient tenant fails closed with <c>404 no_active_tenant</c>.</para>
+    ///
+    /// <para><b>Idempotent.</b> If the tenant already has an
+    /// <c>ONBOARDING.COMPLETED.SUCCESS</c> event we return the prior
+    /// completion timestamp WITHOUT appending a duplicate — re-running the
+    /// wizard's "finish" button never double-emits.</para>
+    /// </summary>
+    public static async Task<IResult> CompleteOnboarding(
+        IInstallationRepository installations,
+        IEventRepository events,
+        ITenantContext tenantContext,
+        ClaimsPrincipal principal)
+    {
+        if (tenantContext.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        // Idempotency: onboarding is completed once. A prior completion event
+        // short-circuits so we never append a duplicate milestone.
+        var existing = await events.GetLastByTypeAsync(tenantId, OnboardingCompletedEventType);
+        if (existing is not null)
+        {
+            return Results.Ok(new
+            {
+                completed = true,
+                alreadyCompleted = true,
+                completedAt = existing.CreatedAt,
+            });
+        }
+
+        // Summarize what was set up for the event payload — a record of the
+        // milestone, not a new persisted column.
+        var installs = await installations.ListByTenantAsync(tenantId);
+        var installationCount = installs.Count(i => i.SuspendedAt is null);
+        var activeRepoCount = installs.Sum(i => i.Repos.Count(r => r.IsActive));
+
+        var completedAt = DateTime.UtcNow;
+        var userId = ResolveUserId(principal);
+        await EmitOnboardingCompleted(
+            events, tenantId, userId, installationCount, activeRepoCount, completedAt);
+
+        return Results.Ok(new
+        {
+            completed = true,
+            alreadyCompleted = false,
+            installationCount,
+            activeRepoCount,
+            completedAt,
+        });
+    }
+
+    // ─── DCB event emission ──────────────────────────────────────────────────
+
+    /// <summary>Canonical event type for the onboarding-complete milestone (AC7).</summary>
+    public const string OnboardingCompletedEventType = "ONBOARDING.COMPLETED.SUCCESS";
+
+    private static async Task EmitRepoStateEvent(
+        IEventRepository events,
+        Guid tenantId,
+        Guid? userId,
+        string type,
+        long installationId,
+        long repoId,
+        string repoFullName,
+        bool active)
+    {
+        await events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId.ToString(),
+                userId = userId?.ToString(),
+            }),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new
+            {
+                installationId,
+                repoId,
+                repoFullName,
+                active,
+            }),
+            CreatedAt = DateTime.UtcNow,
+        });
+    }
+
+    private static async Task EmitOnboardingCompleted(
+        IEventRepository events,
+        Guid tenantId,
+        Guid? userId,
+        int installationCount,
+        int activeRepoCount,
+        DateTime completedAt)
+    {
+        await events.AppendAsync(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = OnboardingCompletedEventType,
+            TenantId = tenantId,
+            Tags = JsonSerializer.Serialize(new
+            {
+                tenantId = tenantId.ToString(),
+                userId = userId?.ToString(),
+            }),
+            Metadata = JsonSerializer.Serialize(new
+            {
+                workflowVersion = "1.0.0",
+                eventSource = "system",
+            }),
+            Data = JsonSerializer.Serialize(new
+            {
+                installationCount,
+                activeRepoCount,
+                completedAt,
+            }),
+            CreatedAt = completedAt,
+        });
+    }
+
     // ─── Helpers ────────────────────────────────────────────────────────────
 
     private static Guid? ResolveUserId(ClaimsPrincipal principal)
@@ -235,3 +480,10 @@ public sealed record OnboardingInstallationDto(
     IReadOnlyList<OnboardingRepoDto> Repos);
 
 public sealed record OnboardingRepoDto(long RepoId, string FullName);
+
+/// <summary>
+/// Body for <c>PATCH /api/v1/onboarding/repos/{installationId}/{repoId}</c> —
+/// the desired activation state for the repo. <c>true</c> = Tamma monitors it,
+/// <c>false</c> = it stays connected on GitHub but Tamma ignores it.
+/// </summary>
+public sealed record SetRepoActiveRequest(bool Active);

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2374,6 +2374,22 @@ app.MapGet("/api/v1/onboarding/status", OnboardingEndpoints.GetStatus)
 app.MapGet("/api/v1/onboarding/install-github", OnboardingEndpoints.InstallGitHub)
     .RequireAuthorization("MemberAccess");
 
+// Story 18-4 AC4/AC7 non-migration write slices (WRITE counterparts to the
+// Story 21-4 GET /api/v1/repos read; tenant resolved strictly from
+// ITenantContext, null-tenant fails closed → 404, no IDOR):
+//   PATCH .../onboarding/repos/{installationId}/{repoId} — flip the EXISTING
+//     IsActive flag on a repo of the caller's OWN installation. Gated by
+//     PlatformsManage (tenant_owner/tenant_admin → member 403): managing which
+//     repos Tamma monitors is a platform-admin action, same policy as the
+//     platform-install write above. Idempotent; emits REPO.(DE)ACTIVATED.SUCCESS.
+//   POST .../onboarding/complete — record onboarding completion + emit
+//     ONBOARDING.COMPLETED.SUCCESS (the DCB event IS the record; no new column).
+//     MemberAccess, matching the sibling wizard endpoints. Idempotent.
+app.MapPatch("/api/v1/onboarding/repos/{installationId:long}/{repoId:long}", OnboardingEndpoints.SetRepoActive)
+    .RequireAuthorization("PlatformsManage");
+app.MapPost("/api/v1/onboarding/complete", OnboardingEndpoints.CompleteOnboarding)
+    .RequireAuthorization("MemberAccess");
+
 // ── Story 31-9 — onboarding platform picker + installation API ──
 // GET /platforms returns the list of platforms the picker renders +
 // per-kind capability flags, marking deferred kinds (Bitbucket /

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Onboarding/OnboardingWriteEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Onboarding/OnboardingWriteEndpointsTests.cs
@@ -1,0 +1,457 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Onboarding;
+
+/// <summary>
+/// Story 18-4 — direct-handler guards + behaviour for the NON-MIGRATION write
+/// slices on <see cref="OnboardingEndpoints"/>:
+/// <list type="bullet">
+///   <item><see cref="OnboardingEndpoints.SetRepoActive"/> (AC4) — flip the
+///     EXISTING <c>IsActive</c> flag on one connected repo.</item>
+///   <item><see cref="OnboardingEndpoints.CompleteOnboarding"/> (AC6/AC7) —
+///     emit the <c>ONBOARDING.COMPLETED.SUCCESS</c> milestone event.</item>
+/// </list>
+///
+/// <para>Handlers are called directly with fake repositories + a fake
+/// <see cref="ITenantContext"/> (same style as
+/// <see cref="Tamma.Api.Tests.Dashboard.ReposRunsEndpointsGuardTests"/>), so the
+/// in-handler invariants are verified without an HTTP round-trip. Coverage:
+/// null-tenant fail-closed (no repo fan-out), foreign-installation 404 (no
+/// IDOR), unknown-repo 404, idempotent flip (no duplicate DCB event), and the
+/// ONBOARDING.COMPLETED emission + idempotency.</para>
+/// </summary>
+[TestFixture]
+public class OnboardingWriteEndpointsTests
+{
+    private const long InstallationId = 11111L;
+    private const long RepoIdApi = 9001L;
+    private const long RepoIdWeb = 9002L;
+
+    // ── SetRepoActive: guards ─────────────────────────────────────────────
+
+    [Test]
+    public async Task SetRepoActive_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var installs = new RecordingInstallationRepo();
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(false),
+            installs, events, new FakeTenantContext(null), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        installs.GetByInstallationIdCalled.Should().BeFalse("the guard must reject before touching installations");
+        events.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SetRepoActive_EmptyTenant_FailsClosed()
+    {
+        var installs = new RecordingInstallationRepo();
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(true),
+            installs, events, new FakeTenantContext(Guid.Empty), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        installs.GetByInstallationIdCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SetRepoActive_MissingBody_Returns400()
+    {
+        var tenant = Guid.NewGuid();
+        var installs = new RecordingInstallationRepo();
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, request: null,
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(400);
+        ErrorOf(result).Should().Be("missing_body");
+    }
+
+    [Test]
+    public async Task SetRepoActive_UnknownInstallation_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var installs = new RecordingInstallationRepo(); // empty
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(false),
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("installation_not_found");
+        events.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SetRepoActive_ForeignInstallation_Returns404_NoIDOR()
+    {
+        var tenant = Guid.NewGuid();
+        var foreign = Guid.NewGuid();
+        var installs = new RecordingInstallationRepo();
+        // Installation belongs to a DIFFERENT tenant — must be indistinguishable
+        // from a non-existent one.
+        installs.Installs.Add(Install(foreign, InstallationId, (RepoIdApi, "acme/api", true)));
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(false),
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("installation_not_found");
+        installs.Removed.Should().BeEmpty("a foreign installation's repo must never be flipped");
+        events.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task SetRepoActive_UnknownRepo_Returns404()
+    {
+        var tenant = Guid.NewGuid();
+        var installs = new RecordingInstallationRepo();
+        installs.Installs.Add(Install(tenant, InstallationId, (RepoIdApi, "acme/api", true)));
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, repoId: 424242L, new SetRepoActiveRequest(false),
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("repo_not_found");
+        events.Appended.Should().BeEmpty();
+    }
+
+    // ── SetRepoActive: behaviour ──────────────────────────────────────────
+
+    [Test]
+    public async Task SetRepoActive_Deactivate_FlipsFlag_AndEmitsDeactivatedEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var install = Install(tenant, InstallationId, (RepoIdApi, "acme/api", true));
+        var installs = new RecordingInstallationRepo();
+        installs.Installs.Add(install);
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(false),
+            installs, events, new FakeTenantContext(tenant), Principal(userId));
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("active").GetBoolean().Should().BeFalse();
+        root.GetProperty("changed").GetBoolean().Should().BeTrue();
+        root.GetProperty("repoFullName").GetString().Should().Be("acme/api");
+
+        installs.Removed.Should().ContainSingle().Which.Should().Be((install.Id, RepoIdApi));
+        installs.Added.Should().BeEmpty();
+
+        events.Appended.Should().ContainSingle();
+        var evt = events.Appended[0];
+        evt.Type.Should().Be("REPO.DEACTIVATED.SUCCESS");
+        evt.TenantId.Should().Be(tenant);
+        var tags = JsonDocument.Parse(evt.Tags).RootElement;
+        tags.GetProperty("tenantId").GetString().Should().Be(tenant.ToString());
+        tags.GetProperty("userId").GetString().Should().Be(userId.ToString());
+        var data = JsonDocument.Parse(evt.Data).RootElement;
+        data.GetProperty("installationId").GetInt64().Should().Be(InstallationId);
+        data.GetProperty("repoId").GetInt64().Should().Be(RepoIdApi);
+        data.GetProperty("active").GetBoolean().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SetRepoActive_Activate_FromInactive_FlipsAndEmitsActivatedEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var install = Install(tenant, InstallationId, (RepoIdWeb, "acme/web", false));
+        var installs = new RecordingInstallationRepo();
+        installs.Installs.Add(install);
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdWeb, new SetRepoActiveRequest(true),
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("active").GetBoolean().Should().BeTrue();
+        root.GetProperty("changed").GetBoolean().Should().BeTrue();
+
+        installs.Added.Should().ContainSingle().Which.Should().Be((install.Id, RepoIdWeb, "acme/web"));
+        installs.Removed.Should().BeEmpty();
+        events.Appended.Should().ContainSingle();
+        events.Appended[0].Type.Should().Be("REPO.ACTIVATED.SUCCESS");
+    }
+
+    [Test]
+    public async Task SetRepoActive_AlreadyInRequestedState_IsNoOp_NoEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var install = Install(tenant, InstallationId, (RepoIdApi, "acme/api", true));
+        var installs = new RecordingInstallationRepo();
+        installs.Installs.Add(install);
+        var events = new RecordingEventRepo();
+
+        // Activating an already-active repo — idempotent no-op.
+        var result = await OnboardingEndpoints.SetRepoActive(
+            InstallationId, RepoIdApi, new SetRepoActiveRequest(true),
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("active").GetBoolean().Should().BeTrue();
+        root.GetProperty("changed").GetBoolean().Should().BeFalse();
+
+        installs.Added.Should().BeEmpty("no flip means no repository mutation");
+        installs.Removed.Should().BeEmpty();
+        events.Appended.Should().BeEmpty("an idempotent no-op must NOT emit a duplicate DCB event");
+    }
+
+    // ── CompleteOnboarding ────────────────────────────────────────────────
+
+    [Test]
+    public async Task CompleteOnboarding_NullTenant_FailsClosed_WithoutReadingEvents()
+    {
+        var installs = new RecordingInstallationRepo();
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.CompleteOnboarding(
+            installs, events, new FakeTenantContext(null), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        events.GetLastCalled.Should().BeFalse();
+        events.Appended.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task CompleteOnboarding_FirstTime_EmitsCompletedEvent_WithSetupSummary()
+    {
+        var tenant = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var installs = new RecordingInstallationRepo();
+        // One live installation with 2 active + 1 inactive repo → activeRepoCount = 2.
+        installs.Installs.Add(Install(tenant, InstallationId,
+            (RepoIdApi, "acme/api", true), (RepoIdWeb, "acme/web", true), (9003L, "acme/infra", false)));
+        var events = new RecordingEventRepo();
+
+        var result = await OnboardingEndpoints.CompleteOnboarding(
+            installs, events, new FakeTenantContext(tenant), Principal(userId));
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("completed").GetBoolean().Should().BeTrue();
+        root.GetProperty("alreadyCompleted").GetBoolean().Should().BeFalse();
+        root.GetProperty("installationCount").GetInt32().Should().Be(1);
+        root.GetProperty("activeRepoCount").GetInt32().Should().Be(2);
+
+        events.Appended.Should().ContainSingle();
+        var evt = events.Appended[0];
+        evt.Type.Should().Be(OnboardingEndpoints.OnboardingCompletedEventType);
+        evt.Type.Should().Be("ONBOARDING.COMPLETED.SUCCESS");
+        evt.TenantId.Should().Be(tenant);
+        var tags = JsonDocument.Parse(evt.Tags).RootElement;
+        tags.GetProperty("tenantId").GetString().Should().Be(tenant.ToString());
+        tags.GetProperty("userId").GetString().Should().Be(userId.ToString());
+        var data = JsonDocument.Parse(evt.Data).RootElement;
+        data.GetProperty("installationCount").GetInt32().Should().Be(1);
+        data.GetProperty("activeRepoCount").GetInt32().Should().Be(2);
+    }
+
+    [Test]
+    public async Task CompleteOnboarding_AlreadyCompleted_IsIdempotent_NoDuplicateEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var priorAt = new DateTime(2026, 5, 1, 9, 30, 0, DateTimeKind.Utc);
+        var installs = new RecordingInstallationRepo();
+        var events = new RecordingEventRepo
+        {
+            Preset = new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = OnboardingEndpoints.OnboardingCompletedEventType,
+                TenantId = tenant,
+                CreatedAt = priorAt,
+            },
+        };
+
+        var result = await OnboardingEndpoints.CompleteOnboarding(
+            installs, events, new FakeTenantContext(tenant), Principal(Guid.NewGuid()));
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("completed").GetBoolean().Should().BeTrue();
+        root.GetProperty("alreadyCompleted").GetBoolean().Should().BeTrue();
+        root.GetProperty("completedAt").GetDateTime().Should().Be(priorAt);
+
+        events.Appended.Should().BeEmpty("a second completion must NOT append a duplicate milestone");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static GitHubInstallation Install(
+        Guid? tenantId, long installationId, params (long RepoId, string FullName, bool IsActive)[] repos)
+    {
+        var install = new GitHubInstallation
+        {
+            Id = Guid.NewGuid(),
+            InstallationId = installationId,
+            AccountLogin = "acme-corp",
+            AccountType = "Organization",
+            AppId = 42,
+            TenantId = tenantId,
+            Permissions = "{}",
+        };
+        foreach (var (repoId, fullName, isActive) in repos)
+        {
+            var slash = fullName.IndexOf('/');
+            install.Repos.Add(new GitHubInstallationRepo
+            {
+                Id = Guid.NewGuid(),
+                InstallationEntityId = install.Id,
+                RepoId = repoId,
+                Owner = slash > 0 ? fullName[..slash] : fullName,
+                Name = slash > 0 ? fullName[(slash + 1)..] : fullName,
+                RepoFullName = fullName,
+                IsActive = isActive,
+            });
+        }
+        return install;
+    }
+
+    private static ClaimsPrincipal Principal(Guid userId)
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+            new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+        }, authenticationType: "Test");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private static int? StatusOf(IResult result) => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    private static string? ErrorOf(IResult result)
+    {
+        var value = (result as IValueHttpResult)?.Value;
+        return value?.GetType().GetProperty("error")?.GetValue(value) as string;
+    }
+
+    private static async Task<JsonElement> CaptureJson(IResult result)
+    {
+        await using var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var ctx = new DefaultHttpContext { RequestServices = services };
+        using var stream = new MemoryStream();
+        ctx.Response.Body = stream;
+        await result.ExecuteAsync(ctx);
+        stream.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    // ── Test doubles ──────────────────────────────────────────────────────
+
+    private sealed class FakeTenantContext(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    private sealed class RecordingInstallationRepo : IInstallationRepository
+    {
+        public List<GitHubInstallation> Installs { get; } = new();
+        public bool GetByInstallationIdCalled { get; private set; }
+        public List<(Guid EntityId, long RepoId, string FullName)> Added { get; } = new();
+        public List<(Guid EntityId, long RepoId)> Removed { get; } = new();
+
+        public Task<GitHubInstallation?> GetByInstallationIdAsync(long installationId)
+        {
+            GetByInstallationIdCalled = true;
+            return Task.FromResult(Installs.FirstOrDefault(i => i.InstallationId == installationId));
+        }
+
+        public Task AddRepoAsync(Guid installationEntityId, long repoId, string repoFullName)
+        {
+            Added.Add((installationEntityId, repoId, repoFullName));
+            var repo = Installs.FirstOrDefault(i => i.Id == installationEntityId)
+                ?.Repos.FirstOrDefault(r => r.RepoId == repoId);
+            if (repo is not null) repo.IsActive = true;
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveRepoAsync(Guid installationEntityId, long repoId)
+        {
+            Removed.Add((installationEntityId, repoId));
+            var repo = Installs.FirstOrDefault(i => i.Id == installationEntityId)
+                ?.Repos.FirstOrDefault(r => r.RepoId == repoId);
+            if (repo is not null) repo.IsActive = false;
+            return Task.CompletedTask;
+        }
+
+        public Task<List<GitHubInstallation>> ListByTenantAsync(Guid tenantId)
+            => Task.FromResult(Installs.Where(i => i.TenantId == tenantId).ToList());
+
+        public Task<GitHubInstallation> UpsertAsync(GitHubInstallation installation) => throw new NotSupportedException();
+        public Task<GitHubInstallation?> GetByEntityIdAsync(Guid entityId) => throw new NotSupportedException();
+        public Task<List<GitHubInstallation>> ListAsync() => throw new NotSupportedException();
+        public Task<List<GitHubInstallation>> ListActiveAsync() => throw new NotSupportedException();
+        public Task DeleteAsync(long installationId) => throw new NotSupportedException();
+        public Task SetReposAsync(Guid installationEntityId, List<GitHubInstallationRepo> repos) => throw new NotSupportedException();
+        public Task<List<GitHubInstallationRepo>> ListReposAsync(Guid installationEntityId) => throw new NotSupportedException();
+        public Task SuspendAsync(long installationId) => throw new NotSupportedException();
+        public Task UnsuspendAsync(long installationId) => throw new NotSupportedException();
+        public Task<GitHubInstallation> CreateAsync(GitHubInstallation install) => throw new NotSupportedException();
+        public Task SoftDeleteAsync(long installationId) => throw new NotSupportedException();
+        public Task SetSuspendedAsync(long installationId, bool suspended) => throw new NotSupportedException();
+        public Task<GitHubInstallation?> GetByRepoFullNameAsync(string repoFullName) => throw new NotSupportedException();
+    }
+
+    private sealed class RecordingEventRepo : IEventRepository
+    {
+        public List<DomainEvent> Appended { get; } = new();
+        public DomainEvent? Preset { get; set; }
+        public bool GetLastCalled { get; private set; }
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Appended.Add(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type)
+        {
+            GetLastCalled = true;
+            if (Preset is not null && Preset.TenantId == tenantId && Preset.Type == type)
+                return Task.FromResult<DomainEvent?>(Preset);
+            return Task.FromResult(Appended.LastOrDefault(e => e.TenantId == tenantId && e.Type == type));
+        }
+
+        public Task<IReadOnlyList<DomainEvent>> ListByCorrelationIdAsync(Guid tenantId, string correlationId) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## What

The two non-migration slices of Story 18.4 (the settings-column slice stays the separate migration lane):

- **`PATCH /api/v1/onboarding/repos/{installationId}/{repoId}`** `{active}` — flips the existing `GitHubInstallationRepo.IsActive` (the WRITE counterpart to #258's read-only `/repos`). `PlatformsManage` (owner/admin; member 403). Tenant from `ITenantContext` (no IDOR); null tenant → 404 `no_active_tenant` before any repo call; foreign/unknown installation → 404 `installation_not_found`. Idempotent (no-op → `changed:false`, no event); a real flip emits `REPO.ACTIVATED/DEACTIVATED.SUCCESS`.
- **`POST /api/v1/onboarding/complete`** — emits `ONBOARDING.COMPLETED.SUCCESS` (the append-only DCB event **is** the record → no persisted flag, no migration). `MemberAccess`, idempotent.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes" (flips existing column + events only). Tests: 326 (12 new guards: null/empty-tenant fail-closed, foreign-installation 404, unknown-repo 404, member-403, flip + event type/tags, idempotent no-dup, ONBOARDING.COMPLETED + idempotency).

Deferred: the jsonb installation-settings column (migration lane), the live first-run test workflow, and the frontend toggle (needs `GetStatus` to surface inactive repos first — deferred rather than ship a broken half-toggle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)