### PR TITLE
feat(epic-6): wire the KB/RAG sidecar composition root to a real vector store

### DIFF
--- a/packages/intelligence-server/Dockerfile
+++ b/packages/intelligence-server/Dockerfile
@@ -16,14 +16,15 @@ FROM node:22-alpine AS deps
 RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 WORKDIR /app
 
-# Copy only the manifests the intelligence-server needs. The sidecar itself
-# does not import @tamma/intelligence at compile time (services use narrow
-# adapter interfaces) so the set of workspace packages we must install for
-# runtime is small: shared, observability, providers, intelligence.
+# Copy only the manifests the intelligence-server needs. Its runtime closure is
+# small: intelligence-server → { @tamma/intelligence, @tamma/shared } and
+# @tamma/intelligence → { @tamma/observability, @tamma/shared, chromadb, pg }.
+# NOTE: @tamma/intelligence deliberately does NOT depend on @tamma/providers
+# (which drags in @tamma/cost-monitor + heavy AI SDKs) — the sidecar never uses
+# it, so providers/cost-monitor are intentionally absent from this build context.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY packages/shared/package.json packages/shared/
 COPY packages/observability/package.json packages/observability/
-COPY packages/providers/package.json packages/providers/
 COPY packages/intelligence/package.json packages/intelligence/
 COPY packages/intelligence-server/package.json packages/intelligence-server/
 
@@ -37,14 +38,14 @@ FROM deps AS build
 COPY tsconfig.json ./
 COPY packages/shared packages/shared
 COPY packages/observability packages/observability
-COPY packages/providers packages/providers
 COPY packages/intelligence packages/intelligence
 COPY packages/intelligence-server packages/intelligence-server
 
-# Build only the intelligence-server. It references @tamma/shared via
-# `references` in tsconfig, so shared is built first. @tamma/intelligence is
-# NOT required for compilation (sidecar uses narrow local interfaces), so we
-# skip its pre-existing strict-mode build errors.
+# Build the intelligence-server. Via tsconfig `references` it builds its deps
+# first: @tamma/intelligence → { @tamma/shared, @tamma/observability }. That
+# chain must NOT reach @tamma/providers/@tamma/cost-monitor (which are not in
+# this build context) — @tamma/intelligence's tsconfig references only shared +
+# observability, so `tsc --build` stays inside the copied packages.
 RUN pnpm --filter @tamma/shared --filter @tamma/intelligence-server run build
 
 # `pnpm prune --prod --filter` isn't supported in pnpm 9; re-install prod-only

--- a/packages/intelligence-server/src/__tests__/env-composition.test.ts
+++ b/packages/intelligence-server/src/__tests__/env-composition.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for the environment-driven composition root (`env-composition.ts`).
+ *
+ * Covers three layers without needing a live ChromaDB/pgvector:
+ *   1. Pure config resolution + the REAL `createVectorStore` factory picking the
+ *      right provider class from env (exercises the env → provider path).
+ *   2. Embedder construction from env (mock/openai/graceful-absent).
+ *   3. End-to-end: a configured (in-memory) store bridged through the real
+ *      `wrapVectorStore` adapter makes `/kb/vector-db/*` return REAL data, while
+ *      an unconfigured deployment degrades to `not_configured` without crashing.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { buildServer } from '../server.js';
+import {
+  resolveVectorStoreConfig,
+  hasVectorStoreEnv,
+  createEmbedderFromEnv,
+  buildIntelligenceBundleFromEnv,
+  createVectorStoreFromEnv,
+  createRagPipelineFromEnv,
+  wrapVectorStore,
+} from '../env-composition.js';
+import type { IntelligenceServicesBundle, IRagPipeline } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// 1. Config resolution (pure) + real provider selection
+// ---------------------------------------------------------------------------
+
+describe('resolveVectorStoreConfig', () => {
+  it('selects chromadb from CHROMADB_URL', () => {
+    const cfg = resolveVectorStoreConfig({ CHROMADB_URL: 'http://chromadb:8000' }, 1536);
+    expect(cfg?.provider).toBe('chromadb');
+    expect(cfg?.chromadb?.persistPath).toBe('http://chromadb:8000');
+    expect(cfg?.dimensions).toBe(1536);
+  });
+
+  it('selects chromadb from CHROMADB_TEST_URL (CI fallback)', () => {
+    const cfg = resolveVectorStoreConfig({ CHROMADB_TEST_URL: 'http://localhost:8000' });
+    expect(cfg?.provider).toBe('chromadb');
+  });
+
+  it('selects chromadb from host + port', () => {
+    const cfg = resolveVectorStoreConfig({ CHROMADB_HOST: 'chromadb', CHROMADB_PORT: '9000' });
+    expect(cfg?.provider).toBe('chromadb');
+    expect(cfg?.chromadb?.host).toBe('chromadb');
+    expect(cfg?.chromadb?.port).toBe(9000);
+  });
+
+  it('selects pgvector from a Postgres connection string', () => {
+    const cfg = resolveVectorStoreConfig({ PGVECTOR_URL: 'postgres://u:p@h:5432/db' });
+    expect(cfg?.provider).toBe('pgvector');
+    expect(cfg?.pgvector?.connectionString).toContain('postgres://');
+  });
+
+  it('honours explicit KB_VECTOR_STORE=pgvector even when chroma env present', () => {
+    const cfg = resolveVectorStoreConfig({
+      KB_VECTOR_STORE: 'pgvector',
+      VECTOR_DB_URL: 'postgres://x',
+      CHROMADB_URL: 'http://c:8000',
+    });
+    expect(cfg?.provider).toBe('pgvector');
+  });
+
+  it('returns undefined / hasVectorStoreEnv=false when nothing is configured', () => {
+    expect(resolveVectorStoreConfig({})).toBeUndefined();
+    expect(hasVectorStoreEnv({})).toBe(false);
+    expect(hasVectorStoreEnv({ CHROMADB_URL: 'http://c:8000' })).toBe(true);
+  });
+});
+
+describe('createVectorStore factory — real provider selection from env', () => {
+  it('builds a ChromaDBVectorStore from chromadb config (constructor only, no connection)', async () => {
+    const { createVectorStore } = await import('@tamma/intelligence/vector-store');
+    const cfg = resolveVectorStoreConfig({ CHROMADB_URL: 'http://localhost:8000' }, 1536);
+    expect(cfg).toBeDefined();
+    const store = createVectorStore(cfg!);
+    expect(store.constructor.name).toBe('ChromaDBVectorStore');
+  });
+
+  it('builds a PgVectorStore from pgvector config (constructor only, no connection)', async () => {
+    const { createVectorStore } = await import('@tamma/intelligence/vector-store');
+    const cfg = resolveVectorStoreConfig({ PGVECTOR_URL: 'postgres://u:p@h:5432/db' }, 1536);
+    expect(cfg).toBeDefined();
+    const store = createVectorStore(cfg!);
+    expect(store.constructor.name).toBe('PgVectorStore');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Embedder from env
+// ---------------------------------------------------------------------------
+
+describe('createEmbedderFromEnv', () => {
+  it('returns undefined for the openai default when no key is present (graceful)', async () => {
+    expect(await createEmbedderFromEnv({})).toBeUndefined();
+    expect(await createEmbedderFromEnv({ EMBEDDING_PROVIDER: 'openai' })).toBeUndefined();
+  });
+
+  it('builds a working embedder for EMBEDDING_PROVIDER=mock (no key, no network)', async () => {
+    const svc = await createEmbedderFromEnv({ EMBEDDING_PROVIDER: 'mock' });
+    expect(svc).toBeDefined();
+    const vec = await svc!.embed('hello world');
+    expect(Array.isArray(vec)).toBe(true);
+    expect(vec.length).toBeGreaterThan(0);
+  });
+
+  it('builds an OpenAI embedder when a key is present (init makes no network call)', async () => {
+    const svc = await createEmbedderFromEnv({
+      OPENAI_API_KEY: 'sk-test-not-real',
+      EMBEDDING_MODEL: 'text-embedding-3-small',
+    });
+    expect(svc).toBeDefined();
+    expect(svc!.getDimensions()).toBe(1536);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3a. Graceful degrade — no store env
+// ---------------------------------------------------------------------------
+
+describe('buildIntelligenceBundleFromEnv — graceful degrade when unconfigured', () => {
+  it('returns an empty bundle and undefined factories with no vector-store env', async () => {
+    expect(await buildIntelligenceBundleFromEnv({})).toEqual({});
+    expect(await createVectorStoreFromEnv({})).toBeUndefined();
+    expect(await createRagPipelineFromEnv({})).toBeUndefined();
+  });
+
+  it('server boots with the empty bundle and reports not_configured (no crash)', async () => {
+    const bundle = await buildIntelligenceBundleFromEnv({});
+    const app = await buildServer({ services: bundle });
+    await app.ready();
+
+    const status = await app.inject({ method: 'GET', url: '/kb/vector-db/status' });
+    expect(status.json().status).toBe('not_configured');
+
+    const stats = await app.inject({ method: 'GET', url: '/kb/vector-db/stats' });
+    expect(stats.json().totalVectors).toBe(0);
+
+    const health = await app.inject({ method: 'GET', url: '/health' });
+    expect(health.json()).toEqual({ status: 'ok' });
+
+    await app.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3b. Configured store — REAL data through the real wrapVectorStore bridge
+// ---------------------------------------------------------------------------
+
+interface StoredDoc {
+  id: string;
+  embedding: number[];
+  content: string;
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Minimal in-memory IVectorStore covering exactly the methods `wrapVectorStore`
+ * touches. Stands in for a real ChromaDB/pgvector when none is reachable, while
+ * still exercising the real adapter bridge + sidecar services end-to-end.
+ */
+function makeInMemoryStore() {
+  const collections = new Map<string, Map<string, StoredDoc>>();
+  const ensure = (name: string) => {
+    let c = collections.get(name);
+    if (!c) {
+      c = new Map();
+      collections.set(name, c);
+    }
+    return c;
+  };
+  return {
+    listCollections: async () => [...collections.keys()],
+    createCollection: async (name: string) => {
+      ensure(name);
+    },
+    deleteCollection: async (name: string) => {
+      collections.delete(name);
+    },
+    upsert: async (collection: string, docs: StoredDoc[]) => {
+      const c = ensure(collection);
+      for (const d of docs) c.set(d.id, d);
+    },
+    delete: async (collection: string, ids: string[]) => {
+      const c = collections.get(collection);
+      if (c) for (const id of ids) c.delete(id);
+    },
+    search: async (
+      collection: string,
+      query: { embedding: number[]; topK: number },
+    ) => {
+      const c = collections.get(collection);
+      if (!c) return [];
+      return [...c.values()]
+        .slice(0, query.topK)
+        .map((d) => ({ id: d.id, score: 1, content: d.content, metadata: d.metadata }));
+    },
+    hybridSearch: async (
+      collection: string,
+      query: { text: string; embedding: number[]; topK: number },
+    ) => {
+      const c = collections.get(collection);
+      if (!c) return [];
+      return [...c.values()]
+        .slice(0, query.topK)
+        .map((d) => ({ id: d.id, score: 1, content: d.content, metadata: d.metadata }));
+    },
+    getCollectionStats: async (name: string) => {
+      const c = collections.get(name);
+      const count = c?.size ?? 0;
+      const first = c ? [...c.values()][0] : undefined;
+      return {
+        name,
+        documentCount: count,
+        dimensions: first ? first.embedding.length : 1536,
+        indexSize: count * 16,
+      };
+    },
+  };
+}
+
+const fakeRag: IRagPipeline = {
+  retrieve: async () => ({
+    queryId: 'rag-1',
+    retrievedChunks: [
+      { content: 'chunk', source: 'vectorDb', score: 0.9, metadata: { file: 'a.ts' } },
+    ],
+    cacheHit: false,
+    latencyMs: 12,
+  }),
+  getCacheStats: () => ({ hits: 3, misses: 1, size: 4 }),
+  getFeedbackOverview: () => ({ totalFeedback: 0, averageRelevance: 0 }),
+  configure: () => undefined,
+};
+
+describe('configured store — endpoints return REAL data via wrapVectorStore', () => {
+  async function makeConfiguredApp() {
+    const store = makeInMemoryStore();
+    const embedder = await createEmbedderFromEnv({ EMBEDDING_PROVIDER: 'mock' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vectorStore = wrapVectorStore(store as any, embedder);
+    const bundle: IntelligenceServicesBundle = { vectorStore, ragPipeline: fakeRag };
+    const app = await buildServer({ services: bundle });
+    await app.ready();
+    return app;
+  }
+
+  it('reports ready and reflects real counts after an upsert op', async () => {
+    const app = await makeConfiguredApp();
+
+    const status = await app.inject({ method: 'GET', url: '/kb/vector-db/status' });
+    expect(status.json().status).toBe('ready');
+
+    const upsert = await app.inject({
+      method: 'POST',
+      url: '/kb/vector-db/upsert',
+      payload: {
+        collection: 'codebase',
+        documents: [
+          { id: 'd1', embedding: [0.1, 0.2, 0.3], content: 'alpha', metadata: { path: 'a.ts' } },
+          { id: 'd2', embedding: [0.4, 0.5, 0.6], content: 'beta', metadata: { path: 'b.ts' } },
+          { id: 'd3', embedding: [0.7, 0.8, 0.9], content: 'gamma', metadata: { path: 'c.ts' } },
+        ],
+      },
+    });
+    expect(upsert.statusCode).toBe(200);
+    expect(upsert.json().count).toBe(3);
+
+    const stats = await app.inject({ method: 'GET', url: '/kb/vector-db/stats' });
+    expect(stats.json().totalVectors).toBe(3);
+    expect(stats.json().dimensions).toBe(3);
+
+    const collections = await app.inject({ method: 'GET', url: '/kb/vector-db/collections' });
+    expect(collections.json()).toHaveLength(1);
+    expect(collections.json()[0].name).toBe('codebase');
+    expect(collections.json()[0].vectorCount).toBe(3);
+
+    await app.close();
+  });
+
+  it('text search returns real hits (embedding computed by the wired embedder)', async () => {
+    const app = await makeConfiguredApp();
+    await app.inject({
+      method: 'POST',
+      url: '/kb/vector-db/upsert',
+      payload: {
+        collection: 'codebase',
+        documents: [{ id: 'd1', embedding: [0.1, 0.2, 0.3], content: 'hello', metadata: {} }],
+      },
+    });
+
+    const search = await app.inject({
+      method: 'POST',
+      url: '/kb/vector-db/search',
+      payload: { collection: 'codebase', query: 'hello', topK: 5 },
+    });
+    expect(search.statusCode).toBe(200);
+    expect(search.json().results.length).toBeGreaterThanOrEqual(1);
+    expect(search.json().results[0].content).toBe('hello');
+
+    await app.close();
+  });
+
+  it('rag/metrics is non-stub when a pipeline is wired', async () => {
+    const app = await makeConfiguredApp();
+    await app.inject({ method: 'POST', url: '/kb/rag/query', payload: { query: 'x' } });
+    const metrics = await app.inject({ method: 'GET', url: '/kb/rag/metrics' });
+    expect(metrics.statusCode).toBe(200);
+    expect(metrics.json().queries).toBeGreaterThanOrEqual(1);
+    expect(metrics.json().cacheHitRate).toBeCloseTo(0.75, 2);
+    await app.close();
+  });
+
+  it('search surfaces a clear error when no embedder is configured', async () => {
+    const store = makeInMemoryStore();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vectorStore = wrapVectorStore(store as any, undefined);
+    const app = await buildServer({ services: { vectorStore } });
+    await app.ready();
+
+    // Non-embedding ops still work without an embedder…
+    const status = await app.inject({ method: 'GET', url: '/kb/vector-db/status' });
+    expect(status.json().status).toBe('ready');
+
+    // …but text search (which needs an embedding) rejects clearly.
+    const search = await app.inject({
+      method: 'POST',
+      url: '/kb/vector-db/search',
+      payload: { collection: 'codebase', query: 'hello' },
+    });
+    expect(search.statusCode).toBeGreaterThanOrEqual(500);
+
+    await app.close();
+  });
+});

--- a/packages/intelligence-server/src/__tests__/prod-import-graph.test.ts
+++ b/packages/intelligence-server/src/__tests__/prod-import-graph.test.ts
@@ -24,11 +24,12 @@
  *       anywhere in its reachable set (the chunker stays lazy).
  */
 
+import { execSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // ── Locate the built @tamma/intelligence package (deterministic path walk) ──
 const testFile = fileURLToPath(import.meta.url);
@@ -51,6 +52,31 @@ function resolveSubpath(subpath: string): string {
   if (!entry?.import) throw new Error(`No export for .${subpath} in @tamma/intelligence`);
   return path.resolve(intelDir, entry.import);
 }
+
+/** Repo root = the directory that contains `packages/`. */
+const repoRoot = path.resolve(packagesDir, '..');
+
+/** The dist entrypoints this test crawls; all must be compiled to exist. */
+const REQUIRED_DIST_ENTRIES = ['/embedding', '/vector-store', '/rag', '/indexer'];
+
+/**
+ * These assertions walk the COMPILED `dist` graph (type-only imports erased —
+ * the ground truth for what the runtime links). The CI `TypeScript Tests` job
+ * runs `pnpm vitest run` WITHOUT building workspace packages first (cross-package
+ * source imports resolve via vitest aliases, so no build is needed for the OTHER
+ * suites), which leaves `@tamma/intelligence`'s dist absent. So build it here on
+ * demand — idempotent (a no-op when the dist is already fresh) — rather than
+ * weakening the check to run against source (which would defeat the type-erasure
+ * ground truth). `tsc --build` also builds the referenced projects it needs.
+ */
+beforeAll(() => {
+  const built = REQUIRED_DIST_ENTRIES.every((subpath) => existsSync(resolveSubpath(subpath)));
+  if (built) return;
+  execSync('pnpm --filter @tamma/intelligence run build', {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+}, 180_000);
 
 /**
  * Extract the STATIC import/re-export/side-effect specifiers from a compiled

--- a/packages/intelligence-server/src/__tests__/prod-import-graph.test.ts
+++ b/packages/intelligence-server/src/__tests__/prod-import-graph.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Prod-pruned import-graph guard.
+ *
+ * This test catches a class of failure that is INVISIBLE to `tsc` and to normal
+ * unit tests: the sidecar's runtime image is built with `pnpm install --prod`,
+ * which prunes devDependencies. `typescript` is a devDependency of
+ * `@tamma/intelligence` (its prod deps are only `chromadb` + `pg`). If any module
+ * STATICALLY imported on the sidecar's boot path transitively value-imports
+ * `typescript`, `node dist/server.js` dies at ESM link time with
+ * `ERR_MODULE_NOT_FOUND: Cannot find package 'typescript'` — before any
+ * try/catch can degrade — and the container crash-loops.
+ *
+ * The offender was the `@tamma/intelligence/indexer` barrel, which re-exports the
+ * TypeScript chunker (`indexer/chunking/typescript-chunker.ts`, a value-import of
+ * `typescript`). The sidecar only needs `EmbeddingService`, so it now imports the
+ * narrow `@tamma/intelligence/embedding` subpath instead, and the chunker's
+ * `typescript` import was made lazy (`await import('typescript')`).
+ *
+ * These tests walk the COMPILED `dist` graph (where type-only imports are already
+ * erased — i.e. ground truth for what the runtime actually links) and assert:
+ *   (A) the subpaths the sidecar imports never statically reach `typescript` nor
+ *       the chunker; and
+ *   (B) even the full `./indexer` barrel has NO static `typescript` import
+ *       anywhere in its reachable set (the chunker stays lazy).
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// ── Locate the built @tamma/intelligence package (deterministic path walk) ──
+const testFile = fileURLToPath(import.meta.url);
+const marker = `${path.sep}packages${path.sep}`;
+const packagesDir = testFile.slice(0, testFile.lastIndexOf(marker)) + marker;
+const intelDir = path.join(packagesDir, 'intelligence');
+const intelPkg = JSON.parse(
+  readFileSync(path.join(intelDir, 'package.json'), 'utf8'),
+) as {
+  exports: Record<string, { import: string }>;
+  devDependencies?: Record<string, string>;
+};
+
+/** devDependencies are PRUNED from the `--prod` runtime image. */
+const intelDevDeps = new Set(Object.keys(intelPkg.devDependencies ?? {}));
+
+/** Resolve a `@tamma/intelligence/<subpath>` export to its built dist file. */
+function resolveSubpath(subpath: string): string {
+  const entry = intelPkg.exports[`.${subpath}`];
+  if (!entry?.import) throw new Error(`No export for .${subpath} in @tamma/intelligence`);
+  return path.resolve(intelDir, entry.import);
+}
+
+/**
+ * Extract the STATIC import/re-export/side-effect specifiers from a compiled
+ * (single-line-import) ES module. Dynamic `import('x')` is intentionally NOT
+ * matched — that is the lazy escape hatch and does not force link-time
+ * resolution.
+ */
+function staticSpecifiers(source: string): string[] {
+  const specs: string[] = [];
+  for (const line of source.split('\n')) {
+    const fromMatch = /^\s*(?:import|export)\b[^\n]*?\bfrom\s*["']([^"']+)["']/.exec(line);
+    if (fromMatch?.[1]) {
+      specs.push(fromMatch[1]);
+      continue;
+    }
+    const sideEffect = /^\s*import\s*["']([^"']+)["']\s*;?\s*$/.exec(line);
+    if (sideEffect?.[1]) specs.push(sideEffect[1]);
+  }
+  return specs;
+}
+
+interface CrawlResult {
+  /** Every dist file statically reachable from the entries. */
+  reachedFiles: Set<string>;
+  /** Every bare (non-relative) specifier seen anywhere in the reachable set. */
+  bareSpecifiers: Set<string>;
+}
+
+/**
+ * BFS the static import graph starting from `entries`, following ONLY relative
+ * specifiers (which keeps us inside the intelligence package's dist). Bare
+ * specifiers (`typescript`, `chromadb`, `@tamma/shared`, …) are recorded but not
+ * descended into — we only need to know whether `typescript` is ever pulled.
+ */
+function crawl(entries: string[]): CrawlResult {
+  const reachedFiles = new Set<string>();
+  const bareSpecifiers = new Set<string>();
+  const queue = [...entries];
+
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (reachedFiles.has(file)) continue;
+    reachedFiles.add(file);
+
+    if (!existsSync(file)) {
+      throw new Error(`Reached a dist file that does not exist (build stale?): ${file}`);
+    }
+    const source = readFileSync(file, 'utf8');
+    for (const spec of staticSpecifiers(source)) {
+      if (spec.startsWith('.')) {
+        queue.push(path.resolve(path.dirname(file), spec));
+      } else {
+        bareSpecifiers.add(spec);
+      }
+    }
+  }
+  return { reachedFiles, bareSpecifiers };
+}
+
+describe('prod import graph — the sidecar boot path never pulls `typescript`', () => {
+  it('(A) the subpaths the sidecar imports never reach the chunker or `typescript`', () => {
+    // Exactly the @tamma/intelligence entrypoints env-composition.ts imports.
+    const entries = ['/embedding', '/vector-store', '/rag'].map(resolveSubpath);
+    const { reachedFiles, bareSpecifiers } = crawl(entries);
+
+    expect(bareSpecifiers.has('typescript')).toBe(false);
+    const reachedChunker = [...reachedFiles].some((f) => f.includes('typescript-chunker'));
+    expect(reachedChunker).toBe(false);
+
+    // Generalise beyond `typescript`: NO pruned devDependency of
+    // @tamma/intelligence may be statically reachable from the sidecar boot path.
+    const leakedDevDeps = [...bareSpecifiers].filter((s) => intelDevDeps.has(s));
+    expect(leakedDevDeps).toEqual([]);
+  });
+
+  it('(B) even the full `./indexer` barrel has no STATIC `typescript` import (chunker is lazy)', () => {
+    const { reachedFiles, bareSpecifiers } = crawl([resolveSubpath('/indexer')]);
+
+    // Positive control: the crawler DOES reach the chunker via the barrel…
+    const reachedChunker = [...reachedFiles].some((f) => f.includes('typescript-chunker'));
+    expect(reachedChunker).toBe(true);
+
+    // …yet no reachable module statically links `typescript`.
+    expect(bareSpecifiers.has('typescript')).toBe(false);
+  });
+});
+
+describe('env-composition.ts wiring (source-level guard)', () => {
+  it('imports EmbeddingService from the narrow /embedding subpath, not the /indexer barrel', () => {
+    const envComp = readFileSync(
+      path.join(packagesDir, 'intelligence-server', 'src', 'env-composition.ts'),
+      'utf8',
+    );
+    // Ignore comments so a mention of `/indexer` in prose does not fail the test.
+    const code = envComp
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//'))
+      .join('\n');
+
+    expect(code).toContain("from '@tamma/intelligence/embedding'");
+    expect(code).not.toContain("from '@tamma/intelligence/indexer'");
+  });
+});

--- a/packages/intelligence-server/src/__tests__/startup-degrade.test.ts
+++ b/packages/intelligence-server/src/__tests__/startup-degrade.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Boot-time degrade guard for `startServer`.
+ *
+ * When a vector store IS configured (env present) but is UNREACHABLE at boot —
+ * e.g. the ChromaDB/pgvector host is down or a black hole — `store.initialize()`
+ * throws. The sidecar must NOT crash: `startServer` catches the failure, boots
+ * with an empty bundle, still binds `/health`, and reports `not_configured` so
+ * the C# proxy can render a "degraded" banner instead of a dead port.
+ *
+ * The reviewer flagged this degrade path as untested. We exercise the REAL
+ * `startServer` → `buildIntelligenceBundleFromEnv` path, mocking only the vector
+ * store factory so `initialize()` rejects deterministically (no network, no
+ * hang).
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+// Make the REAL `buildIntelligenceBundleFromEnv` construct a store that fails to
+// initialize. env-composition.ts calls `createVectorStore(config).initialize()`.
+vi.mock('@tamma/intelligence/vector-store', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    createVectorStore: () => ({
+      initialize: () => Promise.reject(new Error('vector store unreachable at boot')),
+    }),
+  };
+});
+
+import { startServer } from '../server.js';
+
+describe('startServer — degrades to not_configured when a configured store is unreachable at boot', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // A configured store (so buildIntelligenceBundleFromEnv attempts init) with
+    // no embedder key (default openai → undefined embedder, irrelevant here).
+    vi.stubEnv('CHROMADB_URL', 'http://black-hole.invalid:8000');
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    warnSpy.mockRestore();
+  });
+
+  it('boots (binds an ephemeral port), serves /health, and reports not_configured', async () => {
+    // port 0 → OS picks a free port; no fixed-port collision in CI.
+    const app = await startServer({ port: 0, host: '127.0.0.1' });
+    try {
+      const health = await app.inject({ method: 'GET', url: '/health' });
+      expect(health.json()).toEqual({ status: 'ok' });
+
+      const status = await app.inject({ method: 'GET', url: '/kb/vector-db/status' });
+      expect(status.json().status).toBe('not_configured');
+
+      // The degrade path logged its warning rather than crashing.
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/intelligence-server/src/adapters.ts
+++ b/packages/intelligence-server/src/adapters.ts
@@ -15,6 +15,12 @@
  *     ragPipeline: await createRagPipelineFromEnv(),
  *   };
  *   await startServer({ services: bundle });
+ *
+ * The concrete `createVectorStoreFromEnv` / `createRagPipelineFromEnv` (and the
+ * `buildIntelligenceBundleFromEnv` composition root that `startServer` calls)
+ * are implemented in `./env-composition.ts`, which imports the real ChromaDB /
+ * pgvector providers + OpenAI embedder from `@tamma/intelligence` and bridges
+ * them through the adapters below.
  */
 
 import type {

--- a/packages/intelligence-server/src/env-composition.ts
+++ b/packages/intelligence-server/src/env-composition.ts
@@ -1,0 +1,427 @@
+/**
+ * Environment-driven composition root for the intelligence sidecar.
+ *
+ * Turns process env into a live {@link IntelligenceServicesBundle}: it constructs
+ * a real `@tamma/intelligence` vector store (ChromaDB or pgvector) + an
+ * OpenAI-style embedder + a RAG pipeline, adapted to the narrow sidecar
+ * interfaces through {@link adaptVectorStore} / {@link adaptRagPipeline}.
+ *
+ * Degrades gracefully: when NO vector-store env is configured the factories
+ * return `undefined` / an empty bundle, so an unconfigured deployment still
+ * boots with the pre-existing `not_configured` stub behaviour. A configured
+ * store makes the `/kb/vector-db/*` (and, with an embedder, `/kb/rag/*`)
+ * endpoints return real data.
+ *
+ * Env vars consumed:
+ *   Vector store (pick one; ChromaDB wins if both present):
+ *     - CHROMADB_URL              e.g. http://chromadb:8000  (preferred)
+ *     - CHROMADB_HOST / CHROMADB_PORT
+ *     - CHROMADB_TEST_URL         (CI fallback)
+ *     - PGVECTOR_URL / VECTOR_DB_URL / KB_PGVECTOR_CONNECTION_STRING  (Postgres conn string)
+ *     - KB_VECTOR_STORE / VECTOR_STORE_PROVIDER = 'chromadb' | 'pgvector'  (explicit override)
+ *   Embedder (needed for text search + RAG; absent => those ops surface a clear error):
+ *     - OPENAI_API_KEY / EMBEDDING_API_KEY
+ *     - EMBEDDING_PROVIDER = 'openai' | 'cohere' | 'ollama' | 'local' | 'mock'  (default 'openai')
+ *     - EMBEDDING_MODEL           (default 'text-embedding-3-small')
+ *     - EMBEDDING_BASE_URL / OPENAI_BASE_URL
+ *     - EMBEDDING_DIMENSIONS      (informational; overridden by the provider's real dims)
+ *   RAG:
+ *     - KB_RAG_COLLECTION / KB_INDEX_COLLECTION  (default 'codebase')
+ */
+
+import {
+  createVectorStore,
+  type IVectorStore,
+  type VectorStoreConfig,
+  type ChromaDBConfig,
+  type CollectionOptions,
+  type VectorMetadata,
+} from '@tamma/intelligence/vector-store';
+import {
+  EmbeddingService,
+  type EmbeddingProviderType,
+  type EmbeddingProviderConfig,
+} from '@tamma/intelligence/indexer';
+import {
+  createRAGPipeline,
+  type RAGPipeline,
+  type RAGQuery,
+  type RAGConfig,
+  type RAGSourceType,
+} from '@tamma/intelligence/rag';
+
+import { adaptVectorStore, adaptRagPipeline } from './adapters.js';
+import type {
+  IVectorStoreAdapter,
+  IRagPipeline,
+  IntelligenceServicesBundle,
+} from './types.js';
+
+type Env = Record<string, string | undefined>;
+
+/** The exact `real` shape {@link adaptVectorStore} expects to bridge from. */
+type RealVectorStore = Parameters<typeof adaptVectorStore>[0];
+/** The exact `real` shape {@link adaptRagPipeline} expects to bridge from. */
+type RealRagPipeline = Parameters<typeof adaptRagPipeline>[0];
+
+const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
+const DEFAULT_EMBEDDING_DIMENSIONS = 1536;
+const DEFAULT_RAG_COLLECTION = 'codebase';
+
+/**
+ * Message thrown lazily when a text-search / RAG operation needs an embedder
+ * that was never configured (store env present but embedding key absent). This
+ * is the "clear failure if the key is absent" contract: non-embedding vector
+ * ops (status, stats, collections, upsert, delete) still work; text search and
+ * RAG surface this explicit error instead of silently returning empty results.
+ */
+export const EMBEDDER_MISSING_MESSAGE =
+  'KB embedding provider is not configured: set OPENAI_API_KEY (or EMBEDDING_API_KEY) ' +
+  'and optionally EMBEDDING_MODEL to enable vector text search and RAG retrieval.';
+
+// ---------------------------------------------------------------------------
+// Config resolution (pure — no network)
+// ---------------------------------------------------------------------------
+
+function resolveChromaEndpoint(env: Env): string | undefined {
+  return env['CHROMADB_URL'] ?? env['CHROMADB_TEST_URL'];
+}
+
+function resolvePgConnectionString(env: Env): string | undefined {
+  return (
+    env['KB_PGVECTOR_CONNECTION_STRING'] ??
+    env['PGVECTOR_URL'] ??
+    env['VECTOR_DB_URL']
+  );
+}
+
+/** Cheap predicate: is ANY vector-store backend configured in env? */
+export function hasVectorStoreEnv(env: Env = process.env): boolean {
+  return resolveVectorStoreConfig(env, DEFAULT_EMBEDDING_DIMENSIONS) !== undefined;
+}
+
+function resolveDimensions(env: Env): number {
+  const raw = env['EMBEDDING_DIMENSIONS'];
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_EMBEDDING_DIMENSIONS;
+}
+
+/**
+ * Resolve a {@link VectorStoreConfig} from env, or `undefined` when no backend
+ * is configured. ChromaDB is preferred (it is what docker-compose/CI provide);
+ * pgvector is used when a Postgres connection string is supplied. An explicit
+ * `KB_VECTOR_STORE` / `VECTOR_STORE_PROVIDER` overrides the inference.
+ */
+export function resolveVectorStoreConfig(
+  env: Env = process.env,
+  dimensions: number = DEFAULT_EMBEDDING_DIMENSIONS,
+): VectorStoreConfig | undefined {
+  const explicit = (env['KB_VECTOR_STORE'] ?? env['VECTOR_STORE_PROVIDER'])?.toLowerCase();
+
+  const chromaEndpoint = resolveChromaEndpoint(env);
+  const chromaHost = env['CHROMADB_HOST'];
+  const hasChroma = Boolean(chromaEndpoint || chromaHost);
+
+  const pgConn = resolvePgConnectionString(env);
+  const hasPg = Boolean(pgConn);
+
+  let provider: 'chromadb' | 'pgvector' | undefined;
+  if (explicit === 'chromadb' || explicit === 'pgvector') {
+    provider = explicit;
+  } else if (hasChroma) {
+    provider = 'chromadb';
+  } else if (hasPg) {
+    provider = 'pgvector';
+  }
+
+  if (provider === 'chromadb') {
+    if (!hasChroma) return undefined;
+    // chromadb v3's ChromaDBVectorStore accepts a full URL / host:port string
+    // via `persistPath`, and parses host/port/ssl from it. When only a bare
+    // host is supplied we set host+port explicitly (client mode).
+    const chromadb: ChromaDBConfig = {
+      persistPath: chromaEndpoint ?? '',
+      anonymizedTelemetry: false,
+    };
+    if (!chromaEndpoint && chromaHost) {
+      const port = env['CHROMADB_PORT'] ? Number.parseInt(env['CHROMADB_PORT'], 10) : 8000;
+      chromadb.host = chromaHost;
+      chromadb.port = port;
+      chromadb.persistPath = `${chromaHost}:${port}`;
+    }
+    return { provider: 'chromadb', dimensions, distanceMetric: 'cosine', chromadb };
+  }
+
+  if (provider === 'pgvector') {
+    if (!pgConn) return undefined;
+    return {
+      provider: 'pgvector',
+      dimensions,
+      distanceMetric: 'cosine',
+      pgvector: { connectionString: pgConn },
+    };
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Embedder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build + initialize an {@link EmbeddingService} from env, or `undefined` when
+ * a cloud provider is selected but no API key is present. `ollama`/`local`/
+ * `mock` providers need no key. Initialization is network-free for OpenAI (it
+ * only stores config), so this is cheap to call.
+ */
+export async function createEmbedderFromEnv(
+  env: Env = process.env,
+): Promise<EmbeddingService | undefined> {
+  const provider = (env['EMBEDDING_PROVIDER'] ?? 'openai').toLowerCase() as EmbeddingProviderType;
+  const apiKey = env['EMBEDDING_API_KEY'] ?? env['OPENAI_API_KEY'];
+  const needsKey = provider === 'openai' || provider === 'cohere';
+  if (needsKey && !apiKey) {
+    return undefined;
+  }
+
+  const providerConfig: EmbeddingProviderConfig = {
+    model: env['EMBEDDING_MODEL'] ?? DEFAULT_EMBEDDING_MODEL,
+  };
+  if (apiKey) providerConfig.apiKey = apiKey;
+  const baseUrl = env['EMBEDDING_BASE_URL'] ?? env['OPENAI_BASE_URL'];
+  if (baseUrl) providerConfig.baseUrl = baseUrl;
+
+  const service = new EmbeddingService({ provider, providerConfig });
+  await service.initialize();
+  return service;
+}
+
+// ---------------------------------------------------------------------------
+// Vector store adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge a concrete `@tamma/intelligence` {@link IVectorStore} to the narrow
+ * {@link IVectorStoreAdapter} the sidecar services consume, mapping the small
+ * shape differences (VectorDocument defaults, CollectionStats field names) and
+ * wiring the text→embedding function.
+ */
+export function wrapVectorStore(
+  store: IVectorStore,
+  embeddingService?: EmbeddingService,
+): IVectorStoreAdapter {
+  const embedText: (text: string) => Promise<number[]> = embeddingService
+    ? (text) => embeddingService.embed(text)
+    : () => Promise.reject(new Error(EMBEDDER_MISSING_MESSAGE));
+
+  const real: RealVectorStore = {
+    listCollections: () => store.listCollections(),
+    createCollection: (name, opts) =>
+      store.createCollection(name, opts as CollectionOptions | undefined),
+    deleteCollection: (name) => store.deleteCollection(name),
+    upsert: (collection, docs) =>
+      store.upsert(
+        collection,
+        docs.map((d) => ({
+          id: d.id,
+          embedding: d.embedding,
+          content: d.content ?? '',
+          metadata: (d.metadata ?? {}) as VectorMetadata,
+        })),
+      ),
+    delete: (collection, ids) => store.delete(collection, ids),
+    search: async (collection, query) => {
+      const results = await store.search(collection, {
+        embedding: query.embedding,
+        topK: query.topK,
+        includeContent: query.includeContent ?? true,
+        includeMetadata: query.includeMetadata ?? true,
+      });
+      return results.map((r) => ({
+        id: r.id,
+        score: r.score,
+        content: r.content ?? '',
+        metadata: r.metadata ?? {},
+      }));
+    },
+    hybridSearch: async (collection, query) => {
+      const results = await store.hybridSearch(collection, {
+        text: query.text,
+        embedding: query.embedding,
+        topK: query.topK,
+        includeContent: query.includeContent ?? true,
+        includeMetadata: query.includeMetadata ?? true,
+      });
+      return results.map((r) => ({
+        id: r.id,
+        score: r.score,
+        content: r.content ?? '',
+        metadata: r.metadata ?? {},
+      }));
+    },
+    getCollectionStats: async (name) => {
+      const stats = await store.getCollectionStats(name);
+      return {
+        vectorCount: stats.documentCount,
+        dimensions: stats.dimensions,
+        storageBytes: stats.indexSize ?? 0,
+      };
+    },
+  };
+
+  return adaptVectorStore(real, embedText);
+}
+
+// ---------------------------------------------------------------------------
+// RAG pipeline adapter
+// ---------------------------------------------------------------------------
+
+function wrapRagPipeline(pipeline: RAGPipeline): RealRagPipeline {
+  return {
+    retrieve: async (query, options) => {
+      const ragQuery: RAGQuery = { text: query.text };
+      if (query.maxResults !== undefined) ragQuery.topK = query.maxResults;
+      if (query.sources) ragQuery.sources = query.sources as RAGSourceType[];
+      const maxTokens = options?.['maxTokens'];
+      if (typeof maxTokens === 'number') ragQuery.maxTokens = maxTokens;
+
+      const result = await pipeline.retrieve(ragQuery);
+      return {
+        queryId: result.queryId,
+        retrievedChunks: result.retrievedChunks.map((chunk) => ({
+          content: chunk.content,
+          source: String(chunk.source),
+          score: chunk.score,
+          metadata: chunk.metadata as unknown as Record<string, unknown>,
+        })),
+        cacheHit: result.cacheHit,
+        latencyMs: result.latencyMs,
+      };
+    },
+    getCacheStats: () => {
+      const stats = pipeline.getCacheStats();
+      return { hits: stats.hits, misses: stats.misses, size: stats.hits + stats.misses };
+    },
+    getFeedbackOverview: () => {
+      const overview = pipeline.getFeedbackOverview();
+      return {
+        totalFeedback: overview.totalQueries,
+        averageRelevance: overview.avgHelpfulRate,
+      };
+    },
+    configure: (config) => {
+      void pipeline.configure(config as Partial<RAGConfig>);
+    },
+  };
+}
+
+/**
+ * Build + initialize a real {@link RAGPipeline} over the supplied store +
+ * embedder, adapted to the sidecar {@link IRagPipeline} interface.
+ */
+export async function buildRagPipeline(
+  store: IVectorStore,
+  embeddingService: EmbeddingService,
+  env: Env = process.env,
+): Promise<IRagPipeline> {
+  const collectionName =
+    env['KB_RAG_COLLECTION'] ?? env['KB_INDEX_COLLECTION'] ?? DEFAULT_RAG_COLLECTION;
+  const pipeline = createRAGPipeline();
+  await pipeline.initialize({ embeddingService, vectorStore: store, collectionName });
+  return adaptRagPipeline(wrapRagPipeline(pipeline));
+}
+
+// ---------------------------------------------------------------------------
+// Shared resource construction
+// ---------------------------------------------------------------------------
+
+interface EnvResources {
+  store: IVectorStore;
+  embeddingService: EmbeddingService | undefined;
+}
+
+/**
+ * Construct + initialize the raw store (and embedder, if configured) from env.
+ * Returns `undefined` when no vector-store backend is configured. Throws if a
+ * store IS configured but cannot be reached (callers decide whether to degrade).
+ */
+async function buildResourcesFromEnv(env: Env): Promise<EnvResources | undefined> {
+  if (!hasVectorStoreEnv(env)) {
+    return undefined;
+  }
+  const embeddingService = await createEmbedderFromEnv(env);
+  const dimensions = embeddingService?.getDimensions() ?? resolveDimensions(env);
+  const config = resolveVectorStoreConfig(env, dimensions);
+  if (!config) {
+    return undefined;
+  }
+  const store = createVectorStore(config);
+  await store.initialize();
+  return { store, embeddingService };
+}
+
+// ---------------------------------------------------------------------------
+// Public factories (referenced by adapters.ts JSDoc / used by startServer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a real vector-store adapter from env, or `undefined` when no store is
+ * configured. Opens its own store connection — prefer
+ * {@link buildIntelligenceBundleFromEnv} when you also want RAG, so the store
+ * is shared.
+ */
+export async function createVectorStoreFromEnv(
+  env: Env = process.env,
+): Promise<IVectorStoreAdapter | undefined> {
+  const resources = await buildResourcesFromEnv(env);
+  if (!resources) {
+    return undefined;
+  }
+  return wrapVectorStore(resources.store, resources.embeddingService);
+}
+
+/**
+ * Build a real RAG pipeline from env, or `undefined` when no store OR no
+ * embedder is configured (RAG retrieval fundamentally requires embeddings).
+ */
+export async function createRagPipelineFromEnv(
+  env: Env = process.env,
+): Promise<IRagPipeline | undefined> {
+  const resources = await buildResourcesFromEnv(env);
+  if (!resources || !resources.embeddingService) {
+    return undefined;
+  }
+  return buildRagPipeline(resources.store, resources.embeddingService, env);
+}
+
+/**
+ * The composition root used by `startServer`. Builds the store + embedder ONCE
+ * and shares them across the vector-store and RAG adapters. Returns an empty
+ * bundle (all endpoints degrade to `not_configured` stubs) when no vector-store
+ * env is configured.
+ */
+export async function buildIntelligenceBundleFromEnv(
+  env: Env = process.env,
+): Promise<IntelligenceServicesBundle> {
+  const resources = await buildResourcesFromEnv(env);
+  if (!resources) {
+    return {};
+  }
+  const bundle: IntelligenceServicesBundle = {
+    vectorStore: wrapVectorStore(resources.store, resources.embeddingService),
+  };
+  if (resources.embeddingService) {
+    bundle.ragPipeline = await buildRagPipeline(
+      resources.store,
+      resources.embeddingService,
+      env,
+    );
+  }
+  return bundle;
+}

--- a/packages/intelligence-server/src/env-composition.ts
+++ b/packages/intelligence-server/src/env-composition.ts
@@ -37,11 +37,17 @@ import {
   type CollectionOptions,
   type VectorMetadata,
 } from '@tamma/intelligence/vector-store';
+// Import EmbeddingService from the NARROW `/embedding` subpath — NOT the full
+// `/indexer` barrel. The barrel transitively value-imports `typescript` (a
+// devDependency of @tamma/intelligence, pruned in the `--prod` runtime image)
+// via the TypeScript chunker, which would fail ESM link-time resolution and
+// crash-loop `node dist/server.js` even with no vector-store env. The sidecar
+// never uses the chunker, so this subpath keeps the prod import graph clean.
 import {
   EmbeddingService,
   type EmbeddingProviderType,
   type EmbeddingProviderConfig,
-} from '@tamma/intelligence/indexer';
+} from '@tamma/intelligence/embedding';
 import {
   createRAGPipeline,
   type RAGPipeline,

--- a/packages/intelligence-server/src/index.ts
+++ b/packages/intelligence-server/src/index.ts
@@ -8,6 +8,17 @@
 
 export { buildServer, registerKbRoutes, startServer } from './server.js';
 export { adaptVectorStore, adaptRagPipeline } from './adapters.js';
+export {
+  buildIntelligenceBundleFromEnv,
+  createVectorStoreFromEnv,
+  createRagPipelineFromEnv,
+  createEmbedderFromEnv,
+  buildRagPipeline,
+  wrapVectorStore,
+  resolveVectorStoreConfig,
+  hasVectorStoreEnv,
+  EMBEDDER_MISSING_MESSAGE,
+} from './env-composition.js';
 export { IndexManagementService } from './services/IndexManagementService.js';
 export { VectorDbManagementService } from './services/VectorDbManagementService.js';
 export { RagManagementService } from './services/RagManagementService.js';

--- a/packages/intelligence-server/src/server.ts
+++ b/packages/intelligence-server/src/server.ts
@@ -18,6 +18,7 @@ import { RagManagementService } from './services/RagManagementService.js';
 import { McpManagementService } from './services/McpManagementService.js';
 import { ContextTestingService } from './services/ContextTestingService.js';
 import { AnalyticsService } from './services/AnalyticsService.js';
+import { buildIntelligenceBundleFromEnv } from './env-composition.js';
 import type { IntelligenceServicesBundle } from './types.js';
 
 export interface BuildServerOptions {
@@ -199,7 +200,25 @@ export async function startServer(opts: {
   host?: string;
   services?: IntelligenceServicesBundle;
 } = {}): Promise<FastifyInstance> {
-  const app = await buildServer({ ...(opts.services ? { services: opts.services } : {}) });
+  // Compose the real service bundle from env (ChromaDB/pgvector + embedder +
+  // RAG). When no vector-store env is configured this returns an empty bundle
+  // and every endpoint keeps its `not_configured` stub behaviour. When a store
+  // IS configured but unreachable at boot, degrade to stubs rather than crash
+  // so the sidecar still serves /health and the C# proxy can render a banner.
+  let services = opts.services;
+  if (!services) {
+    try {
+      services = await buildIntelligenceBundleFromEnv();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[intelligence-server] failed to build services from env; booting in not_configured mode:',
+        err instanceof Error ? err.message : err,
+      );
+      services = {};
+    }
+  }
+  const app = await buildServer({ services });
   const port = opts.port ?? Number.parseInt(process.env['INTELLIGENCE_PORT'] ?? '4100', 10);
   const host = opts.host ?? process.env['INTELLIGENCE_HOST'] ?? '0.0.0.0';
   await app.listen({ port, host });

--- a/packages/intelligence-server/tsconfig.json
+++ b/packages/intelligence-server/tsconfig.json
@@ -7,7 +7,8 @@
     "tsBuildInfoFile": "./dist/.tsbuildinfo"
   },
   "references": [
-    { "path": "../shared" }
+    { "path": "../shared" },
+    { "path": "../intelligence" }
   ],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/packages/intelligence/package.json
+++ b/packages/intelligence/package.json
@@ -18,6 +18,10 @@
       "types": "./dist/indexer/index.d.ts",
       "import": "./dist/indexer/index.js"
     },
+    "./embedding": {
+      "types": "./dist/indexer/embedding/index.d.ts",
+      "import": "./dist/indexer/embedding/index.js"
+    },
     "./knowledge-base": {
       "types": "./dist/knowledge-base/index.d.ts",
       "import": "./dist/knowledge-base/index.js"
@@ -41,7 +45,6 @@
   },
   "dependencies": {
     "@tamma/observability": "workspace:*",
-    "@tamma/providers": "workspace:*",
     "@tamma/shared": "workspace:*",
     "chromadb": "^3.4.3",
     "pg": "^8.20.0"

--- a/packages/intelligence/src/index.ts
+++ b/packages/intelligence/src/index.ts
@@ -19,6 +19,12 @@ export * from './knowledge-base/index.js';
 // RAG Pipeline Module
 export * from './rag/index.js';
 
+// Disambiguate names exported by more than one of the modules above.
+// An explicit named re-export takes precedence over `export *`, resolving TS2308.
+export { InvalidConfigError, NotInitializedError } from './vector-store/index.js';
+export { EmbeddingError } from './indexer/index.js';
+export type { IEmbeddingProvider } from './indexer/index.js';
+
 // Context Aggregator Module
 // Re-export with explicit names to avoid conflicts with rag/vector-store modules
 export type {

--- a/packages/intelligence/src/indexer/chunking/base-chunker.ts
+++ b/packages/intelligence/src/indexer/chunking/base-chunker.ts
@@ -53,7 +53,7 @@ export abstract class BaseChunker implements ICodeChunker {
       parentScope?: string;
       imports?: string[];
       exports?: string[];
-      docstring?: string;
+      docstring?: string | undefined;
     },
   ): CodeChunk {
     const hash = calculateHash(content);
@@ -100,7 +100,7 @@ export abstract class BaseChunker implements ICodeChunker {
     let overlapLines: string[] = [];
 
     for (let i = 0; i < lines.length; i++) {
-      currentChunkLines.push(lines[i]);
+      currentChunkLines.push(lines[i]!);
       const currentContent = currentChunkLines.join('\n');
       const currentTokens = this.estimateTokens(currentContent);
 
@@ -120,12 +120,12 @@ export abstract class BaseChunker implements ICodeChunker {
         overlapLines = [];
         let overlapTokenCount = 0;
         for (let j = currentChunkLines.length - 1; j >= 0 && overlapTokenCount < overlapTokens; j--) {
-          overlapLines.unshift(currentChunkLines[j]);
+          overlapLines.unshift(currentChunkLines[j]!);
           overlapTokenCount = this.estimateTokens(overlapLines.join('\n'));
         }
 
         // Start new chunk with overlap + current line
-        currentChunkLines = [...overlapLines, lines[i]];
+        currentChunkLines = [...overlapLines, lines[i]!];
         currentChunkStart = currentChunkStart + (currentChunkLines.length - overlapLines.length - 1);
       }
     }

--- a/packages/intelligence/src/indexer/chunking/generic-chunker.ts
+++ b/packages/intelligence/src/indexer/chunking/generic-chunker.ts
@@ -128,7 +128,7 @@ export class GenericChunker extends BaseChunker {
     name?: string;
     startLine: number;
     endLine: number;
-    docstring?: string;
+    docstring?: string | undefined;
   }> {
     const lines = content.split('\n');
     const sections: Array<{
@@ -136,7 +136,7 @@ export class GenericChunker extends BaseChunker {
       name?: string;
       startLine: number;
       endLine: number;
-      docstring?: string;
+      docstring?: string | undefined;
     }> = [];
 
     // Language-specific patterns
@@ -144,7 +144,7 @@ export class GenericChunker extends BaseChunker {
 
     let i = 0;
     while (i < lines.length) {
-      const line = lines[i];
+      const line = lines[i]!;
       const lineNumber = i + 1;
 
       // Check for function/class definitions
@@ -247,7 +247,7 @@ export class GenericChunker extends BaseChunker {
    * Find end of Python indentation-based block
    */
   private findPythonBlockEnd(lines: string[], startIndex: number): number {
-    const startLine = lines[startIndex];
+    const startLine = lines[startIndex]!;
     const startIndent = this.getIndentation(startLine);
 
     // Find the colon that starts the block
@@ -259,7 +259,7 @@ export class GenericChunker extends BaseChunker {
 
     // Look for the first line with content at the block's indentation level
     for (let i = startIndex + 1; i < lines.length; i++) {
-      const line = lines[i];
+      const line = lines[i]!;
       const trimmed = line.trim();
 
       // Skip empty lines and comments
@@ -286,7 +286,7 @@ export class GenericChunker extends BaseChunker {
     let foundOpenBrace = false;
 
     for (let i = startIndex; i < lines.length; i++) {
-      const line = lines[i];
+      const line = lines[i]!;
 
       // Count braces, ignoring strings and comments
       for (const char of line) {
@@ -311,7 +311,7 @@ export class GenericChunker extends BaseChunker {
   private getIndentation(line: string): number {
     const match = line.match(/^(\s*)/);
     if (!match) return 0;
-    const spaces = match[1];
+    const spaces = match[1]!;
     // Convert tabs to 4 spaces
     return spaces.replace(/\t/g, '    ').length;
   }
@@ -359,7 +359,7 @@ export class GenericChunker extends BaseChunker {
   /**
    * Extract Python docstring (triple-quoted string)
    */
-  private extractPythonDocstring(lines: string[], startIndex: number): string | undefined {
+  private extractPythonDocstring(_lines: string[], _startIndex: number): string | undefined {
     // Check for docstring in the line after the definition
     // Python docstrings are inside the function
     return undefined;
@@ -373,7 +373,7 @@ export class GenericChunker extends BaseChunker {
     let i = startIndex;
 
     while (i >= 0) {
-      const line = lines[i].trim();
+      const line = lines[i]!.trim();
       if (line.startsWith('//')) {
         comments.unshift(line.slice(2).trim());
         i--;
@@ -395,7 +395,7 @@ export class GenericChunker extends BaseChunker {
     let i = startIndex;
 
     while (i >= 0) {
-      const line = lines[i].trim();
+      const line = lines[i]!.trim();
       if (line.startsWith('///')) {
         comments.unshift(line.slice(3).trim());
         i--;
@@ -422,7 +422,7 @@ export class GenericChunker extends BaseChunker {
     const commentLines: string[] = [];
 
     while (i >= 0) {
-      const line = lines[i].trim();
+      const line = lines[i]!.trim();
 
       if (line.endsWith('*/') && !inComment) {
         inComment = true;

--- a/packages/intelligence/src/indexer/chunking/typescript-chunker.ts
+++ b/packages/intelligence/src/indexer/chunking/typescript-chunker.ts
@@ -3,9 +3,19 @@
  *
  * Uses the TypeScript compiler API to parse and chunk TypeScript and JavaScript files
  * into semantic units (functions, classes, interfaces, etc.).
+ *
+ * NOTE: `typescript` is a devDependency of @tamma/intelligence and is pruned from
+ * the `--prod` runtime image (e.g. the intelligence sidecar). It is therefore
+ * imported LAZILY, via `await import('typescript')` inside {@link TypeScriptChunker.chunk},
+ * rather than as a top-level value import. This keeps merely *importing* the
+ * `./indexer` barrel (or any module that re-exports this class) safe on a
+ * prod-pruned graph: `typescript` is only required when a file is actually
+ * chunked, which never happens on the KB HTTP sidecar's boot path. The top-level
+ * import below is `import type`, so it is erased at compile time and creates no
+ * runtime dependency.
  */
 
-import * as ts from 'typescript';
+import type * as ts from 'typescript';
 import { BaseChunker } from './base-chunker.js';
 import type {
   CodeChunk,
@@ -13,6 +23,22 @@ import type {
   SupportedLanguage,
   ChunkType,
 } from '../types.js';
+
+/** The runtime shape of the lazily-loaded `typescript` module. */
+type TsModule = typeof import('typescript');
+
+/**
+ * Memoized lazy loader for the `typescript` compiler API. Importing this module
+ * (and therefore the `./indexer` barrel) does NOT require `typescript` to be
+ * installed; it is only resolved on first chunk of a TS/JS file.
+ */
+let tsModulePromise: Promise<TsModule> | undefined;
+function loadTypeScript(): Promise<TsModule> {
+  if (!tsModulePromise) {
+    tsModulePromise = import('typescript');
+  }
+  return tsModulePromise;
+}
 
 /**
  * Extract information from a TypeScript AST node
@@ -43,20 +69,25 @@ export class TypeScriptChunker extends BaseChunker {
     fileId: string,
     strategy: ChunkingStrategy,
   ): Promise<CodeChunk[]> {
+    // Lazily resolve the compiler API. See the module-level note: `typescript`
+    // is a devDependency and may be absent in a prod-pruned runtime image, so we
+    // only load it when a file is actually chunked.
+    const tsm = await loadTypeScript();
+
     const chunks: CodeChunk[] = [];
     let chunkIndex = 0;
 
     // Parse the content using TypeScript compiler API
-    const sourceFile = ts.createSourceFile(
+    const sourceFile = tsm.createSourceFile(
       filePath,
       content,
-      ts.ScriptTarget.Latest,
+      tsm.ScriptTarget.Latest,
       true, // setParentNodes
-      this.getScriptKind(filePath),
+      this.getScriptKind(tsm, filePath),
     );
 
     // Extract imports
-    const imports = this.extractImports(sourceFile);
+    const imports = this.extractImports(tsm, sourceFile);
 
     // Create imports chunk if preserveImports is enabled
     if (strategy.preserveImports && imports.content) {
@@ -79,7 +110,7 @@ export class TypeScriptChunker extends BaseChunker {
     }
 
     // Extract top-level declarations
-    const declarations = this.extractDeclarations(sourceFile, content);
+    const declarations = this.extractDeclarations(tsm, sourceFile, content);
 
     // Group small declarations if enabled
     const groupedDeclarations = strategy.groupRelatedCode
@@ -189,28 +220,28 @@ export class TypeScriptChunker extends BaseChunker {
   /**
    * Get TypeScript script kind from file extension
    */
-  private getScriptKind(filePath: string): ts.ScriptKind {
+  private getScriptKind(tsm: TsModule, filePath: string): ts.ScriptKind {
     const ext = filePath.toLowerCase().split('.').pop();
     switch (ext) {
       case 'ts':
-        return ts.ScriptKind.TS;
+        return tsm.ScriptKind.TS;
       case 'tsx':
-        return ts.ScriptKind.TSX;
+        return tsm.ScriptKind.TSX;
       case 'js':
       case 'mjs':
       case 'cjs':
-        return ts.ScriptKind.JS;
+        return tsm.ScriptKind.JS;
       case 'jsx':
-        return ts.ScriptKind.JSX;
+        return tsm.ScriptKind.JSX;
       default:
-        return ts.ScriptKind.TS;
+        return tsm.ScriptKind.TS;
     }
   }
 
   /**
    * Extract import statements from source file
    */
-  private extractImports(sourceFile: ts.SourceFile): {
+  private extractImports(tsm: TsModule, sourceFile: ts.SourceFile): {
     content: string;
     modules: string[];
     startLine: number;
@@ -221,20 +252,20 @@ export class TypeScriptChunker extends BaseChunker {
     const modules: string[] = [];
     let endPosition = 0;
 
-    ts.forEachChild(sourceFile, (node) => {
-      if (ts.isImportDeclaration(node)) {
+    tsm.forEachChild(sourceFile, (node) => {
+      if (tsm.isImportDeclaration(node)) {
         imports.push(node);
         endPosition = Math.max(endPosition, node.end);
 
         // Extract module specifier
-        if (node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+        if (node.moduleSpecifier && tsm.isStringLiteral(node.moduleSpecifier)) {
           modules.push(node.moduleSpecifier.text);
         }
       } else if (
-        ts.isImportEqualsDeclaration(node) ||
-        (ts.isExpressionStatement(node) &&
-          ts.isCallExpression(node.expression) &&
-          ts.isIdentifier(node.expression.expression) &&
+        tsm.isImportEqualsDeclaration(node) ||
+        (tsm.isExpressionStatement(node) &&
+          tsm.isCallExpression(node.expression) &&
+          tsm.isIdentifier(node.expression.expression) &&
           node.expression.expression.text === 'require')
       ) {
         imports.push(node);
@@ -260,23 +291,24 @@ export class TypeScriptChunker extends BaseChunker {
    * Extract top-level declarations from source file
    */
   private extractDeclarations(
+    tsm: TsModule,
     sourceFile: ts.SourceFile,
     _content: string,
   ): NodeInfo[] {
     const declarations: NodeInfo[] = [];
 
     const visit = (node: ts.Node, parentName?: string) => {
-      const nodeInfo = this.getNodeInfo(node, sourceFile, parentName);
+      const nodeInfo = this.getNodeInfo(tsm, node, sourceFile, parentName);
       if (nodeInfo) {
         declarations.push(nodeInfo);
       }
 
       // For classes, also extract methods
-      if (ts.isClassDeclaration(node) && node.name) {
+      if (tsm.isClassDeclaration(node) && node.name) {
         const className = node.name.text;
         node.members.forEach((member) => {
-          if (ts.isMethodDeclaration(member) || ts.isPropertyDeclaration(member)) {
-            const memberInfo = this.getNodeInfo(member, sourceFile, className);
+          if (tsm.isMethodDeclaration(member) || tsm.isPropertyDeclaration(member)) {
+            const memberInfo = this.getNodeInfo(tsm, member, sourceFile, className);
             if (memberInfo && this.estimateTokens(memberInfo.content) > 100) {
               // Only extract large methods/properties separately
               declarations.push(memberInfo);
@@ -286,7 +318,7 @@ export class TypeScriptChunker extends BaseChunker {
       }
     };
 
-    ts.forEachChild(sourceFile, (node) => visit(node));
+    tsm.forEachChild(sourceFile, (node) => visit(node));
 
     return declarations;
   }
@@ -295,6 +327,7 @@ export class TypeScriptChunker extends BaseChunker {
    * Get information about a node
    */
   private getNodeInfo(
+    tsm: TsModule,
     node: ts.Node,
     sourceFile: ts.SourceFile,
     _parentScope?: string,
@@ -305,34 +338,34 @@ export class TypeScriptChunker extends BaseChunker {
     const exports: string[] = [];
 
     // Check for export modifiers
-    if (ts.canHaveModifiers(node)) {
-      const modifiers = ts.getModifiers(node);
+    if (tsm.canHaveModifiers(node)) {
+      const modifiers = tsm.getModifiers(node);
       if (modifiers) {
         isExported = modifiers.some(
           (m) =>
-            m.kind === ts.SyntaxKind.ExportKeyword ||
-            m.kind === ts.SyntaxKind.DefaultKeyword,
+            m.kind === tsm.SyntaxKind.ExportKeyword ||
+            m.kind === tsm.SyntaxKind.DefaultKeyword,
         );
       }
     }
 
     // Function declarations
-    if (ts.isFunctionDeclaration(node)) {
+    if (tsm.isFunctionDeclaration(node)) {
       name = node.name?.text ?? 'anonymous';
       chunkType = 'function';
       if (isExported) exports.push(name);
     }
     // Arrow functions / function expressions assigned to variables
-    else if (ts.isVariableStatement(node)) {
+    else if (tsm.isVariableStatement(node)) {
       const declarations = node.declarationList.declarations;
       if (declarations.length > 0) {
         const decl = declarations[0]!;
-        if (ts.isIdentifier(decl.name)) {
+        if (tsm.isIdentifier(decl.name)) {
           name = decl.name.text;
           if (decl.initializer) {
             if (
-              ts.isArrowFunction(decl.initializer) ||
-              ts.isFunctionExpression(decl.initializer)
+              tsm.isArrowFunction(decl.initializer) ||
+              tsm.isFunctionExpression(decl.initializer)
             ) {
               chunkType = 'function';
             }
@@ -342,43 +375,43 @@ export class TypeScriptChunker extends BaseChunker {
       }
     }
     // Class declarations
-    else if (ts.isClassDeclaration(node)) {
+    else if (tsm.isClassDeclaration(node)) {
       name = node.name?.text ?? 'anonymous';
       chunkType = 'class';
       if (isExported) exports.push(name);
     }
     // Interface declarations
-    else if (ts.isInterfaceDeclaration(node)) {
+    else if (tsm.isInterfaceDeclaration(node)) {
       name = node.name.text;
       chunkType = 'interface';
       if (isExported) exports.push(name);
     }
     // Type alias declarations
-    else if (ts.isTypeAliasDeclaration(node)) {
+    else if (tsm.isTypeAliasDeclaration(node)) {
       name = node.name.text;
       chunkType = 'type';
       if (isExported) exports.push(name);
     }
     // Enum declarations
-    else if (ts.isEnumDeclaration(node)) {
+    else if (tsm.isEnumDeclaration(node)) {
       name = node.name.text;
       chunkType = 'enum';
       if (isExported) exports.push(name);
     }
     // Method declarations (within classes)
-    else if (ts.isMethodDeclaration(node)) {
-      if (ts.isIdentifier(node.name)) {
+    else if (tsm.isMethodDeclaration(node)) {
+      if (tsm.isIdentifier(node.name)) {
         name = node.name.text;
       }
       chunkType = 'function';
     }
     // Export declarations
-    else if (ts.isExportDeclaration(node)) {
+    else if (tsm.isExportDeclaration(node)) {
       // Skip export declarations, they're typically re-exports
       return null;
     }
     // Import declarations - skip
-    else if (ts.isImportDeclaration(node)) {
+    else if (tsm.isImportDeclaration(node)) {
       return null;
     }
     // Other statements - skip small ones
@@ -393,7 +426,7 @@ export class TypeScriptChunker extends BaseChunker {
     const content = sourceFile.text.slice(startPos, endPos).trim();
 
     // Extract JSDoc comment if present
-    const jsDocComment = this.extractJSDoc(node, sourceFile);
+    const jsDocComment = this.extractJSDoc(tsm, node, sourceFile);
 
     return {
       name,
@@ -410,10 +443,10 @@ export class TypeScriptChunker extends BaseChunker {
   /**
    * Extract JSDoc comment from a node
    */
-  private extractJSDoc(node: ts.Node, sourceFile: ts.SourceFile): string | undefined {
+  private extractJSDoc(tsm: TsModule, node: ts.Node, sourceFile: ts.SourceFile): string | undefined {
     const fullText = sourceFile.text;
     const nodeStart = node.getFullStart();
-    const leadingComments = ts.getLeadingCommentRanges(fullText, nodeStart);
+    const leadingComments = tsm.getLeadingCommentRanges(fullText, nodeStart);
 
     if (!leadingComments || leadingComments.length === 0) {
       return undefined;

--- a/packages/intelligence/src/indexer/chunking/typescript-chunker.ts
+++ b/packages/intelligence/src/indexer/chunking/typescript-chunker.ts
@@ -13,7 +13,6 @@ import type {
   SupportedLanguage,
   ChunkType,
 } from '../types.js';
-import { ParseError } from '../errors.js';
 
 /**
  * Extract information from a TypeScript AST node
@@ -24,7 +23,7 @@ interface NodeInfo {
   startLine: number;
   endLine: number;
   content: string;
-  docstring?: string;
+  docstring?: string | undefined;
   exports: string[];
   isExported: boolean;
 }
@@ -89,8 +88,8 @@ export class TypeScriptChunker extends BaseChunker {
 
     // Create chunks for each declaration or group
     for (const group of groupedDeclarations) {
-      const firstDecl = group[0];
-      const lastDecl = group[group.length - 1];
+      const firstDecl = group[0]!;
+      const lastDecl = group[group.length - 1]!;
 
       // Combine content for grouped declarations
       const combinedContent = group.map(d => d.content).join('\n\n');
@@ -158,7 +157,7 @@ export class TypeScriptChunker extends BaseChunker {
     }
 
     // If no declarations found, create a single module chunk
-    if (chunks.length === 0 || (chunks.length === 1 && chunks[0].chunkType === 'imports')) {
+    if (chunks.length === 0 || (chunks.length === 1 && chunks[0]!.chunkType === 'imports')) {
       const moduleContent = strategy.preserveImports
         ? content.slice(imports.endPosition).trim()
         : content;
@@ -247,8 +246,8 @@ export class TypeScriptChunker extends BaseChunker {
       return { content: '', modules: [], startLine: 0, endLine: 0, endPosition: 0 };
     }
 
-    const firstImport = imports[0];
-    const lastImport = imports[imports.length - 1];
+    const firstImport = imports[0]!;
+    const lastImport = imports[imports.length - 1]!;
     const startLine = sourceFile.getLineAndCharacterOfPosition(firstImport.pos).line + 1;
     const endLine = sourceFile.getLineAndCharacterOfPosition(lastImport.end).line + 1;
 
@@ -298,7 +297,7 @@ export class TypeScriptChunker extends BaseChunker {
   private getNodeInfo(
     node: ts.Node,
     sourceFile: ts.SourceFile,
-    parentScope?: string,
+    _parentScope?: string,
   ): NodeInfo | null {
     let name = 'anonymous';
     let chunkType: ChunkType = 'block';
@@ -327,7 +326,7 @@ export class TypeScriptChunker extends BaseChunker {
     else if (ts.isVariableStatement(node)) {
       const declarations = node.declarationList.declarations;
       if (declarations.length > 0) {
-        const decl = declarations[0];
+        const decl = declarations[0]!;
         if (ts.isIdentifier(decl.name)) {
           name = decl.name.text;
           if (decl.initializer) {
@@ -422,7 +421,7 @@ export class TypeScriptChunker extends BaseChunker {
 
     // Find the last JSDoc comment before the node
     for (let i = leadingComments.length - 1; i >= 0; i--) {
-      const comment = leadingComments[i];
+      const comment = leadingComments[i]!;
       const commentText = fullText.slice(comment.pos, comment.end);
 
       if (commentText.startsWith('/**')) {

--- a/packages/intelligence/src/indexer/codebase-indexer.ts
+++ b/packages/intelligence/src/indexer/codebase-indexer.ts
@@ -24,18 +24,15 @@ import type {
   IndexerEventType,
   ChunkingStrategy,
 } from './types.js';
-import { DEFAULT_INDEXER_CONFIG, mergeConfig, validateConfig } from './config.js';
+import { mergeConfig, validateConfig } from './config.js';
 import { FileDiscovery, createFileDiscovery, createGitDiffDetector } from './discovery/index.js';
-import type { GitDiffDetector } from './discovery/index.js';
 import { ChunkerFactory, chunkerFactory } from './chunking/index.js';
 import { EmbeddingService, type EmbeddingServiceConfig } from './embedding/index.js';
 import {
   generateFileId,
   calculateHash,
-  calculateFileHash,
 } from './metadata/index.js';
 import {
-  IndexerError,
   FileReadError,
   NotInitializedError,
   OperationCancelledError,
@@ -228,7 +225,7 @@ export class CodebaseIndexer implements ICodebaseIndexer {
           throw new OperationCancelledError('indexProject');
         }
 
-        const file = files[i];
+        const file = files[i]!;
         this.emitProgress({
           phase: 'chunking',
           filesTotal: files.length,
@@ -541,7 +538,7 @@ export class CodebaseIndexer implements ICodebaseIndexer {
   /**
    * Clear the entire index for a project
    */
-  async clearIndex(projectPath: string): Promise<void> {
+  async clearIndex(_projectPath: string): Promise<void> {
     if (this.vectorStore) {
       const exists = await this.vectorStore.collectionExists(this.collectionName);
       if (exists) {
@@ -749,7 +746,7 @@ export class CodebaseIndexer implements ICodebaseIndexer {
    */
   private async processFile(
     file: DiscoveredFile,
-    projectPath: string,
+    _projectPath: string,
   ): Promise<CodeChunk[]> {
     // Read file content
     let content: string;
@@ -830,10 +827,10 @@ export class CodebaseIndexer implements ICodebaseIndexer {
       name: chunk.name,
       startLine: chunk.startLine,
       endLine: chunk.endLine,
-      parentScope: chunk.parentScope,
+      ...(chunk.parentScope !== undefined ? { parentScope: chunk.parentScope } : {}),
       imports: chunk.imports,
       exports: chunk.exports,
-      docstring: chunk.docstring,
+      ...(chunk.docstring !== undefined ? { docstring: chunk.docstring } : {}),
       hash: chunk.hash,
       indexedAt: chunk.indexedAt.toISOString(),
     };
@@ -851,7 +848,7 @@ export class CodebaseIndexer implements ICodebaseIndexer {
    */
   private async filterChangedFiles(
     files: DiscoveredFile[],
-    projectPath: string,
+    _projectPath: string,
   ): Promise<DiscoveredFile[]> {
     const changedFiles: DiscoveredFile[] = [];
 

--- a/packages/intelligence/src/indexer/discovery/file-discovery.ts
+++ b/packages/intelligence/src/indexer/discovery/file-discovery.ts
@@ -244,7 +244,7 @@ export class FileDiscovery {
 
     let i = 0;
     while (i < pattern.length) {
-      const char = pattern[i];
+      const char = pattern[i]!;
 
       if (char === '*') {
         if (pattern[i + 1] === '*') {

--- a/packages/intelligence/src/indexer/discovery/git-diff-detector.ts
+++ b/packages/intelligence/src/indexer/discovery/git-diff-detector.ts
@@ -194,8 +194,8 @@ export class GitDiffDetector {
       const parts = trimmed.split('\t');
       if (parts.length < 2) continue;
 
-      const statusCode = parts[0].charAt(0);
-      const filePath = parts[1];
+      const statusCode = parts[0]!.charAt(0);
+      const filePath = parts[1]!;
 
       let changeType: ChangeType;
       switch (statusCode) {

--- a/packages/intelligence/src/indexer/discovery/gitignore-parser.ts
+++ b/packages/intelligence/src/indexer/discovery/gitignore-parser.ts
@@ -149,7 +149,7 @@ export class GitignoreParser {
     // Escape special regex characters except * and ?
     let i = 0;
     while (i < pattern.length) {
-      const char = pattern[i];
+      const char = pattern[i]!;
 
       if (char === '*') {
         // Check for **

--- a/packages/intelligence/src/indexer/embedding/cohere-embedding-provider.ts
+++ b/packages/intelligence/src/indexer/embedding/cohere-embedding-provider.ts
@@ -98,7 +98,7 @@ export class CohereEmbeddingProvider extends BaseEmbeddingProvider {
     this.ensureInitialized();
 
     const embeddings = await this.embedBatch([text]);
-    return embeddings[0];
+    return embeddings[0]!;
   }
 
   /**

--- a/packages/intelligence/src/indexer/embedding/embedding-service.ts
+++ b/packages/intelligence/src/indexer/embedding/embedding-service.ts
@@ -15,7 +15,7 @@ import { OpenAIEmbeddingProvider } from './openai-embedding-provider.js';
 import { CohereEmbeddingProvider } from './cohere-embedding-provider.js';
 import { OllamaEmbeddingProvider } from './ollama-embedding-provider.js';
 import { MockEmbeddingProvider } from './mock-embedding-provider.js';
-import { EmbeddingError, EmbeddingRateLimitError } from '../errors.js';
+import { EmbeddingError } from '../errors.js';
 import { calculateHash } from '../metadata/hash-calculator.js';
 
 /**
@@ -156,16 +156,16 @@ export class EmbeddingService {
     // Check cache for each text
     if (this.config.enableCache) {
       for (let i = 0; i < texts.length; i++) {
-        const cached = this.getFromCache(texts[i]);
+        const cached = this.getFromCache(texts[i]!);
         if (cached) {
           results[i] = cached;
         } else {
-          uncachedTexts.push({ index: i, text: texts[i] });
+          uncachedTexts.push({ index: i, text: texts[i]! });
         }
       }
     } else {
       for (let i = 0; i < texts.length; i++) {
-        uncachedTexts.push({ index: i, text: texts[i] });
+        uncachedTexts.push({ index: i, text: texts[i]! });
       }
     }
 
@@ -181,8 +181,8 @@ export class EmbeddingService {
 
       // Store results and cache
       for (let j = 0; j < batch.length; j++) {
-        const { index, text } = batch[j];
-        const embedding = embeddings[j];
+        const { index, text } = batch[j]!;
+        const embedding = embeddings[j]!;
         results[index] = embedding;
 
         if (this.config.enableCache) {
@@ -211,7 +211,7 @@ export class EmbeddingService {
     // Create indexed chunks
     const indexedChunks: IndexedChunk[] = chunks.map((chunk, i) => ({
       ...chunk,
-      embedding: embeddings[i],
+      embedding: embeddings[i]!,
       indexedAt: new Date(),
     }));
 

--- a/packages/intelligence/src/indexer/embedding/index.ts
+++ b/packages/intelligence/src/indexer/embedding/index.ts
@@ -15,3 +15,14 @@ export {
   EmbeddingService,
   type EmbeddingServiceConfig,
 } from './embedding-service.js';
+
+// Re-export the embedding-related types so consumers (e.g. the intelligence
+// sidecar) can depend on this module alone via the `@tamma/intelligence/embedding`
+// subpath, WITHOUT importing the full `./indexer` barrel — which transitively
+// value-imports `typescript` (a devDependency) through the TypeScript chunker
+// and would crash a prod-pruned runtime image at ESM link time.
+export type {
+  EmbeddingProviderType,
+  EmbeddingProviderConfig,
+  IEmbeddingProvider,
+} from '../types.js';

--- a/packages/intelligence/src/indexer/embedding/mock-embedding-provider.ts
+++ b/packages/intelligence/src/indexer/embedding/mock-embedding-provider.ts
@@ -100,7 +100,7 @@ export class MockEmbeddingProvider extends BaseEmbeddingProvider {
     // Use the hash bytes to seed a simple PRNG
     let seed = 0;
     for (let i = 0; i < Math.min(hash.length, 8); i++) {
-      seed = (seed << 4) | parseInt(hash[i], 16);
+      seed = (seed << 4) | parseInt(hash[i]!, 16);
     }
 
     // Generate deterministic pseudo-random values

--- a/packages/intelligence/src/indexer/embedding/ollama-embedding-provider.ts
+++ b/packages/intelligence/src/indexer/embedding/ollama-embedding-provider.ts
@@ -74,7 +74,7 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider {
     this.ensureInitialized();
 
     const embeddings = await this.embedBatch([text]);
-    return embeddings[0];
+    return embeddings[0]!;
   }
 
   /**
@@ -154,8 +154,8 @@ export class OllamaEmbeddingProvider extends BaseEmbeddingProvider {
       const data = (await response.json()) as OllamaEmbedResponse;
 
       // Update dimensions from actual response if not known
-      if (data.embeddings.length > 0 && data.embeddings[0].length !== this._dimensions) {
-        this._dimensions = data.embeddings[0].length;
+      if (data.embeddings.length > 0 && data.embeddings[0]!.length !== this._dimensions) {
+        this._dimensions = data.embeddings[0]!.length;
       }
 
       return data.embeddings;

--- a/packages/intelligence/src/indexer/embedding/openai-embedding-provider.ts
+++ b/packages/intelligence/src/indexer/embedding/openai-embedding-provider.ts
@@ -97,7 +97,7 @@ export class OpenAIEmbeddingProvider extends BaseEmbeddingProvider {
     this.ensureInitialized();
 
     const embeddings = await this.embedBatch([text]);
-    return embeddings[0];
+    return embeddings[0]!;
   }
 
   /**

--- a/packages/intelligence/src/indexer/metadata/token-counter.ts
+++ b/packages/intelligence/src/indexer/metadata/token-counter.ts
@@ -62,7 +62,7 @@ export function estimateTokensApproximate(text: string): number {
   let i = 0;
 
   while (i < text.length) {
-    const char = text[i];
+    const char = text[i]!;
 
     // Whitespace characters
     if (/\s/.test(char)) {
@@ -73,7 +73,7 @@ export function estimateTokensApproximate(text: string): number {
         i++;
       } else {
         // Skip consecutive spaces, they often get merged
-        while (i < text.length && /[ \t]/.test(text[i])) {
+        while (i < text.length && /[ \t]/.test(text[i]!)) {
           i++;
         }
         count++;
@@ -84,7 +84,7 @@ export function estimateTokensApproximate(text: string): number {
     // Numbers are usually 1 token per digit or grouped
     if (/\d/.test(char)) {
       const numStart = i;
-      while (i < text.length && /[\d.]/.test(text[i])) {
+      while (i < text.length && /[\d.]/.test(text[i]!)) {
         i++;
       }
       const numLen = i - numStart;
@@ -102,7 +102,7 @@ export function estimateTokensApproximate(text: string): number {
     // Words (alphanumeric sequences)
     if (/[a-zA-Z_]/.test(char)) {
       const wordStart = i;
-      while (i < text.length && /[a-zA-Z0-9_]/.test(text[i])) {
+      while (i < text.length && /[a-zA-Z0-9_]/.test(text[i]!)) {
         i++;
       }
       const word = text.slice(wordStart, i);

--- a/packages/intelligence/src/indexer/triggers/file-watcher.ts
+++ b/packages/intelligence/src/indexer/triggers/file-watcher.ts
@@ -73,7 +73,7 @@ export class FileWatcher {
         const watcher = fs.watch(
           resolvedPath,
           { recursive: true },
-          (eventType, filename) => {
+          (_eventType, filename) => {
             if (filename) {
               this.handleChange(resolvedPath, filename);
             }

--- a/packages/intelligence/src/indexer/types.ts
+++ b/packages/intelligence/src/indexer/types.ts
@@ -56,13 +56,13 @@ export interface CodeChunk {
   /** 1-indexed end line */
   endLine: number;
   /** Parent class/module name (for methods) */
-  parentScope?: string;
+  parentScope?: string | undefined;
   /** Import dependencies */
   imports: string[];
   /** Exported symbols */
   exports: string[];
   /** JSDoc/docstring if present */
-  docstring?: string;
+  docstring?: string | undefined;
   /** Estimated token count */
   tokenCount: number;
   /** Content hash for change detection */
@@ -148,7 +148,7 @@ export interface IndexerConfig {
   /** Enable file watcher */
   enableFileWatcher: boolean;
   /** Cron expression for scheduled indexing */
-  scheduleCron?: string;
+  scheduleCron?: string | undefined;
 
   // === Performance ===
   /** Max concurrent file processing */
@@ -227,7 +227,7 @@ export interface IndexStatus {
   /** Path to the indexed project */
   projectPath: string;
   /** When the index was last updated */
-  lastIndexedAt?: Date;
+  lastIndexedAt?: Date | undefined;
   /** Total number of indexed files */
   totalFiles: number;
   /** Total number of chunks */
@@ -309,7 +309,7 @@ export interface ICodeChunker {
  */
 export interface EmbeddingProviderConfig {
   /** API key (for cloud providers) */
-  apiKey?: string;
+  apiKey?: string | undefined;
   /** Base URL (for self-hosted) */
   baseUrl?: string;
   /** Model identifier */

--- a/packages/intelligence/src/knowledge-base/capture/duplicate-detector.ts
+++ b/packages/intelligence/src/knowledge-base/capture/duplicate-detector.ts
@@ -107,7 +107,9 @@ export class DuplicateDetector {
     // Get existing learnings to compare against
     const { entries } = await this.store.list({
       types: ['learning'],
-      projectId: this.options.projectScopeOnly ? capture.projectId : undefined,
+      ...(this.options.projectScopeOnly
+        ? { projectId: capture.projectId }
+        : {}),
       enabled: true,
       limit: 100,
     });

--- a/packages/intelligence/src/knowledge-base/capture/learning-capture.ts
+++ b/packages/intelligence/src/knowledge-base/capture/learning-capture.ts
@@ -154,13 +154,14 @@ export class LearningCaptureService {
   ): LearningCapture {
     const title = this.generateTitle(outcome, 'success');
     const description = this.generateDescription(outcome, 'success');
+    const whatWorked = this.extractWhatWorked(outcome);
 
     return {
       taskId: outcome.taskId,
       projectId: outcome.projectId,
       outcome: 'success',
       description: outcome.output ?? 'Task completed successfully',
-      whatWorked: this.extractWhatWorked(outcome),
+      ...(whatWorked !== undefined ? { whatWorked } : {}),
       suggestedTitle: title,
       suggestedDescription: description,
       suggestedKeywords: keywords,
@@ -178,14 +179,15 @@ export class LearningCaptureService {
   ): LearningCapture {
     const title = this.generateTitle(outcome, 'failure');
     const description = this.generateDescription(outcome, 'failure');
+    const rootCause = this.extractRootCause(outcome);
 
     return {
       taskId: outcome.taskId,
       projectId: outcome.projectId,
       outcome: 'failure',
       description: outcome.error ?? 'Task failed',
-      whatFailed: outcome.error,
-      rootCause: this.extractRootCause(outcome),
+      ...(outcome.error !== undefined ? { whatFailed: outcome.error } : {}),
+      ...(rootCause !== undefined ? { rootCause } : {}),
       suggestedTitle: title,
       suggestedDescription: description,
       suggestedKeywords: keywords,
@@ -203,14 +205,15 @@ export class LearningCaptureService {
   ): LearningCapture {
     const title = this.generateTitle(outcome, 'partial');
     const description = this.generateDescription(outcome, 'partial');
+    const whatWorked = this.extractWhatWorked(outcome);
 
     return {
       taskId: outcome.taskId,
       projectId: outcome.projectId,
       outcome: 'partial',
       description: outcome.output ?? 'Task partially completed',
-      whatWorked: this.extractWhatWorked(outcome),
-      whatFailed: outcome.error,
+      ...(whatWorked !== undefined ? { whatWorked } : {}),
+      ...(outcome.error !== undefined ? { whatFailed: outcome.error } : {}),
       suggestedTitle: title,
       suggestedDescription: description,
       suggestedKeywords: keywords,

--- a/packages/intelligence/src/knowledge-base/knowledge-service.ts
+++ b/packages/intelligence/src/knowledge-base/knowledge-service.ts
@@ -18,8 +18,6 @@ import type {
   UpdateKnowledgeEntry,
   KnowledgeListResult,
   KnowledgeImportResult,
-  KnowledgePriority,
-  AgentType,
 } from '@tamma/shared';
 import type {
   IKnowledgeService,
@@ -41,16 +39,6 @@ import { PreTaskChecker } from './checkers/pre-task-checker.js';
 import { LearningCaptureService } from './capture/learning-capture.js';
 
 /**
- * Priority value mapping for filtering
- */
-const PRIORITY_VALUES: Record<KnowledgePriority, number> = {
-  low: 1,
-  medium: 2,
-  high: 3,
-  critical: 4,
-};
-
-/**
  * Knowledge service implementation
  */
 export class KnowledgeService implements IKnowledgeService {
@@ -63,7 +51,6 @@ export class KnowledgeService implements IKnowledgeService {
   private relevanceRanker: RelevanceRanker;
   private preTaskChecker: PreTaskChecker;
   private learningCapture: LearningCaptureService;
-  private initialized = false;
 
   constructor(store?: IKnowledgeStore, config?: Partial<KnowledgeConfig>) {
     this.config = { ...DEFAULT_KNOWLEDGE_CONFIG, ...config };
@@ -107,11 +94,10 @@ export class KnowledgeService implements IKnowledgeService {
         this.config.capture
       );
     }
-    this.initialized = true;
   }
 
   async dispose(): Promise<void> {
-    this.initialized = false;
+    // No resources to release; provided for interface completeness.
   }
 
   /**
@@ -128,7 +114,9 @@ export class KnowledgeService implements IKnowledgeService {
     // Build filter for applicable entries
     const baseFilter: KnowledgeFilter = {
       enabled: true,
-      priority: query.minPriority,
+      ...(query.minPriority !== undefined
+        ? { priority: query.minPriority }
+        : {}),
     };
 
     // Get all potentially relevant entries
@@ -357,12 +345,13 @@ export class KnowledgeService implements IKnowledgeService {
 
     // Create knowledge entry from pending learning
     const now = new Date();
+    const details = pending.whatWorked || pending.whatFailed || pending.rootCause;
     const entry: KnowledgeEntry = {
       id: randomUUID(),
       type: 'learning',
       title: edits?.title ?? pending.suggestedTitle,
       description: edits?.description ?? pending.suggestedDescription,
-      details: pending.whatWorked || pending.whatFailed || pending.rootCause,
+      ...(details !== undefined ? { details } : {}),
       scope: 'global',
       projectId: pending.projectId,
       keywords: edits?.keywords ?? pending.suggestedKeywords,
@@ -428,7 +417,7 @@ export class KnowledgeService implements IKnowledgeService {
 
   async recordApplication(
     knowledgeId: string,
-    taskId: string,
+    _taskId: string,
     helpful: boolean
   ): Promise<void> {
     await this.store.incrementApplied(knowledgeId);

--- a/packages/intelligence/src/knowledge-base/stores/in-memory-store.ts
+++ b/packages/intelligence/src/knowledge-base/stores/in-memory-store.ts
@@ -4,7 +4,6 @@
  * Simple in-memory implementation of the knowledge store for development and testing.
  */
 
-import { randomUUID } from 'node:crypto';
 import type {
   KnowledgeEntry,
   KnowledgeFilter,

--- a/packages/intelligence/src/knowledge-base/types.ts
+++ b/packages/intelligence/src/knowledge-base/types.ts
@@ -17,8 +17,6 @@ import type {
   UpdateKnowledgeEntry,
   KnowledgeListResult,
   KnowledgeImportResult,
-  KnowledgeMatch,
-  KnowledgeType,
 } from '@tamma/shared';
 
 // === Configuration Types ===
@@ -426,9 +424,9 @@ export interface MatchContext {
   /** Task description */
   taskDescription: string;
   /** File paths involved */
-  filePaths?: string[];
+  filePaths?: string[] | undefined;
   /** Technologies involved */
-  technologies?: string[];
+  technologies?: string[] | undefined;
   /** Task plan approach */
   planApproach?: string;
 }

--- a/packages/intelligence/src/rag/assembler.ts
+++ b/packages/intelligence/src/rag/assembler.ts
@@ -139,7 +139,7 @@ export class ContextAssembler implements IContextAssembler {
     const parts: string[] = [];
 
     for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
+      const chunk = chunks[i]!;
       const location = this.formatLocation(chunk);
       const scoreText = includeScores
         ? ` (relevance: ${(chunk.fusedScore ?? chunk.score).toFixed(2)})`

--- a/packages/intelligence/src/rag/cache.ts
+++ b/packages/intelligence/src/rag/cache.ts
@@ -291,23 +291,23 @@ export class NoOpRAGCache extends RAGCache {
     super({ enabled: false, ttlSeconds: 0, maxEntries: 0 });
   }
 
-  getCachedResult(): RAGResult | null {
+  override getCachedResult(): RAGResult | null {
     return null;
   }
 
-  cacheResult(): void {
+  override cacheResult(): void {
     // No-op
   }
 
-  getCachedEmbedding(): number[] | null {
+  override getCachedEmbedding(): number[] | null {
     return null;
   }
 
-  cacheEmbedding(): void {
+  override cacheEmbedding(): void {
     // No-op
   }
 
-  getStats(): RAGCacheStats {
+  override getStats(): RAGCacheStats {
     return {
       queryCount: 0,
       embeddingCount: 0,

--- a/packages/intelligence/src/rag/errors.ts
+++ b/packages/intelligence/src/rag/errors.ts
@@ -26,7 +26,7 @@ export enum RAGErrorCode {
  */
 export class RAGError extends Error {
   readonly code: RAGErrorCode;
-  readonly cause?: Error;
+  override readonly cause?: Error | undefined;
 
   constructor(code: RAGErrorCode, message: string, cause?: Error) {
     super(message);
@@ -52,7 +52,7 @@ export class NotInitializedError extends RAGError {
  * Error thrown for invalid configuration
  */
 export class InvalidConfigError extends RAGError {
-  readonly field?: string;
+  readonly field?: string | undefined;
 
   constructor(message: string, field?: string) {
     super(RAGErrorCode.INVALID_CONFIG, message);
@@ -80,7 +80,7 @@ export class QueryProcessingError extends RAGError {
  * Error thrown when retrieval fails
  */
 export class RetrievalError extends RAGError {
-  readonly source?: string;
+  readonly source?: string | undefined;
 
   constructor(message: string, source?: string, cause?: Error) {
     super(RAGErrorCode.RETRIEVAL_FAILED, message, cause);

--- a/packages/intelligence/src/rag/query-processor.ts
+++ b/packages/intelligence/src/rag/query-processor.ts
@@ -101,7 +101,7 @@ function collapseWhitespace(text: string): string {
       inWhitespace = true;
     } else {
       inWhitespace = false;
-      result.push(text[i]);
+      result.push(text[i]!);
     }
   }
   // Trim trailing space
@@ -133,7 +133,7 @@ function countWords(text: string): number {
  * Query processor implementation
  */
 export class QueryProcessor implements IQueryProcessor {
-  private embeddingService?: EmbeddingService;
+  private embeddingService?: EmbeddingService | undefined;
 
   constructor(embeddingService?: EmbeddingService) {
     this.embeddingService = embeddingService;

--- a/packages/intelligence/src/rag/rag-pipeline.ts
+++ b/packages/intelligence/src/rag/rag-pipeline.ts
@@ -17,7 +17,7 @@ import type {
   FeedbackStats,
   ProcessedQuery,
 } from './types.js';
-import { NotInitializedError, InvalidConfigError } from './errors.js';
+import { NotInitializedError } from './errors.js';
 import { RAGCache, createRAGCache } from './cache.js';
 import { QueryProcessor, createQueryProcessor } from './query-processor.js';
 import { Ranker, createRanker } from './ranker.js';
@@ -67,8 +67,8 @@ export class RAGPipeline implements IRAGPipeline {
   private feedbackTracker: FeedbackTracker;
 
   // External dependencies
-  private embeddingService?: EmbeddingService;
-  private vectorStore?: IVectorStore;
+  private embeddingService?: EmbeddingService | undefined;
+  private vectorStore?: IVectorStore | undefined;
 
   constructor(config?: Partial<RAGConfig>) {
     // Import default config

--- a/packages/intelligence/src/rag/ranker.ts
+++ b/packages/intelligence/src/rag/ranker.ts
@@ -34,7 +34,7 @@ export class Ranker implements IRanker {
     const chunkMap = new Map<string, RetrievedChunk>();
 
     // Calculate RRF scores for each source
-    for (const [source, chunks] of sourceResults) {
+    for (const [_source, chunks] of sourceResults) {
       // Get weight for this source (default to 1.0 if not specified)
       const weight = 1.0; // Weights are applied during retrieval
 
@@ -107,7 +107,7 @@ export class Ranker implements IRanker {
       let bestMMRScore = -Infinity;
 
       for (let i = 0; i < normalizedChunks.length; i++) {
-        const candidate = normalizedChunks[i];
+        const candidate = normalizedChunks[i]!;
         const relevance = candidate.normalizedScore;
 
         // Calculate max similarity to already selected documents
@@ -131,7 +131,7 @@ export class Ranker implements IRanker {
       }
 
       // Add best candidate to selected
-      const bestChunk = normalizedChunks[bestIdx];
+      const bestChunk = normalizedChunks[bestIdx]!;
       selected.push({
         ...bestChunk,
         fusedScore: bestChunk.fusedScore,

--- a/packages/intelligence/src/rag/sources/github-source.ts
+++ b/packages/intelligence/src/rag/sources/github-source.ts
@@ -196,7 +196,7 @@ export class PullRequestsSource extends GitHubBaseSource {
     super('prs', 'pr');
   }
 
-  protected buildSearchText(entry: GitHubEntry): string {
+  protected override buildSearchText(entry: GitHubEntry): string {
     const base = super.buildSearchText(entry);
 
     // Add file paths with higher weight for PRs
@@ -216,7 +216,7 @@ export class CommitsSource extends GitHubBaseSource {
     super('commits', 'commit');
   }
 
-  protected buildMetadata(entry?: GitHubEntry): ChunkMetadata {
+  protected override buildMetadata(entry?: GitHubEntry): ChunkMetadata {
     if (!entry) {
       return {};
     }

--- a/packages/intelligence/src/rag/sources/vector-source.ts
+++ b/packages/intelligence/src/rag/sources/vector-source.ts
@@ -90,7 +90,10 @@ export class VectorSource extends BaseRAGSource {
 
     // Apply filters if specified
     if (options.filter) {
-      searchQuery.filter = this.buildFilter(options.filter);
+      const builtFilter = this.buildFilter(options.filter);
+      if (builtFilter) {
+        searchQuery.filter = builtFilter;
+      }
     }
 
     try {

--- a/packages/intelligence/src/rag/types.ts
+++ b/packages/intelligence/src/rag/types.ts
@@ -159,23 +159,23 @@ export interface RAGQuery {
  */
 export interface ChunkMetadata {
   /** Source file path */
-  filePath?: string;
+  filePath?: string | undefined;
   /** Starting line number */
-  startLine?: number;
+  startLine?: number | undefined;
   /** Ending line number */
-  endLine?: number;
+  endLine?: number | undefined;
   /** URL (for web sources) */
-  url?: string;
+  url?: string | undefined;
   /** Date of the content */
   date?: Date;
   /** Author of the content */
   author?: string;
   /** Title of the content */
-  title?: string;
+  title?: string | undefined;
   /** Programming language */
-  language?: string;
+  language?: string | undefined;
   /** Symbols (function names, class names, etc.) */
-  symbols?: string[];
+  symbols?: string[] | undefined;
 }
 
 /**
@@ -191,11 +191,11 @@ export interface RetrievedChunk {
   /** Relevance score from source */
   score: number;
   /** Fused score after RRF/ranking */
-  fusedScore?: number;
+  fusedScore?: number | undefined;
   /** Chunk metadata */
   metadata: ChunkMetadata;
   /** Embedding vector (for MMR calculation) */
-  embedding?: number[];
+  embedding?: number[] | undefined;
 }
 
 /**
@@ -288,11 +288,11 @@ export interface ProcessedQuery {
   /** Extracted entities */
   entities: ExtractedEntity[];
   /** Decomposed sub-queries (for complex queries) */
-  decomposed?: string[];
+  decomposed?: string[] | undefined;
   /** Detected language */
-  language?: string;
+  language?: string | undefined;
   /** Query embedding */
-  embedding?: number[];
+  embedding?: number[] | undefined;
   /** Classified intent */
   intent?: QueryIntent;
 }
@@ -315,7 +315,7 @@ export interface RelevanceFeedback {
   /** Relevance rating */
   rating: RelevanceRating;
   /** Optional comment */
-  comment?: string;
+  comment?: string | undefined;
   /** Feedback timestamp */
   timestamp: Date;
 }

--- a/packages/intelligence/src/vector-store/providers/chromadb.ts
+++ b/packages/intelligence/src/vector-store/providers/chromadb.ts
@@ -9,6 +9,7 @@ import type {
   ChromaClient as ChromaClientType,
   Collection as ChromaCollection,
   IncludeEnum,
+  Where,
 } from 'chromadb';
 import type {
   VectorStoreConfig,
@@ -319,7 +320,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
     // ChromaDB doesn't have a direct count with filter, so we need to query
     const whereClause = toChromaDBFilter(filter);
     const result = await col.get({
-      where: whereClause as Record<string, unknown>,
+      where: whereClause as unknown as Where,
       include: [],
     });
 
@@ -343,7 +344,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
       queryEmbeddings: number[][];
       nResults: number;
       include: IncludeEnum[];
-      where?: Record<string, unknown>;
+      where?: Where;
     } = {
       queryEmbeddings: [query.embedding],
       nResults: query.topK,
@@ -351,7 +352,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
     };
 
     if (query.filter && !isEmptyFilter(query.filter)) {
-      queryParams.where = toChromaDBFilter(query.filter) as Record<string, unknown>;
+      queryParams.where = toChromaDBFilter(query.filter) as unknown as Where;
     }
 
     const result = await col.query(queryParams);
@@ -422,7 +423,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
       queryEmbeddings: number[][];
       nResults: number;
       include: IncludeEnum[];
-      where?: Record<string, unknown>;
+      where?: Where;
     } = {
       queryEmbeddings: [query.embedding],
       nResults: query.topK * 2, // Get more results for fusion
@@ -430,7 +431,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
     };
 
     if (query.filter && !isEmptyFilter(query.filter)) {
-      vectorQueryParams.where = toChromaDBFilter(query.filter) as Record<string, unknown>;
+      vectorQueryParams.where = toChromaDBFilter(query.filter) as unknown as Where;
     }
 
     const vectorResults = await col.query(vectorQueryParams);
@@ -440,7 +441,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
       queryTexts: string[];
       nResults: number;
       include: IncludeEnum[];
-      where?: Record<string, unknown>;
+      where?: Where;
     } = {
       queryTexts: [query.text],
       nResults: query.topK * 2,
@@ -448,7 +449,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
     };
 
     if (query.filter && !isEmptyFilter(query.filter)) {
-      textQueryParams.where = toChromaDBFilter(query.filter) as Record<string, unknown>;
+      textQueryParams.where = toChromaDBFilter(query.filter) as unknown as Where;
     }
 
     const textResults = await col.query(textQueryParams);
@@ -582,7 +583,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
       queryEmbeddings: number[][];
       nResults: number;
       include: IncludeEnum[];
-      where?: Record<string, unknown>;
+      where?: Where;
     } = {
       queryEmbeddings: [query.embedding],
       nResults: fetchK,
@@ -590,7 +591,7 @@ export class ChromaDBVectorStore extends BaseVectorStore {
     };
 
     if (query.filter && !isEmptyFilter(query.filter)) {
-      queryParams.where = toChromaDBFilter(query.filter) as Record<string, unknown>;
+      queryParams.where = toChromaDBFilter(query.filter) as unknown as Where;
     }
 
     const result = await col.query(queryParams);
@@ -611,8 +612,8 @@ export class ChromaDBVectorStore extends BaseVectorStore {
       id: string;
       embedding: number[];
       distance: number;
-      metadata?: VectorMetadata;
-      content?: string;
+      metadata?: VectorMetadata | undefined;
+      content?: string | undefined;
     }> = [];
 
     for (let i = 0; i < ids.length; i++) {

--- a/packages/intelligence/src/vector-store/providers/pgvector.ts
+++ b/packages/intelligence/src/vector-store/providers/pgvector.ts
@@ -634,8 +634,8 @@ export class PgVectorStore extends BaseVectorStore {
       id: string;
       embedding: number[];
       distance: number;
-      content?: string;
-      metadata?: VectorMetadata;
+      content?: string | undefined;
+      metadata?: VectorMetadata | undefined;
     }> = result.rows.map((row) => {
       const r = row as Record<string, unknown>;
       return {

--- a/packages/intelligence/tsconfig.json
+++ b/packages/intelligence/tsconfig.json
@@ -8,8 +8,7 @@
   },
   "references": [
     { "path": "../shared" },
-    { "path": "../observability" },
-    { "path": "../providers" }
+    { "path": "../observability" }
   ],
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,9 +441,6 @@ importers:
       '@tamma/observability':
         specifier: workspace:*
         version: link:../observability
-      '@tamma/providers':
-        specifier: workspace:*
-        version: link:../providers
       '@tamma/shared':
         specifier: workspace:*
         version: link:../shared

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       { find: /^@tamma\/shared\/config$/, replacement: pkg('shared', 'config/index.ts') },
       { find: /^@tamma\/shared$/, replacement: pkg('shared') },
       { find: /^@tamma\/intelligence\/vector-store$/, replacement: pkg('intelligence', 'vector-store/index.ts') },
+      { find: /^@tamma\/intelligence\/embedding$/, replacement: pkg('intelligence', 'indexer/embedding/index.ts') },
       { find: /^@tamma\/intelligence\/indexer$/, replacement: pkg('intelligence', 'indexer/index.ts') },
       { find: /^@tamma\/intelligence\/knowledge-base$/, replacement: pkg('intelligence', 'knowledge-base/index.ts') },
       { find: /^@tamma\/intelligence\/rag$/, replacement: pkg('intelligence', 'rag/index.ts') },


### PR DESCRIPTION
## What

Fixes the Epic-6 KB-wiring gap (blocks #286 KB Monitor + real RAG): the `intelligence-server` sidecar called `startServer()` with no args → every vector/KB service held an `undefined` store → all `/api/kb/*` returned permanent 0/`not_configured` stubs.

- Implements `createVectorStoreFromEnv` / `createRagPipelineFromEnv` (the seam that previously existed only in a JSDoc comment) — constructs a real ChromaDB/pgvector store + embedder from env, via `@tamma/intelligence`'s real providers + the `adaptVectorStore`/`adaptRagPipeline` adapters.
- Wires them into `startServer()` so KB/vector/index/rag endpoints return **real** data when the store env is configured.
- **Graceful degrade when unconfigured:** an absent store env keeps the current `not_configured`/stub behavior (the sidecar still boots) — so the current VPS (no ChromaDB/OpenAI env) is unaffected until the env is set.
- Fixes the `@tamma/intelligence` strict-mode build (audit finding #014).
- No C# change — the `KbEndpoints` proxy is a correct passthrough.

## Verification

- `@tamma/intelligence` + `@tamma/intelligence-server` build/typecheck clean (0 errors). Tests: 1037 + 49 + 230 green (incl. env-based factory construction + graceful-degrade-when-unconfigured).

**Deploy note:** to turn real RAG on, set the store env (ChromaDB/`OPENAI_*`/`EMBEDDING_*`) + run ChromaDB in the stack; until then it degrades to the prior stub behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)