### PR TITLE
feat(epic-23-2): Agent Monitor realtime page (live tool-loop tail via the 32-23 stream)

### DIFF
--- a/packages/dashboard/src/hooks/monitoring/__tests__/useRunStreamTail.test.ts
+++ b/packages/dashboard/src/hooks/monitoring/__tests__/useRunStreamTail.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import {
+  parseRunStreamFrame,
+  runStreamUrl,
+  useRunStreamTail,
+} from '../useRunStreamTail.js';
+import type { EventSourceLike } from '../useMonitoringSSE.js';
+
+interface FakeSource extends EventSourceLike {
+  close: ReturnType<typeof vi.fn>;
+}
+
+function makeFactory() {
+  const instances: FakeSource[] = [];
+  const factory = vi.fn((_url: string): EventSourceLike => {
+    const inst: FakeSource = { onopen: null, onmessage: null, onerror: null, close: vi.fn() };
+    instances.push(inst);
+    return inst;
+  });
+  return { factory, instances };
+}
+
+/** Emit a bridged run-tap frame the way {@link createRunStreamEventSource} does. */
+function emit(inst: FakeSource | undefined, kind: string, payload: Record<string, unknown>): void {
+  inst?.onmessage?.({ data: `${kind}\n${JSON.stringify(payload)}` });
+}
+
+describe('parseRunStreamFrame', () => {
+  it('decodes kind + seq + correlationId + payload', () => {
+    const f = parseRunStreamFrame('tool_call\n{"correlationId":"run-1","seq":3,"toolName":"grep","turn":2}');
+    expect(f.kind).toBe('tool_call');
+    expect(f.seq).toBe(3);
+    expect(f.correlationId).toBe('run-1');
+    expect(f.payload['toolName']).toBe('grep');
+  });
+
+  it('null-safes a missing seq / correlationId (the raw end marker)', () => {
+    const f = parseRunStreamFrame('end\n{"reason":"already_complete"}');
+    expect(f.kind).toBe('end');
+    expect(f.seq).toBeNull();
+    expect(f.correlationId).toBeNull();
+    expect(f.payload['reason']).toBe('already_complete');
+  });
+
+  it('throws on a frame with no newline separator', () => {
+    expect(() => parseRunStreamFrame('nope')).toThrow();
+  });
+});
+
+describe('runStreamUrl', () => {
+  it('builds the tenant-scoped 32-23 tap path and URL-encodes the id', () => {
+    expect(runStreamUrl('a b')).toBe('/api/v1/llm/runs/a%20b/stream');
+  });
+});
+
+describe('useRunStreamTail', () => {
+  it('subscribes via the injected factory and accumulates frames in order', () => {
+    const { factory, instances } = makeFactory();
+    const { result } = renderHook(() =>
+      useRunStreamTail('run-1', { eventSourceFactory: factory }),
+    );
+
+    expect(factory).toHaveBeenCalledWith('/api/v1/llm/runs/run-1/stream');
+    const inst = instances[0];
+    act(() => inst?.onopen?.({}));
+    expect(result.current.connected).toBe(true);
+
+    act(() => emit(inst, 'tool_call', { correlationId: 'run-1', seq: 1, toolName: 'grep' }));
+    act(() => emit(inst, 'tool_result', { correlationId: 'run-1', seq: 2, toolName: 'grep', success: true }));
+
+    expect(result.current.frames.map((f) => f.kind)).toEqual(['tool_call', 'tool_result']);
+    expect(result.current.done).toBe(false);
+  });
+
+  it('dedups a repeated (kind:seq) frame (StrictMode double-invoke safety)', () => {
+    const { factory, instances } = makeFactory();
+    const { result } = renderHook(() =>
+      useRunStreamTail('run-1', { eventSourceFactory: factory }),
+    );
+    const inst = instances[0];
+    act(() => emit(inst, 'tool_call', { correlationId: 'run-1', seq: 1, toolName: 'grep' }));
+    act(() => emit(inst, 'tool_call', { correlationId: 'run-1', seq: 1, toolName: 'grep' }));
+    expect(result.current.frames).toHaveLength(1);
+  });
+
+  it('drops a stale frame from a different run', () => {
+    const { factory, instances } = makeFactory();
+    const { result } = renderHook(() =>
+      useRunStreamTail('run-1', { eventSourceFactory: factory }),
+    );
+    act(() => emit(instances[0], 'tool_call', { correlationId: 'other-run', seq: 1, toolName: 'x' }));
+    expect(result.current.frames).toHaveLength(0);
+  });
+
+  it('marks done on a terminal final frame and closes the stream', () => {
+    const { factory, instances } = makeFactory();
+    const { result } = renderHook(() =>
+      useRunStreamTail('run-1', { eventSourceFactory: factory }),
+    );
+    const inst = instances[0];
+    act(() =>
+      emit(inst, 'final', { correlationId: 'run-1', seq: 9, success: true, totalTurns: 3, totalTokens: 120 }),
+    );
+    expect(result.current.done).toBe(true);
+    expect(result.current.frames[0]?.kind).toBe('final');
+    // Disabling the subscription tears the source down.
+    expect(inst?.close).toHaveBeenCalled();
+  });
+});

--- a/packages/dashboard/src/hooks/monitoring/useRunStreamTail.ts
+++ b/packages/dashboard/src/hooks/monitoring/useRunStreamTail.ts
@@ -1,0 +1,176 @@
+/**
+ * useRunStreamTail — a LIVE tail of one managed LLM run's tool-loop.
+ *
+ * Story 23-2 (Agent Monitor). Composes the Story 23-12 {@link useMonitoringSSE}
+ * primitive (auto-reconnect / backoff / injectable factory) over the Story 32-23
+ * streaming run tap:
+ *   `GET /api/v1/llm/runs/{correlationId}/stream`  (SSE, tenant-scoped)
+ *
+ * The 32-23 stream emits NAMED SSE frames (`event: tool_call`, `event: token`,
+ * `event: final`, …) whereas `useMonitoringSSE` wires only the default
+ * `onmessage` channel. {@link createRunStreamEventSource} bridges the two: it
+ * registers a listener per frame kind on the real browser `EventSource` and
+ * forwards each as an `onmessage` payload of the shape `"{kind}\n{json}"`, which
+ * {@link parseRunStreamFrame} decodes. Tests inject a fake factory that drives
+ * the same `onmessage` seam directly — no live browser stream required.
+ *
+ * Every scrubbed frame carries a per-run monotonic `seq` + its `correlationId`
+ * (Story 32-23 AC9 allowlist), so frames are accumulated idempotently (dedup by
+ * `kind:seq`) and stale frames from a previous run are dropped by correlationId.
+ * On a terminal `final`/`end` frame the tail marks itself `done` and disables the
+ * subscription so a finished run never triggers a reconnect storm.
+ *
+ * Read-only: no cost / margin is ever surfaced — the 32-23 scrubber ships only
+ * agent activity/status fields.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  useMonitoringSSE,
+  type EventSourceLike,
+  type SSEConnectionStatus,
+} from './useMonitoringSSE.js';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+/** The closed frame vocabulary of the 32-23 run tap (plus the `end` marker). */
+export const RUN_STREAM_FRAME_KINDS = [
+  'token',
+  'tool_call',
+  'tool_result',
+  'question',
+  'answer',
+  'final',
+  'replay',
+  'end',
+] as const;
+
+export type RunStreamFrameKind = (typeof RUN_STREAM_FRAME_KINDS)[number];
+
+/** One decoded frame from the run tap. */
+export interface RunStreamFrame {
+  /** SSE event name — the frame kind. */
+  kind: RunStreamFrameKind;
+  /** Per-run monotonic sequence (bus-assigned). Absent on the raw `end` marker. */
+  seq: number | null;
+  /** The run this frame belongs to (absent on the raw `end` marker). */
+  correlationId: string | null;
+  /** Scrubbed, allowlisted fields (toolName, success, delta, reason, …). */
+  payload: Record<string, unknown>;
+  /** Client receipt time (ms epoch) for display ordering. */
+  receivedAt: number;
+}
+
+export interface UseRunStreamTailResult {
+  /** Frames received so far, in arrival order. */
+  frames: RunStreamFrame[];
+  status: SSEConnectionStatus;
+  connected: boolean;
+  error: Error | null;
+  /** True once a terminal `final`/`end` frame arrived — the tail is closed. */
+  done: boolean;
+  reconnectAttempt: number;
+}
+
+export interface UseRunStreamTailOptions {
+  /** Factory for the underlying stream — injected in tests. */
+  eventSourceFactory?: (url: string) => EventSourceLike;
+}
+
+/**
+ * Build the tenant-scoped run-tap URL for a run. The server resolves the tenant
+ * from the caller's session; a foreign / unknown run returns 404 (Story 32-23
+ * AC2), so no tenant id is ever sent from the browser.
+ */
+export function runStreamUrl(correlationId: string): string {
+  return `${API_BASE}/api/v1/llm/runs/${encodeURIComponent(correlationId)}/stream`;
+}
+
+/**
+ * Decode a bridged run-tap message (`"{kind}\n{json}"`) into a
+ * {@link RunStreamFrame}. Throws on malformed input (the hook surfaces it as an
+ * error), never returns a partial frame.
+ */
+export function parseRunStreamFrame(raw: string): RunStreamFrame {
+  const nl = raw.indexOf('\n');
+  if (nl < 0) throw new Error('malformed run-stream frame');
+  const kind = raw.slice(0, nl) as RunStreamFrameKind;
+  const parsed: unknown = JSON.parse(raw.slice(nl + 1));
+  const payload: Record<string, unknown> =
+    typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  const seqVal = payload['seq'];
+  const corrVal = payload['correlationId'];
+  return {
+    kind,
+    seq: typeof seqVal === 'number' ? seqVal : null,
+    correlationId: typeof corrVal === 'string' ? corrVal : null,
+    payload,
+    receivedAt: Date.now(),
+  };
+}
+
+/**
+ * Real-browser factory: wraps an `EventSource`, bridging every named run-tap
+ * frame onto the single `onmessage` channel `useMonitoringSSE` listens on.
+ * `withCredentials` forwards the session cookie so the tenant guard runs.
+ */
+export function createRunStreamEventSource(url: string): EventSourceLike {
+  const es = new EventSource(url, { withCredentials: true });
+  const wrapper: EventSourceLike = {
+    onopen: null,
+    onmessage: null,
+    onerror: null,
+    close: () => es.close(),
+  };
+  es.onopen = (ev): void => wrapper.onopen?.(ev);
+  es.onerror = (ev): void => wrapper.onerror?.(ev);
+  for (const kind of RUN_STREAM_FRAME_KINDS) {
+    es.addEventListener(kind, (ev: MessageEvent): void => {
+      wrapper.onmessage?.({ data: `${kind}\n${ev.data}` });
+    });
+  }
+  return wrapper;
+}
+
+/**
+ * Subscribe to a single run's live tool-loop. The `correlationId` is expected to
+ * be stable for the hook's lifetime (mount the consuming panel with
+ * `key={correlationId}` so switching runs starts a fresh subscription).
+ */
+export function useRunStreamTail(
+  correlationId: string,
+  options: UseRunStreamTailOptions = {},
+): UseRunStreamTailResult {
+  const [frames, setFrames] = useState<RunStreamFrame[]>([]);
+  const [done, setDone] = useState(false);
+  const seenRef = useRef<Set<string>>(new Set());
+
+  const factory = options.eventSourceFactory ?? createRunStreamEventSource;
+
+  const { data, status, connected, error, reconnectAttempt } = useMonitoringSSE<RunStreamFrame>(
+    runStreamUrl(correlationId),
+    {
+      enabled: !done,
+      parse: parseRunStreamFrame,
+      eventSourceFactory: factory,
+    },
+  );
+
+  useEffect(() => {
+    if (!data) return;
+    // Drop a stale frame lingering from a prior run (defence-in-depth; the
+    // consuming panel is keyed by correlationId so this is belt-and-braces).
+    if (data.correlationId !== null && data.correlationId !== correlationId) return;
+
+    const key = `${data.kind}:${data.seq ?? 'end'}`;
+    if (seenRef.current.has(key)) return; // idempotent (StrictMode double-invoke)
+    seenRef.current.add(key);
+
+    setFrames((prev) => [...prev, data]);
+    if (data.kind === 'final' || data.kind === 'end') setDone(true);
+  }, [data, correlationId]);
+
+  return { frames, status, connected, error, done, reconnectAttempt };
+}

--- a/packages/dashboard/src/pages/monitoring/AgentMonitorPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/AgentMonitorPage.tsx
@@ -1,21 +1,475 @@
 /**
- * Agent Monitor page. Scaffold from Story 23-12; full dashboard arrives in
- * Story 23-2.
+ * Agent Monitor (Realtime) — Story 23-2.
+ *
+ * Operator page for REALTIME managed-agent activity:
+ *   • an activity summary + ACTIVE-runs table derived from the `AGENT.*`
+ *     managed-agent event family, loaded through the Story 4-7 keyset query API
+ *     (`GET /api/engine/events/query?type=AGENT.&prefix=true`, tenant-scoped,
+ *     null-tenant fail-closed) via {@link useEventQuery};
+ *   • a recent-agent-activity table over the same set; and
+ *   • the "realtime" part — a LIVE tail of a selected run's tool-loop via the
+ *     Story 32-23 streaming run tap (`GET /api/v1/llm/runs/{id}/stream`, SSE,
+ *     tenant-scoped, foreign run ⇒ 404) through {@link useRunStreamTail}, which
+ *     composes the Story 23-12 {@link useMonitoringSSE} primitive.
+ *
+ * The non-live parts honour the shared time-range + auto-refresh controls. The
+ * whole page is built on the Story 23-12 monitoring primitives + hooks; the route
+ * is already `AdminGuard`-gated and lazy-mounted by Story 23-12, so this module
+ * only supplies the page body. NO cost / margin is surfaced anywhere — agent
+ * activity & status only.
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useCallback, useEffect, useMemo, useRef, useState, type JSX } from 'react';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import { MetricGrid } from '../../components/monitoring/MetricGrid.js';
+import { MetricCard } from '../../components/monitoring/MetricCard.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { DataTable, type DataTableColumn } from '../../components/monitoring/DataTable.js';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { useEventQuery, type DomainEventRow } from '../../hooks/monitoring/useEventQuery.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import { useTimeRange } from '../../hooks/monitoring/useTimeRange.js';
+import {
+  useRunStreamTail,
+  type RunStreamFrame,
+  type UseRunStreamTailOptions,
+} from '../../hooks/monitoring/useRunStreamTail.js';
+import type { EventSourceLike } from '../../hooks/monitoring/useMonitoringSSE.js';
+import {
+  AGENT_EVENT_PREFIX,
+  agentEventTone,
+  correlationOf,
+  deriveActiveRuns,
+  deriveSummary,
+  frameTone,
+  tagString,
+  type ActiveRun,
+} from './agent-monitor-utils.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/agents');
 
-export function AgentMonitorPage(): JSX.Element {
+/** Max `AGENT.*` events fetched per query page. */
+const PAGE_SIZE = 200;
+
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…` : id;
+}
+
+function timeOf(iso: string): string {
+  return new Date(iso).toLocaleTimeString();
+}
+
+function readString(payload: Record<string, unknown>, key: string): string | null {
+  const v = payload[key];
+  return typeof v === 'string' ? v : null;
+}
+
+function readNumber(payload: Record<string, unknown>, key: string): number | null {
+  const v = payload[key];
+  return typeof v === 'number' ? v : null;
+}
+
+function readBool(payload: Record<string, unknown>, key: string): boolean | null {
+  const v = payload[key];
+  return typeof v === 'boolean' ? v : null;
+}
+
+/** Human description for one run-stream frame. */
+function describeFrame(frame: RunStreamFrame): string {
+  const p = frame.payload;
+  switch (frame.kind) {
+    case 'tool_call': {
+      const name = readString(p, 'toolName') ?? 'tool';
+      const turn = readNumber(p, 'turn');
+      return turn !== null ? `${name} (turn ${turn})` : name;
+    }
+    case 'tool_result': {
+      const name = readString(p, 'toolName') ?? 'tool';
+      const ok = readBool(p, 'success');
+      const ms = readNumber(p, 'durationMs');
+      const suffix = ms !== null ? ` · ${Math.round(ms)}ms` : '';
+      return `${name} ${ok === false ? 'failed' : 'ok'}${suffix}`;
+    }
+    case 'token':
+      return readString(p, 'delta') ?? '';
+    case 'question':
+      return readString(p, 'question') ?? '(question)';
+    case 'answer':
+      return readString(p, 'answer') ?? '(answer)';
+    case 'final': {
+      const ok = readBool(p, 'success');
+      const turns = readNumber(p, 'totalTurns');
+      const tokens = readNumber(p, 'totalTokens');
+      const exhausted = readBool(p, 'exhausted');
+      const parts = [ok === false ? 'failed' : 'succeeded'];
+      if (turns !== null) parts.push(`${turns} turns`);
+      if (tokens !== null) parts.push(`${tokens} tokens`);
+      if (exhausted) parts.push('exhausted');
+      return parts.join(' · ');
+    }
+    case 'end':
+      return readString(p, 'reason') ?? 'closed';
+    default:
+      return frame.kind;
+  }
+}
+
+const CONNECTION_LABEL: Record<string, { kind: 'healthy' | 'info' | 'degraded' | 'unknown'; label: string }> = {
+  connected: { kind: 'healthy', label: 'Live' },
+  connecting: { kind: 'info', label: 'Connecting…' },
+  reconnecting: { kind: 'degraded', label: 'Reconnecting…' },
+  disconnected: { kind: 'unknown', label: 'Offline' },
+};
+
+interface RunStreamPanelProps {
+  correlationId: string;
+  onClose: () => void;
+  eventSourceFactory?: UseRunStreamTailOptions['eventSourceFactory'];
+}
+
+/**
+ * The live tool-loop tail for one selected run. Mounted with
+ * `key={correlationId}` so switching runs starts a completely fresh
+ * subscription (no stale-frame bleed).
+ */
+function RunStreamPanel({ correlationId, onClose, eventSourceFactory }: RunStreamPanelProps): JSX.Element {
+  const tail = useRunStreamTail(
+    correlationId,
+    eventSourceFactory ? { eventSourceFactory } : {},
+  );
+  const conn = tail.done
+    ? { kind: 'unknown' as const, label: 'Completed' }
+    : (CONNECTION_LABEL[tail.status] ?? CONNECTION_LABEL['disconnected']!);
+
+  // Newest frame first so the latest activity is always visible without scroll.
+  const ordered = useMemo(() => [...tail.frames].reverse(), [tail.frames]);
+
   return (
-    <MonitoringPlaceholder
+    <section
+      data-testid="run-stream-panel"
+      aria-label="Live run tail"
+      className="mb-6 rounded-lg border border-blue-200 bg-white shadow-sm dark:border-blue-900/50 dark:bg-gray-800"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Live tail ·{' '}
+            <code className="text-xs" title={correlationId}>
+              {shortId(correlationId)}
+            </code>
+          </h2>
+          <StatusBadge status={conn.kind}>{conn.label}</StatusBadge>
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {tail.frames.length} frame{tail.frames.length === 1 ? '' : 's'}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+        >
+          Stop tail
+        </button>
+      </div>
+
+      {tail.error && (
+        <p className="px-4 py-2 text-xs text-red-600 dark:text-red-400" role="alert">
+          Stream error: {tail.error.message}
+        </p>
+      )}
+
+      <ol className="max-h-80 divide-y divide-gray-100 overflow-y-auto dark:divide-gray-800">
+        {ordered.length === 0 ? (
+          <li className="px-4 py-6">
+            <EmptyState
+              title={tail.done ? 'Run finished' : 'Waiting for activity…'}
+              description={
+                tail.done
+                  ? 'This run produced no further live frames.'
+                  : 'Tool calls and results will appear here as the run executes.'
+              }
+            />
+          </li>
+        ) : (
+          ordered.map((frame) => (
+            <li
+              key={`${frame.kind}:${frame.seq ?? frame.receivedAt}`}
+              data-testid="run-stream-frame"
+              className="flex items-start gap-3 px-4 py-2 text-sm"
+            >
+              <span className="mt-0.5 shrink-0">
+                <StatusBadge
+                  status={frameTone(frame.kind, readBool(frame.payload, 'success'))}
+                  showDot={false}
+                >
+                  {frame.kind}
+                </StatusBadge>
+              </span>
+              <span className="min-w-0 flex-1 break-words text-gray-700 dark:text-gray-300">
+                {describeFrame(frame)}
+              </span>
+              <span className="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                {new Date(frame.receivedAt).toLocaleTimeString()}
+              </span>
+            </li>
+          ))
+        )}
+      </ol>
+    </section>
+  );
+}
+
+export interface AgentMonitorPageProps {
+  /** Injected in tests so the live tail can be driven by a fake EventSource. */
+  eventSourceFactory?: (url: string) => EventSourceLike;
+}
+
+export function AgentMonitorPage({ eventSourceFactory }: AgentMonitorPageProps = {}): JSX.Element {
+  const { preset, range, setPreset } = useTimeRange('24h');
+  const { events, total, hasMore, loading, error, lastUpdated, runQuery, loadMore } = useEventQuery();
+  const [selected, setSelected] = useState<string | null>(null);
+
+  // Stable trigger that always reads the latest time-range window.
+  const searchRef = useRef<() => void>(() => {});
+  useEffect(() => {
+    searchRef.current = () => {
+      void runQuery({
+        type: AGENT_EVENT_PREFIX,
+        typeMatch: 'prefix',
+        from: range.start,
+        to: range.end,
+        limit: PAGE_SIZE,
+      });
+    };
+  }, [runQuery, range]);
+  const trigger = useCallback(() => searchRef.current(), []);
+
+  const autoRefresh = useAutoRefresh(trigger, {
+    storageKey: NAV.storageKey,
+    defaultInterval: null,
+  });
+
+  // Run on mount and whenever the time-range preset changes.
+  useEffect(() => {
+    trigger();
+  }, [trigger, preset]);
+
+  const summary = useMemo(() => deriveSummary(events), [events]);
+  const activeRuns = useMemo(() => deriveActiveRuns(events), [events]);
+
+  const activeColumns: DataTableColumn<ActiveRun>[] = useMemo(
+    () => [
+      {
+        key: 'startedAt',
+        header: 'Started',
+        accessor: (r) => r.startedAt,
+        render: (r) => (
+          <span title={r.startedAt} className="whitespace-nowrap text-gray-600 dark:text-gray-300">
+            {timeOf(r.startedAt)}
+          </span>
+        ),
+        sortable: true,
+      },
+      { key: 'agentId', header: 'Agent', accessor: (r) => r.agentId ?? '—', sortable: true },
+      { key: 'role', header: 'Role', accessor: (r) => r.role ?? '—', sortable: true },
+      {
+        key: 'provider',
+        header: 'Provider / model',
+        accessor: (r) => r.provider ?? '',
+        render: (r) => (
+          <span className="text-gray-600 dark:text-gray-300">
+            {r.provider ?? '—'}
+            {r.model ? <span className="text-gray-400 dark:text-gray-500"> · {r.model}</span> : null}
+          </span>
+        ),
+      },
+      { key: 'toolCalls', header: 'Tools', accessor: (r) => r.toolCalls, align: 'right', sortable: true },
+      {
+        key: 'action',
+        header: '',
+        align: 'right',
+        hideable: false,
+        render: (r) => (
+          <button
+            type="button"
+            onClick={() => setSelected(r.correlationId)}
+            title={`Tap live: ${r.correlationId}`}
+            className={`rounded-md px-3 py-1 text-xs font-medium ${
+              selected === r.correlationId
+                ? 'bg-blue-600 text-white'
+                : 'border border-gray-300 text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            {selected === r.correlationId ? 'Watching' : 'Tap live'}
+          </button>
+        ),
+      },
+    ],
+    [selected],
+  );
+
+  const activityColumns: DataTableColumn<DomainEventRow>[] = useMemo(
+    () => [
+      {
+        key: 'createdAt',
+        header: 'Time',
+        accessor: (r) => r.createdAt,
+        render: (r) => (
+          <span title={r.createdAt} className="whitespace-nowrap text-gray-600 dark:text-gray-300">
+            {timeOf(r.createdAt)}
+          </span>
+        ),
+        sortable: true,
+      },
+      {
+        key: 'type',
+        header: 'Event',
+        accessor: (r) => r.type,
+        render: (r) => (
+          <StatusBadge status={agentEventTone(r.type)} showDot={false}>
+            {r.type}
+          </StatusBadge>
+        ),
+        sortable: true,
+      },
+      { key: 'agentId', header: 'Agent', accessor: (r) => tagString(r, 'agentId') ?? '—', sortable: true },
+      { key: 'role', header: 'Role', accessor: (r) => tagString(r, 'role') ?? '—', sortable: true },
+      { key: 'provider', header: 'Provider', accessor: (r) => tagString(r, 'provider') ?? '—', sortable: true },
+      {
+        key: 'run',
+        header: 'Run',
+        accessor: (r) => correlationOf(r) ?? '',
+        render: (r) => {
+          const cid = correlationOf(r);
+          if (cid === null) return <span className="text-gray-400">—</span>;
+          return (
+            <button
+              type="button"
+              onClick={() => setSelected(cid)}
+              aria-label={`Tap live run ${cid}`}
+              className="rounded font-mono text-xs text-blue-600 hover:underline dark:text-blue-400"
+              title={`Tap live: ${cid}`}
+            >
+              {shortId(cid)}
+            </button>
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  const hasEvents = events.length > 0;
+
+  return (
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="Realtime managed-agent activity — active runs, recent agent events, and a live tail of a selected run's tool-loop."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={trigger}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      timeRange={preset}
+      onTimeRangeChange={setPreset}
+      showTimeRange
+    >
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={trigger} />
+        </div>
+      )}
+
+      <MetricGrid columns={4} className="mb-6">
+        <MetricCard label="Active runs" value={summary.active} tone={summary.active > 0 ? 'blue' : 'gray'} />
+        <MetricCard label="Runs started" value={summary.started} hint="in the selected window" />
+        <MetricCard
+          label="Succeeded / failed"
+          value={`${summary.succeeded} / ${summary.failed}`}
+          tone={summary.failed > 0 ? 'red' : 'green'}
+        />
+        <MetricCard label="Tool calls" value={summary.toolCalls} />
+      </MetricGrid>
+
+      {selected && (
+        <RunStreamPanel
+          key={selected}
+          correlationId={selected}
+          onClose={() => setSelected(null)}
+          {...(eventSourceFactory ? { eventSourceFactory } : {})}
+        />
+      )}
+
+      <section aria-label="Active runs" className="mb-8">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+          Active runs
+          {activeRuns.length > 0 && (
+            <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">
+              {activeRuns.length} in flight
+            </span>
+          )}
+        </h2>
+        {activeRuns.length === 0 ? (
+          <EmptyState
+            title="No active runs"
+            description="No managed-agent run is currently in flight in the selected window. Tap a run below to watch its tool-loop live."
+          />
+        ) : (
+          <DataTable
+            columns={activeColumns}
+            rows={activeRuns}
+            getRowId={(r) => r.correlationId}
+            pageSize={10}
+            filterable={false}
+            initialSort={{ key: 'startedAt', direction: 'desc' }}
+            emptyTitle="No active runs"
+          />
+        )}
+      </section>
+
+      <section aria-label="Recent agent activity">
+        <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">Recent agent activity</h2>
+        {!hasEvents && !loading ? (
+          <EmptyState
+            title="No agent activity"
+            description="No AGENT.* events were recorded in the selected time range."
+          />
+        ) : (
+          <>
+            <DataTable
+              columns={activityColumns}
+              rows={events}
+              getRowId={(r) => r.id}
+              pageSize={25}
+              filterPlaceholder="Quick-filter loaded events…"
+              initialSort={{ key: 'createdAt', direction: 'desc' }}
+              emptyTitle="No agent activity"
+              emptyMessage="No AGENT.* events match the current filters and time range."
+            />
+            <div
+              className="mt-4 flex items-center justify-between text-sm text-gray-500 dark:text-gray-400"
+              data-testid="agent-activity-footer"
+            >
+              <span>
+                Showing {events.length}
+                {total != null ? ` of ${total}` : ''} event{events.length === 1 ? '' : 's'}
+              </span>
+              {hasMore && (
+                <button
+                  type="button"
+                  onClick={() => void loadMore()}
+                  disabled={loading}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  Load more
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </section>
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/agent-monitor-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/agent-monitor-page.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { AgentMonitorPage } from '../AgentMonitorPage.js';
+import type { EventSourceLike } from '../../../hooks/monitoring/useMonitoringSSE.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+interface WireEvent {
+  id: string;
+  type: string;
+  tags: unknown;
+  data: unknown;
+  createdAt: string;
+  issueNumber: number | null;
+  sequenceNumber: number;
+}
+
+function wireEvent(over: Partial<WireEvent>): WireEvent {
+  return {
+    id: over.id ?? 'id-1',
+    type: over.type ?? 'AGENT.RUN.STARTED',
+    tags: over.tags ?? { correlationId: 'run-1' },
+    data: over.data ?? null,
+    createdAt: over.createdAt ?? '2026-07-05T12:00:00.000Z',
+    issueNumber: over.issueNumber ?? null,
+    sequenceNumber: over.sequenceNumber ?? 1,
+  };
+}
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function pageBody(events: WireEvent[]): unknown {
+  return { events, total: events.length, limit: 200, nextCursor: null, hasMore: false };
+}
+
+// One active run (run-1, no terminal), plus a completed run (run-2).
+const ACTIVE_SET: WireEvent[] = [
+  wireEvent({
+    id: 'e1',
+    type: 'AGENT.RUN.STARTED',
+    createdAt: '2026-07-05T12:00:10.000Z',
+    tags: { correlationId: 'run-1', agentId: 'coder', role: 'dev', provider: 'anthropic', model: 'sonnet' },
+  }),
+  wireEvent({
+    id: 'e2',
+    type: 'AGENT.TOOL_CALL.SUCCESS',
+    createdAt: '2026-07-05T12:00:12.000Z',
+    tags: { correlationId: 'run-1', agentId: 'coder' },
+  }),
+  wireEvent({
+    id: 'e3',
+    type: 'AGENT.RUN.STARTED',
+    createdAt: '2026-07-05T12:00:00.000Z',
+    tags: { correlationId: 'run-2', agentId: 'planner' },
+  }),
+  wireEvent({
+    id: 'e4',
+    type: 'AGENT.RUN.SUCCESS',
+    createdAt: '2026-07-05T12:00:05.000Z',
+    tags: { correlationId: 'run-2', agentId: 'planner' },
+  }),
+];
+
+const fetchMock = vi.fn();
+
+/** A fake EventSource factory for the live tail (mirrors the useMonitoringSSE seam). */
+function makeStreamFactory() {
+  const instances: Array<EventSourceLike & { close: ReturnType<typeof vi.fn> }> = [];
+  const factory = vi.fn((_url: string): EventSourceLike => {
+    const inst = { onopen: null, onmessage: null, onerror: null, close: vi.fn() } as EventSourceLike & {
+      close: ReturnType<typeof vi.fn>;
+    };
+    instances.push(inst);
+    return inst;
+  });
+  return { factory, instances };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(okResponse(pageBody(ACTIVE_SET)));
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(factory?: (url: string) => EventSourceLike): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/agents']}>
+      {factory ? <AgentMonitorPage eventSourceFactory={factory} /> : <AgentMonitorPage />}
+    </MemoryRouter>,
+  );
+}
+
+describe('AgentMonitorPage', () => {
+  it('queries the AGENT.* family via the 4-7 prefix query', async () => {
+    renderPage();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain('/api/engine/events/query');
+    expect(url).toContain('type=AGENT.');
+    expect(url).toContain('prefix=true');
+  });
+
+  it('renders the activity summary and the active-runs table (STARTED w/o terminal)', async () => {
+    renderPage();
+    // Active run run-1 shows its agent; the completed run-2 is NOT active.
+    expect(await screen.findByText('1 in flight')).toBeInTheDocument();
+    const activeRegion = screen.getByRole('region', { name: 'Active runs' });
+    expect(within(activeRegion).getByText('coder')).toBeInTheDocument();
+    // Recent activity table lists the raw AGENT.* events.
+    expect(screen.getByText('AGENT.TOOL_CALL.SUCCESS')).toBeInTheDocument();
+  });
+
+  it('shows an empty active-runs state when nothing is in flight', async () => {
+    fetchMock.mockResolvedValue(
+      okResponse(
+        pageBody([
+          wireEvent({ id: 'a', type: 'AGENT.RUN.STARTED', tags: { correlationId: 'r' } }),
+          wireEvent({ id: 'b', type: 'AGENT.RUN.SUCCESS', tags: { correlationId: 'r' } }),
+        ]),
+      ),
+    );
+    renderPage();
+    expect(await screen.findByText('No active runs')).toBeInTheDocument();
+  });
+
+  it('shows a global empty state when there is no agent activity', async () => {
+    fetchMock.mockResolvedValue(okResponse(pageBody([])));
+    renderPage();
+    // Target the settled page-level empty state by its unique description
+    // (distinct from the DataTable's transient empty message).
+    expect(
+      await screen.findByText('No AGENT.* events were recorded in the selected time range.'),
+    ).toBeInTheDocument();
+  });
+
+  it('LIVE tail: taps a run and streams its tool-loop frames via the 32-23 stream', async () => {
+    const { factory, instances } = makeStreamFactory();
+    renderPage(factory);
+
+    // Tap the active run.
+    await userEvent.click(await screen.findByRole('button', { name: 'Tap live' }));
+
+    // The panel mounts and subscribes to the tenant-scoped 32-23 tap URL.
+    const panel = await screen.findByTestId('run-stream-panel');
+    await waitFor(() => expect(factory).toHaveBeenCalled());
+    expect(String(factory.mock.calls[0]?.[0])).toBe('/api/v1/llm/runs/run-1/stream');
+
+    const inst = instances[0];
+    act(() => inst?.onopen?.({}));
+    expect(within(panel).getByText('Live')).toBeInTheDocument();
+
+    // Drive live frames (bridged shape: "{kind}\n{json}").
+    act(() =>
+      inst?.onmessage?.({
+        data: 'tool_call\n{"correlationId":"run-1","seq":1,"toolName":"grep","turn":1}',
+      }),
+    );
+    act(() =>
+      inst?.onmessage?.({
+        data: 'tool_result\n{"correlationId":"run-1","seq":2,"toolName":"grep","success":true,"durationMs":42}',
+      }),
+    );
+
+    expect(within(panel).getByText('grep (turn 1)')).toBeInTheDocument();
+    expect(within(panel).getByText(/grep ok/)).toBeInTheDocument();
+
+    // A terminal `final` closes the tail.
+    act(() =>
+      inst?.onmessage?.({
+        data: 'final\n{"correlationId":"run-1","seq":3,"success":true,"totalTurns":2,"totalTokens":120}',
+      }),
+    );
+    expect(within(panel).getByText('Completed')).toBeInTheDocument();
+    expect(inst?.close).toHaveBeenCalled();
+  });
+});
+
+describe('AgentMonitorPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/agents']}>
+        <AdminGuard>
+          <AgentMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'Agent Monitor' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/agents']}>
+        <AdminGuard>
+          <AgentMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'Agent Monitor' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/pages/monitoring/__tests__/agent-monitor-utils.test.ts
+++ b/packages/dashboard/src/pages/monitoring/__tests__/agent-monitor-utils.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import {
+  agentEventTone,
+  correlationOf,
+  deriveActiveRuns,
+  deriveSummary,
+  frameTone,
+  tagString,
+} from '../agent-monitor-utils.js';
+import type { DomainEventRow } from '../../../hooks/monitoring/useEventQuery.js';
+
+function row(over: Partial<DomainEventRow>): DomainEventRow {
+  return {
+    id: over.id ?? 'id-1',
+    type: over.type ?? 'AGENT.RUN.STARTED',
+    tags: over.tags ?? null,
+    data: over.data ?? null,
+    createdAt: over.createdAt ?? '2026-07-05T12:00:00.000Z',
+    issueNumber: over.issueNumber ?? null,
+    sequenceNumber: over.sequenceNumber ?? 1,
+  };
+}
+
+describe('agent-monitor-utils', () => {
+  describe('tagString / correlationOf', () => {
+    it('reads a string tag and null-safes absent / non-string tags', () => {
+      const r = row({ tags: { agentId: 'a1', correlationId: 'run-1', n: 5 } });
+      expect(tagString(r, 'agentId')).toBe('a1');
+      expect(correlationOf(r)).toBe('run-1');
+      expect(tagString(r, 'n')).toBeNull();
+      expect(tagString(row({ tags: null }), 'agentId')).toBeNull();
+    });
+  });
+
+  describe('deriveActiveRuns', () => {
+    it('returns STARTED runs with no terminal event, newest-first, with tool-call counts', () => {
+      const events = [
+        row({
+          id: 'e3',
+          type: 'AGENT.TOOL_CALL.SUCCESS',
+          createdAt: '2026-07-05T12:00:30.000Z',
+          tags: { correlationId: 'run-A' },
+        }),
+        row({
+          id: 'e2',
+          type: 'AGENT.RUN.STARTED',
+          createdAt: '2026-07-05T12:00:10.000Z',
+          tags: { correlationId: 'run-B', agentId: 'coder', role: 'dev', provider: 'anthropic', model: 'sonnet' },
+        }),
+        row({
+          id: 'e1',
+          type: 'AGENT.RUN.STARTED',
+          createdAt: '2026-07-05T12:00:00.000Z',
+          tags: { correlationId: 'run-A', agentId: 'planner', role: 'architect', provider: 'openai', model: 'gpt-4o' },
+        }),
+      ];
+
+      const active = deriveActiveRuns(events);
+      expect(active.map((r) => r.correlationId)).toEqual(['run-B', 'run-A']); // newest-first
+      const runA = active.find((r) => r.correlationId === 'run-A');
+      expect(runA?.toolCalls).toBe(1);
+      expect(runA?.agentId).toBe('planner');
+      expect(runA?.provider).toBe('openai');
+    });
+
+    it('excludes a run once a terminal SUCCESS/FAILED is present', () => {
+      const events = [
+        row({ id: 'a', type: 'AGENT.RUN.STARTED', tags: { correlationId: 'run-1' } }),
+        row({ id: 'b', type: 'AGENT.RUN.SUCCESS', tags: { correlationId: 'run-1' } }),
+        row({ id: 'c', type: 'AGENT.RUN.STARTED', tags: { correlationId: 'run-2' } }),
+        row({ id: 'd', type: 'AGENT.RUN.FAILED', tags: { correlationId: 'run-2' } }),
+      ];
+      expect(deriveActiveRuns(events)).toEqual([]);
+    });
+
+    it('ignores STARTED events with no correlationId', () => {
+      const events = [row({ type: 'AGENT.RUN.STARTED', tags: { agentId: 'x' } })];
+      expect(deriveActiveRuns(events)).toEqual([]);
+    });
+  });
+
+  describe('deriveSummary', () => {
+    it('counts started / active / succeeded / failed / tool-calls', () => {
+      const events = [
+        row({ id: '1', type: 'AGENT.RUN.STARTED', tags: { correlationId: 'r1' } }),
+        row({ id: '2', type: 'AGENT.RUN.STARTED', tags: { correlationId: 'r2' } }),
+        row({ id: '3', type: 'AGENT.RUN.SUCCESS', tags: { correlationId: 'r1' } }),
+        row({ id: '4', type: 'AGENT.TOOL_CALL.SUCCESS', tags: { correlationId: 'r2' } }),
+        row({ id: '5', type: 'AGENT.TOOL_CALL.FAILED', tags: { correlationId: 'r2' } }),
+      ];
+      expect(deriveSummary(events)).toEqual({
+        started: 2,
+        active: 1, // r2 has no terminal
+        succeeded: 1,
+        failed: 0,
+        toolCalls: 2,
+      });
+    });
+  });
+
+  describe('agentEventTone', () => {
+    it('maps event types to badge kinds', () => {
+      expect(agentEventTone('AGENT.RUN.SUCCESS')).toBe('healthy');
+      expect(agentEventTone('AGENT.TOOL_CALL.FAILED')).toBe('down');
+      expect(agentEventTone('AGENT.RUN.STARTED')).toBe('info');
+      expect(agentEventTone('AGENT.TASK.PARTIAL')).toBe('degraded');
+      expect(agentEventTone('AGENT.ITERATION.COMPLETED')).toBe('unknown');
+    });
+  });
+
+  describe('frameTone', () => {
+    it('maps run-stream frame kinds to badge kinds', () => {
+      expect(frameTone('tool_call', null)).toBe('info');
+      expect(frameTone('tool_result', true)).toBe('healthy');
+      expect(frameTone('tool_result', false)).toBe('down');
+      expect(frameTone('final', false)).toBe('down');
+      expect(frameTone('question', null)).toBe('degraded');
+      expect(frameTone('token', null)).toBe('unknown');
+    });
+  });
+});

--- a/packages/dashboard/src/pages/monitoring/agent-monitor-utils.ts
+++ b/packages/dashboard/src/pages/monitoring/agent-monitor-utils.ts
@@ -1,0 +1,170 @@
+/**
+ * agent-monitor-utils — pure derivations for the Agent Monitor (Story 23-2).
+ *
+ * The page loads the `AGENT.*` managed-agent event family from the Story 4-7
+ * query API (`GET /api/engine/events/query?type=AGENT.&prefix=true`, tenant-
+ * scoped) and derives, entirely client-side:
+ *   • the ACTIVE runs (an `AGENT.RUN.STARTED` with no matching terminal
+ *     `AGENT.RUN.SUCCESS`/`AGENT.RUN.FAILED` in the loaded window), and
+ *   • a small activity summary (started / active / succeeded / failed / tool
+ *     calls) — agent activity & status only, never cost or margin.
+ *
+ * `AGENT.` (with the trailing dot) is a strict dotted prefix, so it selects the
+ * managed-agent family (`AGENT.RUN.*`, `AGENT.TASK.*`, `AGENT.TOOL_CALL.*`,
+ * `AGENT.ITERATION.*`, `AGENT.PANEL.*`) and NOT the `AGENT_DISPATCH.*` family
+ * (underscore — different aggregate).
+ */
+
+import type { StatusKind } from '../../components/monitoring/StatusBadge.js';
+import type { DomainEventRow } from '../../hooks/monitoring/useEventQuery.js';
+
+export const AGENT_EVENT_PREFIX = 'AGENT.';
+
+export const AGENT_RUN_STARTED = 'AGENT.RUN.STARTED';
+export const AGENT_RUN_SUCCESS = 'AGENT.RUN.SUCCESS';
+export const AGENT_RUN_FAILED = 'AGENT.RUN.FAILED';
+export const AGENT_TOOL_CALL_SUCCESS = 'AGENT.TOOL_CALL.SUCCESS';
+export const AGENT_TOOL_CALL_FAILED = 'AGENT.TOOL_CALL.FAILED';
+
+/** One in-flight managed run (a STARTED with no terminal in the loaded set). */
+export interface ActiveRun {
+  correlationId: string;
+  agentId: string | null;
+  role: string | null;
+  provider: string | null;
+  model: string | null;
+  /** ISO-8601 timestamp of the `AGENT.RUN.STARTED` event. */
+  startedAt: string;
+  /** `AGENT.TOOL_CALL.*` count observed for this run in the loaded window. */
+  toolCalls: number;
+}
+
+/** Activity counters over the loaded window (no economics). */
+export interface AgentActivitySummary {
+  started: number;
+  active: number;
+  succeeded: number;
+  failed: number;
+  toolCalls: number;
+}
+
+/** Read a string tag off an event row (null when absent / non-string). */
+export function tagString(row: DomainEventRow, key: string): string | null {
+  const value = row.tags?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** The correlationId tag of an event row (the managed-run id), or null. */
+export function correlationOf(row: DomainEventRow): string | null {
+  return tagString(row, 'correlationId');
+}
+
+/**
+ * Derive the ACTIVE runs from a loaded `AGENT.*` event set: an
+ * `AGENT.RUN.STARTED` whose correlationId has no terminal `AGENT.RUN.SUCCESS`/
+ * `AGENT.RUN.FAILED` in the same set. Newest-first. Runs whose STARTED aged out
+ * of the window are simply not shown (a monitoring, not accounting, view).
+ */
+export function deriveActiveRuns(events: readonly DomainEventRow[]): ActiveRun[] {
+  const terminal = new Set<string>();
+  const toolCalls = new Map<string, number>();
+
+  for (const e of events) {
+    const cid = correlationOf(e);
+    if (cid === null) continue;
+    if (e.type === AGENT_RUN_SUCCESS || e.type === AGENT_RUN_FAILED) {
+      terminal.add(cid);
+    } else if (e.type === AGENT_TOOL_CALL_SUCCESS || e.type === AGENT_TOOL_CALL_FAILED) {
+      toolCalls.set(cid, (toolCalls.get(cid) ?? 0) + 1);
+    }
+  }
+
+  // Keep the newest STARTED per correlationId (first wins if the caller already
+  // sorted newest-first; otherwise compare timestamps explicitly).
+  const startedByRun = new Map<string, DomainEventRow>();
+  for (const e of events) {
+    if (e.type !== AGENT_RUN_STARTED) continue;
+    const cid = correlationOf(e);
+    if (cid === null || terminal.has(cid)) continue;
+    const existing = startedByRun.get(cid);
+    if (!existing || e.createdAt > existing.createdAt) startedByRun.set(cid, e);
+  }
+
+  const runs: ActiveRun[] = [];
+  for (const [cid, e] of startedByRun) {
+    runs.push({
+      correlationId: cid,
+      agentId: tagString(e, 'agentId'),
+      role: tagString(e, 'role'),
+      provider: tagString(e, 'provider'),
+      model: tagString(e, 'model'),
+      startedAt: e.createdAt,
+      toolCalls: toolCalls.get(cid) ?? 0,
+    });
+  }
+
+  runs.sort((a, b) => (a.startedAt < b.startedAt ? 1 : a.startedAt > b.startedAt ? -1 : 0));
+  return runs;
+}
+
+/** Derive the activity summary counters over the loaded window. */
+export function deriveSummary(events: readonly DomainEventRow[]): AgentActivitySummary {
+  let started = 0;
+  let succeeded = 0;
+  let failed = 0;
+  let toolCalls = 0;
+
+  for (const e of events) {
+    switch (e.type) {
+      case AGENT_RUN_STARTED:
+        started += 1;
+        break;
+      case AGENT_RUN_SUCCESS:
+        succeeded += 1;
+        break;
+      case AGENT_RUN_FAILED:
+        failed += 1;
+        break;
+      case AGENT_TOOL_CALL_SUCCESS:
+      case AGENT_TOOL_CALL_FAILED:
+        toolCalls += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return { started, active: deriveActiveRuns(events).length, succeeded, failed, toolCalls };
+}
+
+/**
+ * Map an `AGENT.*` event type to a status-badge kind for the activity table.
+ * SUCCESS→green, FAILED→red, STARTED→blue, PARTIAL→yellow, others→gray.
+ */
+export function agentEventTone(type: string): StatusKind {
+  if (type.endsWith('.FAILED') || type.endsWith('.WRITE_FAILED')) return 'down';
+  if (type.endsWith('.SUCCESS')) return 'healthy';
+  if (type === AGENT_RUN_STARTED) return 'info';
+  if (type.endsWith('.PARTIAL')) return 'degraded';
+  return 'unknown';
+}
+
+/** Map a run-stream frame to a badge kind for the live tail. */
+export function frameTone(kind: string, success: boolean | null): StatusKind {
+  switch (kind) {
+    case 'tool_call':
+      return 'info';
+    case 'tool_result':
+      return success === false ? 'down' : 'healthy';
+    case 'final':
+      return success === false ? 'down' : 'healthy';
+    case 'question':
+      return 'degraded';
+    case 'answer':
+      return 'info';
+    case 'end':
+      return 'unknown';
+    default:
+      return 'unknown';
+  }
+}


### PR DESCRIPTION
## What

Story 23.2 — the realtime Agent Monitor page. **Pure frontend** — composes the 4-7 query + the 32-23 stream, no backend/endpoint.

- Activity summary (active runs / started / succeeded-failed / tool-calls), an active-runs table (`AGENT.RUN.STARTED` with no terminal event in the window), and a recent-agent-activity table. Each run has a **Tap live** button.
- **Live tail:** new `useRunStreamTail` hook composes `useMonitoringSSE` over the Story 32-23 tap `GET /api/v1/llm/runs/{correlationId}/stream` — registering a listener per *named* frame (`tool_call`/`token`/`final`), deduped by the per-run `seq`, terminal frame disables the subscription (no reconnect storm). `RunStreamPanel` remounts `key={correlationId}` for a clean switch.
- Reuses `useEventQuery` (4-7, `type=AGENT.` strict prefix — excludes `AGENT_DISPATCH.*`) + #289 primitives.

## Safety

`AdminGuard`-gated. Null-tenant fail-closed (4-7 returns empty; 32-23 is tenant-scoped, foreign run → 404) — relied on as-is, no tenant id from the browser. **No economics leak** — activity/status only (cost/rate-limit stay on the Provider Diagnostics page). Non-migration (frontend-only).

## Verification

- `pnpm --filter @tamma/dashboard test` → 22 new + full dashboard 427 pass (renders, active-runs derivation, live-tail via mocked EventSource, RBAC). Typecheck 0 errors in changed files. Build clean (lazy chunk). No backend change → both `has-pending-model-changes` trivially "No changes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)