### PR TITLE
feat(epic-6): self-hosted KB/RAG embeddings via local Ollama (no OpenAI key/cost)

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -11,6 +11,7 @@
 #   PostgreSQL:       2G
 #   RabbitMQ:       512M
 #   ChromaDB:         1G
+#   Ollama:           2G   (nomic-embed-text, local KB/RAG embeddings)
 #   elsa-server:      1G
 #   tamma-api:        768M  (consolidated C# API)
 #   tamma-engine:     1G
@@ -18,7 +19,7 @@
 #   elsa-studio:      128M
 #   nginx-proxy:      128M
 #   ─────────────────────
-#   Total:          ~6.8G  (leaves ~9.2G for OS, Docker, and headroom)
+#   Total:          ~8.8G  (leaves ~7.2G for OS, Docker, and headroom)
 #
 # With observability profile (+opensearch +dashboards):
 #   opensearch:       3G
@@ -52,6 +53,14 @@ services:
         limits:
           cpus: "1.0"
           memory: 1G
+
+  ollama:
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
 
   elsa-server:
     restart: unless-stopped

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -26,7 +26,9 @@
 #   opensearch-dashboards: 1.5G
 #   opensearch-setup: 128M
 #   ─────────────────────
-#   Total:         ~11.8G  (leaves ~4.2G for OS and Docker)
+#   Total:         ~13.4G  (sum of LIMITS/caps, not reservations — actual RSS
+#                           is far lower; but do not run the observability
+#                           profile + ollama on a 16GB box without headroom care)
 # =============================================================================
 
 services:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -80,6 +80,42 @@ services:
       - tamma-net
 
   # ---------------------------------------------------------------------------
+  # Infrastructure: Ollama (local embedding model server)
+  #
+  # Serves a self-hosted nomic-embed-text model (768-dim) so KB vector search
+  # and RAG embeddings run locally — no OpenAI key, no per-token cost. The
+  # model is pulled on first boot into the persisted volume (instant on every
+  # later boot). intelligence-server's ollama embedder initializes config-only
+  # (network-free), so it depends_on ollama with `service_started` — the
+  # sidecar boots + reports "configured" immediately and the first embed call
+  # simply waits for the one-time pull to finish. The healthcheck below is for
+  # ops visibility (passes once the model is present).
+  # ---------------------------------------------------------------------------
+  ollama:
+    image: ollama/ollama:0.31.1
+    restart: unless-stopped
+    volumes:
+      - tamma-ollama-data:/root/.ollama
+    environment:
+      OLLAMA_HOST: "0.0.0.0"
+    # Start the server, wait until it answers, pull the embedding model, then
+    # hand the foreground back to it. Deliberately NO shell $vars — docker
+    # compose would interpolate them; bare `wait` blocks on the backgrounded
+    # `ollama serve`.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "ollama serve & until ollama list >/dev/null 2>&1; do sleep 1; done; ollama pull nomic-embed-text; wait"
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list | grep -q nomic-embed-text || exit 1"]
+      interval: 15s
+      timeout: 10s
+      start_period: 180s
+      retries: 5
+    networks:
+      - tamma-net
+
+  # ---------------------------------------------------------------------------
   # Intelligence sidecar (TypeScript Fastify bridge to @tamma/intelligence)
   #
   # The C# API delegates its 30 /api/kb/* knowledge-base endpoints here over
@@ -95,10 +131,18 @@ services:
       INTELLIGENCE_PORT: "4100"
       INTELLIGENCE_HOST: "0.0.0.0"
       CHROMADB_URL: http://chromadb:8000
+      # Self-hosted embeddings via the local Ollama server (no OpenAI key/cost).
+      # 768-dim nomic-embed-text; overridable via .env if a cloud provider is
+      # ever wanted (set EMBEDDING_PROVIDER=openai + OPENAI_API_KEY).
+      EMBEDDING_PROVIDER: ${INTELLIGENCE_EMBEDDING_PROVIDER:-ollama}
+      EMBEDDING_MODEL: ${INTELLIGENCE_EMBEDDING_MODEL:-nomic-embed-text}
+      EMBEDDING_BASE_URL: ${INTELLIGENCE_EMBEDDING_BASE_URL:-http://ollama:11434}
       LOG_LEVEL: ${INTELLIGENCE_LOG_LEVEL:-info}
     depends_on:
       chromadb:
         condition: service_healthy
+      ollama:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:4100/health"]
       interval: 15s
@@ -411,6 +455,7 @@ volumes:
   tamma-pg-data:
   tamma-rmq-data:
   tamma-chroma-data:
+  tamma-ollama-data:
   tamma-engine-workdir:
   tamma-os-data:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,9 +87,13 @@ services:
   # model is pulled on first boot into the persisted volume (instant on every
   # later boot). intelligence-server's ollama embedder initializes config-only
   # (network-free), so it depends_on ollama with `service_started` — the
-  # sidecar boots + reports "configured" immediately and the first embed call
-  # simply waits for the one-time pull to finish. The healthcheck below is for
-  # ops visibility (passes once the model is present).
+  # sidecar boots + reports "configured" immediately without blocking on the
+  # one-time pull. (An embed call landing in the ~60s first-boot pull window
+  # gets a model-not-found from Ollama; the embedder holds no bad state, so the
+  # next call after the pull succeeds. Nothing embeds at boot — RAG indexing is
+  # on-demand.) The healthcheck below is for ops visibility (passes once the
+  # model is present); using it as a `service_healthy` gate would instead block
+  # the deploy on the pull, so it is deliberately not a dependency condition.
   # ---------------------------------------------------------------------------
   ollama:
     image: ollama/ollama:0.31.1


### PR DESCRIPTION
## What

Turns on the now-wired KB/RAG embeddings **without OpenAI** — a self-hosted `ollama/ollama:0.31.1` service serving `nomic-embed-text` (768-dim), with the `intelligence-server` sidecar pointed at it (`EMBEDDING_PROVIDER=ollama`, `EMBEDDING_BASE_URL=http://ollama:11434`). No API key, no per-token cost.

- Model pulled on first boot into a persisted volume (`tamma-ollama-data`) — instant on every later boot. Entrypoint serves → waits → pulls → `wait` (holds PID 1). No shell `$vars` (compose would interpolate).
- `depends_on: ollama: service_started` — the ollama embedder inits config-only (network-free), so the sidecar boots + reports *configured* without blocking on the one-time pull. (`service_healthy` would block the deploy on the pull — deliberately avoided.)
- Ollama has **no host-port mapping** (its API is unauthenticated) — reachable only on `tamma-net`; nginx does not route to it.
- prod overlay: 2G cap. Provider/model/URL overridable via `INTELLIGENCE_EMBEDDING_*` if a cloud provider is ever wanted.

## Safety

Deploy-safety reviewed (adversarial): entrypoint liveness ✓, no `$` footgun ✓, `/api/embed` correct for 0.31.1 ✓, unauth API not exposed ✓, `service_started` non-blocking + nothing the deploy gates on waits for ollama ✓, 768-dim safe on clean Chroma (nothing auto-creates a 1536 collection) ✓. Known operational note: first deploy pulls a ~4GB image (rerun on a Docker Hub flake).

## Verification

Merged compose renders clean (`docker compose config` rc=0). Infra-only — no app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)