### PR TITLE
fix(epic-6): bootstrap the RAG collection so the KB sidecar boots configured

### DIFF
--- a/packages/intelligence-server/src/__tests__/env-composition.test.ts
+++ b/packages/intelligence-server/src/__tests__/env-composition.test.ts
@@ -20,6 +20,7 @@ import {
   buildIntelligenceBundleFromEnv,
   createVectorStoreFromEnv,
   createRagPipelineFromEnv,
+  buildRagPipeline,
   wrapVectorStore,
 } from '../env-composition.js';
 import type { IntelligenceServicesBundle, IRagPipeline } from '../types.js';
@@ -173,6 +174,7 @@ function makeInMemoryStore() {
   };
   return {
     listCollections: async () => [...collections.keys()],
+    collectionExists: async (name: string) => collections.has(name),
     createCollection: async (name: string) => {
       ensure(name);
     },
@@ -234,6 +236,38 @@ const fakeRag: IRagPipeline = {
   getFeedbackOverview: () => ({ totalFeedback: 0, averageRelevance: 0 }),
   configure: () => undefined,
 };
+
+describe('buildRagPipeline — bootstraps a missing RAG collection', () => {
+  it('creates the codebase collection on a fresh store so the pipeline initializes (no throw, no bundle degrade)', async () => {
+    const store = makeInMemoryStore();
+    const embedder = await createEmbedderFromEnv({ EMBEDDING_PROVIDER: 'mock' });
+    if (!embedder) throw new Error('mock embedder should be defined');
+    // A fresh / never-indexed store: the RAG collection does not exist yet.
+    // Before the fix, VectorSource.doInitialize threw `Collection 'codebase'
+    // does not exist` here, which degraded the ENTIRE sidecar bundle to
+    // not_configured (reproduced in prod: the sidecar reported not_configured
+    // even with ChromaDB + Ollama wired and healthy).
+    expect(await store.collectionExists('codebase')).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pipeline = await buildRagPipeline(store as any, embedder, {});
+    expect(pipeline).toBeDefined();
+    // The collection was bootstrapped, so a later index run + RAG retrieval work.
+    expect(await store.collectionExists('codebase')).toBe(true);
+  });
+
+  it('honours KB_RAG_COLLECTION and is a no-op when the collection already exists', async () => {
+    const store = makeInMemoryStore();
+    await store.createCollection('kb-custom');
+    const embedder = await createEmbedderFromEnv({ EMBEDDING_PROVIDER: 'mock' });
+    if (!embedder) throw new Error('mock embedder should be defined');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pipeline = await buildRagPipeline(store as any, embedder, {
+      KB_RAG_COLLECTION: 'kb-custom',
+    });
+    expect(pipeline).toBeDefined();
+    expect(await store.listCollections()).toContain('kb-custom');
+  });
+});
 
 describe('configured store — endpoints return REAL data via wrapVectorStore', () => {
   async function makeConfiguredApp() {

--- a/packages/intelligence-server/src/env-composition.ts
+++ b/packages/intelligence-server/src/env-composition.ts
@@ -338,6 +338,20 @@ export async function buildRagPipeline(
 ): Promise<IRagPipeline> {
   const collectionName =
     env['KB_RAG_COLLECTION'] ?? env['KB_INDEX_COLLECTION'] ?? DEFAULT_RAG_COLLECTION;
+  // The RAG pipeline's vector-source hard-requires its collection to exist at
+  // initialize() and throws `Collection '<name>' does not exist` otherwise. On a
+  // fresh / never-indexed store the collection has not been created yet (the
+  // codebase-indexer creates it lazily on first index), so a configured-but-
+  // empty deployment would throw here and degrade the ENTIRE bundle to
+  // not_configured. Ensure it exists (empty, at the embedder's dimensions) so
+  // the sidecar boots fully configured; this mirrors the indexer's own
+  // collectionExists→createCollection guard (codebase-indexer.ts), so a later
+  // index run sees it and skips re-creation. No-op when it already exists.
+  if (!(await store.collectionExists(collectionName))) {
+    await store.createCollection(collectionName, {
+      dimensions: embeddingService.getDimensions(),
+    });
+  }
   const pipeline = createRAGPipeline();
   await pipeline.initialize({ embeddingService, vectorStore: store, collectionName });
   return adaptRagPipeline(wrapRagPipeline(pipeline));


### PR DESCRIPTION
## Problem (found live)

After deploying self-hosted embeddings (`qa-2026-07-05h`), an on-VPS check showed Ollama healthy, `nomic-embed-text` pulled, a live `/api/embed` returning a real 768-dim vector, ChromaDB healthy — **yet the sidecar's `/kb/vector-db/status` returned `not_configured`.**

Boot log root cause:
```
[intelligence-server] failed to build services from env; booting in not_configured mode: Collection 'codebase' does not exist
```
`buildRagPipeline` → `RAGPipeline.initialize` → `VectorSource.doInitialize` **hard-requires** the `codebase` collection to exist and throws otherwise. On a fresh / never-indexed store it doesn't exist yet (the indexer creates it lazily on first index), so the throw propagated and the startup try/catch degraded the **entire** bundle to `not_configured` — even though the store + embedder were both fine.

## Fix

Create-if-missing the RAG collection (at the embedder's dimensions) before initializing the pipeline — mirroring the codebase-indexer's own `collectionExists`→`createCollection` guard, so a later index run sees it and skips re-creation. The sidecar now boots **configured** on an empty store; retrieval correctly returns nothing until content is indexed.

## Verification

TDD: the new regression test fails **without** the fix with the exact prod error (`RetrievalError: Collection 'codebase' does not exist`) and passes with it. `env-composition.test.ts` 19/19; `@tamma/intelligence-server` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)