### PR TITLE
feat(epic-23-5): Workflow Monitor page (+/api/v1/runs/summary counts)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/ReposRunsEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/ReposRunsEndpoints.cs
@@ -17,6 +17,10 @@ namespace Tamma.Api.Endpoints;
 ///   <item><c>GET /api/v1/runs/{runId}</c> — a single run's DCB event/log
 ///     timeline + the tenant's OWN recorded per-run cost
 ///     (<see cref="IEventRepository.ListByCorrelationIdAsync"/>).</item>
+///   <item><c>GET /api/v1/runs/summary</c> — Story 23-5 Workflow Monitor:
+///     per-status + per-definition instance counts over an optional time
+///     window (<see cref="IWorkflowRepository.SummarizeInstancesAsync"/>).
+///     Counts only — no cost/economics.</item>
 /// </list>
 ///
 /// <para><b>Tenant is resolved strictly from
@@ -228,7 +232,79 @@ public static class ReposRunsEndpoints
         });
     }
 
+    // ─── GET /api/v1/runs/summary ─────────────────────────────────────────
+
+    /// <summary>
+    /// Story 23-5 Workflow Monitor: aggregate the caller's tenant's workflow
+    /// instances into per-status and per-definition counts over an optional
+    /// <c>[from, to)</c> window. Backs the monitor's metric cards + filters.
+    ///
+    /// <para>Tenant is resolved strictly from <see cref="ITenantContext"/>; a
+    /// null / empty ambient tenant <b>FAILS CLOSED</b> with
+    /// <c>404 no_active_tenant</c> BEFORE any repository call (mirrors
+    /// <see cref="ListRuns"/> and the Story 23-6 / #283 fix).</para>
+    ///
+    /// <para><b>No economics leak.</b> The projection is pure instance counts —
+    /// it never reads or returns any cost, price, margin or spend figure.</para>
+    ///
+    /// <para><c>from</c>/<c>to</c> are ISO-8601 strings parsed as UTC
+    /// (<see cref="System.Globalization.DateTimeStyles.AssumeUniversal"/> +
+    /// <see cref="System.Globalization.DateTimeStyles.AdjustToUniversal"/>) so a
+    /// naive/offset timestamp can't drift the window by the host timezone.
+    /// Unparseable values are ignored (treated as no bound).</para>
+    /// </summary>
+    public static async Task<IResult> GetRunsSummary(
+        IWorkflowRepository workflows,
+        ITenantContext tc,
+        string? from,
+        string? to)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+        {
+            return Results.NotFound(new { error = "no_active_tenant" });
+        }
+
+        var fromUtc = ParseUtc(from);
+        var toUtc = ParseUtc(to);
+
+        var summary = await workflows
+            .SummarizeInstancesAsync(tenantId, fromUtc, toUtc)
+            .ConfigureAwait(false);
+
+        return Results.Ok(new
+        {
+            tenantId,
+            from = fromUtc,
+            to = toUtc,
+            total = summary.Total,
+            byStatus = summary.ByStatus
+                .Select(s => new { status = s.Status, count = s.Count })
+                .ToList(),
+            byDefinition = summary.ByDefinition
+                .Select(d => new { definitionId = d.DefinitionId, definitionName = d.DefinitionName, count = d.Count })
+                .ToList(),
+        });
+    }
+
     // ─── Projections / helpers ────────────────────────────────────────────
+
+    /// <summary>
+    /// Parse an ISO-8601 query string to a UTC-kind <see cref="DateTime"/>;
+    /// null / blank / unparseable → null (no window bound). A trailing 'Z' or a
+    /// naive value is treated as UTC so the window is host-timezone independent.
+    /// </summary>
+    private static DateTime? ParseUtc(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return DateTime.TryParse(
+            value,
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.AssumeUniversal
+                | System.Globalization.DateTimeStyles.AdjustToUniversal,
+            out var parsed)
+            ? parsed
+            : null;
+    }
 
     private static object ToRunSummary(WorkflowInstance i) => new
     {

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2719,6 +2719,10 @@ engine.MapGet("/agent-available", EngineEndpoints.AgentAvailable);
 // concurrent System Health work (#277) does not conflict.
 app.MapGet("/api/v1/repos", ReposRunsEndpoints.ListRepos).RequireAuthorization("MemberAccess");
 app.MapGet("/api/v1/runs", ReposRunsEndpoints.ListRuns).RequireAuthorization("MemberAccess");
+// Story 23-5 Workflow Monitor: windowed per-status/per-definition instance counts
+// (literal segment — never collides with the {runId:guid} route below). Counts
+// only; same fail-closed tenant scoping, no economics.
+app.MapGet("/api/v1/runs/summary", ReposRunsEndpoints.GetRunsSummary).RequireAuthorization("MemberAccess");
 app.MapGet("/api/v1/runs/{runId:guid}", ReposRunsEndpoints.GetRunDetail).RequireAuthorization("MemberAccess");
 
 // ── Workflows ──

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IWorkflowRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IWorkflowRepository.cs
@@ -12,4 +12,12 @@ public interface IWorkflowRepository
     Task<WorkflowInstance?> GetInstanceAsync(Guid id);
     Task<bool> DeleteInstanceAsync(Guid id);
     Task<(List<WorkflowInstance> Instances, int Total)> ListInstancesAsync(Guid? definitionId, Guid? tenantId, int page, int pageSize);
+
+    /// <summary>
+    /// Aggregate the tenant's workflow instances into per-status and
+    /// per-definition counts over an optional [from, to) time window (matched
+    /// on <see cref="WorkflowInstance.CreatedAt"/>). Tenant-scoped read backing
+    /// the Story 23-5 Workflow Monitor — counts only, never cost/economics.
+    /// </summary>
+    Task<WorkflowInstanceSummary> SummarizeInstancesAsync(Guid tenantId, DateTime? from, DateTime? to);
 }

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/WorkflowInstanceSummary.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/WorkflowInstanceSummary.cs
@@ -1,0 +1,21 @@
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Aggregate view over a tenant's workflow instances for the Story 23-5
+/// Workflow Monitor. Pure counts — no cost / economics fields are ever
+/// projected here (the monitor never reads a MarginPolicy or platform price).
+/// </summary>
+/// <param name="Total">Total instances matching the window.</param>
+/// <param name="ByStatus">Instance count grouped by workflow status.</param>
+/// <param name="ByDefinition">Instance count grouped by workflow definition
+/// (id + friendly name).</param>
+public sealed record WorkflowInstanceSummary(
+    int Total,
+    IReadOnlyList<WorkflowStatusCount> ByStatus,
+    IReadOnlyList<WorkflowDefinitionCount> ByDefinition);
+
+/// <summary>Instance count for a single workflow status value.</summary>
+public sealed record WorkflowStatusCount(string Status, int Count);
+
+/// <summary>Instance count for a single workflow definition.</summary>
+public sealed record WorkflowDefinitionCount(Guid DefinitionId, string DefinitionName, int Count);

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/WorkflowRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/WorkflowRepository.cs
@@ -161,4 +161,59 @@ public class WorkflowRepository(
             .ToListAsync();
         return (instances, total);
     }
+
+    public async Task<WorkflowInstanceSummary> SummarizeInstancesAsync(
+        Guid tenantId, DateTime? from, DateTime? to)
+    {
+        // Structurally tenant-scoped: the tenant db + the TenantId equality both
+        // fence the aggregate to this tenant's rows. Callers pass a concrete
+        // tenant id (the endpoint fails closed on a null/empty ambient tenant
+        // BEFORE reaching here), so there is no cross-tenant fan-out.
+        await using var db = await tenantDbFactory.CreateAsync(tenantId);
+        var query = db.WorkflowInstances.Where(i => i.TenantId == tenantId);
+        if (from.HasValue)
+            query = query.Where(i => i.CreatedAt >= from.Value);
+        if (to.HasValue)
+            query = query.Where(i => i.CreatedAt < to.Value);
+
+        // Per-status counts: a single GROUP BY status COUNT(*) in SQL. The record
+        // is materialised in memory (anonymous SQL projection → record) so EF only
+        // has to translate the group/count, never a record constructor.
+        var byStatusRaw = await query
+            .GroupBy(i => i.Status)
+            .Select(g => new { Status = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        // Per-definition counts: GROUP BY definition_id COUNT(*). Names are joined
+        // in memory from the tenant's definition list (a small set) so the SQL stays
+        // a plain grouped count and there is no string[]/array-parameter predicate.
+        var byDefinitionRaw = await query
+            .GroupBy(i => i.DefinitionId)
+            .Select(g => new { DefinitionId = g.Key, Count = g.Count() })
+            .ToListAsync();
+
+        var definitionNames = await db.WorkflowDefinitions
+            .Where(d => d.TenantId == tenantId)
+            .Select(d => new { d.Id, d.Name })
+            .ToListAsync();
+        var nameById = definitionNames.ToDictionary(d => d.Id, d => d.Name);
+
+        var byStatus = byStatusRaw
+            .Select(s => new WorkflowStatusCount(s.Status, s.Count))
+            .OrderByDescending(s => s.Count)
+            .ToList();
+
+        var byDefinition = byDefinitionRaw
+            .Select(d => new WorkflowDefinitionCount(
+                d.DefinitionId,
+                nameById.TryGetValue(d.DefinitionId, out var name) && !string.IsNullOrWhiteSpace(name)
+                    ? name
+                    : d.DefinitionId.ToString(),
+                d.Count))
+            .OrderByDescending(d => d.Count)
+            .ToList();
+
+        var total = byStatusRaw.Sum(s => s.Count);
+        return new WorkflowInstanceSummary(total, byStatus, byDefinition);
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Dashboard/ReposRunsEndpointsGuardTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Dashboard/ReposRunsEndpointsGuardTests.cs
@@ -148,6 +148,95 @@ public class ReposRunsEndpointsGuardTests
         repo.RequestedPage.Should().Be(3);
     }
 
+    // ── /api/v1/runs/summary (Story 23-5 Workflow Monitor) ────────────────
+
+    [Test]
+    public async Task GetRunsSummary_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingWorkflowRepo();
+
+        var result = await ReposRunsEndpoints.GetRunsSummary(
+            repo, new FakeTenantContext(null), from: null, to: null);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.SummaryCalled.Should().BeFalse("the guard must reject before aggregating instances");
+    }
+
+    [Test]
+    public async Task GetRunsSummary_EmptyTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingWorkflowRepo();
+
+        var result = await ReposRunsEndpoints.GetRunsSummary(
+            repo, new FakeTenantContext(Guid.Empty), from: null, to: null);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.SummaryCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetRunsSummary_ConcreteTenant_ProjectsCountsAndParsesWindowAsUtc()
+    {
+        var tenant = Guid.NewGuid();
+        var defId = Guid.NewGuid();
+        var repo = new RecordingWorkflowRepo
+        {
+            Summary = new WorkflowInstanceSummary(
+                Total: 3,
+                ByStatus: new List<WorkflowStatusCount>
+                {
+                    new("completed", 2),
+                    new("failed", 1),
+                },
+                ByDefinition: new List<WorkflowDefinitionCount>
+                {
+                    new(defId, "code-workflow", 3),
+                }),
+        };
+
+        var result = await ReposRunsEndpoints.GetRunsSummary(
+            repo, new FakeTenantContext(tenant),
+            from: "2026-04-16T00:00:00.000Z", to: "2026-04-17T00:00:00.000Z");
+
+        StatusOf(result).Should().Be(200);
+        repo.RequestedTenant.Should().Be(tenant);
+        // A trailing-Z window is parsed to UTC-kind (host-timezone independent).
+        repo.RequestedFrom.Should().Be(new DateTime(2026, 4, 16, 0, 0, 0, DateTimeKind.Utc));
+        repo.RequestedFrom!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        repo.RequestedTo.Should().Be(new DateTime(2026, 4, 17, 0, 0, 0, DateTimeKind.Utc));
+
+        var root = await CaptureJson(result);
+        root.GetProperty("total").GetInt32().Should().Be(3);
+        var byStatus = root.GetProperty("byStatus");
+        byStatus.GetArrayLength().Should().Be(2);
+        byStatus[0].GetProperty("status").GetString().Should().Be("completed");
+        byStatus[0].GetProperty("count").GetInt32().Should().Be(2);
+        var byDef = root.GetProperty("byDefinition");
+        byDef[0].GetProperty("definitionId").GetGuid().Should().Be(defId);
+        byDef[0].GetProperty("definitionName").GetString().Should().Be("code-workflow");
+        byDef[0].GetProperty("count").GetInt32().Should().Be(3);
+        // No economics leak: the summary carries counts only — never a cost field.
+        root.TryGetProperty("totalCostUsd", out _).Should().BeFalse();
+        root.TryGetProperty("costUsd", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetRunsSummary_UnparseableWindow_IsIgnored_NoBound()
+    {
+        var tenant = Guid.NewGuid();
+        var repo = new RecordingWorkflowRepo();
+
+        var result = await ReposRunsEndpoints.GetRunsSummary(
+            repo, new FakeTenantContext(tenant), from: "not-a-date", to: "");
+
+        StatusOf(result).Should().Be(200);
+        repo.SummaryCalled.Should().BeTrue();
+        repo.RequestedFrom.Should().BeNull("an unparseable from is treated as no lower bound");
+        repo.RequestedTo.Should().BeNull();
+    }
+
     // ── /api/v1/runs/{runId} ──────────────────────────────────────────────
 
     [Test]
@@ -362,11 +451,15 @@ public class ReposRunsEndpointsGuardTests
     {
         public bool ListCalled { get; private set; }
         public bool GetCalled { get; private set; }
+        public bool SummaryCalled { get; private set; }
         public Guid? RequestedTenant { get; private set; }
+        public DateTime? RequestedFrom { get; private set; }
+        public DateTime? RequestedTo { get; private set; }
         public int RequestedPage { get; private set; }
         public int RequestedPageSize { get; private set; }
         public List<WorkflowInstance> Instances { get; } = new();
         public WorkflowInstance? InstanceById { get; set; }
+        public WorkflowInstanceSummary? Summary { get; set; }
 
         public Task<(List<WorkflowInstance> Instances, int Total)> ListInstancesAsync(
             Guid? definitionId, Guid? tenantId, int page, int pageSize)
@@ -376,6 +469,19 @@ public class ReposRunsEndpointsGuardTests
             RequestedPage = page;
             RequestedPageSize = pageSize;
             return Task.FromResult((Instances.ToList(), Instances.Count));
+        }
+
+        public Task<WorkflowInstanceSummary> SummarizeInstancesAsync(
+            Guid tenantId, DateTime? from, DateTime? to)
+        {
+            SummaryCalled = true;
+            RequestedTenant = tenantId;
+            RequestedFrom = from;
+            RequestedTo = to;
+            return Task.FromResult(Summary ?? new WorkflowInstanceSummary(
+                0,
+                new List<WorkflowStatusCount>(),
+                new List<WorkflowDefinitionCount>()));
         }
 
         public Task<WorkflowInstance?> GetInstanceAsync(Guid id)

--- a/packages/dashboard/src/hooks/monitoring/useWorkflowMonitor.ts
+++ b/packages/dashboard/src/hooks/monitoring/useWorkflowMonitor.ts
@@ -1,0 +1,84 @@
+/**
+ * useWorkflowMonitor — data hook for the Workflow Monitor (Story 23-5).
+ *
+ * Composes two EXISTING tenant-scoped, fail-closed read endpoints (Story 21-4 /
+ * Story 23-5) into one refresh:
+ *   • `GET /api/v1/runs?limit=…`     — the newest workflow-instance rows for the
+ *                                      table (id, definition, status, timings).
+ *   • `GET /api/v1/runs/summary?from&to` — windowed per-status / per-definition
+ *                                      instance counts for the metric cards.
+ *
+ * Both resolve the tenant from the caller's session (no tenant id sent from the
+ * browser); a null / cross-tenant read fails closed with 404. The summary is a
+ * pure count projection — it carries no cost / economics figure.
+ *
+ * The `/runs` list is newest-first and has no server-side time filter, so the
+ * page applies the selected time window client-side over the loaded rows; the
+ * windowed authoritative counts come from the summary endpoint.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import {
+  runsApi,
+  type WorkflowRunSummary,
+  type WorkflowRunsSummary,
+} from '../../services/runs/runs-api-client.js';
+
+/** The largest run page the table loads in one shot. */
+export const WORKFLOW_MONITOR_RUN_LIMIT = 100;
+
+export interface WorkflowMonitorWindow {
+  from?: Date;
+  to?: Date;
+}
+
+export interface UseWorkflowMonitorResult {
+  runs: WorkflowRunSummary[];
+  /** Total instances the tenant has (from the `/runs` list), or null. */
+  total: number | null;
+  summary: WorkflowRunsSummary | null;
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  /** Reload both the run list and the windowed summary for `window`. */
+  load: (window: WorkflowMonitorWindow) => Promise<void>;
+}
+
+export function useWorkflowMonitor(): UseWorkflowMonitorResult {
+  const [runs, setRuns] = useState<WorkflowRunSummary[]>([]);
+  const [total, setTotal] = useState<number | null>(null);
+  const [summary, setSummary] = useState<WorkflowRunsSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  // Guards against a slow earlier request overwriting a newer one's result.
+  const requestSeq = useRef(0);
+
+  const load = useCallback(async (window: WorkflowMonitorWindow): Promise<void> => {
+    const seq = ++requestSeq.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const [list, sum] = await Promise.all([
+        runsApi.list({ limit: WORKFLOW_MONITOR_RUN_LIMIT }),
+        runsApi.summary({
+          ...(window.from ? { from: window.from.toISOString() } : {}),
+          ...(window.to ? { to: window.to.toISOString() } : {}),
+        }),
+      ]);
+      if (seq !== requestSeq.current) return; // superseded
+      setRuns(list.runs);
+      setTotal(list.total);
+      setSummary(sum);
+      setLastUpdated(new Date());
+    } catch (err) {
+      if (seq !== requestSeq.current) return;
+      setError(err instanceof Error ? err.message : 'Failed to load workflow instances');
+    } finally {
+      if (seq === requestSeq.current) setLoading(false);
+    }
+  }, []);
+
+  return { runs, total, summary, loading, error, lastUpdated, load };
+}

--- a/packages/dashboard/src/pages/monitoring/WorkflowMonitorPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/WorkflowMonitorPage.tsx
@@ -1,21 +1,422 @@
 /**
- * Workflow Monitor page. Scaffold from Story 23-12; full dashboard arrives in
- * Story 23-5.
+ * Workflow Monitor (Story 23-5).
+ *
+ * Operator page over the tenant's WORKFLOW instances: a run-instance table
+ * (id, definition, status, started, duration), per-status + per-definition
+ * counts, a recent-failures highlight, status/definition filters, and the
+ * global time-range + auto-refresh controls.
+ *
+ * Data sources are EXISTING tenant-scoped, fail-closed reads (no new lib):
+ *   • `GET /api/v1/runs`          — the Story 21-4 (#258) run list (table).
+ *   • `GET /api/v1/runs/summary`  — the Story 23-5 windowed count aggregate
+ *                                   (metric cards / filters). Counts only, no
+ *                                   cost / economics.
+ * Both resolve the tenant from the session and fail closed (404) on a null /
+ * cross-tenant read. The route is already `AdminGuard`-gated + lazy-mounted by
+ * Story 23-12; this module only supplies the page body.
+ *
+ * A row links to the run detail (`/runs/:runId`) — the DCB event timeline for
+ * that correlationId.
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import { MetricGrid } from '../../components/monitoring/MetricGrid.js';
+import { MetricCard } from '../../components/monitoring/MetricCard.js';
+import { DataTable, type DataTableColumn } from '../../components/monitoring/DataTable.js';
+import { StatusBadge, type StatusTone } from '../../components/monitoring/StatusBadge.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { useWorkflowMonitor } from '../../hooks/monitoring/useWorkflowMonitor.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import { useTimeRange } from '../../hooks/monitoring/useTimeRange.js';
+import type { WorkflowRunSummary } from '../../services/runs/runs-api-client.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/workflows');
 
-export function WorkflowMonitorPage(): JSX.Element {
+const INPUT_CLASS =
+  'rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100';
+
+/** Map a raw workflow status onto the shared monitoring colour vocabulary. */
+function statusTone(status: string): StatusTone {
+  switch (status.toLowerCase()) {
+    case 'completed':
+    case 'succeeded':
+    case 'success':
+      return 'green';
+    case 'failed':
+    case 'error':
+    case 'faulted':
+      return 'red';
+    case 'running':
+      return 'blue';
+    case 'paused':
+    case 'awaiting_approval':
+    case 'suspended':
+      return 'yellow';
+    default:
+      return 'gray';
+  }
+}
+
+function isFailed(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === 'failed' || s === 'error' || s === 'faulted';
+}
+
+function isInProgress(status: string): boolean {
+  const s = status.toLowerCase();
   return (
-    <MonitoringPlaceholder
+    s === 'running' ||
+    s === 'pending' ||
+    s === 'paused' ||
+    s === 'awaiting_approval' ||
+    s === 'suspended'
+  );
+}
+
+function isCompleted(status: string): boolean {
+  const s = status.toLowerCase();
+  return s === 'completed' || s === 'succeeded' || s === 'success';
+}
+
+/** Format an elapsed millisecond span as "Xh Ym" / "Xm Ys" / "Xs". */
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m ${totalSeconds % 60}s`;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${hours}h ${totalMinutes % 60}m`;
+}
+
+/** Live duration for a run: recorded span, else elapsed-since-start if active. */
+function runDurationMs(run: WorkflowRunSummary, nowMs: number): number | null {
+  if (run.durationMs != null) return run.durationMs;
+  if (run.startedAt && isInProgress(run.status)) {
+    return nowMs - new Date(run.startedAt).getTime();
+  }
+  return null;
+}
+
+function shortId(id: string): string {
+  return id.length > 8 ? id.slice(0, 8) : id;
+}
+
+export function WorkflowMonitorPage(): JSX.Element {
+  const navigate = useNavigate();
+  const { preset, range, setPreset } = useTimeRange('24h');
+  const { runs, total, summary, loading, error, lastUpdated, load } = useWorkflowMonitor();
+
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [definitionFilter, setDefinitionFilter] = useState('all');
+  const [failuresOnly, setFailuresOnly] = useState(false);
+
+  // Stable trigger that always reads the latest window, so the auto-refresh
+  // interval is not re-armed on every render (mirrors the Event Explorer).
+  const loadRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    loadRef.current = () => {
+      void load({ from: range.start, to: range.end });
+    };
+  }, [load, range]);
+
+  const triggerLoad = useCallback(() => loadRef.current(), []);
+
+  const autoRefresh = useAutoRefresh(triggerLoad, {
+    storageKey: NAV.storageKey,
+    defaultInterval: null,
+  });
+
+  useEffect(() => {
+    triggerLoad();
+  }, [triggerLoad, preset]);
+
+  // definitionId → friendly name, resolved from the windowed summary.
+  const definitionNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const d of summary?.byDefinition ?? []) map.set(d.definitionId, d.definitionName);
+    return map;
+  }, [summary]);
+
+  // Windowed metric counts (authoritative, from the summary endpoint).
+  const counts = useMemo(() => {
+    let inProgress = 0;
+    let completed = 0;
+    let failed = 0;
+    for (const s of summary?.byStatus ?? []) {
+      if (isFailed(s.status)) failed += s.count;
+      else if (isCompleted(s.status)) completed += s.count;
+      else if (isInProgress(s.status)) inProgress += s.count;
+    }
+    return { total: summary?.total ?? 0, inProgress, completed, failed };
+  }, [summary]);
+
+  const statusOptions = useMemo(
+    () => (summary?.byStatus ?? []).map((s) => s.status).sort((a, b) => a.localeCompare(b)),
+    [summary],
+  );
+
+  const definitionOptions = useMemo(
+    () =>
+      (summary?.byDefinition ?? [])
+        .map((d) => ({ id: d.definitionId, name: d.definitionName }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [summary],
+  );
+
+  // Client-side filtering over the loaded run list: time window (the /runs list
+  // is not server-windowed) + status + definition + failures-only.
+  const visibleRuns = useMemo(() => {
+    const startMs = range.start.getTime();
+    const endMs = range.end.getTime();
+    return runs.filter((r) => {
+      const created = new Date(r.createdAt).getTime();
+      if (Number.isFinite(created) && (created < startMs || created > endMs)) return false;
+      if (failuresOnly && !isFailed(r.status)) return false;
+      if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+      if (definitionFilter !== 'all' && r.definitionId !== definitionFilter) return false;
+      return true;
+    });
+  }, [runs, range, statusFilter, definitionFilter, failuresOnly]);
+
+  const nowMs = lastUpdated?.getTime() ?? Date.now();
+
+  const columns: DataTableColumn<WorkflowRunSummary>[] = useMemo(
+    () => [
+      {
+        key: 'id',
+        header: 'Run',
+        accessor: (r) => r.id,
+        render: (r) => (
+          <code
+            className="text-xs text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+            title={r.id}
+          >
+            {shortId(r.id)}
+          </code>
+        ),
+        sortable: true,
+      },
+      {
+        key: 'definition',
+        header: 'Definition',
+        accessor: (r) => definitionNameById.get(r.definitionId) ?? r.definitionId,
+        render: (r) => (
+          <span className="text-gray-700 dark:text-gray-300">
+            {definitionNameById.get(r.definitionId) ?? shortId(r.definitionId)}
+          </span>
+        ),
+        sortable: true,
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        accessor: (r) => r.status,
+        render: (r) => <StatusBadge status={statusTone(r.status)}>{r.status}</StatusBadge>,
+        sortable: true,
+      },
+      {
+        key: 'currentActivity',
+        header: 'Activity',
+        accessor: (r) => r.currentActivity,
+        render: (r) => (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {r.currentActivity ?? '—'}
+          </span>
+        ),
+      },
+      {
+        key: 'startedAt',
+        header: 'Started',
+        accessor: (r) => r.startedAt ?? r.createdAt,
+        render: (r) => {
+          const at = r.startedAt ?? r.createdAt;
+          return (
+            <span className="whitespace-nowrap text-gray-600 dark:text-gray-300" title={at}>
+              {new Date(at).toLocaleString()}
+            </span>
+          );
+        },
+        sortable: true,
+      },
+      {
+        key: 'duration',
+        header: 'Duration',
+        accessor: (r) => runDurationMs(r, nowMs) ?? -1,
+        render: (r) => {
+          const ms = runDurationMs(r, nowMs);
+          return (
+            <span className="whitespace-nowrap text-gray-600 dark:text-gray-300">
+              {ms == null ? '—' : formatDuration(ms)}
+            </span>
+          );
+        },
+        sortable: true,
+        align: 'right',
+      },
+    ],
+    [definitionNameById, nowMs],
+  );
+
+  return (
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="Workflow instances by status and definition — durations, recent failures and per-run event trail."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={triggerLoad}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      timeRange={preset}
+      onTimeRangeChange={setPreset}
+      showTimeRange
+    >
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={triggerLoad} />
+        </div>
+      )}
+
+      {/* Windowed count metrics */}
+      <MetricGrid columns={4} className="mb-4">
+        <MetricCard
+          label="Total (window)"
+          value={counts.total}
+          tone="blue"
+          hint="Instances started in range"
+        />
+        <MetricCard label="In progress" value={counts.inProgress} tone="blue" />
+        <MetricCard label="Completed" value={counts.completed} tone="green" />
+        <MetricCard
+          label="Failed"
+          value={counts.failed}
+          tone="red"
+          {...(counts.failed > 0 ? { hint: 'Click to filter failures' } : {})}
+          onClick={() => {
+            setFailuresOnly(true);
+            setStatusFilter('all');
+          }}
+        />
+      </MetricGrid>
+
+      {/* Per-status + per-definition breakdown chips */}
+      {(statusOptions.length > 0 || definitionOptions.length > 0) && (
+        <section
+          data-testid="workflow-breakdown"
+          className="mb-4 grid grid-cols-1 gap-4 rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900 lg:grid-cols-2"
+        >
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">By status</h3>
+            <ul className="flex flex-wrap gap-2">
+              {(summary?.byStatus ?? []).map((s) => (
+                <li key={s.status}>
+                  <StatusBadge status={statusTone(s.status)}>
+                    {s.status} · {s.count}
+                  </StatusBadge>
+                </li>
+              ))}
+              {statusOptions.length === 0 && (
+                <li className="text-sm text-gray-500 dark:text-gray-400">No instances in range.</li>
+              )}
+            </ul>
+          </div>
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              By definition
+            </h3>
+            <ul className="flex flex-wrap gap-2">
+              {(summary?.byDefinition ?? []).map((d) => (
+                <li key={d.definitionId}>
+                  <StatusBadge status="blue" showDot={false}>
+                    {d.definitionName} · {d.count}
+                  </StatusBadge>
+                </li>
+              ))}
+              {definitionOptions.length === 0 && (
+                <li className="text-sm text-gray-500 dark:text-gray-400">No definitions in range.</li>
+              )}
+            </ul>
+          </div>
+        </section>
+      )}
+
+      {/* Filter bar */}
+      <div className="mb-4 flex flex-wrap items-end gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800/50">
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Status
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            aria-label="Status filter"
+            className={INPUT_CLASS}
+          >
+            <option value="all">All statuses</option>
+            {statusOptions.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-gray-500 dark:text-gray-400">
+          Definition
+          <select
+            value={definitionFilter}
+            onChange={(e) => setDefinitionFilter(e.target.value)}
+            aria-label="Definition filter"
+            className={INPUT_CLASS}
+          >
+            <option value="all">All definitions</option>
+            {definitionOptions.map((d) => (
+              <option key={d.id} value={d.id}>
+                {d.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+          <input
+            type="checkbox"
+            checked={failuresOnly}
+            onChange={(e) => setFailuresOnly(e.target.checked)}
+            aria-label="Failures only"
+          />
+          Failures only
+        </label>
+        {(statusFilter !== 'all' || definitionFilter !== 'all' || failuresOnly) && (
+          <button
+            type="button"
+            onClick={() => {
+              setStatusFilter('all');
+              setDefinitionFilter('all');
+              setFailuresOnly(false);
+            }}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            Clear filters
+          </button>
+        )}
+      </div>
+
+      <DataTable
+        columns={columns}
+        rows={visibleRuns}
+        getRowId={(row) => row.id}
+        pageSize={25}
+        initialSort={{ key: 'startedAt', direction: 'desc' }}
+        filterPlaceholder="Quick-filter loaded runs…"
+        emptyTitle="No workflow instances"
+        emptyMessage="No workflow runs match the current filters and time range."
+        onRowClick={(row) => navigate(`/runs/${encodeURIComponent(row.id)}`)}
+      />
+
+      <div className="mt-4 text-sm text-gray-500 dark:text-gray-400" data-testid="workflow-footer">
+        Showing {visibleRuns.length} of {runs.length} loaded
+        {total != null ? ` (tenant total ${total})` : ''}
+      </div>
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/workflow-monitor-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/workflow-monitor-page.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { WorkflowMonitorPage } from '../WorkflowMonitorPage.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+/** A run createdAt inside the default 24h window. */
+const recent = new Date(Date.now() - 60_000).toISOString();
+
+interface WireRun {
+  id: string;
+  definitionId: string;
+  status: string;
+  currentActivity: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+}
+
+function run(over: Partial<WireRun>): WireRun {
+  return {
+    id: over.id ?? 'comp0001-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    definitionId: over.definitionId ?? 'def-1',
+    status: over.status ?? 'completed',
+    currentActivity: over.currentActivity ?? null,
+    createdAt: over.createdAt ?? recent,
+    startedAt: over.startedAt ?? recent,
+    completedAt: over.completedAt ?? null,
+    durationMs: over.durationMs ?? null,
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+const DEFAULT_RUNS: WireRun[] = [
+  run({ id: 'comp0001-aaaa-4aaa-8aaa-aaaaaaaaaaaa', definitionId: 'def-1', status: 'completed', durationMs: 120_000 }),
+  run({ id: 'fail0002-bbbb-4bbb-8bbb-bbbbbbbbbbbb', definitionId: 'def-2', status: 'failed' }),
+];
+
+const DEFAULT_SUMMARY = {
+  tenantId: 't-1',
+  from: null,
+  to: null,
+  total: 2,
+  byStatus: [
+    { status: 'completed', count: 1 },
+    { status: 'failed', count: 1 },
+  ],
+  byDefinition: [
+    { definitionId: 'def-1', definitionName: 'code-workflow', count: 1 },
+    { definitionId: 'def-2', definitionName: 'triage-workflow', count: 1 },
+  ],
+};
+
+const fetchMock = vi.fn();
+
+function stubApi(runs: WireRun[] = DEFAULT_RUNS, summary: unknown = DEFAULT_SUMMARY): void {
+  fetchMock.mockImplementation((url: string | URL) => {
+    const u = String(url);
+    // /runs/summary must be matched BEFORE the /runs prefix.
+    if (u.includes('/api/v1/runs/summary')) {
+      return Promise.resolve(okResponse(summary));
+    }
+    if (u.includes('/api/v1/runs')) {
+      return Promise.resolve(
+        okResponse({ tenantId: 't-1', total: runs.length, page: 1, pageSize: 100, runs }),
+      );
+    }
+    return Promise.resolve(okResponse({}));
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  stubApi();
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/workflows']}>
+      <WorkflowMonitorPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('WorkflowMonitorPage', () => {
+  it('renders workflow instances from /api/v1/runs and windowed counts from the summary', async () => {
+    renderPage();
+
+    // Run rows (short-id cells).
+    expect(await screen.findByText('comp0001')).toBeInTheDocument();
+    expect(screen.getByText('fail0002')).toBeInTheDocument();
+
+    // Per-status + per-definition breakdown from the summary endpoint.
+    expect(screen.getByText('completed · 1')).toBeInTheDocument();
+    expect(screen.getByText('code-workflow · 1')).toBeInTheDocument();
+
+    // Both existing endpoints were composed (list + summary).
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes('/api/v1/runs/summary'))).toBe(true);
+      expect(urls.some((u) => /\/api\/v1\/runs(\?|$)/.test(u))).toBe(true);
+    });
+  });
+
+  it('filters the table by status', async () => {
+    renderPage();
+    await screen.findByText('comp0001');
+
+    await userEvent.selectOptions(screen.getByLabelText('Status filter'), 'failed');
+
+    expect(screen.getByText('fail0002')).toBeInTheDocument();
+    expect(screen.queryByText('comp0001')).not.toBeInTheDocument();
+  });
+
+  it('filters the table by definition', async () => {
+    renderPage();
+    await screen.findByText('comp0001');
+
+    await userEvent.selectOptions(screen.getByLabelText('Definition filter'), 'def-2');
+
+    expect(screen.getByText('fail0002')).toBeInTheDocument();
+    expect(screen.queryByText('comp0001')).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state when there are no workflow instances', async () => {
+    stubApi([], { ...DEFAULT_SUMMARY, total: 0, byStatus: [], byDefinition: [] });
+    renderPage();
+    expect(await screen.findByTestId('empty-state')).toBeInTheDocument();
+  });
+});
+
+describe('WorkflowMonitorPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/workflows']}>
+        <AdminGuard>
+          <WorkflowMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'Workflows' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/workflows']}>
+        <AdminGuard>
+          <WorkflowMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'Workflows' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/services/runs/runs-api-client.ts
+++ b/packages/dashboard/src/services/runs/runs-api-client.ts
@@ -3,6 +3,8 @@
  *
  * Typed HTTP client for the tenant-facing workflow-runs read endpoints:
  *   • GET /api/v1/runs            — paginated run list (WorkflowInstance rows)
+ *   • GET /api/v1/runs/summary    — Story 23-5 Workflow Monitor: windowed
+ *                                   per-status/per-definition instance counts.
  *   • GET /api/v1/runs/{runId}    — one run's DCB event/log timeline + the
  *                                   tenant's OWN recorded cost.
  *
@@ -83,6 +85,32 @@ export interface WorkflowRunDetail {
   logs: string[];
 }
 
+/** Instance count for a single workflow status (Story 23-5). */
+export interface WorkflowStatusCount {
+  status: string;
+  count: number;
+}
+
+/** Instance count for a single workflow definition (Story 23-5). */
+export interface WorkflowDefinitionCount {
+  definitionId: string;
+  definitionName: string;
+  count: number;
+}
+
+/**
+ * Windowed aggregate of the tenant's workflow instances (Story 23-5). Pure
+ * counts — the endpoint never returns any cost / economics figure.
+ */
+export interface WorkflowRunsSummary {
+  tenantId: string;
+  from: string | null;
+  to: string | null;
+  total: number;
+  byStatus: WorkflowStatusCount[];
+  byDefinition: WorkflowDefinitionCount[];
+}
+
 export const runsApi = {
   /** List the current tenant's workflow runs (newest first). */
   list: (params?: { limit?: number; page?: number }): Promise<RunsListResponse> => {
@@ -91,6 +119,18 @@ export const runsApi = {
     if (params?.page !== undefined) search.set('page', String(params.page));
     const qs = search.toString();
     return fetchJSON<RunsListResponse>(`/api/v1/runs${qs ? `?${qs}` : ''}`);
+  },
+
+  /**
+   * Windowed per-status / per-definition instance counts for the current
+   * tenant (Story 23-5 Workflow Monitor). `from`/`to` are ISO-8601 strings.
+   */
+  summary: (params?: { from?: string; to?: string }): Promise<WorkflowRunsSummary> => {
+    const search = new URLSearchParams();
+    if (params?.from !== undefined) search.set('from', params.from);
+    if (params?.to !== undefined) search.set('to', params.to);
+    const qs = search.toString();
+    return fetchJSON<WorkflowRunsSummary>(`/api/v1/runs/summary${qs ? `?${qs}` : ''}`);
   },
 
   /** Get one run's detail (event timeline, logs, files changed, cost). */


### PR DESCRIPTION
## What

Story 23.5 — the Workflow Monitor monitoring page over the tenant's workflow instances.

- **Frontend:** run-instance `DataTable` (id → `/runs/:id`, definition, status, duration), status/definition filters + "failures only", per-status/per-definition metric cards. `AdminGuard`-gated, time-range + auto-refresh.
- **Backend:** one new `GET /api/v1/runs/summary` — windowed per-status + per-definition **counts** via `WorkflowRepository.SummarizeInstancesAsync` (GROUP BY, parameterized, names joined in-memory — no `string[]`-in-EF-predicate). Table data reuses the #258 `/api/v1/runs`.

## Safety

Tenant strictly from `ITenantContext`; null/empty tenant → **404 `no_active_tenant` before any repo call** (mirrors #283, 2 guard tests assert the repo is untouched). **No economics leak** — projection is pure counts, a test asserts no `costUsd`/`totalCostUsd` field. `from`/`to` parsed `AssumeUniversal|AdjustToUniversal` (host-TZ-independent). Non-migration.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Backend tests: guard 15 (4 new), Workflow 94 (real Postgres), Dashboard 31. Frontend 6 new + 47 related. Build clean.

Deferred (full-story ACs beyond scope): Gantt timeline, queue-depth, ELSA-definitions tab, retry/cancel actions (per-run detail already served by the linked `/runs/:id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)