### PR TITLE
feat(epic-23-4): Configuration Audit page (effective config + change history)

### DIFF
--- a/packages/dashboard/src/hooks/monitoring/useConfigAudit.ts
+++ b/packages/dashboard/src/hooks/monitoring/useConfigAudit.ts
@@ -1,0 +1,433 @@
+/**
+ * useConfigAudit — data hook for the Configuration Audit page (Story 23-4).
+ *
+ * Like the System Health overview (Story 23-1) this page adds NO new backend
+ * surface: it COMPOSES existing, read-only, tenant-scoped endpoints entirely on
+ * the client via `Promise.allSettled`, so one unavailable source degrades that
+ * section rather than blanking the whole page. Two halves:
+ *
+ *   Effective configuration (the "what is configured right now" summary):
+ *     • `GET /api/providers/health`        — configured AI providers + circuit
+ *                                            state (metadata only — never keys).
+ *     • `GET /api/prompts`                 — the tenant/user prompt OVERRIDES
+ *                                            (source = user|tenant), i.e. every
+ *                                            prompt diffing from the system
+ *                                            default. Count + list.
+ *     • `GET /api/conventions`             — resolved conventions with an
+ *                                            `isOverride` flag (tenant vs system).
+ *     • `GET /api/pricing/entitlements`    — the tenant's OWN resolved plan +
+ *                                            entitlement limits / live headroom.
+ *                                            Carries NO price/margin fields.
+ *
+ *   Change history (the "who changed what, when" audit):
+ *     • `GET /api/v1/orgs/{tenantId}/audit` — the Epic-37 curated, redacted,
+ *                                            tenant-scoped audit read-model,
+ *                                            filtered client-side to the
+ *                                            configuration-relevant categories
+ *                                            (config / persona / byok / billing).
+ *                                            The tenant id comes from `/auth/me`;
+ *                                            with no active tenant the audit call
+ *                                            is skipped entirely (fail-closed —
+ *                                            never fans out cross-tenant).
+ *
+ * SECURITY: the page NEVER renders a secret value. `/api/config/providers`
+ * (which returns the raw user-settings blob that can hold plaintext keys) is
+ * deliberately NOT read; the curated audit rows are already redacted and this
+ * hook never surfaces their `payload`. No cost / margin / sell-price figure is
+ * read from any source (entitlements carries none; the platform price-book lives
+ * behind platform-owner-only `/api/admin/pricing/*` and is never touched here).
+ *
+ * Responses arrive with ASP.NET Core's camelCase policy.
+ */
+
+import { useCallback, useState } from 'react';
+import type { StatusKind, StatusTone } from '../../components/monitoring/StatusBadge.js';
+
+/** The configuration-relevant audit categories surfaced on this page. Security /
+ *  auth / rbac / tenant-lifecycle categories are the Security Audit page's scope
+ *  (Story 23-10), NOT this one. */
+export const CONFIG_AUDIT_CATEGORIES = ['config', 'persona', 'byok', 'billing'] as const;
+export type ConfigAuditCategory = (typeof CONFIG_AUDIT_CATEGORIES)[number];
+
+const CONFIG_CATEGORY_SET = new Set<string>(CONFIG_AUDIT_CATEGORIES);
+
+/** Max curated audit rows pulled per window (the endpoint's own MaxLimit). */
+const AUDIT_LIMIT = 200;
+
+// ── Public row/summary shapes ───────────────────────────────────────────────
+
+/** A configured AI provider (circuit-breaker roll-up — metadata only). */
+export interface ProviderConfigRow {
+  providerKey: string;
+  kind: StatusKind;
+  label: string;
+}
+
+/** A prompt or convention override diffing from the shipped system default. */
+export interface OverrideRow {
+  id: string;
+  scope: 'prompt' | 'convention';
+  role: string;
+  action: string;
+  /** `user` / `tenant` (an override) — system rows are excluded from this list. */
+  source: string;
+}
+
+/** One resolved entitlement limit (no monetary fields — never a price/margin). */
+export interface EntitlementRow {
+  metricKey: string;
+  limitValue: number | null;
+  period: string | null;
+  currentUsage: number | null;
+  remaining: number | null;
+  isOver: boolean;
+}
+
+/** The tenant's OWN plan identity (never a price). */
+export interface PlanSummary {
+  planId: string | null;
+  planVersion: number | null;
+  isCustom: boolean;
+}
+
+/** A single configuration-change audit record (who / what / when). */
+export interface ConfigChangeRow {
+  id: string;
+  occurredAt: string;
+  /** Point-in-time actor email snapshot, or `System` for system actions. */
+  actor: string;
+  actionCode: string;
+  category: string;
+  /** `type:id` target, or `—`. */
+  target: string;
+  severity: string;
+  outcome: string;
+}
+
+export interface ConfigAuditSummary {
+  providers: ProviderConfigRow[];
+  providerHealthy: number;
+  promptOverrideCount: number;
+  overrides: OverrideRow[];
+  conventionOverrideCount: number;
+  conventionTotal: number;
+  plan: PlanSummary | null;
+  entitlements: EntitlementRow[];
+  changes: ConfigChangeRow[];
+  /** True when the audit read 403'd (caller is not a tenant admin). */
+  changesForbidden: boolean;
+  /** True when there is no active tenant, so the audit read was skipped. */
+  changesNoTenant: boolean;
+  /** Per-source availability so the UI can show a degraded note per section. */
+  sources: {
+    providers: boolean;
+    prompts: boolean;
+    conventions: boolean;
+    entitlements: boolean;
+    changes: boolean;
+  };
+}
+
+export interface UseConfigAuditResult {
+  summary: ConfigAuditSummary | null;
+  loading: boolean;
+  /** Set only when EVERY source failed (catastrophic). Per-source failures
+   *  degrade their own section instead. */
+  error: string | null;
+  lastUpdated: Date | null;
+  load: (range: { start: Date; end: Date }) => Promise<void>;
+}
+
+// ── Wire shapes (subset of each endpoint's camelCase response) ──────────────
+
+interface MeResponse {
+  user?: { tenantId?: string | null };
+}
+
+interface ProviderHealthWire {
+  providerKey: string;
+  status?: string;
+}
+
+interface ProviderHealthResponse {
+  providers?: ProviderHealthWire[];
+}
+
+interface PromptOverrideWire {
+  role: string | null;
+  action: string | null;
+  source?: string;
+}
+
+interface ConventionWire {
+  id?: string;
+  role: string;
+  action: string;
+  source?: string;
+  isOverride?: boolean;
+}
+
+interface EntitlementLimitWire {
+  metricKey: string;
+  limitValue?: number | null;
+  period?: string | null;
+  currentUsage?: number | null;
+  remaining?: number | null;
+  isOver?: boolean;
+}
+
+interface EntitlementsResponse {
+  planId?: string | null;
+  planVersion?: number | null;
+  isCustom?: boolean;
+  limits?: EntitlementLimitWire[];
+}
+
+interface AuditRecordWire {
+  id: string;
+  actionCategory: string;
+  actionCode: string;
+  actorLabel?: string | null;
+  targetType?: string | null;
+  targetId?: string | null;
+  severity: string;
+  outcome: string;
+  occurredAt: string;
+}
+
+interface AuditQueryResponse {
+  records?: AuditRecordWire[];
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+/** Sentinel: no active tenant, so the curated audit read is skipped. */
+const NO_TENANT = Symbol('no-active-tenant');
+
+interface HttpError extends Error {
+  status?: number;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // keep the default status message
+    }
+    const err = new Error(message) as HttpError;
+    err.status = res.status;
+    throw err;
+  }
+  return (await res.json()) as T;
+}
+
+/** Map a provider circuit-breaker `status` to a badge kind + label. */
+function providerKind(status: string | undefined): { kind: StatusKind; label: string } {
+  switch (status) {
+    case 'healthy':
+      return { kind: 'healthy', label: 'Healthy' };
+    case 'degraded':
+      return { kind: 'degraded', label: 'Half-open' };
+    case 'down':
+      return { kind: 'down', label: 'Circuit open' };
+    default:
+      return { kind: 'unknown', label: 'Configured' };
+  }
+}
+
+/** Severity → badge tone for the change-history table. */
+export function severityTone(severity: string): StatusTone {
+  switch (severity.toLowerCase()) {
+    case 'critical':
+      return 'red';
+    case 'warning':
+      return 'yellow';
+    case 'notice':
+      return 'blue';
+    default:
+      return 'gray';
+  }
+}
+
+export function useConfigAudit(): UseConfigAuditResult {
+  const [summary, setSummary] = useState<ConfigAuditSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const load = useCallback(async (range: { start: Date; end: Date }): Promise<void> => {
+    setLoading(true);
+    setError(null);
+
+    // Resolve the active tenant id — needed ONLY to address the curated tenant
+    // audit URL. Best-effort + fail-closed: no tenant → the audit read is
+    // skipped (the hook never fans out cross-tenant).
+    let tenantId: string | null = null;
+    try {
+      const me = await fetchJson<MeResponse>(`${API_BASE}/api/auth/me`);
+      tenantId = me.user?.tenantId ?? null;
+    } catch {
+      tenantId = null;
+    }
+
+    const auditParams = new URLSearchParams({
+      from: range.start.toISOString(),
+      to: range.end.toISOString(),
+      limit: String(AUDIT_LIMIT),
+    });
+    const auditUrl = tenantId
+      ? `${API_BASE}/api/v1/orgs/${tenantId}/audit?${auditParams.toString()}`
+      : null;
+
+    const [healthR, promptsR, conventionsR, entitlementsR, auditR] = await Promise.allSettled([
+      fetchJson<ProviderHealthResponse>(`${API_BASE}/api/providers/health`),
+      fetchJson<PromptOverrideWire[]>(`${API_BASE}/api/prompts`),
+      fetchJson<ConventionWire[]>(`${API_BASE}/api/conventions`),
+      fetchJson<EntitlementsResponse>(`${API_BASE}/api/pricing/entitlements`),
+      auditUrl ? fetchJson<AuditQueryResponse>(auditUrl) : Promise.reject(NO_TENANT),
+    ]);
+
+    // Catastrophic: every configuration source failed (e.g. logged out).
+    if (
+      healthR.status === 'rejected' &&
+      promptsR.status === 'rejected' &&
+      conventionsR.status === 'rejected' &&
+      entitlementsR.status === 'rejected'
+    ) {
+      setError(
+        healthR.reason instanceof Error
+          ? healthR.reason.message
+          : 'Failed to load configuration',
+      );
+      setLoading(false);
+      return;
+    }
+
+    // ── Providers ──
+    let providers: ProviderConfigRow[] = [];
+    if (healthR.status === 'fulfilled') {
+      providers = (healthR.value.providers ?? []).map((p) => {
+        const { kind, label } = providerKind(p.status);
+        return { providerKey: p.providerKey, kind, label };
+      });
+    }
+    const providerHealthy = providers.filter((p) => p.kind === 'healthy').length;
+
+    // ── Prompt overrides ── (the list IS the overrides — system defaults excluded)
+    const overrides: OverrideRow[] = [];
+    let promptOverrideCount = 0;
+    if (promptsR.status === 'fulfilled') {
+      for (const p of promptsR.value ?? []) {
+        if ((p.source ?? '') === 'system') continue;
+        promptOverrideCount += 1;
+        overrides.push({
+          id: `prompt:${p.role ?? '*'}:${p.action ?? '*'}`,
+          scope: 'prompt',
+          role: p.role ?? '—',
+          action: p.action ?? '—',
+          source: p.source ?? 'override',
+        });
+      }
+    }
+
+    // ── Convention overrides ── (list resolves every eligible pair; count the
+    // tenant-overridden ones and add them to the overrides table).
+    let conventionOverrideCount = 0;
+    let conventionTotal = 0;
+    if (conventionsR.status === 'fulfilled') {
+      const rows = conventionsR.value ?? [];
+      conventionTotal = rows.length;
+      for (const c of rows) {
+        const isOverride = c.isOverride === true || c.source === 'tenant';
+        if (!isOverride) continue;
+        conventionOverrideCount += 1;
+        overrides.push({
+          id: `convention:${c.id ?? `${c.role}:${c.action}`}`,
+          scope: 'convention',
+          role: c.role,
+          action: c.action,
+          source: c.source ?? 'tenant',
+        });
+      }
+    }
+
+    // ── Plan + entitlements ── (own plan/limits only — NEVER a price/margin)
+    let plan: PlanSummary | null = null;
+    let entitlements: EntitlementRow[] = [];
+    if (entitlementsR.status === 'fulfilled') {
+      const e = entitlementsR.value;
+      plan = {
+        planId: e.planId ?? null,
+        planVersion: e.planVersion ?? null,
+        isCustom: e.isCustom ?? false,
+      };
+      entitlements = (e.limits ?? []).map((l) => ({
+        metricKey: l.metricKey,
+        limitValue: l.limitValue ?? null,
+        period: l.period ?? null,
+        currentUsage: l.currentUsage ?? null,
+        remaining: l.remaining ?? null,
+        isOver: l.isOver ?? false,
+      }));
+    }
+
+    // ── Change history ── (curated, redacted; config-relevant categories only)
+    let changes: ConfigChangeRow[] = [];
+    let changesForbidden = false;
+    const changesNoTenant = auditUrl === null;
+    if (auditR.status === 'fulfilled') {
+      changes = (auditR.value.records ?? [])
+        .filter((r) => CONFIG_CATEGORY_SET.has(r.actionCategory.toLowerCase()))
+        .map((r) => ({
+          id: r.id,
+          occurredAt: r.occurredAt,
+          actor: r.actorLabel && r.actorLabel.length > 0 ? r.actorLabel : 'System',
+          actionCode: r.actionCode,
+          category: r.actionCategory,
+          target:
+            r.targetType && r.targetType.length > 0
+              ? r.targetId && r.targetId.length > 0
+                ? `${r.targetType}:${r.targetId}`
+                : r.targetType
+              : '—',
+          severity: r.severity,
+          outcome: r.outcome,
+        }));
+    } else if (auditR.reason !== NO_TENANT) {
+      const status = (auditR.reason as HttpError | undefined)?.status;
+      changesForbidden = status === 403;
+    }
+
+    setSummary({
+      providers,
+      providerHealthy,
+      promptOverrideCount,
+      overrides,
+      conventionOverrideCount,
+      conventionTotal,
+      plan,
+      entitlements,
+      changes,
+      changesForbidden,
+      changesNoTenant,
+      sources: {
+        providers: healthR.status === 'fulfilled',
+        prompts: promptsR.status === 'fulfilled',
+        conventions: conventionsR.status === 'fulfilled',
+        entitlements: entitlementsR.status === 'fulfilled',
+        changes: auditR.status === 'fulfilled',
+      },
+    });
+    setLastUpdated(new Date());
+    setLoading(false);
+  }, []);
+
+  return { summary, loading, error, lastUpdated, load };
+}

--- a/packages/dashboard/src/pages/monitoring/ConfigAuditPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/ConfigAuditPage.tsx
@@ -1,21 +1,413 @@
 /**
- * Configuration Audit page. Scaffold from Story 23-12; full dashboard arrives in
- * Story 23-4.
+ * Configuration Audit — Story 23-4.
+ *
+ * An operator page that audits the tenant's effective CONFIGURATION (providers,
+ * prompt/convention overrides, plan/entitlements) alongside a config-change
+ * history (who changed what, when). Like System Health (Story 23-1) it adds NO
+ * backend surface — {@link useConfigAudit} COMPOSES existing read-only,
+ * tenant-scoped endpoints on the client:
+ *   • `GET /api/providers/health`         — configured providers (metadata only)
+ *   • `GET /api/prompts`                  — prompt overrides (diff vs defaults)
+ *   • `GET /api/conventions`              — conventions + `isOverride`
+ *   • `GET /api/pricing/entitlements`     — own plan + entitlement limits
+ *   • `GET /api/v1/orgs/{tenantId}/audit` — Epic-37 curated, redacted audit
+ *                                           (config-relevant categories only)
+ *
+ * SECURITY: never renders a secret value (the raw-settings `/api/config/providers`
+ * blob is deliberately not read; audit rows are redacted server-side and their
+ * payload is never surfaced) and never surfaces a cost / margin / sell-price
+ * figure (entitlements carries none; the platform price-book is not touched).
+ *
+ * The route is already `AdminGuard`-gated + lazy-mounted by Story 23-12; the
+ * curated audit read additionally requires tenant-admin server-side, and with no
+ * active tenant it is skipped entirely (fail-closed — never cross-tenant).
+ * This module only supplies the page body, on the Story 23-12 primitives.
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import { MetricGrid } from '../../components/monitoring/MetricGrid.js';
+import { MetricCard } from '../../components/monitoring/MetricCard.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { DataTable, type DataTableColumn } from '../../components/monitoring/DataTable.js';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import { useTimeRange } from '../../hooks/monitoring/useTimeRange.js';
+import {
+  useConfigAudit,
+  severityTone,
+  CONFIG_AUDIT_CATEGORIES,
+  type ProviderConfigRow,
+  type OverrideRow,
+  type EntitlementRow,
+  type ConfigChangeRow,
+} from '../../hooks/monitoring/useConfigAudit.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/config');
 
-export function ConfigAuditPage(): JSX.Element {
+const SELECT_CLASS =
+  'rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200';
+
+function formatInt(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+function formatLimit(value: number | null): string {
+  if (value == null) return '—';
+  if (value < 0) return 'Unlimited';
+  return formatInt(value);
+}
+
+// ── Column definitions for the effective-config + change-history tables ─────
+
+const PROVIDER_COLUMNS: DataTableColumn<ProviderConfigRow>[] = [
+  { key: 'providerKey', header: 'Provider', accessor: (r) => r.providerKey, sortable: true },
+  {
+    key: 'status',
+    header: 'Status',
+    accessor: (r) => r.label,
+    render: (r) => <StatusBadge status={r.kind}>{r.label}</StatusBadge>,
+    sortable: true,
+  },
+];
+
+const OVERRIDE_COLUMNS: DataTableColumn<OverrideRow>[] = [
+  {
+    key: 'scope',
+    header: 'Kind',
+    accessor: (r) => r.scope,
+    render: (r) => (
+      <StatusBadge status={r.scope === 'prompt' ? 'blue' : 'gray'} showDot={false}>
+        {r.scope}
+      </StatusBadge>
+    ),
+    sortable: true,
+  },
+  { key: 'role', header: 'Role', accessor: (r) => r.role, sortable: true },
+  { key: 'action', header: 'Action', accessor: (r) => r.action, sortable: true },
+  {
+    key: 'source',
+    header: 'Source',
+    accessor: (r) => r.source,
+    render: (r) => <code className="text-xs">{r.source}</code>,
+    sortable: true,
+  },
+];
+
+const ENTITLEMENT_COLUMNS: DataTableColumn<EntitlementRow>[] = [
+  {
+    key: 'metricKey',
+    header: 'Entitlement',
+    accessor: (r) => r.metricKey,
+    render: (r) => <code className="text-xs">{r.metricKey}</code>,
+    sortable: true,
+  },
+  {
+    key: 'limitValue',
+    header: 'Limit',
+    accessor: (r) => r.limitValue ?? -1,
+    render: (r) => formatLimit(r.limitValue),
+    align: 'right',
+    sortable: true,
+  },
+  {
+    key: 'currentUsage',
+    header: 'Used',
+    accessor: (r) => r.currentUsage ?? -1,
+    render: (r) => (r.currentUsage == null ? '—' : formatInt(r.currentUsage)),
+    align: 'right',
+    sortable: true,
+  },
+  {
+    key: 'remaining',
+    header: 'Remaining',
+    accessor: (r) => r.remaining ?? -1,
+    render: (r) =>
+      r.remaining == null ? (
+        '—'
+      ) : (
+        <span className={r.isOver ? 'font-medium text-red-600 dark:text-red-400' : undefined}>
+          {formatInt(r.remaining)}
+        </span>
+      ),
+    align: 'right',
+    sortable: true,
+  },
+  { key: 'period', header: 'Period', accessor: (r) => r.period ?? '—', sortable: true },
+];
+
+const CHANGE_COLUMNS: DataTableColumn<ConfigChangeRow>[] = [
+  {
+    key: 'occurredAt',
+    header: 'When',
+    accessor: (r) => r.occurredAt,
+    render: (r) => <span className="whitespace-nowrap">{formatTime(r.occurredAt)}</span>,
+    sortable: true,
+  },
+  { key: 'actor', header: 'Who', accessor: (r) => r.actor, sortable: true },
+  {
+    key: 'actionCode',
+    header: 'What',
+    accessor: (r) => r.actionCode,
+    render: (r) => <code className="text-xs">{r.actionCode}</code>,
+    sortable: true,
+  },
+  {
+    key: 'category',
+    header: 'Category',
+    accessor: (r) => r.category,
+    render: (r) => (
+      <StatusBadge status="gray" showDot={false}>
+        {r.category}
+      </StatusBadge>
+    ),
+    sortable: true,
+  },
+  { key: 'target', header: 'Target', accessor: (r) => r.target, sortable: true },
+  {
+    key: 'severity',
+    header: 'Severity',
+    accessor: (r) => r.severity,
+    render: (r) => <StatusBadge status={severityTone(r.severity)}>{r.severity}</StatusBadge>,
+    sortable: true,
+  },
+  {
+    key: 'outcome',
+    header: 'Outcome',
+    accessor: (r) => r.outcome,
+    render: (r) => (
+      <StatusBadge status={r.outcome === 'success' ? 'green' : 'red'} showDot={false}>
+        {r.outcome}
+      </StatusBadge>
+    ),
+    sortable: true,
+  },
+];
+
+function SectionHeading({ children }: { children: string }): JSX.Element {
   return (
-    <MonitoringPlaceholder
+    <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">{children}</h2>
+  );
+}
+
+export function ConfigAuditPage(): JSX.Element {
+  const { preset, range, setPreset } = useTimeRange('24h');
+  const { summary, loading, error, lastUpdated, load } = useConfigAudit();
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+
+  // Stable trigger that always reads the latest time-range window, so the
+  // interval timer / manual refresh / preset change reuse it without re-arming.
+  const loadRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    loadRef.current = () => {
+      void load({ start: range.start, end: range.end });
+    };
+  }, [load, range]);
+  const trigger = useCallback(() => loadRef.current(), []);
+
+  const autoRefresh = useAutoRefresh(trigger, {
+    storageKey: NAV.storageKey,
+    defaultInterval: null,
+  });
+
+  // Run on mount and whenever the time-range preset changes.
+  useEffect(() => {
+    trigger();
+  }, [trigger, preset]);
+
+  const providers = summary?.providers ?? [];
+  const overrides = summary?.overrides ?? [];
+  const entitlements = summary?.entitlements ?? [];
+  const changes = summary?.changes ?? [];
+
+  const visibleChanges = useMemo(
+    () =>
+      categoryFilter === 'all'
+        ? changes
+        : changes.filter((c) => c.category.toLowerCase() === categoryFilter),
+    [changes, categoryFilter],
+  );
+
+  const planLabel = useMemo(() => {
+    if (!summary?.plan) return '—';
+    if (summary.plan.isCustom) return 'Custom';
+    return summary.plan.planVersion != null ? `v${summary.plan.planVersion}` : 'Assigned';
+  }, [summary]);
+
+  return (
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="Audit the effective tenant configuration — providers, prompt & convention overrides, plan/entitlements — and the who/what/when history of configuration changes."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={trigger}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      timeRange={preset}
+      onTimeRangeChange={setPreset}
+      showTimeRange
+      actions={
+        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          <span className="sr-only">Change category</span>
+          <select
+            aria-label="Change category filter"
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            <option value="all">All config changes</option>
+            {CONFIG_AUDIT_CATEGORIES.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+        </label>
+      }
+    >
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={trigger} />
+        </div>
+      )}
+
+      {/* Effective config summary */}
+      {summary && (
+        <MetricGrid columns={4} className="mb-6">
+          <MetricCard
+            label="Providers configured"
+            value={formatInt(providers.length)}
+            hint={`${formatInt(summary.providerHealthy)} healthy`}
+          />
+          <MetricCard
+            label="Prompt overrides"
+            value={formatInt(summary.promptOverrideCount)}
+            hint="vs system defaults"
+            tone={summary.promptOverrideCount > 0 ? 'blue' : 'gray'}
+          />
+          <MetricCard
+            label="Convention overrides"
+            value={formatInt(summary.conventionOverrideCount)}
+            hint={`${formatInt(summary.conventionTotal)} resolved`}
+            tone={summary.conventionOverrideCount > 0 ? 'blue' : 'gray'}
+          />
+          <MetricCard
+            label="Plan"
+            value={planLabel}
+            hint={`${formatInt(entitlements.length)} entitlement limits`}
+          />
+        </MetricGrid>
+      )}
+
+      {/* Effective configuration detail */}
+      <div className="mb-6 grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <section aria-label="Providers configured">
+          <SectionHeading>Providers configured</SectionHeading>
+          {summary && !summary.sources.providers ? (
+            <EmptyState title="Unavailable" description="Provider configuration could not be read." />
+          ) : providers.length === 0 ? (
+            <EmptyState
+              title="No providers configured"
+              description="No AI providers are currently configured for this tenant."
+            />
+          ) : (
+            <DataTable
+              columns={PROVIDER_COLUMNS}
+              rows={providers}
+              getRowId={(r) => r.providerKey}
+              pageSize={10}
+              filterable={false}
+              initialSort={{ key: 'providerKey', direction: 'asc' }}
+              emptyTitle="No providers configured"
+            />
+          )}
+        </section>
+
+        <section aria-label="Plan entitlements">
+          <SectionHeading>Plan &amp; entitlement limits</SectionHeading>
+          {summary && !summary.sources.entitlements ? (
+            <EmptyState title="Unavailable" description="Plan / entitlements could not be read." />
+          ) : entitlements.length === 0 ? (
+            <EmptyState
+              title="No entitlement limits"
+              description="No resolved plan entitlements for this tenant."
+            />
+          ) : (
+            <DataTable
+              columns={ENTITLEMENT_COLUMNS}
+              rows={entitlements}
+              getRowId={(r) => r.metricKey}
+              pageSize={10}
+              filterable={false}
+              initialSort={{ key: 'metricKey', direction: 'asc' }}
+              emptyTitle="No entitlement limits"
+            />
+          )}
+        </section>
+      </div>
+
+      {/* Overrides diffing from the shipped defaults */}
+      <section className="mb-6" aria-label="Configuration overrides">
+        <SectionHeading>Overrides (diff from system defaults)</SectionHeading>
+        {summary && !summary.sources.prompts && !summary.sources.conventions ? (
+          <EmptyState title="Unavailable" description="Overrides could not be read." />
+        ) : overrides.length === 0 ? (
+          <EmptyState
+            title="No overrides"
+            description="Every prompt and convention resolves to its shipped system default."
+          />
+        ) : (
+          <DataTable
+            columns={OVERRIDE_COLUMNS}
+            rows={overrides}
+            getRowId={(r) => r.id}
+            pageSize={10}
+            filterPlaceholder="Filter overrides…"
+            initialSort={{ key: 'scope', direction: 'asc' }}
+            emptyTitle="No overrides"
+          />
+        )}
+      </section>
+
+      {/* Config change history */}
+      <section aria-label="Configuration change history">
+        <SectionHeading>Configuration change history</SectionHeading>
+        {summary?.changesNoTenant ? (
+          <EmptyState
+            title="No active tenant"
+            description="Change history is scoped to a tenant; no active tenant is available."
+          />
+        ) : summary?.changesForbidden ? (
+          <EmptyState
+            title="Change history restricted"
+            description="Viewing the configuration change history requires a tenant admin role."
+          />
+        ) : summary && !summary.sources.changes ? (
+          <EmptyState title="Unavailable" description="The audit history could not be read." />
+        ) : visibleChanges.length === 0 ? (
+          <EmptyState
+            title="No configuration changes"
+            description="No configuration changes were recorded in the selected time range."
+          />
+        ) : (
+          <DataTable
+            columns={CHANGE_COLUMNS}
+            rows={visibleChanges}
+            getRowId={(r) => r.id}
+            pageSize={15}
+            filterPlaceholder="Filter changes…"
+            initialSort={{ key: 'occurredAt', direction: 'desc' }}
+            emptyTitle="No configuration changes"
+          />
+        )}
+      </section>
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/config-audit-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/config-audit-page.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { ConfigAuditPage } from '../ConfigAuditPage.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function errResponse(status: number, error = 'nope'): Response {
+  return { ok: false, status, json: async () => ({ error }) } as unknown as Response;
+}
+
+// A curated audit record whose (redacted) payload deliberately contains a
+// secret-looking value — the page must NEVER render the payload.
+const LEAKED_SECRET = 'sk-LEAKED-KEY-should-never-render';
+
+const me = { user: { id: 'u1', tenantId: 't1', role: 'owner' } };
+
+const health = {
+  providers: [
+    { providerKey: 'anthropic-claude', status: 'healthy' },
+    { providerKey: 'openai', status: 'down' },
+  ],
+};
+
+const prompts = [
+  { role: 'developer', action: 'code', source: 'tenant' },
+  { role: 'reviewer', action: 'review', source: 'system' }, // system → not an override
+];
+
+const conventions = [
+  { id: 'c1', role: 'developer', action: 'code', source: 'tenant', isOverride: true },
+  { id: 'c2', role: 'reviewer', action: 'review', source: 'system', isOverride: false },
+];
+
+const entitlements = {
+  planId: 'plan-guid',
+  planVersion: 3,
+  isCustom: false,
+  limits: [
+    {
+      metricKey: 'agents',
+      limitValue: 5,
+      period: 'month',
+      currentUsage: 2,
+      remaining: 3,
+      isOver: false,
+    },
+  ],
+};
+
+const audit = {
+  records: [
+    {
+      id: 'a1',
+      actionCategory: 'config',
+      actionCode: 'CONVENTION.UPDATED.SUCCESS',
+      actorLabel: 'admin@example.com',
+      targetType: 'convention',
+      targetId: 'developer/code',
+      severity: 'notice',
+      outcome: 'success',
+      occurredAt: '2026-07-05T10:00:00.000Z',
+      payload: '{}',
+    },
+    {
+      id: 'a2',
+      actionCategory: 'byok',
+      actionCode: 'PROVIDER_KEY.CHANGED.SUCCESS',
+      actorLabel: 'owner@example.com',
+      targetType: 'provider',
+      targetId: 'anthropic',
+      severity: 'warning',
+      outcome: 'success',
+      occurredAt: '2026-07-05T09:00:00.000Z',
+      payload: `{"secret":"${LEAKED_SECRET}"}`,
+    },
+    {
+      id: 'a3',
+      actionCategory: 'persona',
+      actionCode: 'PROMPT.UPDATED.SUCCESS',
+      actorLabel: null,
+      targetType: 'prompt',
+      targetId: 'developer/code',
+      severity: 'notice',
+      outcome: 'success',
+      occurredAt: '2026-07-05T08:00:00.000Z',
+      payload: '{}',
+    },
+    {
+      // NOT a configuration category → must be filtered out of this page.
+      id: 'a4',
+      actionCategory: 'auth',
+      actionCode: 'AUTH.LOGIN.SUCCESS',
+      actorLabel: 'admin@example.com',
+      targetType: 'user',
+      targetId: 'u1',
+      severity: 'info',
+      outcome: 'success',
+      occurredAt: '2026-07-05T07:00:00.000Z',
+      payload: '{}',
+    },
+  ],
+  nextCursor: null,
+  total: 4,
+  totalIsCapped: false,
+};
+
+const fetchMock = vi.fn();
+
+function routeFetch(overrides: Partial<Record<string, unknown>> = {}): void {
+  fetchMock.mockImplementation((url: string) => {
+    const u = String(url);
+    if (u.includes('/api/auth/me')) return Promise.resolve(okResponse(overrides.me ?? me));
+    if (u.includes('/providers/health')) return Promise.resolve(okResponse(overrides.health ?? health));
+    if (u.includes('/api/prompts')) return Promise.resolve(okResponse(overrides.prompts ?? prompts));
+    if (u.includes('/api/conventions'))
+      return Promise.resolve(okResponse(overrides.conventions ?? conventions));
+    if (u.includes('/pricing/entitlements'))
+      return Promise.resolve(okResponse(overrides.entitlements ?? entitlements));
+    if (u.includes('/audit')) {
+      if (overrides.auditStatus) return Promise.resolve(errResponse(overrides.auditStatus as number));
+      return Promise.resolve(okResponse(overrides.audit ?? audit));
+    }
+    return Promise.resolve(okResponse({}));
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  routeFetch();
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'owner' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/config']}>
+      <ConfigAuditPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ConfigAuditPage', () => {
+  it('renders the effective-config summary + detail tables from composed sources', async () => {
+    renderPage();
+
+    // Summary cards.
+    expect(await screen.findByText('Providers configured')).toBeInTheDocument();
+    expect(screen.getByText('Prompt overrides')).toBeInTheDocument();
+    expect(screen.getByText('Convention overrides')).toBeInTheDocument();
+
+    // Providers table (both configured providers appear).
+    expect(await screen.findByText('anthropic-claude')).toBeInTheDocument();
+    expect(screen.getByText('openai')).toBeInTheDocument();
+
+    // Entitlement limits table.
+    expect(screen.getByText('agents')).toBeInTheDocument();
+
+    // Overrides table shows the tenant-overridden prompt + convention only.
+    expect(screen.getAllByText('developer').length).toBeGreaterThan(0);
+
+    // All the composed sources were queried.
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes('/api/auth/me'))).toBe(true);
+      expect(urls.some((u) => u.includes('/providers/health'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/prompts'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/conventions'))).toBe(true);
+      expect(urls.some((u) => u.includes('/pricing/entitlements'))).toBe(true);
+      expect(urls.some((u) => u.includes('/api/v1/orgs/t1/audit'))).toBe(true);
+    });
+  });
+
+  it('renders config-change history (who/what/when) and filters out non-config categories', async () => {
+    renderPage();
+
+    // Config-relevant change rows appear.
+    expect(await screen.findByText('CONVENTION.UPDATED.SUCCESS')).toBeInTheDocument();
+    expect(screen.getByText('PROVIDER_KEY.CHANGED.SUCCESS')).toBeInTheDocument();
+    expect(screen.getByText('admin@example.com')).toBeInTheDocument();
+
+    // A non-config (auth) category is excluded from the Configuration Audit page.
+    expect(screen.queryByText('AUTH.LOGIN.SUCCESS')).not.toBeInTheDocument();
+  });
+
+  it('NEVER renders a secret value and never reads the secret-bearing settings endpoint', async () => {
+    renderPage();
+    await screen.findByText('CONVENTION.UPDATED.SUCCESS');
+
+    // The (redacted) audit payload is never surfaced — no secret leaks into the DOM.
+    expect(screen.queryByText(new RegExp(LEAKED_SECRET))).not.toBeInTheDocument();
+    expect(document.body.textContent ?? '').not.toContain(LEAKED_SECRET);
+
+    // The raw-settings endpoint that can hold plaintext keys is never called.
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/api/config/providers'))).toBe(false);
+  });
+
+  it('filters change history by config category', async () => {
+    renderPage();
+    await screen.findByText('CONVENTION.UPDATED.SUCCESS');
+
+    await userEvent.selectOptions(screen.getByLabelText('Change category filter'), 'byok');
+
+    expect(screen.getByText('PROVIDER_KEY.CHANGED.SUCCESS')).toBeInTheDocument();
+    expect(screen.queryByText('CONVENTION.UPDATED.SUCCESS')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing is configured', async () => {
+    routeFetch({
+      health: { providers: [] },
+      prompts: [],
+      conventions: [],
+      entitlements: { planId: null, planVersion: null, isCustom: false, limits: [] },
+      audit: { records: [], nextCursor: null, total: 0, totalIsCapped: false },
+    });
+    renderPage();
+
+    expect(await screen.findByText('No providers configured')).toBeInTheDocument();
+    expect(screen.getByText('No overrides')).toBeInTheDocument();
+    expect(screen.getByText('No configuration changes')).toBeInTheDocument();
+  });
+
+  it('shows a restricted note when the audit read is forbidden (non tenant-admin)', async () => {
+    routeFetch({ auditStatus: 403 });
+    renderPage();
+
+    expect(await screen.findByText('Change history restricted')).toBeInTheDocument();
+    // The effective-config summary still renders (per-source degradation).
+    expect(screen.getByText('anthropic-claude')).toBeInTheDocument();
+  });
+
+  it('skips the audit read and notes no active tenant when none is set (fail-closed)', async () => {
+    routeFetch({ me: { user: { id: 'u1', tenantId: null, role: 'owner' } } });
+    renderPage();
+
+    expect(await screen.findByText('No active tenant')).toBeInTheDocument();
+    // No cross-tenant fan-out: the audit endpoint is never called.
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes('/audit'))).toBe(false);
+    });
+  });
+
+  it('surfaces an error banner when every configuration source fails', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      const u = String(url);
+      if (u.includes('/api/auth/me')) return Promise.resolve(okResponse(me));
+      return Promise.resolve(errResponse(500, 'boom'));
+    });
+    renderPage();
+    expect(await screen.findByTestId('error-banner')).toHaveTextContent('boom');
+  });
+});
+
+describe('ConfigAuditPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/config']}>
+        <AdminGuard>
+          <ConfigAuditPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'Config Audit' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/config']}>
+        <AdminGuard>
+          <ConfigAuditPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'Config Audit' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

Story 23.4 — the Config Audit monitoring page. **Pure frontend** — composes existing endpoints, no backend change.

- Effective-config summary (providers, prompt-overrides, conventions, plan/entitlements) + a config-change history table (category-filtered) from the Epic-37 audit surface (`/api/v1/orgs/{tenantId}/audit`, server-redacted).
- `useConfigAudit` hook (`Promise.allSettled`, per-source graceful degradation, modeled on `useSystemHealth`). `AdminGuard`-gated.

## Safety

- **No secret leak:** deliberately uses `/api/providers/health` (metadata only) and **avoids** `/api/config/providers` (which can return raw plaintext keys) — a test asserts no secret value reaches the DOM and that endpoint is never called. Audit `payload` is never rendered.
- **No economics leak** (entitlements DTO has no cost/margin; the admin price-book is never touched). Audit read additionally requires tenant-admin server-side (403 → "restricted" note, summary still renders). **Null-tenant fail-closed** (audit URL never constructed → no cross-tenant fan-out).

## Verification

- `pnpm --filter @tamma/dashboard test` → 10 new + 51 monitoring pass. Build clean (lazy chunk). Typecheck 0 errors in changed files. **No backend change** → both `has-pending-model-changes` trivially "No changes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)