### PR TITLE
feat(epic-2-14): IssueDecompositionWorkflow (+decompose-issue action, DECOMPOSITION.* events)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Decomposition/DecompositionEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Decomposition/DecompositionEvents.cs
@@ -1,0 +1,70 @@
+namespace Tamma.Activities.Decomposition;
+
+/// <summary>
+/// Story 2.14 (Issue Decomposition) — central catalogue of the <c>DECOMPOSITION.*</c> DCB event
+/// types emitted by the <c>issue-decomposition</c> sub-workflow via
+/// <see cref="EmitDecompositionEventActivity"/>. Type pattern follows the platform's
+/// <c>AGGREGATE.ACTION.STATUS</c> convention (<c>CLAUDE.md</c>) and mirrors the sibling event
+/// catalogues (<see cref="Tamma.Activities.Research.ResearchEvents"/>,
+/// <see cref="Tamma.Activities.Ambiguity.AmbiguityEvents"/>).
+///
+/// <para>The decomposition workflow breaks a complex issue / requirement into an ordered set of
+/// smaller, implementable sub-tasks (with rationale, sizing and declared dependencies) by asking
+/// the LLM via the mediated <c>llm-call</c> path — the engine holds no LLM credential. Each
+/// transition — start, context gathered, and the terminal outcome — is an auditable step so
+/// time-travel debugging and the Epic-32 learning loop can reconstruct WHAT issue was decomposed,
+/// HOW it was broken down, and HOW MANY sub-tasks resulted (Story 2.14 AC6 traceability + AC8
+/// learning). Without these events the decomposition is invisible to the audit trail.</para>
+///
+/// <para>Events are emitted via <c>TammaEventEmitter.Emit</c> into the workflow's
+/// <c>tamma:events</c> transient list and persisted <i>durably</i> by the engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) — the same pattern the sibling
+/// catalogues use. No activity holds a DB / repository dependency of its own; the drain resolves
+/// the tenant from the workflow scope and each event carries a <c>tenantId</c> tag so per-tenant
+/// data stays tenant-scoped.</para>
+///
+/// <list type="bullet">
+///   <item><description><c>DECOMPOSITION.STARTED</c> — the workflow began analysing the issue for
+///     decomposition.</description></item>
+///   <item><description><c>DECOMPOSITION.CONTEXT_GATHERED</c> — the codebase / prior-art context
+///     was gathered (via the reused <c>context-gathering</c> sub-workflow) to inform the
+///     breakdown.</description></item>
+///   <item><description><c>DECOMPOSITION.COMPLETED</c> — terminal success: the LLM returned a valid
+///     decomposition; the sub-task set (with its count) is recorded.</description></item>
+///   <item><description><c>DECOMPOSITION.FAILED</c> — LOUD (error-status): the decomposition
+///     <c>llm-call</c> failed or returned unparseable / empty output; the workflow fails closed
+///     rather than emitting a fabricated breakdown.</description></item>
+/// </list>
+/// </summary>
+public static class DecompositionEvents
+{
+    public const string Started = "DECOMPOSITION.STARTED";
+    public const string ContextGathered = "DECOMPOSITION.CONTEXT_GATHERED";
+    public const string Completed = "DECOMPOSITION.COMPLETED";
+
+    // LOUD (error-status) terminal — a fabricated / degraded breakdown must never be recorded as a
+    // false success.
+    public const string Failed = "DECOMPOSITION.FAILED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow inputs. Returns
+    /// <c>null</c> for empty / single-user / unparseable values (decomposition events in
+    /// single-user mode are platform-scope, TenantId null). Mirrors
+    /// <see cref="Tamma.Activities.Research.ResearchEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: a failed decomposition is a LOUD (error-status) audit row; the start
+    /// transition is an informational (started) row; every other transition (context gathered,
+    /// completed) is a normal (success-status) row. Keeps a degraded terminal from ever being
+    /// recorded as a false success.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        Failed => "error",
+        Started => "started",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Decomposition/DecompositionParsing.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Decomposition/DecompositionParsing.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using Tamma.Activities.Decomposition.Models;
+
+namespace Tamma.Activities.Decomposition;
+
+/// <summary>
+/// Story 2.14 — pure, context-free parser that recovers the structured
+/// <see cref="IssueDecomposition"/> from a mediated <c>llm-call</c> decomposition response. Kept
+/// side-effect-free (no Elsa context) so the fail-closed behaviour is unit-testable without a live
+/// LLM. Mirrors the JSON-slice approach in <c>ResearchParsing</c> / <c>AmbiguityParsing</c> /
+/// <c>ClarifyParsing</c>.
+///
+/// <para>The parser is <b>fail-closed</b>: an empty response, a response with no JSON object, a
+/// decomposition missing its load-bearing <c>summary</c> (the intent-preservation rationale,
+/// AC5), or a decomposition with no usable sub-tasks all yield <c>null</c>. The workflow routes a
+/// <c>null</c> parse to its <c>DECOMPOSITION.FAILED</c> error terminal — it NEVER fabricates a
+/// sub-task, a summary, or a dependency the downstream (Stories 2.15/2.16) would act on.</para>
+///
+/// <para>Sub-task ids are load-bearing (dependencies reference them), so a sub-task with no
+/// <c>id</c>, or with neither a <c>title</c> nor a <c>description</c>, is dropped as an empty shell
+/// (item-level fail-closed) rather than admitted blank. Duplicate ids keep the first occurrence.
+/// After the surviving sub-task set is known, each sub-task's <c>dependsOn</c> is pruned to ids
+/// that actually exist in the set (dangling references removed) with self-references stripped, so
+/// #138 receives a clean edge set. Cycle detection / topological ordering is deliberately NOT done
+/// here — that is the scope of Stories 2.15 (#138) and 2.16 (#139).</para>
+/// </summary>
+public static class DecompositionParsing
+{
+    /// <summary>
+    /// Extract the structured decomposition from an <c>llm-call</c> text response. Expects a JSON
+    /// object of the shape
+    /// <c>{"summary":"...","subtasks":[{"id":"ST-1","title":"...","description":"...",
+    /// "acceptanceCriteria":"...","estimateHours":4,"complexity":"medium","dependsOn":["ST-2"]}]}</c>.
+    ///
+    /// <para>The <c>summary</c> and at least one valid sub-task are load-bearing: the summary
+    /// records how the breakdown preserves the parent intent (AC5) and a decomposition with no
+    /// sub-tasks broke nothing down. Complexity labels are normalised onto the canonical buckets
+    /// (<see cref="SubtaskComplexities"/>); estimate hours are clamped to be non-negative.</para>
+    ///
+    /// <para>Returns <c>null</c> (fail-closed) when the text is empty, carries no JSON object, has
+    /// no non-empty <c>summary</c>, or contains no usable sub-task.</para>
+    /// </summary>
+    /// <param name="llmText">The raw LLM decomposition response.</param>
+    public static IssueDecomposition? ParseDecomposition(string? llmText)
+    {
+        if (string.IsNullOrWhiteSpace(llmText))
+            return null;
+
+        var objStart = llmText.IndexOf('{');
+        var objEnd = llmText.LastIndexOf('}');
+        if (objStart < 0 || objEnd <= objStart)
+            return null;
+
+        try
+        {
+            var element = JsonSerializer.Deserialize<JsonElement>(llmText[objStart..(objEnd + 1)]);
+
+            var summary = ReadString(element, "summary");
+
+            // Fail-closed: a decomposition with no overview rationale is not auditable/actionable
+            // and cannot demonstrate intent preservation (AC5).
+            if (string.IsNullOrWhiteSpace(summary))
+                return null;
+
+            var subtasks = ParseSubtasks(element);
+
+            // Fail-closed: no sub-tasks → nothing was actually decomposed.
+            if (subtasks.Count == 0)
+                return null;
+
+            PruneDependencies(subtasks);
+
+            return new IssueDecomposition
+            {
+                Summary = summary,
+                Subtasks = subtasks,
+            };
+        }
+        catch
+        {
+            // Malformed JSON → fail closed.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Recover the sub-task list from the decomposition object. Each sub-task must carry a
+    /// non-empty <c>id</c> (load-bearing — dependencies reference it) AND at least a title or a
+    /// description; empty shells are dropped. Duplicate ids keep the first occurrence.
+    /// </summary>
+    private static List<Subtask> ParseSubtasks(JsonElement element)
+    {
+        if (!element.TryGetProperty("subtasks", out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<Subtask>();
+
+        var subtasks = new List<Subtask>();
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var item in arr.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var id = ReadString(item, "id").Trim();
+            var title = ReadString(item, "title");
+            var description = ReadString(item, "description");
+
+            // A sub-task with no id cannot be referenced by dependencies; a sub-task with neither a
+            // title nor a description is an empty shell. Either → drop rather than admit blank.
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+            if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(description))
+                continue;
+
+            // Duplicate ids would make the dependency graph ambiguous — keep the first.
+            if (!seenIds.Add(id))
+                continue;
+
+            subtasks.Add(new Subtask
+            {
+                Id = id,
+                Title = title,
+                Description = description,
+                AcceptanceCriteria = ReadString(item, "acceptanceCriteria"),
+                EstimateHours = Math.Max(0m, ReadNumber(item, "estimateHours")),
+                Complexity = SubtaskComplexities.Normalize(ReadString(item, "complexity")),
+                DependsOn = ReadStringList(item, "dependsOn"),
+            });
+        }
+
+        return subtasks;
+    }
+
+    /// <summary>
+    /// Prune every sub-task's <c>dependsOn</c> to the ids that actually exist in the surviving set,
+    /// dropping self-references and duplicates. Keeps the edge set clean for #138 (which owns cycle
+    /// detection and graph analysis) without ever fabricating an edge.
+    /// </summary>
+    private static void PruneDependencies(List<Subtask> subtasks)
+    {
+        var validIds = subtasks.Select(s => s.Id).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var subtask in subtasks)
+        {
+            var pruned = new List<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var dep in subtask.DependsOn)
+            {
+                var d = dep?.Trim() ?? string.Empty;
+                if (string.IsNullOrEmpty(d)) continue;
+                if (string.Equals(d, subtask.Id, StringComparison.Ordinal)) continue; // no self-loop
+                if (!validIds.Contains(d)) continue;                                   // no dangling ref
+                if (!seen.Add(d)) continue;                                            // dedupe
+                pruned.Add(d);
+            }
+            subtask.DependsOn = pruned;
+        }
+    }
+
+    private static string ReadString(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString() ?? string.Empty
+            : string.Empty;
+
+    private static decimal ReadNumber(JsonElement element, string key)
+        => element.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.Number
+            ? (decimal)v.GetDouble()
+            : 0m;
+
+    private static List<string> ReadStringList(JsonElement element, string key)
+    {
+        if (!element.TryGetProperty(key, out var arr) || arr.ValueKind != JsonValueKind.Array)
+            return new List<string>();
+
+        return arr.EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.String)
+            .Select(e => e.GetString())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!.Trim())
+            .ToList();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Decomposition/EmitDecompositionEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Decomposition/EmitDecompositionEventActivity.cs
@@ -1,0 +1,110 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Decomposition;
+
+/// <summary>
+/// Story 2.14 — emits a <c>DECOMPOSITION.*</c> DCB event for the <c>issue-decomposition</c>
+/// sub-workflow by appending a <see cref="TammaEvent"/> to the workflow's <c>tamma:events</c>
+/// transient list via <see cref="TammaEventEmitter.Emit"/>. The merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes that list <i>durably</i> to the
+/// tenant <c>domain_events</c> store — the same pattern
+/// <see cref="Tamma.Activities.Research.EmitResearchEventActivity"/> and
+/// <see cref="Tamma.Activities.Ambiguity.EmitAmbiguityEventActivity"/> use. No activity holds a
+/// DB / repository dependency of its own (none is registered in the Elsa engine — a directly
+/// injected repository would be inert and silently drop every event).
+/// </summary>
+[Activity(
+    "Tamma.Decomposition",
+    "Emit Decomposition Event",
+    "Emit a DECOMPOSITION.* DCB event for the issue-decomposition workflow audit trail",
+    Kind = ActivityKind.Task
+)]
+public class EmitDecompositionEventActivity : Activity
+{
+    private readonly ILogger<EmitDecompositionEventActivity>? _logger;
+
+    [Input(Description = "Event type — DECOMPOSITION.STARTED / .CONTEXT_GATHERED / .COMPLETED / .FAILED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Decomposition session id (unguessable Guid string)")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id being decomposed")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Number of sub-tasks produced (0 until completion / on failure)")]
+    public Input<int> SubtaskCount { get; set; } = new(0);
+
+    [Input(Description = "Free-text detail for the audit payload")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitDecompositionEventActivity() { }
+
+    public EmitDecompositionEventActivity(ILogger<EmitDecompositionEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? DecompositionEvents.Failed;
+        var sessionId = SessionId.Get(context);
+        var issueId = IssueId.Get(context);
+        var tenantId = DecompositionEvents.ParseTenantId(TenantId.Get(context));
+        var subtaskCount = SubtaskCount.Get(context);
+        var detail = Detail.Get(context);
+
+        var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, subtaskCount, detail);
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for decomposition session {Session} issue {Issue} (subtasks={Count})",
+            type, sessionId, issueId, subtaskCount);
+
+        return default;
+    }
+
+    /// <summary>
+    /// Map the decomposition event inputs onto a <see cref="TammaEvent"/> expressed as the engine's
+    /// transient-list event so the merged drain persists it. Tags carry the queryable DCB index
+    /// keys (<c>sessionId</c>/<c>issueId</c>/<c>tenantId</c>); <c>Data</c> carries the
+    /// per-transition payload (<c>subtaskCount</c>/<c>detail</c>). Status is driven off the event
+    /// type (<see cref="DecompositionEvents.StatusForEvent"/>) so a failed terminal is a LOUD error
+    /// row, never a false success. Pure (no Elsa context); exposed for unit testing the mapping.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? sessionId,
+        string? issueId,
+        Guid? tenantId,
+        int subtaskCount,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>();
+        if (subtaskCount > 0) data["subtaskCount"] = subtaskCount;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = DecompositionEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Decomposition/Models/DecompositionModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Decomposition/Models/DecompositionModels.cs
@@ -1,0 +1,122 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Activities.Decomposition.Models;
+
+/// <summary>
+/// Story 2.14 — the canonical complexity buckets for a single decomposed sub-task
+/// (Story 2.14 AC1/AC4 — sizing is driven off scope/complexity). Kept as a small closed set so
+/// a drifting LLM label (<c>"trivial"</c>, <c>"Medium."</c>) is normalised onto a known bucket
+/// rather than leaking an arbitrary string downstream to Stories 2.15 (#138 dependency mapping)
+/// and 2.16 (#139 sequencing). An unrecognised / empty label normalises to
+/// <see cref="Medium"/> — a neutral middle, never silently dropped.
+/// </summary>
+public static class SubtaskComplexities
+{
+    public const string Low = "low";
+    public const string Medium = "medium";
+    public const string High = "high";
+
+    private static readonly IReadOnlySet<string> Canonical = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Low, Medium, High,
+    };
+
+    /// <summary>
+    /// Normalise a raw LLM complexity label onto the canonical set: trimmed + lower-cased, with
+    /// a couple of common synonyms folded in. Anything unrecognised → <see cref="Medium"/>.
+    /// Pure; exposed for unit testing.
+    /// </summary>
+    public static string Normalize(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return Medium;
+
+        var c = raw.Trim().TrimEnd('.').ToLowerInvariant();
+        if (Canonical.Contains(c)) return c;
+
+        return c switch
+        {
+            "trivial" or "simple" or "easy" or "xs" or "s" => Low,
+            "moderate" or "m" => Medium,
+            "complex" or "hard" or "large" or "xl" or "l" => High,
+            _ => Medium,
+        };
+    }
+}
+
+/// <summary>
+/// Story 2.14 — one implementable sub-task produced by decomposing a complex issue. This is the
+/// FOUNDATION shape that Story 2.15 (#138 dependency mapping) and Story 2.16 (#139 sequencing)
+/// build on, so it is designed to be consumed as a dependency graph node:
+/// <list type="bullet">
+///   <item><see cref="Id"/> — a stable identifier the LLM assigns (e.g. <c>ST-1</c>). Load-bearing:
+///     <see cref="DependsOn"/> references sub-tasks by this id, so a sub-task with no id cannot be
+///     wired into the graph and is dropped by the parser.</item>
+///   <item><see cref="Title"/> / <see cref="Description"/> — what the sub-task is.</item>
+///   <item><see cref="AcceptanceCriteria"/> — the definition of done (Story 2.14 AC2/AC4).</item>
+///   <item><see cref="EstimateHours"/> — rough effort in hours (Story 2.14 AC4 — sub-tasks sized
+///     ~2-8h); a soft guide, not enforced by the parser.</item>
+///   <item><see cref="Complexity"/> — one of the <see cref="SubtaskComplexities"/> buckets.</item>
+///   <item><see cref="DependsOn"/> — the ids of prerequisite sub-tasks (Story 2.14 AC3). The
+///     parser prunes these to ids that exist in the same decomposition and removes self-references,
+///     so #138 receives a clean edge set (it owns cycle detection / graph analysis).</item>
+/// </list>
+/// The position of a sub-task in <see cref="IssueDecomposition.Subtasks"/> is the initial suggested
+/// order; #139 refines it into a topological sequence using <see cref="DependsOn"/>.
+/// </summary>
+public sealed class Subtask
+{
+    /// <summary>Stable sub-task id (load-bearing — <see cref="DependsOn"/> references it).</summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Short title / headline for the sub-task.</summary>
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>What the sub-task does — the implementable slice of the parent issue.</summary>
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>The definition of done for this sub-task (Story 2.14 AC2/AC4).</summary>
+    [JsonPropertyName("acceptanceCriteria")]
+    public string AcceptanceCriteria { get; set; } = string.Empty;
+
+    /// <summary>Rough effort estimate in hours (Story 2.14 AC4 — ~2-8h target); a soft guide.</summary>
+    [JsonPropertyName("estimateHours")]
+    public decimal EstimateHours { get; set; }
+
+    /// <summary>Complexity bucket — one of the <see cref="SubtaskComplexities"/> values.</summary>
+    [JsonPropertyName("complexity")]
+    public string Complexity { get; set; } = SubtaskComplexities.Medium;
+
+    /// <summary>Ids of prerequisite sub-tasks (Story 2.14 AC3). Pruned to existing ids by the parser.</summary>
+    [JsonPropertyName("dependsOn")]
+    public List<string> DependsOn { get; set; } = new();
+}
+
+/// <summary>
+/// Story 2.14 — the structured decomposition of a complex issue into an ordered set of smaller,
+/// implementable <see cref="Subtask"/>s plus an overview <see cref="Summary"/> explaining the
+/// breakdown (Story 2.14 AC5 — the decomposition must preserve the original issue's intent and
+/// business value; the summary is where that rationale is recorded and is load-bearing).
+///
+/// <para>Serialised into the <c>issue-decomposition</c> workflow's <c>decompositionJson</c> output
+/// and carried onto the <c>DECOMPOSITION.COMPLETED</c> DCB event so the breakdown is fully auditable
+/// and feeds the Epic-32 learning loop (Story 2.14 AC8). The parser
+/// (<see cref="DecompositionParsing.ParseDecomposition"/>) fails closed on a missing summary or zero
+/// usable sub-tasks, so a fabricated / empty decomposition is never acted on.</para>
+///
+/// <para>This shape is the input contract for Story 2.15 (#138 dependency mapping — consumes
+/// <see cref="Subtask.Id"/> + <see cref="Subtask.DependsOn"/> as graph edges) and Story 2.16
+/// (#139 sequencing — topologically orders the sub-tasks). Keep it stable.</para>
+/// </summary>
+public sealed class IssueDecomposition
+{
+    /// <summary>Overview of the breakdown / how it preserves the parent intent — load-bearing (fail-closed if empty).</summary>
+    [JsonPropertyName("summary")]
+    public string Summary { get; set; } = string.Empty;
+
+    /// <summary>The ordered sub-tasks; position is the initial suggested order (#139 refines it).</summary>
+    [JsonPropertyName("subtasks")]
+    public List<Subtask> Subtasks { get; set; } = new();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/SystemPrompts.cs
@@ -247,6 +247,10 @@ public static class SystemPrompts
         //    JSON AmbiguityParsing recovers; NOT a transitional family) ──
         AgentAction.ScoreAmbiguity => ScoreAmbiguityBody,
 
+        // ── decompose-issue (Story 2.14 — real per-cell body producing the ordered sub-task
+        //    JSON DecompositionParsing recovers; NOT a transitional family) ──
+        AgentAction.DecomposeIssue => DecomposeIssueBody,
+
         // ── summarize / documentation / write-ups → Summarize ──
         AgentAction.SummarizeStakeholder => Summarize,
         AgentAction.SummarizeTechnical => Summarize,
@@ -870,6 +874,97 @@ public static class SystemPrompts
         Variables: ["role", "workItemJson", "contextFindings", "conventions"],
         EnableTools: false,
         MaxTokens: 2048);
+
+    // -----------------------------------------------------------------------
+    // Issue-decomposition body builder (Story 2.14)
+    //
+    // Purpose-written for the IssueDecompositionWorkflow llm-call dispatch
+    // (Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs). It breaks a
+    // complex issue into an ORDERED set of smaller, implementable sub-tasks — each
+    // with a rationale, a definition of done, a rough sizing, a complexity, and its
+    // declared prerequisite dependencies — and returns the EXACT JSON object
+    // DecompositionParsing.ParseDecomposition recovers:
+    //   { "summary", "subtasks":[{ "id","title","description","acceptanceCriteria",
+    //     "estimateHours","complexity","dependsOn":[...] }] }
+    // The parser fails closed on a missing summary or zero usable sub-tasks, so the
+    // template is explicit that both are load-bearing (resolution is
+    // tenant→system→error — this body is never empty/plain). Sub-task ids +
+    // dependsOn are the FOUNDATION contract for Story 2.15 (#138 dependency mapping)
+    // and Story 2.16 (#139 sequencing).
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Prompt for <c>(senior_developer, decompose-issue)</c>: break a complex issue into an
+    /// ordered set of smaller, implementable sub-tasks (with rationale, sizing and dependencies)
+    /// and emit the structured decomposition as the JSON
+    /// <see cref="Tamma.Activities.Decomposition.DecompositionParsing"/> parses. Variables:
+    /// <c>workItemJson</c> (the issue under decomposition) and <c>findings</c> (the codebase /
+    /// prior-art context that informs the breakdown's scope/dependency judgement).
+    /// </summary>
+    private static PromptTemplate DecomposeIssueBody(string role, string action) => new(
+        Role: role,
+        Action: action,
+        Template:
+            "You are a {{role}} decomposing a complex issue into an ORDERED set of smaller, " +
+            "independently implementable sub-tasks so the team can deliver it incrementally with " +
+            "continuous integration.\n\n" +
+            "## Issue / Work Item\n{{workItemJson}}\n\n" +
+            "## Gathered Context (codebase / prior art)\n{{findings}}\n\n" +
+            "## Conventions\n{{conventions}}\n\n" +
+            "## Instructions\n\n" +
+            "<thinking>\n" +
+            "1. Understand the issue's full intent and business value — the decomposition MUST " +
+            "preserve it (the sub-tasks together must fully deliver the parent issue)\n" +
+            "2. Use the gathered context to judge scope, integration points, and where the natural " +
+            "seams are (vertical slices, then supporting layers)\n" +
+            "3. Break the work into sub-tasks each sized ROUGHLY 2-8 hours, each with a clear " +
+            "definition of done — small enough to implement and review in one pass\n" +
+            "4. Assign each sub-task a short STABLE id (e.g. `ST-1`, `ST-2`) — dependencies " +
+            "reference these ids\n" +
+            "5. For each sub-task, declare which OTHER sub-tasks (by id) must be completed first in " +
+            "`dependsOn` (a prerequisite / blocking relationship). Independent sub-tasks have an " +
+            "empty `dependsOn`\n" +
+            "6. Order the `subtasks` array so prerequisites come before the sub-tasks that depend " +
+            "on them (a sensible initial implementation sequence)\n" +
+            "7. Rate each sub-task's `complexity` as `low`, `medium`, or `high`\n" +
+            "</thinking>\n\n" +
+            "Base the breakdown on the issue and context provided — do NOT invent scope the issue " +
+            "does not call for, and do NOT fabricate dependencies. Only reference sub-task ids you " +
+            "actually define.\n\n" +
+            "Return ONLY a single JSON object (no markdown fences, no prose outside it) of this " +
+            "EXACT shape:\n" +
+            "```json\n" +
+            "{\n" +
+            "  \"summary\": \"1-3 sentence overview of the breakdown and how it preserves the " +
+            "issue's intent\",\n" +
+            "  \"subtasks\": [\n" +
+            "    {\n" +
+            "      \"id\": \"ST-1\",\n" +
+            "      \"title\": \"short headline for the sub-task\",\n" +
+            "      \"description\": \"what to implement in this sub-task\",\n" +
+            "      \"acceptanceCriteria\": \"the definition of done for this sub-task\",\n" +
+            "      \"estimateHours\": 4,\n" +
+            "      \"complexity\": \"low|medium|high\",\n" +
+            "      \"dependsOn\": [\"ST-0\"]\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}\n" +
+            "```\n\n" +
+            "Requirements (the downstream parser fails closed if these are not met):\n" +
+            "- `summary` MUST be a non-empty overview — it is load-bearing (it records intent " +
+            "preservation).\n" +
+            "- `subtasks` MUST contain at least one sub-task; each MUST carry a non-empty `id` and " +
+            "at least a `title` or `description`.\n" +
+            "- `id`s MUST be unique within the decomposition.\n" +
+            "- `estimateHours` is a number (rough hours); `complexity` is one of `low`, `medium`, " +
+            "`high`.\n" +
+            "- Every entry in `dependsOn` MUST be the `id` of another sub-task in this " +
+            "decomposition (no self-references, no dangling ids).\n" +
+            "- Order `subtasks` so each sub-task's prerequisites appear before it.",
+        SystemPrompt: SystemFor(role),
+        Variables: ["role", "workItemJson", "findings", "conventions"],
+        EnableTools: false,
+        MaxTokens: 4096);
 
     // -----------------------------------------------------------------------
     // Role-specific review lenses (inlined in plan-review / code-review bodies)

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/AgentAction.cs
@@ -54,6 +54,7 @@ public enum AgentAction
     [Wire("summarize-technical")] SummarizeTechnical,
     [Wire("resolve-blocker")] ResolveBlocker,
     [Wire("mentor-feedback")] MentorFeedback,
+    [Wire("decompose-issue")] DecomposeIssue,
 
     // developer
     [Wire("plan-fix")] PlanFix,

--- a/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Agents/RolePhaseMap.cs
@@ -86,7 +86,8 @@ public static class RolePhaseMap
                 AgentAction.TriageTechnical,
                 AgentAction.SummarizeTechnical,
                 AgentAction.ResolveBlocker,
-                AgentAction.MentorFeedback),
+                AgentAction.MentorFeedback,
+                AgentAction.DecomposeIssue),
 
             // developer — implementation
             [AgentRole.Developer] = FreezeSet(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs
@@ -1,0 +1,388 @@
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using System.Text.Json;
+using Tamma.Activities;
+using Tamma.Activities.Decomposition;
+using Tamma.Activities.Decomposition.Models;
+using Tamma.Api.Services.Agents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 2.14 — Issue Decomposition sub-workflow. Given a complex issue / requirement it
+/// investigates the codebase / prior art and uses the LLM (via the MEDIATED <c>llm-call</c> path —
+/// the engine holds no LLM credential, TAMMA001) to break the issue into an ORDERED set of smaller,
+/// implementable sub-tasks — each with a rationale, a definition of done, a rough sizing, a
+/// complexity, and its declared prerequisite dependencies — then emits the results as
+/// <c>DECOMPOSITION.*</c> DCB events.
+///
+/// Flow:
+///   1. Read inputs (issue/requirement + repository + issueNumber + workItemJson + tenantId;
+///      mint a session id if none)
+///   2. Emit DECOMPOSITION.STARTED
+///   3. Gather codebase / prior-art context by REUSING DispatchWorkflow("context-gathering")
+///      (Story 7-1F multi-role scan) — same reuse as <see cref="ResearchWorkflow"/> /
+///      <see cref="AssessmentWorkflow"/>; the scope/dependency signal it surfaces informs the
+///      complexity assessment (Story 2.14 AC1)
+///   4. Emit DECOMPOSITION.CONTEXT_GATHERED
+///   5. Decompose the issue via DispatchWorkflow("llm-call")
+///      role=senior_developer / action=decompose-issue
+///   6. Parse the decomposition fail-closed (empty/unparseable/no-subtasks → error terminal)
+///   7a. On success: emit DECOMPOSITION.COMPLETED (with the sub-task count), set outputs
+///       (decomposition JSON, sub-task count)
+///   7b. On failure: emit DECOMPOSITION.FAILED (LOUD) and route to the DecompositionError terminal
+///
+/// Reuses the <see cref="ResearchWorkflow"/> / <see cref="AmbiguityScoringWorkflow"/> skeleton
+/// (gather-context → llm-call → parse → fail-closed gate + error terminal). Decomposition is
+/// AUTONOMOUS — there is no in-workflow human gate / bookmark. The Story 2.14 AC7 "human approval
+/// before executing decomposed tasks" is a downstream orchestration concern (a parent flow presents
+/// the emitted sub-task set for approval before dispatching implementation); this workflow's job is
+/// to PRODUCE the auditable, structured breakdown, not to execute it.
+///
+/// Fail-closed: if the decomposition <c>llm-call</c> returns success=false, or the response cannot
+/// be parsed into a non-empty, valid sub-task set with a rationale, the workflow emits a LOUD
+/// <c>DECOMPOSITION.FAILED</c> event and routes to the DecompositionError terminal — it NEVER
+/// proceeds with a fabricated breakdown. Prompt resolution is tenant→system→error (the
+/// <c>llm-call</c> registry never falls back to an empty/plain prompt).
+///
+/// NOTE (taxonomy): the decomposition dispatches the dedicated <c>(senior_developer,
+/// decompose-issue)</c> pair (Story 2.14). The <c>decompose-issue</c> action is a first-class
+/// member of the <see cref="AgentAction"/> taxonomy and is eligible for <c>senior_developer</c> in
+/// <c>RolePhaseMap</c> — decomposition is the tech-lead's charter (the senior_developer identity
+/// prompt is literally "decompose complex tasks", alongside <c>create-tasks</c> and
+/// <c>plan-implementation</c>). Its system-default prompt template
+/// (<c>SystemPrompts.DecomposeIssueBody</c>) emits the structured sub-task JSON
+/// <see cref="DecompositionParsing"/> parses, so the happy path produces a real
+/// <c>DECOMPOSITION.COMPLETED</c> breakdown rather than failing closed. The sub-task output shape
+/// (<see cref="IssueDecomposition"/> — ordered sub-tasks with ids + <c>dependsOn</c> edges) is the
+/// input contract for Story 2.15 (#138 dependency mapping) and Story 2.16 (#139 sequencing).
+/// </summary>
+public class IssueDecompositionWorkflow : WorkflowBase
+{
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "IssueDecomposition";
+        builder.DefinitionId = "issue-decomposition";
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description = "Decompose a complex issue into an ordered set of implementable sub-tasks (with rationale, sizing and dependencies) via the mediated LLM";
+
+        // ── Workflow variables ──────────────────────────────────────────
+        var sessionId       = builder.WithVariable<Guid>();
+        var issueId         = builder.WithVariable<string>();
+        var issueTitle      = builder.WithVariable<string>();
+        var repository      = builder.WithVariable<string>();
+        var issueNumber     = builder.WithVariable<int>();
+        var workItemJson    = builder.WithVariable<string>();
+        var tenantId        = builder.WithVariable<string>("TenantId", "");
+
+        var decompositionContext = builder.WithVariable<string>();
+        var contextIds      = builder.WithVariable<string>("[]");
+        var decompositionJson = builder.WithVariable<string>();
+        var subtaskCount    = builder.WithVariable<int>();
+
+        // Dispatched-workflow result containers
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
+        var decomposeLlm        = builder.WithVariable<IDictionary<string, object>?>();
+
+        // Success flag (fail-closed guard)
+        var decompositionLlmOk = builder.WithVariable<bool>();
+
+        // Captured parse output
+        var decomposition   = builder.WithVariable<IssueDecomposition>();
+
+        // Output variables (readable by a parent workflow)
+        var outputStatus    = builder.WithVariable<string>();
+
+        // ── Step 1: Read inputs ────────────────────────────────────────
+        var readInputs = new SetVariable
+        {
+            Id = "ReadInputs",
+            Name = "Read Inputs",
+            Variable = sessionId,
+            Value = new(context =>
+            {
+                var sid = context.GetInput<Guid>("sessionId");
+                if (sid == Guid.Empty) sid = Guid.NewGuid();
+
+                issueId.Set(context, context.GetInput<string>("issueId") ?? string.Empty);
+                issueTitle.Set(context, context.GetInput<string>("issueTitle") ?? string.Empty);
+                repository.Set(context, context.GetInput<string>("repository") ?? string.Empty);
+                issueNumber.Set(context, context.GetInput<int>("issueNumber"));
+                workItemJson.Set(context, context.GetInput<string>("workItemJson") ?? string.Empty);
+                tenantId.Set(context, context.GetInput<string>("tenantId") ?? string.Empty);
+                return sid;
+            })
+        };
+        readInputs.SetDisplayText("Read Inputs");
+
+        // ── Step 2: Emit DECOMPOSITION.STARTED ─────────────────────────
+        var emitStarted = new EmitDecompositionEventActivity
+        {
+            Id = "EmitDecompositionStarted",
+            Name = "Emit Decomposition Started",
+            EventType = new(DecompositionEvents.Started),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Issue decomposition started"),
+        };
+        emitStarted.SetDisplayText("Emit Decomposition Started");
+
+        // ── Step 3: Gather context via ContextGathering workflow (7-1F) ─
+        var gatherContext = new DispatchWorkflow
+        {
+            Id = "GatherContext",
+            Name = "Gather Context",
+            WorkflowDefinitionId = new("context-gathering"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["repository"]   = repository.Get(ctx) ?? "",
+                ["issueNumber"]  = issueNumber.Get(ctx),
+                ["workItemJson"] = BuildWorkItem(issueTitle.Get(ctx), workItemJson.Get(ctx), issueId.Get(ctx)),
+                ["tenantId"]     = tenantId.Get(ctx) ?? "",
+            }),
+            WaitForCompletion = new(true),
+            Result = new(contextGatherResult),
+        };
+        gatherContext.SetDisplayText("Gather Context");
+
+        var storeContextResult = new SetVariable
+        {
+            Id = "StoreContextResult",
+            Name = "Store Context Result",
+            Variable = decompositionContext,
+            Value = new(ctx =>
+            {
+                var result = contextGatherResult.Get(ctx);
+                if (result != null && result.TryGetValue("contextIds", out var ids) && ids != null)
+                    contextIds.Set(ctx, ids.ToString() ?? "[]");
+                if (result != null && result.TryGetValue("summary", out var s) && s != null)
+                    return s.ToString() ?? string.Empty;
+                return string.Empty;
+            })
+        };
+        storeContextResult.SetDisplayText("Store Context Result");
+
+        // ── Step 4: Emit DECOMPOSITION.CONTEXT_GATHERED ────────────────
+        var emitContextGathered = new EmitDecompositionEventActivity
+        {
+            Id = "EmitContextGathered",
+            Name = "Emit Context Gathered",
+            EventType = new(DecompositionEvents.ContextGathered),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("Codebase / prior-art context gathered via context-gathering"),
+        };
+        emitContextGathered.SetDisplayText("Emit Context Gathered");
+
+        // ── Step 5: Decompose the issue via llm-call ───────────────────
+        var decomposeIssueLlm = new DispatchWorkflow
+        {
+            Id = "DecomposeIssueLlm",
+            Name = "Decompose Issue (LLM)",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                // Dedicated decomposition action (Story 2.14): (senior_developer, decompose-issue)
+                // resolves the structured-subtask prompt template that yields the JSON
+                // DecompositionParsing recovers. Prompt resolution is tenant→system→error.
+                ["role"]     = AgentRole.SeniorDeveloper.ToWire(),
+                ["action"]   = AgentAction.DecomposeIssue.ToWire(),
+                ["tenantId"] = tenantId.Get(ctx),
+                ["variables"] = new Dictionary<string, object>
+                {
+                    ["workItemJson"] = BuildWorkItem(issueTitle.Get(ctx), workItemJson.Get(ctx), issueId.Get(ctx)),
+                    ["findings"]     = decompositionContext.Get(ctx) ?? "",
+                    ["conventions"]  = "",
+                },
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(decomposeLlm),
+        };
+        decomposeIssueLlm.SetDisplayText("Decompose Issue (LLM)");
+
+        // ── Step 6: Parse the decomposition (fail-closed) ──────────────
+        var parseDecomposition = new SetVariable
+        {
+            Id = "ParseDecomposition",
+            Name = "Parse Decomposition",
+            Variable = decompositionJson,
+            Value = new(ctx =>
+            {
+                var result = decomposeLlm.Get(ctx);
+                if (!ReadSuccessFlag(result))
+                {
+                    decompositionLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                var text = result!.TryGetValue("llmResponse", out var r) ? r?.ToString() ?? "" : "";
+                var parsed = DecompositionParsing.ParseDecomposition(text);
+                if (parsed is null)
+                {
+                    // Fail-closed — no fabricated breakdown.
+                    decompositionLlmOk.Set(ctx, false);
+                    return "{}";
+                }
+
+                decompositionLlmOk.Set(ctx, true);
+                decomposition.Set(ctx, parsed);
+                subtaskCount.Set(ctx, parsed.Subtasks.Count);
+                return JsonSerializer.Serialize(parsed);
+            })
+        };
+        parseDecomposition.SetDisplayText("Parse Decomposition");
+
+        // Fail-closed gate: route to error terminal if decomposition failed / unparseable.
+        var decompositionSuccessCheck = new FlowDecision(ctx => decompositionLlmOk.Get(ctx))
+        { Id = "DecompositionLlmOk", Name = "Decomposition LLM OK?" };
+        decompositionSuccessCheck.SetDisplayText("Decomposition LLM OK?");
+
+        // ── Step 7a: Success path ──────────────────────────────────────
+        var emitDecompositionCompleted = new EmitDecompositionEventActivity
+        {
+            Id = "EmitDecompositionCompleted",
+            Name = "Emit Decomposition Completed",
+            EventType = new(DecompositionEvents.Completed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            SubtaskCount = new(ctx => subtaskCount.Get(ctx)),
+            Detail = new("Issue decomposed into ordered, implementable sub-tasks"),
+        };
+        emitDecompositionCompleted.SetDisplayText("Emit Decomposition Completed");
+
+        var setOutputResult = new SetVariable
+        {
+            Id = "SetOutputResult",
+            Name = "Set Output Result",
+            Variable = outputStatus,
+            Value = new(_ => "completed")
+        };
+        setOutputResult.SetDisplayText("Set Output Result");
+
+        var exposeOutput = new Sequence
+        {
+            Id = "ExposeOutput",
+            Name = "Expose Output",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutputSessionId", Name = "Output Session Id", OutputName = new("sessionId"), OutputValue = new(ctx => (object)sessionId.Get(ctx).ToString()) }, "Output Session Id"),
+                WithLabel(new SetOutput { Id = "OutputStatus", Name = "Output Status", OutputName = new("status"), OutputValue = new(ctx => (object)(outputStatus.Get(ctx) ?? "")) }, "Output Status"),
+                WithLabel(new SetOutput { Id = "OutputDecomposition", Name = "Output Decomposition", OutputName = new("decomposition"), OutputValue = new(ctx => (object)(decompositionJson.Get(ctx) ?? "{}")) }, "Output Decomposition"),
+                WithLabel(new SetOutput { Id = "OutputSubtaskCount", Name = "Output Subtask Count", OutputName = new("subtaskCount"), OutputValue = new(ctx => (object)subtaskCount.Get(ctx)) }, "Output Subtask Count"),
+                WithLabel(new SetOutput { Id = "OutputContextIds", Name = "Output Context Ids", OutputName = new("contextIds"), OutputValue = new(ctx => (object)(contextIds.Get(ctx) ?? "[]")) }, "Output Context Ids"),
+            }
+        };
+        exposeOutput.SetDisplayText("Expose Output");
+
+        // ── Step 7b: Fail-closed error terminal (LOUD event + Finish) ──
+        var emitDecompositionFailed = new EmitDecompositionEventActivity
+        {
+            Id = "EmitDecompositionFailed",
+            Name = "Emit Decomposition Failed",
+            EventType = new(DecompositionEvents.Failed),
+            SessionId = new(ctx => sessionId.Get(ctx).ToString()),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            Detail = new("llm-call for issue decomposition failed or returned unparseable/empty output"),
+        };
+        emitDecompositionFailed.SetDisplayText("Emit Decomposition Failed");
+
+        var decompositionError = new Finish
+        {
+            Id = "DecompositionError",
+            Name = "Decomposition Error"
+        };
+        decompositionError.SetDisplayText("Decomposition Error");
+
+        // ── Build the flowchart ────────────────────────────────────────
+        builder.Root = new Flowchart
+        {
+            Id = "IssueDecompositionFlowchart",
+            Name = "Issue Decomposition Flowchart",
+            Start = readInputs,
+            Activities =
+            {
+                readInputs,
+                emitStarted,
+                gatherContext,
+                storeContextResult,
+                emitContextGathered,
+                decomposeIssueLlm,
+                parseDecomposition,
+                decompositionSuccessCheck,
+
+                // Success path
+                emitDecompositionCompleted,
+                setOutputResult,
+                exposeOutput,
+
+                // Fail-closed error terminal
+                emitDecompositionFailed,
+                decompositionError,
+            },
+            Connections =
+            {
+                new(readInputs, emitStarted),
+                new(emitStarted, gatherContext),
+                new(gatherContext, storeContextResult),
+                new(storeContextResult, emitContextGathered),
+                new(emitContextGathered, decomposeIssueLlm),
+                new(decomposeIssueLlm, parseDecomposition),
+                new(parseDecomposition, decompositionSuccessCheck),
+
+                // Success path
+                new(new FlowEndpoint(decompositionSuccessCheck, "True"),  new FlowEndpoint(emitDecompositionCompleted)),
+                new(emitDecompositionCompleted, setOutputResult),
+                new(setOutputResult, exposeOutput),
+
+                // Fail-closed error path
+                new(new FlowEndpoint(decompositionSuccessCheck, "False"), new FlowEndpoint(emitDecompositionFailed)),
+                new(emitDecompositionFailed, decompositionError),
+            }
+        };
+    }
+
+    /// <summary>
+    /// Read the <c>success</c> flag from a dispatched workflow's Result dictionary. Returns
+    /// <c>false</c> if the dictionary is null, the key is absent, or the value is falsy —
+    /// fail-closed by design. Uses the tolerant <see cref="ResumeInput.AsBool"/> read (boxed
+    /// bool / string / JsonElement).
+    /// </summary>
+    internal static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return ResumeInput.AsBool(s);
+    }
+
+    /// <summary>
+    /// Compose the work-item JSON handed to the context-gathering scan and the decomposition
+    /// prompt. Prefers an explicit <paramref name="workItemJson"/>; otherwise wraps the free-text
+    /// <paramref name="issueTitle"/> (plus the issue id) into a minimal JSON object so the
+    /// downstream template has a stable shape. Pure; exposed for unit testing.
+    /// </summary>
+    internal static string BuildWorkItem(string? issueTitle, string? workItemJson, string? issueId)
+    {
+        if (!string.IsNullOrWhiteSpace(workItemJson))
+            return workItemJson!;
+
+        return JsonSerializer.Serialize(new Dictionary<string, string?>
+        {
+            ["type"] = "issue",
+            ["issueId"] = issueId ?? "",
+            ["title"] = issueTitle ?? "",
+        });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Decomposition/DecompositionParsingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Decomposition/DecompositionParsingTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Decomposition;
+using Tamma.Activities.Decomposition.Models;
+
+namespace Tamma.Activities.Tests.Decomposition;
+
+/// <summary>
+/// Story 2.14 — unit coverage for <see cref="DecompositionParsing.ParseDecomposition"/>. Proves
+/// the parser recovers the structured decomposition on a well-formed response, keeps the
+/// dependency edge set clean (prunes dangling / self references, drops shell + duplicate-id
+/// sub-tasks), and FAILS CLOSED (returns null) on every degraded/empty/malformed input so the
+/// workflow routes to DECOMPOSITION.FAILED rather than fabricating a breakdown.
+/// </summary>
+[TestFixture]
+public class DecompositionParsingTests
+{
+    private const string ValidDecomposition =
+        """
+        Here is the decomposition:
+        {
+          "summary": "Split the auth feature into a schema slice, an endpoint slice, and a UI slice, preserving the login/logout intent.",
+          "subtasks": [
+            { "id": "ST-1", "title": "Add users table", "description": "Create the users schema + migration", "acceptanceCriteria": "migration applies cleanly", "estimateHours": 3, "complexity": "low", "dependsOn": [] },
+            { "id": "ST-2", "title": "Login endpoint", "description": "POST /login issuing a token", "acceptanceCriteria": "returns 200 + token", "estimateHours": 6, "complexity": "medium", "dependsOn": ["ST-1"] },
+            { "id": "ST-3", "title": "Login UI", "description": "Login form wired to the endpoint", "acceptanceCriteria": "user can log in", "estimateHours": 5, "complexity": "high", "dependsOn": ["ST-2"] }
+          ]
+        }
+        """;
+
+    [Test]
+    public void ParseDecomposition_ValidResponse_RecoversDecomposition()
+    {
+        var d = DecompositionParsing.ParseDecomposition(ValidDecomposition);
+
+        d.Should().NotBeNull();
+        d!.Summary.Should().Contain("Split the auth feature");
+        d.Subtasks.Should().HaveCount(3);
+        d.Subtasks[0].Id.Should().Be("ST-1");
+        d.Subtasks[0].EstimateHours.Should().Be(3m);
+        d.Subtasks[1].DependsOn.Should().Equal("ST-1");
+        d.Subtasks[2].Complexity.Should().Be(SubtaskComplexities.High);
+    }
+
+    [Test]
+    public void ParseDecomposition_PreservesSubtaskOrder()
+    {
+        var d = DecompositionParsing.ParseDecomposition(ValidDecomposition);
+
+        d!.Subtasks.Select(s => s.Id).ToList()
+            .Should().Equal(new[] { "ST-1", "ST-2", "ST-3" },
+                "the array order is the initial suggested sequence that Story 2.16 (#139) refines");
+    }
+
+    [Test]
+    public void ParseDecomposition_NormalizesComplexity_AndClampsNegativeHours()
+    {
+        const string messy =
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "A", "title": "t", "complexity": "Trivial.", "estimateHours": -4 }
+            ] }
+            """;
+
+        var d = DecompositionParsing.ParseDecomposition(messy);
+
+        d!.Subtasks[0].Complexity.Should().Be(SubtaskComplexities.Low, "'trivial' folds onto low");
+        d.Subtasks[0].EstimateHours.Should().Be(0m, "a negative estimate is clamped to zero");
+    }
+
+    [Test]
+    public void ParseDecomposition_PrunesDanglingAndSelfDependencies()
+    {
+        const string withBadDeps =
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "a", "dependsOn": ["ST-1", "ST-99"] },
+              { "id": "ST-2", "title": "b", "dependsOn": ["ST-1", "ST-1"] }
+            ] }
+            """;
+
+        var d = DecompositionParsing.ParseDecomposition(withBadDeps);
+
+        d!.Subtasks[0].DependsOn.Should().BeEmpty(
+            "a self-reference (ST-1→ST-1) and a dangling id (ST-99) must both be pruned");
+        d.Subtasks[1].DependsOn.Should().Equal(new[] { "ST-1" },
+            "a duplicate valid dependency must be de-duplicated to a single edge");
+    }
+
+    [Test]
+    public void ParseDecomposition_DropsShellSubtasks_AndDuplicateIds()
+    {
+        const string withShells =
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "", "title": "no id" },
+              { "id": "ST-1", "title": "", "description": "" },
+              { "id": "ST-2", "title": "real" },
+              { "id": "ST-2", "title": "duplicate id kept as first" }
+            ] }
+            """;
+
+        var d = DecompositionParsing.ParseDecomposition(withShells);
+
+        d!.Subtasks.Should().ContainSingle();
+        d.Subtasks[0].Id.Should().Be("ST-2");
+        d.Subtasks[0].Title.Should().Be("real", "the first occurrence of a duplicate id wins");
+    }
+
+    /// <summary>
+    /// A sample matching the EXACT shape the (senior_developer, decompose-issue) system-default
+    /// prompt template (SystemPrompts.DecomposeIssueBody, Story 2.14) instructs the LLM to emit.
+    /// Proves the template's documented output is parseable end-to-end, so the
+    /// IssueDecompositionWorkflow happy path emits a real DECOMPOSITION.COMPLETED breakdown.
+    /// </summary>
+    private const string TemplateShapedDecomposition =
+        """
+        {
+          "summary": "Deliver per-tenant rate limiting incrementally: middleware first, then config, then metrics — preserving the 'protect the API per tenant' intent.",
+          "subtasks": [
+            { "id": "ST-1", "title": "Token-bucket middleware", "description": "Add a token-bucket limiter keyed by tenant id", "acceptanceCriteria": "requests over the limit get 429", "estimateHours": 6, "complexity": "medium", "dependsOn": [] },
+            { "id": "ST-2", "title": "Per-tenant config", "description": "Read the limit from tenant config", "acceptanceCriteria": "limit is configurable per tenant", "estimateHours": 4, "complexity": "low", "dependsOn": ["ST-1"] }
+          ]
+        }
+        """;
+
+    [Test]
+    public void ParseDecomposition_TemplateShapedOutput_RecoversDecomposition()
+    {
+        var d = DecompositionParsing.ParseDecomposition(TemplateShapedDecomposition);
+
+        d.Should().NotBeNull(
+            "the (senior_developer, decompose-issue) template's documented JSON shape must parse into a real decomposition");
+        d!.Summary.Should().NotBeNullOrWhiteSpace();
+        d.Subtasks.Should().HaveCount(2);
+        d.Subtasks[1].DependsOn.Should().Equal("ST-1");
+    }
+
+    // ── Fail-closed cases (all → null) ─────────────────────────────────
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("no json here at all")]
+    [TestCase("{ not valid json")]
+    public void ParseDecomposition_DegradedInput_FailsClosed(string? input)
+    {
+        DecompositionParsing.ParseDecomposition(input).Should().BeNull(
+            "degraded/empty/malformed decomposition output must fail closed (no fabricated breakdown)");
+    }
+
+    [Test]
+    public void ParseDecomposition_MissingSummary_FailsClosed()
+    {
+        const string noSummary = """{ "subtasks": [ { "id": "ST-1", "title": "a" } ] }""";
+        DecompositionParsing.ParseDecomposition(noSummary).Should().BeNull(
+            "the overview summary is load-bearing (it records intent preservation) — fail closed without it");
+    }
+
+    [Test]
+    public void ParseDecomposition_NoSubtasks_FailsClosed()
+    {
+        const string emptySubtasks = """{ "summary": "s", "subtasks": [] }""";
+        DecompositionParsing.ParseDecomposition(emptySubtasks).Should().BeNull(
+            "a decomposition with no sub-tasks decomposed nothing — it must fail closed");
+    }
+
+    [Test]
+    public void ParseDecomposition_AllShellSubtasks_FailsClosed()
+    {
+        const string allShells =
+            """{ "summary": "s", "subtasks": [ { "id": "", "title": "" }, { "id": "ST-1", "title": "", "description": "" } ] }""";
+        DecompositionParsing.ParseDecomposition(allShells).Should().BeNull(
+            "when every sub-task is an empty shell / has no id the decomposition has no usable content — fail closed");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Decomposition/EmitDecompositionEventActivityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Decomposition/EmitDecompositionEventActivityTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Decomposition;
+
+namespace Tamma.Activities.Tests.Decomposition;
+
+/// <summary>
+/// Story 2.14 — unit coverage for the DECOMPOSITION.* event mapping
+/// (<see cref="EmitDecompositionEventActivity.BuildTammaEvent"/> +
+/// <see cref="DecompositionEvents.StatusForEvent"/>). Verifies the queryable DCB tags, the
+/// per-transition data payload, and — critically — that the failed terminal is a LOUD
+/// error-status row (never a false success).
+/// </summary>
+[TestFixture]
+public class EmitDecompositionEventActivityTests
+{
+    private static readonly Guid Tenant = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Test]
+    public void BuildTammaEvent_Completed_CarriesTagsAndData()
+    {
+        var evt = EmitDecompositionEventActivity.BuildTammaEvent(
+            DecompositionEvents.Completed, "sess-1", "issue-137", Tenant, subtaskCount: 4, detail: "done");
+
+        evt.EventType.Should().Be("DECOMPOSITION.COMPLETED");
+        evt.Status.Should().Be("success");
+        evt.Tags!["sessionId"].Should().Be("sess-1");
+        evt.Tags["issueId"].Should().Be("issue-137");
+        evt.Tags["tenantId"].Should().Be(Tenant.ToString("D"));
+        evt.Data["subtaskCount"].Should().Be(4);
+        evt.Data["detail"].Should().Be("done");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Failed_IsLoudErrorStatus()
+    {
+        var evt = EmitDecompositionEventActivity.BuildTammaEvent(
+            DecompositionEvents.Failed, "sess-1", "issue-137", Tenant, subtaskCount: 0, detail: "boom");
+
+        evt.Status.Should().Be("error",
+            "a failed decomposition must be a LOUD error-status row, never a false success");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Started_IsStartedStatus_AndOmitsEmptyPayload()
+    {
+        var evt = EmitDecompositionEventActivity.BuildTammaEvent(
+            DecompositionEvents.Started, "sess-1", "issue-137", Tenant, subtaskCount: 0, detail: null);
+
+        evt.Status.Should().Be("started");
+        evt.Data.Should().NotContainKey("subtaskCount", "no sub-tasks yet at start (count 0 is omitted)");
+        evt.Data.Should().NotContainKey("detail", "a null detail is omitted");
+    }
+
+    [Test]
+    public void BuildTammaEvent_NullTenant_OmitsTenantTag()
+    {
+        var evt = EmitDecompositionEventActivity.BuildTammaEvent(
+            DecompositionEvents.Completed, "sess-1", "issue-137", tenantId: null, subtaskCount: 2, detail: null);
+
+        evt.Tags.Should().NotContainKey("tenantId",
+            "single-user / platform-scope decomposition events carry no tenantId tag");
+    }
+
+    [Test]
+    public void ParseTenantId_RoundTrips_AndRejectsGarbage()
+    {
+        DecompositionEvents.ParseTenantId(Tenant.ToString()).Should().Be(Tenant);
+        DecompositionEvents.ParseTenantId("").Should().BeNull();
+        DecompositionEvents.ParseTenantId("not-a-guid").Should().BeNull();
+    }
+
+    [TestCase("DECOMPOSITION.STARTED", "started")]
+    [TestCase("DECOMPOSITION.CONTEXT_GATHERED", "success")]
+    [TestCase("DECOMPOSITION.COMPLETED", "success")]
+    [TestCase("DECOMPOSITION.FAILED", "error")]
+    public void StatusForEvent_MapsCorrectly(string type, string expected)
+    {
+        DecompositionEvents.StatusForEvent(type).Should().Be(expected);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueDecompositionWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueDecompositionWorkflowStructureTests.cs
@@ -1,0 +1,151 @@
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Decomposition;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 2.14 — structural verification for <see cref="IssueDecompositionWorkflow"/>.
+///
+/// Asserts the workflow:
+/// 1. Builds and has DefinitionId "issue-decomposition".
+/// 2. Threads <c>TenantId</c> so the prompt registry resolves tenant-scoped prompts
+///    (resolution is tenant→system→error — never empty/plain).
+/// 3. Investigates the codebase / prior art by REUSING the <c>context-gathering</c>
+///    sub-workflow (not reinventing a scan).
+/// 4. Decomposes the issue via <c>DispatchWorkflow("llm-call")</c> (mediated — the engine holds
+///    no LLM credential, TAMMA001) rather than any in-engine provider call.
+/// 5. Is fail-closed: a <c>DecompositionError</c> terminal exists and a <c>FlowDecision</c> gate
+///    checks LLM-call success before proceeding.
+/// 6. Emits the required DECOMPOSITION.* DCB events (started / context gathered / completed /
+///    failed) via <see cref="EmitDecompositionEventActivity"/> nodes.
+/// 7. Is AUTONOMOUS — no in-workflow human gate / bookmark (approval before EXECUTION, AC7, is a
+///    downstream orchestration concern).
+/// </summary>
+[TestFixture]
+public class IssueDecompositionWorkflowStructureTests
+{
+    private static Flowchart Flowchart()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new IssueDecompositionWorkflow());
+        return WorkflowTestHelper.GetFlowchart(builder);
+    }
+
+    [Test]
+    public void Workflow_BuildsWithoutError()
+    {
+        var act = () => WorkflowTestHelper.BuildWorkflow(new IssueDecompositionWorkflow());
+        act.Should().NotThrow("IssueDecompositionWorkflow.Build() must complete without exceptions");
+    }
+
+    [Test]
+    public void Workflow_HasCorrectDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new IssueDecompositionWorkflow());
+        builder.Object.DefinitionId.Should().Be("issue-decomposition");
+    }
+
+    [Test]
+    public void Workflow_ThreadsTenantId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new IssueDecompositionWorkflow());
+        builder.Object.Variables
+            .Any(v => v.Name == "TenantId")
+            .Should().BeTrue(
+                "the workflow must thread TenantId so llm-call resolves tenant-scoped prompts " +
+                "(tenant→system→error) for the decomposition");
+    }
+
+    [Test]
+    public void Workflow_ReusesContextGatheringForInvestigation()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "GatherContext",
+                "the workflow must investigate the codebase / prior art by REUSING the " +
+                "context-gathering sub-workflow rather than reinventing a scan");
+    }
+
+    [Test]
+    public void Workflow_DecomposesViaMediatedLlmCall()
+    {
+        Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Should().Contain(d => d.Id == "DecomposeIssueLlm",
+                "the decomposition must be produced via the mediated llm-call " +
+                "(engine holds no LLM credential, TAMMA001)");
+    }
+
+    [Test]
+    public void Workflow_HasFailClosedErrorTerminal()
+    {
+        Flowchart().Activities
+            .OfType<Finish>()
+            .Should().Contain(f => f.Id == "DecompositionError",
+                "a fail-closed DecompositionError terminal must exist — decomposition failures " +
+                "route there, never proceeding with a fabricated breakdown");
+    }
+
+    [Test]
+    public void Workflow_HasSuccessGateForDecomposition()
+    {
+        Flowchart().Activities
+            .OfType<FlowDecision>()
+            .Select(d => d.Id)
+            .Should().Contain("DecompositionLlmOk",
+                "the decomposition output must be gated behind a DecompositionLlmOk decision (fail-closed)");
+    }
+
+    [Test]
+    public void Workflow_EmitsRequiredDecompositionEvents()
+    {
+        var emitIds = Flowchart().Activities
+            .OfType<EmitDecompositionEventActivity>()
+            .Select(a => a.Id)
+            .ToList();
+
+        emitIds.Should().Contain("EmitDecompositionStarted",
+            "must emit DECOMPOSITION.STARTED when the decomposition begins");
+        emitIds.Should().Contain("EmitContextGathered",
+            "must emit DECOMPOSITION.CONTEXT_GATHERED when the codebase/prior-art context is gathered");
+        emitIds.Should().Contain("EmitDecompositionCompleted",
+            "must emit DECOMPOSITION.COMPLETED when a valid sub-task set is produced");
+        emitIds.Should().Contain("EmitDecompositionFailed",
+            "must emit a LOUD DECOMPOSITION.FAILED when decomposition fails / is unparseable");
+    }
+
+    [Test]
+    public void Workflow_IsAutonomous_NoHumanBookmark()
+    {
+        // Decomposition is autonomous: it PRODUCES the breakdown but does not suspend on a human
+        // bookmark. Story 2.14 AC7 ("human approval before executing decomposed tasks") is a
+        // downstream orchestration concern, not this workflow's job. Assert no bookmark-style
+        // "Wait*" activity is present in the graph.
+        var waitActivities = Flowchart().Activities
+            .Where(a => a.GetType().Name.StartsWith("Wait", StringComparison.Ordinal))
+            .Select(a => a.GetType().Name)
+            .ToList();
+
+        waitActivities.Should().BeEmpty(
+            "the issue-decomposition workflow is autonomous — it must not suspend on a human " +
+            "bookmark (no Wait* activity)");
+    }
+
+    [Test]
+    public void Workflow_OnlyDispatchesContextGatheringAndLlmCall()
+    {
+        var dispatchIds = Flowchart().Activities
+            .OfType<DispatchWorkflow>()
+            .Select(d => d.Id)
+            .OrderBy(x => x)
+            .ToList();
+
+        dispatchIds.Should().BeEquivalentTo(new[] { "DecomposeIssueLlm", "GatherContext" },
+            "decomposition reuses context-gathering for investigation and the mediated llm-call " +
+            "for the breakdown — no other dispatch and, crucially, no direct in-engine provider call");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -109,6 +109,7 @@ public class TaxonomyDriftBuildTests
         "ContextGatheringWorkflow",
         "DebuggingWorkflow",
         "DeploymentPipelineWorkflow",
+        "IssueDecompositionWorkflow",   // Story 2.14: dispatches the dedicated (senior_developer, decompose-issue) pair
         "MentorshipWorkflow",
         "PlanGenerationWorkflow",
         "PlanReviewWorkflow",

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/AgentActionTests.cs
@@ -28,8 +28,9 @@ public class AgentActionTests
         // analyze-assessment-response) added in assessment P0 + 1 research action
         // (Story 3.4 — dedicated research/investigate token under product_owner)
         // + 1 score-ambiguity action (Story 3.6 — dedicated ambiguity-scoring token
-        // under product_owner).
-        Enum.GetValues<AgentAction>().Length.Should().Be(76);
+        // under product_owner) + 1 decompose-issue action (Story 2.14 — dedicated
+        // issue-decomposition token under senior_developer).
+        Enum.GetValues<AgentAction>().Length.Should().Be(77);
     }
 
     [TestCase("context-scan", AgentAction.ContextScan)]
@@ -37,6 +38,7 @@ public class AgentActionTests
     [TestCase("code-review-security", AgentAction.CodeReviewSecurity)]
     [TestCase("research", AgentAction.Research)]
     [TestCase("score-ambiguity", AgentAction.ScoreAmbiguity)]
+    [TestCase("decompose-issue", AgentAction.DecomposeIssue)]
     public void Parse_resolves_canonical_wire(string wire, AgentAction expected)
     {
         AgentActionExtensions.Parse(wire).Should().Be(expected);

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RolePhaseMapTests.cs
@@ -11,11 +11,12 @@ namespace Tamma.Api.Tests.Agents;
 /// The 8 roles: developer, tester, security, devops, architect, product_owner,
 /// senior_developer, tech_writer.
 ///
-/// The 76 actions are the union of the per-role action sets in SPEC §4
+/// The 77 actions are the union of the per-role action sets in SPEC §4
 /// (72 original + 2 assessment actions: generate-assessment-questions,
 /// analyze-assessment-response under product_owner — added in assessment P0 —
 /// + 1 research action under product_owner, Story 3.4
-/// + 1 score-ambiguity action under product_owner, Story 3.6).
+/// + 1 score-ambiguity action under product_owner, Story 3.6
+/// + 1 decompose-issue action under senior_developer, Story 2.14).
 /// Which (role, action) pairs are valid is the per-role eligibility matrix.
 /// </summary>
 [TestFixture]
@@ -43,14 +44,15 @@ public class RolePhaseMapTests
     }
 
     [Test]
-    public void ValidActions_Should_Contain_Seventy_Six_Actions()
+    public void ValidActions_Should_Contain_Seventy_Seven_Actions()
     {
         // 72 original actions + 2 assessment actions added in assessment P0
         // (generate-assessment-questions, analyze-assessment-response under product_owner)
         // + 1 research action (Story 3.4 — dedicated research token under product_owner)
         // + 1 score-ambiguity action (Story 3.6 — dedicated ambiguity-scoring token
-        // under product_owner).
-        RolePhaseMap.ValidActions.Should().HaveCount(76);
+        // under product_owner) + 1 decompose-issue action (Story 2.14 — dedicated
+        // issue-decomposition token under senior_developer).
+        RolePhaseMap.ValidActions.Should().HaveCount(77);
     }
 
     [Test]
@@ -411,6 +413,40 @@ public class RolePhaseMapTests
     {
         // score-ambiguity is a product_owner-only action; a developer must not be eligible.
         RolePhaseMap.IsRoleEligibleForPhase("score-ambiguity", "developer").Should().BeFalse();
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 2.14 — dedicated decompose-issue action (senior_developer-eligible)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void ValidActions_Contains_DecomposeIssue()
+    {
+        RolePhaseMap.ValidActions.Should().Contain("decompose-issue");
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_DecomposeIssue_SeniorDeveloper_Returns_True()
+    {
+        // Breaking a complex issue into implementable sub-tasks is the tech-lead's charter (the
+        // senior_developer identity prompt is literally "decompose complex tasks"), so the
+        // dedicated decompose-issue action is eligible for senior_developer (Story 2.14 —
+        // IssueDecompositionWorkflow dispatches (senior_developer, decompose-issue)).
+        RolePhaseMap.IsRoleEligibleForPhase("decompose-issue", "senior_developer").Should().BeTrue();
+    }
+
+    [Test]
+    public void GetEligibleRolesForPhase_DecomposeIssue_Is_SeniorDeveloper_Only()
+    {
+        RolePhaseMap.GetEligibleRolesForPhase("decompose-issue")
+            .Should().BeEquivalentTo(new[] { "senior_developer" });
+    }
+
+    [Test]
+    public void IsRoleEligibleForPhase_DecomposeIssue_Developer_Returns_False()
+    {
+        // decompose-issue is a senior_developer-only action; a plain developer must not be eligible.
+        RolePhaseMap.IsRoleEligibleForPhase("decompose-issue", "developer").Should().BeFalse();
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## What

Story 2.14 — rebuilt on the **post-pivot arch** (the original TS design was superseded). `IssueDecompositionWorkflow` (`issue-decomposition`) on the Research/Assessment skeleton: read inputs → gather context → mediated LLM → fail-closed parse → emit. Breaks a complex issue into ordered sub-tasks with dependencies — the foundation #138 (dependency mapping) + #139 (sequencing) consume.

- **Taxonomy 76→77:** added `[Wire("decompose-issue")] DecomposeIssue` under `senior_developer` (its charter is literally "decompose complex tasks"), all coupled places (`AgentAction`, `RolePhaseMap`, `SystemPrompts` `DecomposeIssueBody`) + count/drift tests.
- **Sub-task shape** (`{summary, subtasks[{id, title, description, acceptanceCriteria, estimateHours, complexity, dependsOn[]}]}`) — `id`+`dependsOn` are the graph-edge contract for #138/#139; array order = suggested sequence; cycle detection deliberately left to #138.
- Fail-closed parser (drops shells/dupe-ids, prunes dangling/self deps → clean graph). `DECOMPOSITION.STARTED/CONTEXT_GATHERED/COMPLETED/FAILED` events. Auto-registered (no Program.cs). Mediated LLM — no TAMMA001.

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Tests: Activities 40 (Decompos + TaxonomyDrift) + Api 239 (AgentAction/RolePhaseMap 76→77, ConventionSeedDrift, SystemPrompts).

Deferred (downstream orchestration): AC7 human-approval-before-execute, AC8 learning loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)