### PR TITLE
feat(epic-23-8): Infrastructure Monitor page + lightweight infra-metrics endpoint

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminInfrastructureMonitoringEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/Admin/AdminInfrastructureMonitoringEndpoints.cs
@@ -1,0 +1,37 @@
+using Tamma.Api.Services;
+
+namespace Tamma.Api.Endpoints.Admin;
+
+/// <summary>
+/// Story 23-8 — the platform-owner INFRASTRUCTURE MONITOR read surface under
+/// <c>GET /api/admin/monitoring/infrastructure</c>. One read-only, live snapshot
+/// of the API process + host (runtime / CPU / memory / disk / uptime) composed
+/// with the coarse up/down status of every backing dependency (Postgres,
+/// RabbitMQ, ELSA engine, ChromaDB, OpenSearch).
+///
+/// <para><b>RBAC / leak defence:</b> infra metrics are SYSTEM/PLATFORM-level, not
+/// tenant-scoped, so the route is gated <c>PlatformOwnerAccess</c> at the wiring
+/// site (Finding C1) — a regular member / tenant-owner who is not a platform admin
+/// gets 403 and never sees process internals. The response carries ONLY system
+/// statistics + boolean-ish dependency status; it exposes NO connection string,
+/// DB host / user / password, secret, or tenant/customer data (the dependency
+/// <c>Detail</c> is allowlist-sanitized in
+/// <see cref="InfrastructureMetricsService.SanitizeDetail"/>).</para>
+///
+/// <para><b>No new logic, no migration:</b> a pure live read of what .NET / the
+/// container already expose (<c>GC</c>, <c>Process</c>, <c>DriveInfo</c>, the
+/// cgroup filesystem) plus the existing <see cref="IAdminHealthService"/> probe
+/// fan-out. No DB writes, no schema, no external metrics stack (Prometheus /
+/// node-exporter) is stood up.</para>
+/// </summary>
+public static class AdminInfrastructureMonitoringEndpoints
+{
+    // ── GET /api/admin/monitoring/infrastructure ──
+    public static async Task<IResult> GetInfrastructure(
+        IInfrastructureMetricsService metrics,
+        CancellationToken ct)
+    {
+        var snapshot = await metrics.GetMetricsAsync(ct);
+        return Results.Ok(snapshot);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1133,6 +1133,11 @@ builder.Services.AddHealthChecks()
 // Mirrors the TS /api/admin/health behavior.
 builder.Services.AddScoped<IAdminHealthService, AdminHealthService>();
 
+// Story 23-8 — Infrastructure Monitor metrics. A live, read-only snapshot of the
+// API process + host (runtime / CPU / memory / disk / uptime) composed with the
+// admin health probes. No new infra: reads GC / Process / DriveInfo / cgroup only.
+builder.Services.AddScoped<IInfrastructureMetricsService, InfrastructureMetricsService>();
+
 // Story 5.6 / 1.5-37 (Wave C.1) — alert core: sink, dispatcher,
 // four channels (email / slack / pagerduty / webhook), rate
 // limiter, secret reader. Registered before any caller so
@@ -1831,6 +1836,16 @@ admin.MapGet("/tenants/{tenantId:guid}/events/stream",
 // Story 28-R2 / C1: PlatformOwnerAccess (cross-tenant infra state).
 admin.MapGet("/diagnostics/platform-queues",
         Tamma.Api.Endpoints.Admin.PlatformQueuesAdminEndpoints.GetDiagnostics)
+    .RequireAuthorization("PlatformOwnerAccess");
+
+// Story 23-8 — Infrastructure Monitor. Live system/host metrics (runtime, CPU,
+// memory, disk, uptime) + coarse dependency up/down status. These are
+// SYSTEM/PLATFORM-level (not tenant-scoped), so PlatformOwnerAccess: a regular
+// member / tenant-owner who is not a platform admin gets 403 and never sees
+// process internals. Read-only; exposes no connection string / secret / tenant
+// data (dependency detail is allowlist-sanitized).
+admin.MapGet("/monitoring/infrastructure",
+        Tamma.Api.Endpoints.Admin.AdminInfrastructureMonitoringEndpoints.GetInfrastructure)
     .RequireAuthorization("PlatformOwnerAccess");
 
 // Story 28-12 — KEK rotation. Platform-owner only because rotating

--- a/apps/tamma-elsa/src/Tamma.Api/Services/InfrastructureMetricsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/InfrastructureMetricsService.cs
@@ -1,0 +1,408 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Tamma.Api.Services;
+
+// ─── Story 23-8: Infrastructure Monitor — metrics DTOs ─────────────────────────
+//
+// A read-only, live snapshot of the API process + its host, composed with the
+// existing per-dependency health probes. Everything here is derived from what
+// .NET / the container already exposes (GC, Process, DriveInfo, cgroup files) —
+// NO new metrics infrastructure (Prometheus / node-exporter / a metrics cluster)
+// is stood up. System-scoped (not tenant-scoped): the wiring gates it
+// PlatformOwnerAccess so a regular member / tenant never sees process internals.
+//
+// SECURITY: this response carries ONLY system statistics + coarse dependency
+// up/down status. It NEVER carries a connection string, DB host/user, password,
+// API key, or any tenant/customer data. The dependency `Detail` field is
+// allowlist-sanitized (see <see cref="InfrastructureMetricsService"/>) so a raw
+// exception message (which can embed a host or user) can never reach the client.
+
+/// <summary>.NET runtime + host identity and live CPU / uptime for the process.</summary>
+public sealed record RuntimeMetrics(
+    string FrameworkDescription,
+    string OsDescription,
+    string ProcessArchitecture,
+    int ProcessorCount,
+    double CpuUsagePercent,
+    long UptimeSeconds,
+    string StartedAt);
+
+/// <summary>Thread + GC counters for the process (cheap, always-available).</summary>
+public sealed record ProcessMetrics(
+    int ThreadCount,
+    int ThreadPoolThreadCount,
+    long ThreadPoolPendingWorkItems,
+    long ThreadPoolCompletedWorkItems,
+    int Gen0Collections,
+    int Gen1Collections,
+    int Gen2Collections);
+
+/// <summary>
+/// Process memory footprint against the effective limit. <see cref="MemoryLimitSource"/>
+/// is <c>"cgroup"</c> when a container memory cap was read from the cgroup
+/// filesystem, else <c>"gc"</c> (the GC's <c>TotalAvailableMemoryBytes</c> view,
+/// which itself honours a cgroup cap when one is set).
+/// </summary>
+public sealed record MemoryMetrics(
+    long WorkingSetBytes,
+    long PrivateMemoryBytes,
+    long ManagedHeapBytes,
+    long GcHeapSizeBytes,
+    long MemoryLimitBytes,
+    long MemoryUsedBytes,
+    double MemoryUsagePercent,
+    string MemoryLimitSource);
+
+/// <summary>One mounted volume: total / free / used bytes + utilisation.</summary>
+public sealed record DiskMetrics(
+    string Name,
+    string DriveFormat,
+    long TotalBytes,
+    long FreeBytes,
+    long UsedBytes,
+    double UsedPercent);
+
+/// <summary>
+/// Coarse connectivity of one backing service. <see cref="Status"/> is one of
+/// <c>healthy | unhealthy | unknown</c>; <see cref="Detail"/> is a leak-free,
+/// allowlist-sanitized hint (an HTTP status code, a timeout note, or a generic
+/// category) — NEVER a raw exception message.
+/// </summary>
+public sealed record DependencyStatus(
+    string Name,
+    string Status,
+    long ResponseTimeMs,
+    string? Detail);
+
+/// <summary>
+/// The full infrastructure snapshot returned by
+/// <c>GET /api/admin/monitoring/infrastructure</c>.
+/// </summary>
+public sealed record InfrastructureMetricsResponse(
+    RuntimeMetrics Runtime,
+    ProcessMetrics Process,
+    MemoryMetrics Memory,
+    IReadOnlyList<DiskMetrics> Disks,
+    IReadOnlyList<DependencyStatus> Dependencies,
+    string CollectedAt);
+
+public interface IInfrastructureMetricsService
+{
+    Task<InfrastructureMetricsResponse> GetMetricsAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Story 23-8 — composes the lightweight infra snapshot. The process/runtime/
+/// memory/disk tiers are read live from .NET + the container filesystem; the
+/// dependency tier reuses the existing <see cref="IAdminHealthService"/> probe
+/// fan-out (Postgres <c>SELECT 1</c> + HTTP health of ELSA / RabbitMQ / ChromaDB /
+/// OpenSearch) and SANITIZES each probe's detail so no connection host / user /
+/// secret leaks. Read-only: no DB writes, no schema, no external metrics stack.
+/// </summary>
+public sealed class InfrastructureMetricsService : IInfrastructureMetricsService
+{
+    /// <summary>CPU is sampled across this window (keeps round-trip well under 1s).</summary>
+    private static readonly TimeSpan CpuSampleWindow = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// A cgroup "no limit" sentinel (max long, rounded to the page size) — treat
+    /// values at/above this as "unlimited" and fall back to the GC's view.
+    /// </summary>
+    private const long UnlimitedThreshold = 0x7FFF_FFFF_FFFF_F000L;
+
+    private readonly IAdminHealthService _health;
+
+    public InfrastructureMetricsService(IAdminHealthService health)
+    {
+        _health = health;
+    }
+
+    public async Task<InfrastructureMetricsResponse> GetMetricsAsync(CancellationToken ct = default)
+    {
+        using var process = Process.GetCurrentProcess();
+
+        // ── CPU: sample TotalProcessorTime across a short wall-clock window and
+        //        normalise by the core count. Kick off the dependency probes
+        //        first so their latency overlaps the CPU sample window.
+        var healthTask = _health.GetHealthAsync(ct);
+
+        var cpuStart = SafeTotalProcessorTime(process);
+        var sw = Stopwatch.StartNew();
+        await Task.Delay(CpuSampleWindow, ct);
+        process.Refresh();
+        sw.Stop();
+        var cpuEnd = SafeTotalProcessorTime(process);
+
+        var wallMs = sw.Elapsed.TotalMilliseconds * Environment.ProcessorCount;
+        var cpuUsedMs = (cpuEnd - cpuStart).TotalMilliseconds;
+        var cpuPercent = wallMs > 0 ? Math.Clamp(cpuUsedMs / wallMs * 100.0, 0, 100) : 0;
+
+        var runtime = BuildRuntime(process, cpuPercent);
+        var procMetrics = BuildProcess(process);
+        var memory = BuildMemory(process);
+        var disks = ReadDisks();
+
+        var health = await healthTask;
+        var dependencies = health.Services
+            .Select(s => new DependencyStatus(s.Name, s.Status, s.ResponseTime, SanitizeDetail(s.Details)))
+            .ToList();
+
+        return new InfrastructureMetricsResponse(
+            runtime, procMetrics, memory, disks, dependencies, NowIso());
+    }
+
+    private static RuntimeMetrics BuildRuntime(Process process, double cpuPercent)
+    {
+        long uptimeSeconds = 0;
+        var startedAt = NowIso();
+        try
+        {
+            // Process.StartTime is Local-kind; normalise to UTC before it crosses
+            // the HTTP/string boundary, and compute uptime TZ-independently.
+            var startUtc = process.StartTime.ToUniversalTime();
+            uptimeSeconds = Math.Max(0, (long)(DateTime.UtcNow - startUtc).TotalSeconds);
+            startedAt = startUtc.ToString("o", CultureInfo.InvariantCulture);
+        }
+        catch
+        {
+            // StartTime can be denied on some hosts — leave the defaults.
+        }
+
+        return new RuntimeMetrics(
+            RuntimeInformation.FrameworkDescription,
+            RuntimeInformation.OSDescription,
+            RuntimeInformation.ProcessArchitecture.ToString(),
+            Environment.ProcessorCount,
+            Math.Round(cpuPercent, 2),
+            uptimeSeconds,
+            startedAt);
+    }
+
+    private static ProcessMetrics BuildProcess(Process process)
+    {
+        int threadCount;
+        try
+        {
+            threadCount = process.Threads.Count;
+        }
+        catch
+        {
+            threadCount = 0;
+        }
+
+        return new ProcessMetrics(
+            threadCount,
+            ThreadPool.ThreadCount,
+            ThreadPool.PendingWorkItemCount,
+            ThreadPool.CompletedWorkItemCount,
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2));
+    }
+
+    private static MemoryMetrics BuildMemory(Process process)
+    {
+        var gcInfo = GC.GetGCMemoryInfo();
+        var managedHeap = GC.GetTotalMemory(forceFullCollection: false);
+        var gcHeapSize = gcInfo.HeapSizeBytes;
+        var workingSet = process.WorkingSet64;
+        var privateBytes = process.PrivateMemorySize64;
+
+        var (limit, source) = ResolveMemoryLimit(gcInfo.TotalAvailableMemoryBytes);
+        var used = workingSet;
+        var usagePercent = limit > 0 ? Math.Clamp((double)used / limit * 100.0, 0, 100) : 0;
+
+        return new MemoryMetrics(
+            workingSet,
+            privateBytes,
+            managedHeap,
+            gcHeapSize,
+            limit,
+            used,
+            Math.Round(usagePercent, 2),
+            source);
+    }
+
+    /// <summary>
+    /// Best-effort container memory cap: read the cgroup filesystem (v2
+    /// <c>memory.max</c>, then v1 <c>memory.limit_in_bytes</c>). A missing /
+    /// unreadable / "max" / unlimited value falls back to the GC's
+    /// <c>TotalAvailableMemoryBytes</c> (which already honours a cgroup cap).
+    /// No secrets are involved — these are numeric limit files.
+    /// </summary>
+    private static (long Limit, string Source) ResolveMemoryLimit(long gcAvailableBytes)
+    {
+        var cgroup = TryReadCgroupMemoryLimit();
+        if (cgroup is > 0 and < UnlimitedThreshold)
+            return (cgroup.Value, "cgroup");
+
+        return (gcAvailableBytes > 0 ? gcAvailableBytes : 0, "gc");
+    }
+
+    private static long? TryReadCgroupMemoryLimit()
+    {
+        // cgroup v2 unified hierarchy.
+        var v2 = TryReadLimitFile("/sys/fs/cgroup/memory.max");
+        if (v2 is not null)
+            return v2;
+
+        // cgroup v1.
+        return TryReadLimitFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    }
+
+    private static long? TryReadLimitFile(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            var raw = File.ReadAllText(path).Trim();
+            if (raw.Length == 0 || string.Equals(raw, "max", StringComparison.OrdinalIgnoreCase))
+                return null;
+            return long.TryParse(raw, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : null;
+        }
+        catch
+        {
+            // Not on Linux, or the cgroup files aren't readable — best-effort only.
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pseudo / ephemeral / read-only-image filesystems that add noise but carry no
+    /// operator signal — snap loop-mounts (<c>squashfs</c>), RAM-backed mounts, and
+    /// removable-image formats. Real persistent volumes (ext*/xfs/btrfs/overlay/…) pass.
+    /// </summary>
+    private static readonly HashSet<string> PseudoDriveFormats = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "squashfs", "tmpfs", "devtmpfs", "ramfs", "iso9660", "udf", "overlayfs",
+    };
+
+    private static IReadOnlyList<DiskMetrics> ReadDisks()
+    {
+        DriveInfo[] drives;
+        try
+        {
+            drives = DriveInfo.GetDrives();
+        }
+        catch
+        {
+            drives = Array.Empty<DriveInfo>();
+        }
+
+        // Collect the real, mounted, persistent volumes, then collapse bind-mounts of
+        // the same underlying device (identical format + total + free) to the mount
+        // with the shortest path so the panel shows one row per real volume.
+        var candidates = new List<(string Name, string Format, long Total, long Free)>();
+        foreach (var drive in drives)
+        {
+            try
+            {
+                if (!drive.IsReady || drive.DriveType != DriveType.Fixed || drive.TotalSize <= 0)
+                    continue;
+                var format = SafeDriveFormat(drive);
+                if (PseudoDriveFormats.Contains(format))
+                    continue;
+                candidates.Add((drive.Name, format, drive.TotalSize, drive.AvailableFreeSpace));
+            }
+            catch
+            {
+                // A transient / permission error on one drive must not blank the panel.
+            }
+        }
+
+        var disks = candidates
+            .OrderBy(c => c.Name.Length)
+            .ThenBy(c => c.Name, StringComparer.Ordinal)
+            .GroupBy(c => $"{c.Format}|{c.Total}|{c.Free}")
+            .Select(g => g.First())
+            .Select(c =>
+            {
+                var used = Math.Max(0, c.Total - c.Free);
+                var usedPct = c.Total > 0 ? Math.Clamp((double)used / c.Total * 100.0, 0, 100) : 0;
+                return new DiskMetrics(c.Name, c.Format, c.Total, c.Free, used, Math.Round(usedPct, 2));
+            })
+            .ToList();
+
+        // Fallback: if no fixed drive surfaced (some minimal containers), report the
+        // volume backing the app's content root.
+        if (disks.Count == 0)
+        {
+            try
+            {
+                var root = Path.GetPathRoot(AppContext.BaseDirectory);
+                if (!string.IsNullOrEmpty(root))
+                {
+                    var drive = new DriveInfo(root);
+                    if (drive.IsReady && drive.TotalSize > 0)
+                    {
+                        var total = drive.TotalSize;
+                        var free = drive.AvailableFreeSpace;
+                        var used = Math.Max(0, total - free);
+                        var usedPct = total > 0 ? Math.Clamp((double)used / total * 100.0, 0, 100) : 0;
+                        disks.Add(new DiskMetrics(
+                            drive.Name, SafeDriveFormat(drive), total, free, used, Math.Round(usedPct, 2)));
+                    }
+                }
+            }
+            catch
+            {
+                // Give up gracefully — an empty disk list is a valid (degraded) snapshot.
+            }
+        }
+
+        return disks;
+    }
+
+    private static string SafeDriveFormat(DriveInfo drive)
+    {
+        try
+        {
+            return drive.DriveFormat;
+        }
+        catch
+        {
+            return "unknown";
+        }
+    }
+
+    private static TimeSpan SafeTotalProcessorTime(Process process)
+    {
+        try
+        {
+            return process.TotalProcessorTime;
+        }
+        catch
+        {
+            return TimeSpan.Zero;
+        }
+    }
+
+    /// <summary>
+    /// Allowlist-sanitize a probe detail so no raw exception text (which can embed
+    /// a DB host, user, or connection string) reaches the client. Only three
+    /// leak-free shapes survive verbatim — an HTTP status code, a timeout note, and
+    /// the "URL not configured" marker; everything else collapses to a coarse
+    /// category. A healthy probe carries no detail.
+    /// </summary>
+    internal static string? SanitizeDetail(string? detail)
+    {
+        if (string.IsNullOrEmpty(detail))
+            return null;
+        if (string.Equals(detail, "URL not configured", StringComparison.Ordinal))
+            return detail;
+        if (detail.StartsWith("HTTP ", StringComparison.Ordinal))
+            return detail;
+        if (detail.StartsWith("Timed out after", StringComparison.Ordinal))
+            return detail;
+        // Any other message may carry connection details — collapse it.
+        return "unreachable";
+    }
+
+    private static string NowIso() =>
+        DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture);
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Auth/PlatformOwnerAccessPolicyTests.cs
@@ -183,6 +183,11 @@ public class PlatformOwnerAccessPolicyTests
         // tenant-owner who is not a platform admin must NOT read it (the
         // tenant-facing /api/pricing/* surface only ever exposes the sell price).
         "/api/admin/pricing/overview",
+        // Story 23-8 — the Infrastructure Monitor exposes SYSTEM/PLATFORM-level
+        // process internals (CPU / memory / disk / uptime / dependency status).
+        // These are not tenant-scoped, so a tenant-owner who is not a platform
+        // admin must NOT read them (Finding C1).
+        "/api/admin/monitoring/infrastructure",
     };
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Monitoring/InfrastructureMetricsServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Monitoring/InfrastructureMetricsServiceTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services;
+
+namespace Tamma.Api.Tests.Monitoring;
+
+/// <summary>
+/// Story 23-8 — pins the lightweight infra-metrics contract for
+/// <see cref="InfrastructureMetricsService"/>:
+///   • the live process/runtime/memory/disk snapshot is sane (positive core
+///     count, non-negative uptime, CPU% in [0,100], memory limit resolved);
+///   • dependency status is composed from the admin health probes; a DOWN probe
+///     is surfaced (not thrown); and
+///   • the LEAK DEFENCE — a raw probe detail that embeds a host / user / password
+///     is allowlist-sanitized so it never reaches the serialized response.
+/// The PlatformOwnerAccess 403 gate is pinned separately by
+/// <c>PlatformOwnerAccessPolicyTests</c> (which lists the route).
+/// </summary>
+[TestFixture]
+public class InfrastructureMetricsServiceTests
+{
+    /// <summary>A stand-in that returns a scripted set of probe results.</summary>
+    private sealed class FakeAdminHealthService : IAdminHealthService
+    {
+        private readonly AdminHealthResponse _response;
+        public FakeAdminHealthService(AdminHealthResponse response) => _response = response;
+        public Task<AdminHealthResponse> GetHealthAsync(CancellationToken ct = default) =>
+            Task.FromResult(_response);
+    }
+
+    private static InfrastructureMetricsService NewService(params ServiceCheck[] services)
+    {
+        var response = new AdminHealthResponse(services, DateTime.UtcNow.ToString("o"));
+        return new InfrastructureMetricsService(new FakeAdminHealthService(response));
+    }
+
+    [Test]
+    public async Task GetMetricsAsync_ReturnsSaneLiveSnapshot()
+    {
+        var svc = NewService(
+            new ServiceCheck("Tamma API", "healthy", 0, DateTime.UtcNow.ToString("o")));
+
+        var result = await svc.GetMetricsAsync();
+
+        // Runtime tier — always populated from the live process.
+        result.Runtime.ProcessorCount.Should().BeGreaterThan(0);
+        result.Runtime.UptimeSeconds.Should().BeGreaterThanOrEqualTo(0);
+        result.Runtime.CpuUsagePercent.Should().BeInRange(0, 100);
+        result.Runtime.FrameworkDescription.Should().NotBeNullOrEmpty();
+        result.Runtime.StartedAt.Should().NotBeNullOrEmpty();
+
+        // Process tier — thread + GC counters.
+        result.Process.ThreadCount.Should().BeGreaterThanOrEqualTo(0);
+        result.Process.Gen0Collections.Should().BeGreaterThanOrEqualTo(0);
+
+        // Memory tier — working set + a resolved limit (cgroup or GC view).
+        result.Memory.WorkingSetBytes.Should().BeGreaterThan(0);
+        result.Memory.MemoryLimitBytes.Should().BeGreaterThanOrEqualTo(0);
+        result.Memory.MemoryUsagePercent.Should().BeInRange(0, 100);
+        result.Memory.MemoryLimitSource.Should().BeOneOf("cgroup", "gc");
+
+        result.CollectedAt.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task GetMetricsAsync_ComposesDependencyStatus_FromHealthProbes()
+    {
+        var svc = NewService(
+            new ServiceCheck("PostgreSQL", "healthy", 3, DateTime.UtcNow.ToString("o")),
+            new ServiceCheck("RabbitMQ", "unknown", 0, DateTime.UtcNow.ToString("o"), "URL not configured"),
+            new ServiceCheck("ELSA Server", "unhealthy", 5000, DateTime.UtcNow.ToString("o"), "HTTP 503"));
+
+        var result = await svc.GetMetricsAsync();
+
+        result.Dependencies.Should().HaveCount(3);
+        result.Dependencies.Should().ContainSingle(d => d.Name == "PostgreSQL" && d.Status == "healthy");
+        // A DOWN dependency is surfaced, not thrown.
+        result.Dependencies.Should().ContainSingle(d => d.Name == "ELSA Server" && d.Status == "unhealthy");
+        // Allowlisted details survive verbatim.
+        result.Dependencies.Single(d => d.Name == "ELSA Server").Detail.Should().Be("HTTP 503");
+        result.Dependencies.Single(d => d.Name == "RabbitMQ").Detail.Should().Be("URL not configured");
+        // A healthy probe carries no detail.
+        result.Dependencies.Single(d => d.Name == "PostgreSQL").Detail.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetMetricsAsync_NeverLeaksConnectionDetailsFromProbeException()
+    {
+        // A realistic Npgsql-style failure message embeds a host + user + password.
+        const string leak =
+            "Npgsql.NpgsqlException: Failed to connect to db.internal:5432 "
+            + "(user=tamma password=sup3r-s3cret-p@ss)";
+
+        var svc = NewService(
+            new ServiceCheck("PostgreSQL", "unhealthy", 12, DateTime.UtcNow.ToString("o"), leak));
+
+        var result = await svc.GetMetricsAsync();
+
+        var pg = result.Dependencies.Single(d => d.Name == "PostgreSQL");
+        pg.Status.Should().Be("unhealthy");
+        // The raw exception text is collapsed to a coarse, leak-free category.
+        pg.Detail.Should().Be("unreachable");
+
+        // Belt-and-braces: the leaked host / user / password fragments must be
+        // absent from the WHOLE serialized DTO. (A bare "password" word is NOT
+        // checked — a legitimate disk mount path can contain it, e.g. a
+        // /snap/1password mount on a dev host.)
+        var json = JsonSerializer.Serialize(result);
+        json.Should().NotContain("db.internal");
+        json.Should().NotContain("user=tamma");
+        json.Should().NotContain("sup3r-s3cret-p@ss");
+    }
+
+    [TestCase(null, null)]
+    [TestCase("", null)]
+    [TestCase("URL not configured", "URL not configured")]
+    [TestCase("HTTP 500", "HTTP 500")]
+    [TestCase("Timed out after 5s", "Timed out after 5s")]
+    [TestCase("Host=db.internal;Username=tamma;Password=secret", "unreachable")]
+    [TestCase("Connection refused (10.0.0.5:5672)", "unreachable")]
+    public void SanitizeDetail_AppliesAllowlist(string? input, string? expected)
+    {
+        InfrastructureMetricsService.SanitizeDetail(input).Should().Be(expected);
+    }
+}

--- a/packages/dashboard/src/hooks/monitoring/useInfrastructureMonitor.ts
+++ b/packages/dashboard/src/hooks/monitoring/useInfrastructureMonitor.ts
@@ -1,0 +1,122 @@
+/**
+ * useInfrastructureMonitor — data hook for the Infrastructure Monitor (Story 23-8).
+ *
+ * Fetches a single, read-only, live snapshot from the platform-owner endpoint
+ * `GET /api/admin/monitoring/infrastructure` (PlatformOwnerAccess-gated server-
+ * side; the route is already behind the dashboard's AdminGuard). The snapshot
+ * carries ONLY system statistics — .NET runtime / process / memory / disk / uptime
+ * — plus the coarse up/down status of every backing dependency. It contains NO
+ * connection string, secret, or tenant data.
+ *
+ * The endpoint is a snapshot, not a windowed query, so there is no time range —
+ * the page drives re-fetching via the shared `useAutoRefresh` primitive.
+ */
+
+import { useCallback, useState } from 'react';
+
+/** .NET runtime + host identity and live CPU / uptime. */
+export interface RuntimeMetrics {
+  frameworkDescription: string;
+  osDescription: string;
+  processArchitecture: string;
+  processorCount: number;
+  cpuUsagePercent: number;
+  uptimeSeconds: number;
+  startedAt: string;
+}
+
+/** Thread + GC counters for the process. */
+export interface ProcessMetrics {
+  threadCount: number;
+  threadPoolThreadCount: number;
+  threadPoolPendingWorkItems: number;
+  threadPoolCompletedWorkItems: number;
+  gen0Collections: number;
+  gen1Collections: number;
+  gen2Collections: number;
+}
+
+/** Process memory footprint against the effective (cgroup or GC) limit. */
+export interface MemoryMetrics {
+  workingSetBytes: number;
+  privateMemoryBytes: number;
+  managedHeapBytes: number;
+  gcHeapSizeBytes: number;
+  memoryLimitBytes: number;
+  memoryUsedBytes: number;
+  memoryUsagePercent: number;
+  memoryLimitSource: string;
+}
+
+/** One mounted volume. */
+export interface DiskMetrics {
+  name: string;
+  driveFormat: string;
+  totalBytes: number;
+  freeBytes: number;
+  usedBytes: number;
+  usedPercent: number;
+}
+
+/** Coarse connectivity of one backing service (no secrets in `detail`). */
+export interface DependencyStatus {
+  name: string;
+  status: string;
+  responseTimeMs: number;
+  detail: string | null;
+}
+
+export interface InfrastructureMetrics {
+  runtime: RuntimeMetrics;
+  process: ProcessMetrics;
+  memory: MemoryMetrics;
+  disks: DiskMetrics[];
+  dependencies: DependencyStatus[];
+  collectedAt: string;
+}
+
+export interface UseInfrastructureMonitorResult {
+  metrics: InfrastructureMetrics | null;
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  load: () => Promise<void>;
+}
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export function useInfrastructureMonitor(): UseInfrastructureMonitorResult {
+  const [metrics, setMetrics] = useState<InfrastructureMetrics | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const load = useCallback(async (): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/admin/monitoring/infrastructure`, {
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) {
+        let message = `HTTP ${res.status}`;
+        try {
+          const body = (await res.json()) as { error?: string };
+          if (body?.error) message = body.error;
+        } catch {
+          // keep the default status message
+        }
+        throw new Error(message);
+      }
+      setMetrics((await res.json()) as InfrastructureMetrics);
+      setLastUpdated(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load infrastructure metrics');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { metrics, loading, error, lastUpdated, load };
+}

--- a/packages/dashboard/src/pages/monitoring/InfrastructureMonitorPage.tsx
+++ b/packages/dashboard/src/pages/monitoring/InfrastructureMonitorPage.tsx
@@ -1,21 +1,237 @@
 /**
- * Infrastructure Monitor page. Scaffold from Story 23-12; full dashboard arrives
- * in Story 23-8.
+ * Infrastructure Monitor — Story 23-8.
+ *
+ * Operator page for SYSTEM/PLATFORM-level infrastructure health: the API
+ * process's live runtime / CPU / memory / disk / uptime, plus the coarse up/down
+ * status of every backing dependency (PostgreSQL, RabbitMQ, ELSA engine,
+ * ChromaDB, OpenSearch). All numbers come from a single read-only snapshot,
+ * `GET /api/admin/monitoring/infrastructure`, which is PlatformOwnerAccess-gated
+ * server-side (a member / tenant never reaches it) and carries NO connection
+ * string, secret, or tenant data.
+ *
+ * This is a lightweight metrics tier built from what .NET / the container already
+ * expose (GC, Process, DriveInfo, cgroup) — it deliberately does NOT stand up a
+ * full metrics stack (Prometheus / node-exporter). The richer per-service panels
+ * described in the story (Postgres query stats, RabbitMQ queue depth, Docker
+ * per-container stats, …) would each need their own metrics source and are out of
+ * scope here. The page is built on the Story 23-12 monitoring primitives; the
+ * route is already `AdminGuard`-gated + lazy-mounted, so this module supplies only
+ * the body.
  */
 
-import type { JSX } from 'react';
-import { MonitoringPlaceholder } from './MonitoringPlaceholder.js';
+import { useEffect, type JSX } from 'react';
+import { MonitoringLayout } from '../../components/monitoring/MonitoringLayout.js';
+import { MetricGrid } from '../../components/monitoring/MetricGrid.js';
+import { MetricCard } from '../../components/monitoring/MetricCard.js';
+import { StatusBadge } from '../../components/monitoring/StatusBadge.js';
+import { ProgressRing } from '../../components/monitoring/ProgressRing.js';
+import { EmptyState } from '../../components/monitoring/EmptyState.js';
+import { ErrorBanner } from '../../components/monitoring/ErrorBanner.js';
+import { useInfrastructureMonitor } from '../../hooks/monitoring/useInfrastructureMonitor.js';
+import { useAutoRefresh } from '../../hooks/monitoring/useAutoRefresh.js';
+import {
+  dependencyKind,
+  formatBytes,
+  formatUptime,
+  usageTone,
+} from './infra-monitor-utils.js';
 import { getMonitoringNavItem } from './monitoring-nav.js';
 
 const NAV = getMonitoringNavItem('/monitoring/infrastructure');
 
+/** Story AC: infrastructure metrics refresh at a 5s polling interval by default. */
+const DEFAULT_REFRESH_MS = 5000;
+
 export function InfrastructureMonitorPage(): JSX.Element {
+  const { metrics, loading, error, lastUpdated, load } = useInfrastructureMonitor();
+
+  const autoRefresh = useAutoRefresh(load, {
+    storageKey: NAV.storageKey,
+    defaultInterval: DEFAULT_REFRESH_MS,
+  });
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runtime = metrics?.runtime ?? null;
+  const process = metrics?.process ?? null;
+  const memory = metrics?.memory ?? null;
+  const disks = metrics?.disks ?? [];
+  const dependencies = metrics?.dependencies ?? [];
+  const primaryDisk = disks[0] ?? null;
+
   return (
-    <MonitoringPlaceholder
+    <MonitoringLayout
       title={NAV.label}
-      description={NAV.description}
-      storyRef={NAV.story}
-      storageKey={NAV.storageKey}
-    />
+      description="Live system health of the API process and its backing services — runtime, CPU, memory, disk, uptime and dependency connectivity."
+      loading={loading}
+      lastUpdated={lastUpdated}
+      onRefresh={load}
+      autoRefreshInterval={autoRefresh.interval}
+      onAutoRefreshChange={autoRefresh.setInterval}
+      showTimeRange={false}
+    >
+      {error && (
+        <div className="mb-4">
+          <ErrorBanner message={error} onRetry={load} />
+        </div>
+      )}
+
+      {!metrics && !loading && !error ? (
+        <EmptyState
+          title="No infrastructure data"
+          description="The infrastructure snapshot could not be loaded. Try refreshing."
+        />
+      ) : null}
+
+      {metrics && runtime && memory && process && (
+        <>
+          {/* ── Headline metrics ── */}
+          <MetricGrid columns={4} className="mb-6">
+            <MetricCard
+              label="CPU usage"
+              value={runtime.cpuUsagePercent}
+              unit="%"
+              tone={usageTone(runtime.cpuUsagePercent)}
+              hint={`${runtime.processorCount} core${runtime.processorCount === 1 ? '' : 's'}`}
+            />
+            <MetricCard
+              label="Memory"
+              value={formatBytes(memory.memoryUsedBytes)}
+              unit={`/ ${formatBytes(memory.memoryLimitBytes)}`}
+              tone={usageTone(memory.memoryUsagePercent)}
+              hint={`${memory.memoryUsagePercent}% · limit via ${memory.memoryLimitSource}`}
+            />
+            <MetricCard
+              label="Uptime"
+              value={formatUptime(runtime.uptimeSeconds)}
+              hint={`since ${new Date(runtime.startedAt).toLocaleString()}`}
+            />
+            <MetricCard
+              label="Threads"
+              value={process.threadCount}
+              hint={`${process.threadPoolThreadCount} pooled · ${process.threadPoolPendingWorkItems} pending`}
+            />
+          </MetricGrid>
+
+          {/* ── Utilisation rings ── */}
+          <section aria-label="Utilisation" className="mb-8 flex flex-wrap gap-8">
+            <div className="flex flex-col items-center">
+              <ProgressRing
+                value={memory.memoryUsagePercent}
+                label="Memory"
+                tone={usageTone(memory.memoryUsagePercent)}
+              />
+              <span className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {formatBytes(memory.memoryUsedBytes)} / {formatBytes(memory.memoryLimitBytes)}
+              </span>
+            </div>
+            {primaryDisk && (
+              <div className="flex flex-col items-center">
+                <ProgressRing
+                  value={primaryDisk.usedPercent}
+                  label={`Disk (${primaryDisk.name})`}
+                  tone={usageTone(primaryDisk.usedPercent)}
+                />
+                <span className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {formatBytes(primaryDisk.usedBytes)} / {formatBytes(primaryDisk.totalBytes)}
+                </span>
+              </div>
+            )}
+            <div className="flex flex-col items-center">
+              <ProgressRing
+                value={runtime.cpuUsagePercent}
+                label="CPU"
+                tone={usageTone(runtime.cpuUsagePercent)}
+              />
+              <span className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                {runtime.cpuUsagePercent}% of {runtime.processorCount} core
+                {runtime.processorCount === 1 ? '' : 's'}
+              </span>
+            </div>
+          </section>
+
+          {/* ── Dependency connectivity ── */}
+          <section aria-label="Dependencies" className="mb-8">
+            <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">
+              Dependencies
+            </h2>
+            {dependencies.length === 0 ? (
+              <EmptyState title="No dependency probes" description="No backing services were probed." />
+            ) : (
+              <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {dependencies.map((dep) => (
+                  <li
+                    key={dep.name}
+                    data-testid="dependency-row"
+                    className="flex items-center justify-between rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm dark:border-gray-700 dark:bg-gray-800"
+                  >
+                    <span className="font-medium text-gray-800 dark:text-gray-100">{dep.name}</span>
+                    <span className="flex items-center gap-2">
+                      {dep.status === 'healthy' && (
+                        <span className="text-xs tabular-nums text-gray-400 dark:text-gray-500">
+                          {dep.responseTimeMs}ms
+                        </span>
+                      )}
+                      <StatusBadge status={dependencyKind(dep.status)}>
+                        {dep.detail && dep.status !== 'healthy' ? dep.detail : dep.status}
+                      </StatusBadge>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* ── Disks ── */}
+          {disks.length > 0 && (
+            <section aria-label="Disks" className="mb-8">
+              <h2 className="mb-2 text-sm font-semibold text-gray-700 dark:text-gray-200">Disks</h2>
+              <div className="overflow-x-auto">
+                <table className="min-w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                      <th className="px-3 py-2">Mount</th>
+                      <th className="px-3 py-2">Format</th>
+                      <th className="px-3 py-2 text-right">Used</th>
+                      <th className="px-3 py-2 text-right">Free</th>
+                      <th className="px-3 py-2 text-right">Total</th>
+                      <th className="px-3 py-2 text-right">Usage</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                    {disks.map((disk) => (
+                      <tr key={disk.name} data-testid="disk-row">
+                        <td className="px-3 py-2 font-mono text-gray-700 dark:text-gray-300">{disk.name}</td>
+                        <td className="px-3 py-2 text-gray-500 dark:text-gray-400">{disk.driveFormat}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatBytes(disk.usedBytes)}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatBytes(disk.freeBytes)}</td>
+                        <td className="px-3 py-2 text-right tabular-nums">{formatBytes(disk.totalBytes)}</td>
+                        <td className="px-3 py-2 text-right">
+                          <StatusBadge status={usageTone(disk.usedPercent)} showDot={false}>
+                            {disk.usedPercent}%
+                          </StatusBadge>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+
+          {/* ── Runtime footer ── */}
+          <section aria-label="Runtime" className="text-xs text-gray-500 dark:text-gray-400">
+            <span className="mr-4">{runtime.frameworkDescription}</span>
+            <span className="mr-4">{runtime.osDescription}</span>
+            <span className="mr-4">{runtime.processArchitecture}</span>
+            <span>
+              GC gen0/1/2: {process.gen0Collections}/{process.gen1Collections}/{process.gen2Collections}
+            </span>
+          </section>
+        </>
+      )}
+    </MonitoringLayout>
   );
 }

--- a/packages/dashboard/src/pages/monitoring/__tests__/infra-monitor-utils.test.ts
+++ b/packages/dashboard/src/pages/monitoring/__tests__/infra-monitor-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { dependencyKind, formatBytes, formatUptime, usageTone } from '../infra-monitor-utils.js';
+
+describe('formatBytes', () => {
+  it('formats binary units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(314572800)).toBe('300 MB');
+    expect(formatBytes(1073741824)).toBe('1 GB');
+  });
+
+  it('guards non-finite / negative input', () => {
+    expect(formatBytes(-1)).toBe('0 B');
+    expect(formatBytes(Number.NaN)).toBe('0 B');
+  });
+});
+
+describe('formatUptime', () => {
+  it('renders compact d/h/m', () => {
+    expect(formatUptime(0)).toBe('0m');
+    expect(formatUptime(59)).toBe('0m');
+    expect(formatUptime(60)).toBe('1m');
+    expect(formatUptime(3_600)).toBe('1h');
+    expect(formatUptime(93_784)).toBe('1d 2h 3m');
+  });
+});
+
+describe('dependencyKind', () => {
+  it('maps probe status to a badge kind', () => {
+    expect(dependencyKind('healthy')).toBe('healthy');
+    expect(dependencyKind('unhealthy')).toBe('down');
+    expect(dependencyKind('unknown')).toBe('unknown');
+    expect(dependencyKind('anything-else')).toBe('unknown');
+  });
+});
+
+describe('usageTone', () => {
+  it('escalates green → yellow → red', () => {
+    expect(usageTone(10)).toBe('green');
+    expect(usageTone(74.9)).toBe('green');
+    expect(usageTone(75)).toBe('yellow');
+    expect(usageTone(89.9)).toBe('yellow');
+    expect(usageTone(90)).toBe('red');
+    expect(usageTone(100)).toBe('red');
+  });
+});

--- a/packages/dashboard/src/pages/monitoring/__tests__/infrastructure-monitor-page.test.tsx
+++ b/packages/dashboard/src/pages/monitoring/__tests__/infrastructure-monitor-page.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminGuard } from '../../../guards/AdminGuard.js';
+import { InfrastructureMonitorPage } from '../InfrastructureMonitorPage.js';
+
+const mockUseCurrentUser = vi.fn();
+vi.mock('../../../hooks/admin/useCurrentUser.js', () => ({
+  useCurrentUser: () => mockUseCurrentUser(),
+}));
+
+function okResponse(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as unknown as Response;
+}
+
+function errorResponse(status: number): Response {
+  return { ok: false, status, json: async () => ({}) } as unknown as Response;
+}
+
+const SNAPSHOT = {
+  runtime: {
+    frameworkDescription: '.NET 8.0.20',
+    osDescription: 'Ubuntu 24.04.4 LTS',
+    processArchitecture: 'X64',
+    processorCount: 6,
+    cpuUsagePercent: 12.5,
+    uptimeSeconds: 93_784,
+    startedAt: new Date(Date.now() - 93_784_000).toISOString(),
+  },
+  process: {
+    threadCount: 25,
+    threadPoolThreadCount: 7,
+    threadPoolPendingWorkItems: 0,
+    threadPoolCompletedWorkItems: 100,
+    gen0Collections: 3,
+    gen1Collections: 2,
+    gen2Collections: 1,
+  },
+  memory: {
+    workingSetBytes: 314_572_800,
+    privateMemoryBytes: 314_572_800,
+    managedHeapBytes: 42_000_000,
+    gcHeapSizeBytes: 70_000_000,
+    memoryLimitBytes: 1_073_741_824,
+    memoryUsedBytes: 314_572_800,
+    memoryUsagePercent: 29.3,
+    memoryLimitSource: 'cgroup',
+  },
+  disks: [
+    {
+      name: '/',
+      driveFormat: 'ext4',
+      totalBytes: 210_518_392_832,
+      freeBytes: 37_529_903_104,
+      usedBytes: 172_988_489_728,
+      usedPercent: 82.17,
+    },
+  ],
+  dependencies: [
+    { name: 'PostgreSQL', status: 'healthy', responseTimeMs: 3, detail: null },
+    { name: 'RabbitMQ', status: 'unhealthy', responseTimeMs: 5000, detail: 'unreachable' },
+    { name: 'ELSA Server', status: 'unknown', responseTimeMs: 0, detail: 'URL not configured' },
+  ],
+  collectedAt: new Date().toISOString(),
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(okResponse(SNAPSHOT));
+  vi.stubGlobal('fetch', fetchMock);
+  mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+function renderPage(): void {
+  render(
+    <MemoryRouter initialEntries={['/monitoring/infrastructure']}>
+      <InfrastructureMonitorPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('InfrastructureMonitorPage', () => {
+  it('fetches and renders the live infrastructure snapshot', async () => {
+    renderPage();
+
+    // Headline metrics from the snapshot.
+    expect(await screen.findByText('300 MB')).toBeInTheDocument(); // memory used
+    expect(screen.getByText('1d 2h 3m')).toBeInTheDocument(); // uptime
+    expect(screen.getByText('.NET 8.0.20')).toBeInTheDocument(); // runtime footer
+    // Disk row.
+    expect(screen.getByText('ext4')).toBeInTheDocument();
+
+    // It hit the platform-owner infra endpoint.
+    await waitFor(() => {
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+      expect(urls.some((u) => u.includes('/api/admin/monitoring/infrastructure'))).toBe(true);
+    });
+  });
+
+  it('renders dependency status badges, including a down dependency', async () => {
+    renderPage();
+
+    expect(await screen.findByText('PostgreSQL')).toBeInTheDocument();
+    expect(screen.getByText('RabbitMQ')).toBeInTheDocument();
+    expect(screen.getByText('ELSA Server')).toBeInTheDocument();
+
+    // The DOWN dependency surfaces its (sanitized) detail, not a healthy label.
+    expect(screen.getByText('unreachable')).toBeInTheDocument();
+    expect(screen.getByText('URL not configured')).toBeInTheDocument();
+  });
+
+  it('shows an error banner when the endpoint fails', async () => {
+    fetchMock.mockResolvedValue(errorResponse(500));
+    renderPage();
+    expect(await screen.findByText(/HTTP 500/)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the snapshot is unavailable (403)', async () => {
+    // A member who somehow reaches the fetch gets a 403 → error banner, never
+    // a partial render of process internals.
+    fetchMock.mockResolvedValue(errorResponse(403));
+    renderPage();
+    expect(await screen.findByText(/HTTP 403/)).toBeInTheDocument();
+  });
+});
+
+describe('InfrastructureMonitorPage RBAC (inherited from the route AdminGuard)', () => {
+  it('renders for an admin', async () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u1', role: 'admin' }, loading: false, isAdmin: true });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/infrastructure']}>
+        <AdminGuard>
+          <InfrastructureMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole('heading', { name: 'Infrastructure' })).toBeInTheDocument();
+  });
+
+  it('does NOT render for a non-admin member', () => {
+    mockUseCurrentUser.mockReturnValue({ user: { id: 'u2', role: 'member' }, loading: false, isAdmin: false });
+    render(
+      <MemoryRouter initialEntries={['/monitoring/infrastructure']}>
+        <AdminGuard>
+          <InfrastructureMonitorPage />
+        </AdminGuard>
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('heading', { name: 'Infrastructure' })).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/pages/monitoring/infra-monitor-utils.ts
+++ b/packages/dashboard/src/pages/monitoring/infra-monitor-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers for the Infrastructure Monitor (Story 23-8): byte / uptime
+ * formatting and the dependency-status → badge-kind mapping. Kept dependency-
+ * free and side-effect-free so they unit-test in isolation.
+ */
+
+import type { StatusKind } from '../../components/monitoring/StatusBadge.js';
+
+/** Human-readable bytes (binary units). `1536` → `"1.5 KB"`. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+  const exponent = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / Math.pow(1024, exponent);
+  const rounded = value >= 100 || exponent === 0 ? Math.round(value) : Math.round(value * 10) / 10;
+  return `${rounded} ${units[exponent]}`;
+}
+
+/** Compact duration from whole seconds. `93784` → `"1d 2h 3m"`. */
+export function formatUptime(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return '0m';
+  const days = Math.floor(totalSeconds / 86_400);
+  const hours = Math.floor((totalSeconds % 86_400) / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 || parts.length === 0) parts.push(`${minutes}m`);
+  return parts.join(' ');
+}
+
+/** Map a dependency probe status to a monitoring badge kind. */
+export function dependencyKind(status: string): StatusKind {
+  switch (status) {
+    case 'healthy':
+      return 'healthy';
+    case 'unhealthy':
+      return 'down';
+    default:
+      return 'unknown';
+  }
+}
+
+/** Left-accent tone for a utilisation percentage (green → yellow → red). */
+export function usageTone(percent: number): 'green' | 'yellow' | 'red' {
+  if (percent >= 90) return 'red';
+  if (percent >= 75) return 'yellow';
+  return 'green';
+}


### PR DESCRIPTION
## What

Story 23.8 — the last Epic-23 page. `GET /api/admin/monitoring/infrastructure` (`PlatformOwnerAccess`) reads a live read-only snapshot with **no new infra**:
- Runtime (framework/OS/arch, cores), **CPU%** (200ms sample), **uptime** (TZ-independent), process/GC/threadpool, memory (working set + GC + **cgroup v2/v1 limit** with source), disks (`DriveInfo`, pseudo-fs filtered + bind-mount deduped), and dependency health (reuses the existing `AdminHealthService` fan-out: Postgres `SELECT 1` + ELSA/RabbitMQ/ChromaDB/OpenSearch).
- `InfrastructureMonitorPage` on #289 primitives (metric cards, progress rings, dependency badges), 5s auto-refresh, `AdminGuard`-gated.

## Safety

`PlatformOwnerAccess` (system metrics are admin-only; non-owner → 403, pinned in `PlatformOwnerAccessPolicyTests`). **No secret/connection-string leak** — dependency `Detail` is allowlist-sanitized (`HTTP <code>` / `Timed out` / `unreachable`, never a raw Npgsql/socket exception with a DB host/user/password); a test serializes the whole DTO and asserts no cred fragments appear. Non-migration (live stats, no DB write).

## Verification

- Build 0 errors, no TAMMA001. Both `has-pending-model-changes` → "No changes". Backend 61 tests (new `InfrastructureMetricsServiceTests` + the policy gate), frontend 64.

Boundary: this is the process/container/dependency tier. Deep per-service panels (pg_stat, RabbitMQ mgmt API, docker socket, time-series history) need a dedicated metrics stack — out of scope, reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)