### PR TITLE
docs: sync wiki, docs, and wiki site with 2026-07 landed work

### DIFF
--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -97,7 +97,7 @@ development_status:
   3-2-test-execution-gate-implementation: done      # Coverage/Evaluate/QualityReport activities real and wired; consume pre-parsed data, no dedicated unit tests.
   3-3-escalation-workflow-implementation: done      # Escalation activities wired into 3 workflows and covered by routing/review tests.
   3-4-research-workflow-implementation: done        # ResearchWorkflow (Assessment skeleton, mediated LLM, RESEARCH.* events) + research action/prompt template emitting real findings (9827eb9, 7151b96).
-  3-5-clarifying-questions-workflow-implementation: drafted # No clarifying-questions workflow exists; grep matches were prompt-text substrings only.
+  3-5-clarifying-questions-workflow-implementation: done # ClarifyingQuestionsWorkflow + secure resume endpoint shipped (12a8468, 2026-07-04): Assessment skeleton, mediated LLM, CLARIFY.* events.
   3-6-ambiguity-scoring-implementation: done        # Ambiguity scoring shipped (30e9aa5): mediated LLM, fail-closed parse, AMBIGUITY.* events.
   3-7-design-proposal-workflow-implementation: done # DesignProposalWorkflow shipped (9b4deb2): Assessment skeleton, mediated LLM, approval gate + secure resume, DESIGN.* events.
   3-8-static-analysis-gate-implementation: done     # CheckLintingActivity real and wired into TestingWorkflow; no dedicated unit test.

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2025-10-29
-# updated: 2026-06-17 (added Epics 32/34/35/36/37 — 59 drafted stories for agents/pricing/billing/analytics/audit; Epic 20 superseded)
+# updated: 2026-07-15 (main-branch sync: 2-14 decomposition, 3-4/3-6/3-7 assessment workflows, 4-5/4-8 event capture+replay, 18-4 slices, 21-4 repos/runs pages, 8 Epic-23 monitoring pages, Epic-6 KB/RAG sidecar+Ollama)
 # project: Tamma
 # project_key: Tamma
 # tracking_system: file-system
@@ -83,7 +83,7 @@ development_status:
   2-11-auto-next-issue-selection: done              # ADL orchestrator loops to next item with cooldown + limit checks; routing tests cover cycle behavior.
   2-12-intelligent-provider-selection: in-progress  # Health+circuit+budget fallback chain done; AC1-3/5 task-classification & weighted cost/complexity scoring not implemented.
   2-13-prompt-engineering-optimization: done        # Prompts resolved from DB-backed registry with role/action + conventions injection; covered by tests.
-  2-14-issue-decomposition-engine: ready-for-dev    # Spec exists; no decomposition engine code in TS packages or C# engine.
+  2-14-issue-decomposition-engine: done             # IssueDecompositionWorkflow shipped (a984a26): mediated LLM, ordered sub-tasks + deps, DECOMPOSITION.* events.
   2-15-task-dependency-mapping: ready-for-dev       # Spec exists; dependency-mapping not implemented anywhere.
   2-16-incremental-task-sequencing: ready-for-dev   # Spec exists; incremental sequencing not implemented. Depends on 2-14/2-15.
   epic-2-retrospective: completed
@@ -96,10 +96,10 @@ development_status:
   3-1-build-automation-gate-implementation: done    # TriggerCI/WaitForCI wired; TestingWorkflow has max-3 retry+autofix loop. Gate activities themselves lack unit tests.
   3-2-test-execution-gate-implementation: done      # Coverage/Evaluate/QualityReport activities real and wired; consume pre-parsed data, no dedicated unit tests.
   3-3-escalation-workflow-implementation: done      # Escalation activities wired into 3 workflows and covered by routing/review tests.
-  3-4-research-workflow-implementation: drafted     # No research workflow/activity in Elsa or TS packages; spec only.
+  3-4-research-workflow-implementation: done        # ResearchWorkflow (Assessment skeleton, mediated LLM, RESEARCH.* events) + research action/prompt template emitting real findings (9827eb9, 7151b96).
   3-5-clarifying-questions-workflow-implementation: drafted # No clarifying-questions workflow exists; grep matches were prompt-text substrings only.
-  3-6-ambiguity-scoring-implementation: drafted     # No ambiguity scoring code; only incidental 'ambiguous' substrings in comments.
-  3-7-design-proposal-workflow-implementation: drafted # No design-proposal workflow anywhere; spec only.
+  3-6-ambiguity-scoring-implementation: done        # Ambiguity scoring shipped (30e9aa5): mediated LLM, fail-closed parse, AMBIGUITY.* events.
+  3-7-design-proposal-workflow-implementation: done # DesignProposalWorkflow shipped (9b4deb2): Assessment skeleton, mediated LLM, approval gate + secure resume, DESIGN.* events.
   3-8-static-analysis-gate-implementation: done     # CheckLintingActivity real and wired into TestingWorkflow; no dedicated unit test.
   3-9-security-scanning-gate-implementation: done   # CheckSecurityActivity real and wired into TestingWorkflow; no dedicated unit test.
   3-10-agent-performance-monitoring: done           # Instrumented providers + diagnostics telemetry pipeline implemented and tested.
@@ -114,10 +114,10 @@ development_status:
   4-2-event-store-backend-selection: in-progress    # Append+ordered+filtered reads work (TS in-mem + C# Postgres). No file/EventStore backends, no configurable backend selection, no retention policy (AC5/6/7 unmet)
   4-3-event-capture-issue-selection-analysis: done  # Engine emits ISSUE_SELECTED + ISSUE_ANALYZED with title/url/contextLength/relatedIssues, persisted via event store, tested
   4-4-event-capture-ai-provider-interactions: in-progress # Instrumented providers capture diagnostics, but no dedicated AIRequest/AIResponse events, no prompt/response blob storage, masking or provider rationale (AC1-5 unmet)
-  4-5-event-capture-code-changes-git-operations: in-progress # PR/branch events emitted, but no CodeFileWrittenEvent, no CommitCreatedEvent, no diffs in blob storage (AC1/2/6 unmet)
+  4-5-event-capture-code-changes-git-operations: done # DCB event coverage for code changes & git operations landed (2e6f18d), closing the AC1/2/6 gaps.
   4-6-event-capture-approvals-escalations: in-progress # Plan approve/reject events + escalation activities exist, but no dedicated ApprovalRequested/EscalationTriggered/Resolved events with channel/resolution/time-to-resolve (AC1/3/4/6 unmet)
   4-7-event-query-api-for-time-travel: done         # Paginated, filterable, tenant-scoped, auth-gated history endpoint backed by QueryWithPaginationAsync; tested. No state-projection-at-T query (AC4 unmet)
-  4-8-black-box-replay-for-debugging: drafted       # No replay CLI command or state-reconstruction mechanism implemented; only event capture + query exist
+  4-8-black-box-replay-for-debugging: done          # Black-box replay landed (a079477): point-in-time state reconstruction via pure fold over the DCB event slice; read-endpoint hardening follow-up (3c5894e).
   epic-4-retrospective: optional
 
   epic-5: contexted
@@ -150,6 +150,7 @@ development_status:
   6-10-scrum-master-task-loop: done                 # ScrumMasterService + AgentCoordinator + TaskSupervisor + ApprovalWorkflow with tests
   epic-6-retrospective: optional
   6-11-context-api-wiring: done                     # Doc says Drafted but engine+kb endpoints fully implemented in Tamma.Api, wired+auth'd, real GitHub/Intelligence backing, tested. Done. Not tracked in sprint-status.
+  6-12-kb-rag-sidecar-production-wiring: done       # Untracked (no story doc): KB/RAG sidecar wired to real vector store (createVectorStoreFromEnv/RagPipeline) + prod-image fixes (d8896ae, 7a34f37, 3be01bc); self-hosted Ollama embeddings, nomic-embed-text (7a4cb91, 5a867f1); RAG collection bootstrap (fae205d).
 
   epic-7: contexted
   7-1-mentorship-workflow: done                     # MentorshipWorkflow+controller+service+state tests all present; no stubs.
@@ -255,7 +256,7 @@ development_status:
   18-1-user-registration-email-verification: done   # Register/verify/resend done in C# AuthEndpoints; argon2id+strength+common-pw+email outbox+events+tests. (TS api in doc is obsolete)
   18-2-user-login-session-management: done          # Email+pwd login, lockout, refresh-token rotation/reuse-detect, logout, switch-org, JWT cookie all implemented with broad tests.
   18-3-organization-tenant-creation: done           # Org=tenant create/members/invites/roles/transfer/settings done with M:N membership store + tests. AC13 RLS superseded by schema-per-tenant; scoping still met.
-  18-4-github-app-installation-onboarding: in-progress # Tracker says done but only onboarding status + install-github redirect built; repo select/activate, install settings, first-run, completion event NOT implemented.
+  18-4-github-app-installation-onboarding: in-progress # Non-migration slices landed (a5deab6): repo activate/deactivate (AC4) + first-run ONBOARDING.COMPLETED event (AC6/7). jsonb install-settings migration slice still outstanding.
   18-5-user-facing-dashboard-shell: in-progress     # dash app shell, auth pages, guards, home, settings exist + tested; missing onboarding wizard, org switcher, /repos, /runs/:id, reset-pw routes.
   epic-18-retrospective: optional
   18-6-password-reset: in-progress                  # Backend reset request/confirm done (expiry, single-use, session revoke, no-enum) + email test; reset-password UI page not built yet.
@@ -282,7 +283,7 @@ development_status:
   21-1-marketing-landing-page: superseded           # Landing page built but apps/marketing-site extracted to a standalone repo (4cc8b406); no longer in this monorepo.
   21-2-pricing-page: superseded                     # Tied to extracted marketing-site repo; no Stripe/pricing code present here. Superseded by repo extraction.
   21-3-documentation-site: drafted                  # wiki-site is a project wiki, not the spec'd Astro /docs; no docs content. Marketing host extracted. Only doc exists.
-  21-4-user-dashboard-repos-runs: in-progress       # dashboard-user exists w/ recent-runs+stats on home, but no Repos/Runs/RunDetail pages, filters, or SSE. Partial.
+  21-4-user-dashboard-repos-runs: done              # Repos & Workflow Runs dashboard pages shipped over installations + DCB run events (9a9913a).
   21-5-user-dashboard-settings-billing: drafted     # No billing/settings(profile/API-key) views; only ConnectedPlatforms (Story 31-9). Story doc only.
   epic-21-retrospective: optional
 
@@ -295,18 +296,18 @@ development_status:
   epic-22-retrospective: optional
 
   epic-23: contexted
-  23-1-system-health-dashboard: drafted             # No monitoring/health page built; HealthTab is a separate admin tab, not this story's AC. Spec only.
-  23-2-agent-monitor: drafted                       # No realtime agent monitor page; AgentsPage is config-focused. Spec only.
-  23-3-event-store-explorer: drafted                # No event store explorer page. Spec only.
-  23-4-configuration-audit: drafted                 # No config audit page; settings pages edit not audit. Spec only.
-  23-5-workflow-monitor: drafted                    # No workflow monitor dashboard page. Spec only.
-  23-6-provider-diagnostics: drafted                # ProviderHealthPage is settings health, not deep diagnostics (histograms/token analytics). Spec only.
+  23-1-system-health-dashboard: done                # System Health overview page composing existing health/diagnostics/event sources (f89c72c).
+  23-2-agent-monitor: done                          # Agent Monitor realtime page — active agents + live tool-loop tail via the 32-23 stream (0a2458d).
+  23-3-event-store-explorer: done                   # Event Store Explorer page — search/filter/detail over the DCB store via the 4-7 query API (112e6ce).
+  23-4-configuration-audit: done                    # Configuration Audit page — effective config + change history (35200bb).
+  23-5-workflow-monitor: done                       # Workflow Monitor page — workflow instances/status/durations over existing workflow data (b2ca20f).
+  23-6-provider-diagnostics: done                   # Provider Diagnostics page — latency/error/cost aggregations (07352c1) + fail-closed null-tenant / max-window clamp / UTC bounds fix (2e694ec).
   23-7-log-explorer: drafted                        # No log explorer page (needs OpenSearch tail). Spec only.
-  23-8-infrastructure-monitor: drafted              # No infrastructure monitor page. Spec only.
+  23-8-infrastructure-monitor: done                 # Infrastructure Monitor page + lightweight infra-metrics endpoint (runtime/disk/dependency health, platform-owner) (116d619).
   23-9-knowledge-base-monitor: drafted              # KB dashboard is feature/config UI from KB epic, not this story's monitoring page. Spec only.
   23-10-security-access-audit: drafted              # No security/access audit monitoring page. Spec only.
   23-11-monitoring-api-foundation: superseded       # Foundation targets deleted TS packages/api Fastify backend; superseded by C# Tamma.Api port. Needs respec.
-  23-12-dashboard-navigation: drafted               # No Monitoring nav group, MonitoringLayout, primitives, or useMonitoringSSE built. Spec only.
+  23-12-dashboard-navigation: done                  # Monitoring dashboard nav + layout + shared primitives — foundation for the Epic-23 pages (fb6dd05).
   epic-23-retrospective: optional
 
   epic-24: contexted

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,5 +1,7 @@
 # API Reference
 
+_Last updated: 2026-07-15._
+
 Reference for Tamma's REST surface: the C# ASP.NET minimal APIs in `Tamma.Api` (plus the ELSA engine's resume seams). This page is a **companion** to the machine-generated OpenAPI — it documents the route map, the auth/RBAC policies, the SSE streams, the webhook signature schemes, the DCB event catalog, and how the two operating modes differ. For request/response schemas of an individual endpoint, use Swagger (below).
 
 Related: [Usage & Configuration](Usage-and-Configuration) · [Installation & Setup](Installation) · [Architecture](Architecture) · [Security](Security).
@@ -122,6 +124,7 @@ A large surface, mostly `PlatformOwnerAccess`. Highlights:
 - **KEK rotation:** `POST /kek/rotate/start`, `GET /kek/rotate/status`, `POST /kek/rotate/retry`.
 - **Secrets:** `POST /secrets`, `POST /secrets/{id}/rotate`, `GET /secrets[/{id}[/versions]]`, `POST /secrets/{id}/retire-version/{n}`.
 - **Analytics / impersonation:** `GET /analytics/{summary|tenants|events}`, `POST /tenants/{id}/impersonate`, `GET /impersonations/active`, `GET /diagnostics/platform-queues`.
+- **Infrastructure monitor (Story 23-8):** `GET /monitoring/infrastructure` (PlatformOwnerAccess) — one read-only live snapshot of the API process + host composed with the admin health probes: `runtime` (framework/OS/arch, CPU %, uptime), `process` (threads, GC collections), `memory` (working set / managed heap vs. the cgroup or GC limit, `memoryLimitSource: "cgroup"|"gc"`), `disks[]`, `dependencies[]` (Postgres, RabbitMQ, ELSA, ChromaDB, OpenSearch — `status: healthy|unhealthy|unknown` + allowlist-sanitized `detail`, never a raw exception/host/secret), `collectedAt`. System-level, not tenant-scoped; non-platform-admins get 403.
 - **SSE:** `GET /tenants/{tenantId}/events/stream` (see [SSE](#sse-streams)).
 
 ### Admin alerts / audit / billing (`/api/v1/admin`, mostly `PlatformOwnerAccess`)
@@ -141,12 +144,21 @@ A large surface, mostly `PlatformOwnerAccess`. Highlights:
 
 Org lifecycle, members, invites, audit, secrets, API keys, dashboard, analytics, alerts, and agent trails — all tenant-scoped with `RequireTenantMembershipFilter`. Examples: `POST /`, `GET|PUT /{tenantId}[/settings]`, `POST /{tenantId}/reprovision`, `GET|PUT|DELETE /{tenantId}/members[...]`, `POST|GET|DELETE /{tenantId}/invites[...]`, `POST /{tenantId}/transfer-ownership`, `DELETE /{tenantId}`, `…/secrets[...]` (incl. `/rotate`, `/rotate-workflow`, `/retire-version/{n}`), `…/api-keys[...]`, `…/dashboard/{summary|runs|stats}`, `…/analytics/{usage|usage/breakdown|cost}`, `…/alerts[...]`, `…/alert-channels[...]`, `…/agents/{agentId}/{runs|trail}`. Standalone: `GET /api/v1/tenants`, `GET /api/v1/tenants/{id}/status`, secret reveal `GET /api/v1/secrets/reveal/{token}` (bearer token, rate `SecretReveal`), onboarding `GET /api/v1/onboarding/{status|install-github}`, `GET|POST /api/onboarding/{platforms|install|installations}`.
 
+Onboarding write slices (Story 18-4, tenant strictly from `ITenantContext` — null/empty tenant fails closed `404 no_active_tenant`, no route/body tenant → no IDOR):
+
+| Verb | Path | Auth | Semantics |
+|------|------|------|-----------|
+| PATCH | `/api/v1/onboarding/repos/{installationId}/{repoId}` | PlatformsManage | Flip a connected repo's `IsActive` flag (body `{ "active": bool }`). Foreign/unknown installation → `404 installation_not_found`; unknown repo → `404 repo_not_found`; missing body → 400. Idempotent (a no-op flip emits nothing); a real flip emits `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS`. Returns `{installationId, repoId, repoFullName, active, changed}`. |
+| POST | `/api/v1/onboarding/complete` | MemberAccess | Record the onboarding-complete milestone by emitting `ONBOARDING.COMPLETED.SUCCESS` (the append-only event IS the record — no persisted flag). Idempotent: a prior completion returns `{completed:true, alreadyCompleted:true, completedAt}` without a duplicate append; first call returns installation + active-repo counts. |
+
 ### Agents & providers
 
 - **Agent config** (`/api/v1/agents`, SettingsView): `GET|PUT /config`, `POST /config/validate`, `GET /{role}/resolve`, `POST /resolve-for-phase`, `GET|POST /`, `GET /{id}[/versions[/{n}]]`, `POST /{id}/versions`, `POST /{id}/archive`. **BYOK:** `GET /providers`, `POST /providers/{provider}/credential`, `…/credential/rotate`, `DELETE …/credential`.
 - **Agent registry v2** (`/api/agents`, MemberAccess): `GET /`, `GET /resolve`, `GET /role-selections`, `GET /{id}[/versions[/{n}]]`, `POST /`, `POST /{id}/{versions|archive|rollback}`, `PUT /role-selections/{role}`, `GET|PUT|DELETE /enablement` (`AgentManage` on writes).
 - **Integration BYOK** (`/api/v1/integrations`): `POST|DELETE /jira/credential`, `POST|DELETE /email/credential` (PlatformsManage).
-- **Provider health/diagnostics** (`/api/providers`, SettingsView): `GET /health[/providers[/{key}]]`, `POST /health/providers/{key}/{failure|success|reset}`, `POST /chain/resolve`, `GET /diagnostics[/query|/report|/budget/{acct}]`, `POST /diagnostics[/batch]` (rate `ProviderIngest`), `POST /providers/create`, `POST /providers/{handle}/execute` (rate `ProviderExecute`), `DELETE /providers/{handle}`, `GET /providers/sessions`.
+- **Provider health/diagnostics** (`/api/providers`, SettingsView): `GET /health[/providers[/{key}]]`, `POST /health/providers/{key}/{failure|success|reset}`, `POST /chain/resolve`, `GET /diagnostics[/query|/report|/deep|/budget/{acct}]`, `POST /diagnostics[/batch]` (rate `ProviderIngest`), `POST /providers/create`, `POST /providers/{handle}/execute` (rate `ProviderExecute`), `DELETE /providers/{handle}`, `GET /providers/sessions`.
+  - `GET /diagnostics/deep` (Story 23-6) — per-provider latency percentiles (p50/p95/p99), error-class breakdown (by `ErrorCode`), token/cost analytics and per-model usage over `?from&to&providerKey` (defaults: last 24h). Cost figures are the tenant's own recorded spend — never a platform margin (the cross-tenant view is the separate `PlatformOwnerAccess` admin analytics surface).
+  - **Diagnostics read hardening (Story 23-6 review):** all four tenant-scoped reads (`/diagnostics`, `/diagnostics/query`, `/diagnostics/report`, `/diagnostics/deep`) fail closed on a null ambient tenant with `404 {"error":"no_active_tenant"}` before any repository call — a stale JWT can no longer trigger a cross-tenant fan-out. `from`/`to` are bound as raw ISO-8601 strings and parsed `AssumeUniversal | AdjustToUniversal` (offset-less ⇒ pinned UTC, explicit offset ⇒ converted), unparseable → `400 invalid_from` / `invalid_to`. On `/report` and `/deep`, a `[from,to)` window wider than **90 days** → `400 {"error":"window_too_large","maxDays":90}`.
 
 ### Prompts, conventions, config
 
@@ -155,6 +167,10 @@ See [Usage & Configuration](Usage-and-Configuration#prompt-override-store) for t
 ### Engine / history / DCB (`/api/engine`, group `WorkflowsView`)
 
 `POST /command` (WorkflowsManage), `GET /{state|stats|plan|history|issues|security-alerts|cycle-results|agent-available}`, `GET /events/state` + `GET /events/logs` (SSE), `POST /store-context`, `GET /context/{issueNumber}`, `POST /query-context`, `GET /repo-config`, `POST /{issue-comment|issue-labels|create-issue|trigger-ci|execute-task|cycle-result}`, `DELETE /issue-labels/{repo}/{issueNumber}/{label}`. DCB append: `POST /events` and `POST /platform-events` (`EngineServiceOnly`).
+
+**DCB event query (Story 4-7)** — `GET /api/engine/events/query` (WorkflowsView, tenant-scoped). Cursor-paginated read over `domain_events`, newest-first. Query params: `type` (+ `prefix=true` for prefix match), `correlationId`, `actor`, `from`/`to` (ISO-8601; `from > to` → 400), `cursor` (last `sequenceNumber` of the prior page; `< 1` → 400), `limit` (default 50, clamp 1–200), `includeTotal`. Response: `{events[{id,type,tags,data,createdAt,issueNumber,sequenceNumber}], total, limit, nextCursor, hasMore}`. No resolved tenant → an empty page (never cross-tenant rows). Backs the dashboard's Event Store Explorer and Agent Monitor pages.
+
+**Black-box replay (Story 4-8)** — `GET /api/engine/runs/{correlationId}/replay?upTo={seq|timestamp}&from={seq}` (WorkflowsView, tenant-scoped). Point-in-time state reconstruction: a pure, deterministic left-fold over the run's ordered DCB event slice — nothing is re-executed or written (time-travel for debugging, not re-run). `upTo` = as-of point, either a positive `sequenceNumber` or an ISO-8601 timestamp (parsed `AssumeUniversal | AdjustToUniversal` — offset-less ⇒ UTC, explicit offset ⇒ converted); omitted = whole run. `from` = optional positive `sequenceNumber`; adds a `delta` diff of the two prefix folds. Fail-loud 400s: non-positive/unparseable `upTo` or `from`, and `from` resolving **after** `upTo` (`400` instead of a silent empty diff). Null/empty tenant or a run this tenant doesn't own → `404 run not found` (no IDOR). `upTo` before the run began → `200` with `eventsReplayed = 0`. The event fetch is bounded to **10,000** events; an over-cap run folds the capped oldest-first slice and sets `truncated: true`. The result categorizes events into AI decisions, code changes, approval points, and errors, and derives the step reached + terminal status.
 
 ### Workflows & ADL
 
@@ -166,10 +182,23 @@ The engine holds no external credentials; all outbound integration calls are med
 
 `POST /api/v1/llm/call` · `GET /api/v1/llm/runs/{correlationId}/stream` (SSE, AuthenticatedAny) · `POST|GET|PUT|PATCH|DELETE /api/v1/git/{owner}/{repo}/…` (branches, pull-requests, issues, commits, file-changes, releases) · `POST|GET /api/v1/ci/{owner}/{repo}/{test-runs|build-status}` · `GET|PATCH /api/v1/jira/tickets/{id}` · `POST|GET /api/v1/agent-dispatch/{owner}/{repo}/runs[…]` · `POST /api/v1/notifications/{slack|email}` · `POST /api/v1/workflows/{id}/{status|result}` · `POST /api/v1/installations/{id}/rotate-key`.
 
+### User dashboard: repos & workflow runs (Stories 21-4 / 23-5)
+
+Tenant-facing read surface behind the SPA's `/repos` and `/runs` pages. All four are `MemberAccess`; the tenant is resolved strictly from the ambient `ITenantContext` (never a route/body value → no IDOR), and a null/empty tenant fails closed with `404 {"error":"no_active_tenant"}` before any repository call. Per-run cost is the tenant's **own** recorded spend summed from the run's `costUsd` event fields — no platform margin/markup is ever read.
+
+| Verb | Path | Returns |
+|------|------|---------|
+| GET | `/api/v1/repos` | The tenant's connected platform installations, newest-first: `{tenantId, repos[{id,name,platform,baseUrl,externalId,status,isPrimary,connectedAt,updatedAt}], count}` |
+| GET | `/api/v1/runs?limit&page` | Workflow runs, newest-first, offset-paginated (`limit` clamp 1–100, default 25): `{tenantId, total, page, pageSize, runs[{id,definitionId,status,currentActivity,createdAt,startedAt,completedAt,durationMs}]}` |
+| GET | `/api/v1/runs/summary?from&to` | Workflow Monitor aggregate: per-status + per-definition instance counts over an optional `[from,to)` window (`from`/`to` ISO-8601 parsed as UTC; unparseable values are ignored). Counts only — no cost/economics. |
+| GET | `/api/v1/runs/{runId}` | One run's detail: instance metadata + the full DCB event timeline (correlationId = run id, oldest-first) + derived `logs`, `filesChanged`, `prUrl`, `totalCostUsd`. Foreign/unknown run → `404 run_not_found`. The timeline fetch is bounded to **10,000** events; over the cap the response carries the capped slice with `truncated: true`. |
+
+The Story-23 monitoring pages (System Health, Event Store Explorer, Configuration Audit, Workflow Monitor, Agent Monitor, Provider Diagnostics, Infrastructure Monitor) are dashboard compositions over the endpoints on this page — only `/api/v1/runs/summary`, `/api/providers/diagnostics/deep`, and `/api/admin/monitoring/infrastructure` were added for them; the rest reuse `/api/engine/events/query`, `/api/providers/health`, `/api/v1/llm/runs/{id}/stream`, `/api/health`, config/prompts/conventions reads, and the org audit log.
+
 ### Dashboard, KB, Mentorship
 
 - **Dashboard** (`/api/dashboard`, DashboardView): `GET /{summary|engines|workflows}`.
-- **Knowledge base** (`/api/kb`, SettingsView; writes SettingsManage): ~30 routes across `/index`, `/vector-db`, `/rag`, `/mcp`, `/context`, `/analytics` (e.g. `GET /index/status`, `POST /vector-db/search`, `POST /rag/query`, `GET /mcp/servers`, `POST /mcp/tools/invoke`).
+- **Knowledge base** (`/api/kb`, SettingsView; writes SettingsManage): ~30 routes across `/index`, `/vector-db`, `/rag`, `/mcp`, `/context`, `/analytics` (e.g. `GET /index/status`, `POST /vector-db/search`, `POST /rag/query`, `GET /mcp/servers`, `POST /mcp/tools/invoke`). The C# API proxies these 1-to-1 to the `intelligence-server` sidecar's `/kb/*` routes. Since Epic 6 (2026-07-05/06) the sidecar composition root wires a **real vector store** (ChromaDB via `CHROMADB_URL`, or pgvector) with embeddings served by **local Ollama** (`EMBEDDING_PROVIDER=ollama`, `nomic-embed-text`, 768-dim — no OpenAI key/cost), and bootstraps the RAG collection at startup, so a configured deployment reports `configured` on `GET /index/status` / `GET /vector-db/status`. With no vector-store env set, the pre-existing `not_configured` stub behaviour still applies.
 - **Mentorship** (MVC controller `/api/Mentorship`, `[Authorize]`): `POST /start`, `GET /sessions[/{id}]`, `POST /sessions/{id}/{pause|resume|cancel}`, `GET /sessions/{id}/events`, `GET /analytics/dashboard`.
 
 ## SSE streams
@@ -221,6 +250,7 @@ Representative families (see the `*EventTypes.cs` / `*Events.cs` constant classe
 - **Pricing / entitlements** — `PLAN.VERSION.CREATED`, `TENANT.PLAN.{CHANGED,CANCELLED}`, `PRICING.MARGIN.UPDATED`, `ENTITLEMENT.RESOLVED.{SUCCESS,FAILED}`, `PROVIDER.{REGISTERED,PRICE.VERSIONED,STATUS_CHANGED}`.
 - **Audit / notifications** — `AUDIT.CHAIN.{VERIFIED,TAMPER_DETECTED,CHECKPOINTED}`, `AUDIT.QUERIED`, `EMAIL.SENT.{SUCCESS,FAILED}`, `NOTIFICATION.SLACK.SENT.SUCCESS` / `…SEND.FAILED`.
 - **Tenant lifecycle / secrets** — `TENANT.CREATED.SUCCESS`, `TENANT.PROVISIONED.SUCCESS`, `TENANT.DELETE.*`, `PLATFORM.INSTALLATION.{CONNECTED,DISCONNECTED}.SUCCESS`, `SECRET.ROTATION.*` (`REQUESTED`/`STAGED`/`SWITCHED`/`COMPLETED`/`RETIRED`/…).
+- **Onboarding / repos** — `ONBOARDING.COMPLETED.SUCCESS` (the append-only record of the onboarding milestone; tags `tenantId`/`userId`, data = installation + active-repo counts), `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS` (a connected repo's `IsActive` flip).
 - **Workflow / ADL activities** — e.g. `CYCLE.{STARTED,COMPLETED,FAILED}`, `MERGE_APPROVAL.DECISION.*`, `MERGE.{SUCCESS,FAILED}`, `PR.CREATED.*`, `REVIEW_FIX.*`, `TDD_DEBUG.*`, `DEPLOY.{STAGE,PIPELINE,ROLLBACK}.*`, `GATE.{PASSED,FAILED,ESCALATED}.*`, `TRIAGE.*`, `BLOCKER.*`, `DEBUG.*`, `CODE_REVIEW.*`, `ANALYTICS.ROLLUP.*`.
 
 ## Related

--- a/wiki/Deployment.md
+++ b/wiki/Deployment.md
@@ -4,23 +4,27 @@ This page covers environment variables, the least-privilege app-role runbook, an
 
 ## Docker Compose stack
 
-Production deployment runs on Hetzner CPX42 (16 GB). Services (see `docker-compose.yml`):
+Production deployment runs on Hetzner CPX42 (16 GB). Services (see `docker/docker-compose.yml`; memory column = prod limit from `docker-compose.prod.yml`):
 
 | Service | Tech | Memory | Purpose |
 |---------|------|--------|---------|
-| postgres | 17 | 2 GB | Data, events, ELSA state |
-| rabbitmq | Latest | 512 MB | Message broker |
+| postgres | Postgres 17 | 2 GB | Data, events, ELSA state |
+| rabbitmq | RabbitMQ 3.13 | 512 MB | Message broker |
+| chromadb | Chroma 1.5.8 | 1 GB | Vector store (KB/RAG) |
+| ollama | Ollama 0.31.1 | 2 GB | Local embedding server (`nomic-embed-text`, 768-dim) — self-hosted KB/RAG embeddings, no OpenAI key or per-token cost |
+| intelligence-server | Node.js 22 (Fastify) | — (no prod limit) | KB/RAG sidecar backing the C# API's `/api/kb/*` endpoints |
 | elsa-server | .NET 8 | 1 GB | ELSA workflow engine |
-| tamma-api-dotnet | .NET 8 | 512 MB | .NET REST API (this is the Tamma.Api surface) |
-| tamma-api | Node.js 22 | 512 MB | Fastify REST API (legacy, being ported out) |
+| tamma-api | .NET 8 | 768 MB | Consolidated C# REST API (the `Tamma.Api` surface — the old `tamma-api-dotnet` / Node Fastify split no longer exists) |
 | tamma-engine | Node.js 22 | 1 GB | TypeScript engine |
 | tamma-dashboard | nginx | 256 MB | React SPA |
 | elsa-studio | nginx | 128 MB | Custom Blazor WASM |
-| nginx-proxy | nginx | 128 MB | Reverse proxy |
-| chromadb | Latest | 1 GB | Vector store |
-| opensearch (opt-in) | 2.x | 3 GB | Log aggregation |
+| oauth2-proxy | oauth2-proxy v7.7.1 | 128 MB | GitHub OAuth `auth_request` gate |
+| nginx-proxy | nginx 1.27 | 128 MB | Reverse proxy |
+| opensearch (+ dashboards, opt-in) | 2.19 | 3 GB (+1.5 GB) | Log aggregation (`observability` profile) |
 
-Deploy is **layered** (postgres → rabbitmq → elsa → APIs → dashboard + nginx) so in-flight upgrades never race their own dependencies. DNS + SSL via Cloudflare (`app.tamma.dev`, `api.tamma.dev`, `elsa.tamma.dev`, `wiki.tamma.dev`).
+Memory budget (sum of prod limits, not reservations): **~8.8 GB** without the observability profile, **~13.4 GB** with it — fits the 16 GB VPS, but mind headroom when running observability + ollama together.
+
+Deploy is **layered** (postgres + rabbitmq + chromadb → elsa-server → tamma-api — which pulls up ollama + intelligence-server via `depends_on` — → engine + dashboard + studio + proxies) so in-flight upgrades never race their own dependencies. DNS + SSL via Cloudflare (`app.tamma.dev`, `api.tamma.dev`, `elsa.tamma.dev`, `wiki.tamma.dev`).
 
 ## Core environment variables
 
@@ -54,6 +58,19 @@ When both `AppId` > 0 and `PrivateKey` are set, DI swaps in `OctokitGitHubAppCli
 | `ConnectionStrings:Redis` | StackExchange.Redis connection string. |
 
 When set, the API swaps `InMemoryDistributedRateLimitBackend` → `RedisDistributedRateLimitBackend` (Lua `INCR + EXPIRE`). Multi-pod-safe. Unset means single-pod in-process rate limiting (safe default, matches pre-Redis behaviour).
+
+### KB / RAG sidecar embeddings (optional overrides; defaults to local Ollama)
+
+The `intelligence-server` sidecar's embedding config is passed through compose with self-hosted defaults — **no OpenAI key is required**:
+
+| Variable (`docker/.env`) | Default | Purpose |
+|-----|---------|---------|
+| `INTELLIGENCE_EMBEDDING_PROVIDER` | `ollama` | Embedding provider. Set `openai` (plus an API key) only if a cloud provider is wanted. |
+| `INTELLIGENCE_EMBEDDING_MODEL` | `nomic-embed-text` | 768-dim local embedding model, pulled by the `ollama` service on first boot. |
+| `INTELLIGENCE_EMBEDDING_BASE_URL` | `http://ollama:11434` | Embedding API endpoint (the in-stack Ollama server). |
+| `INTELLIGENCE_LOG_LEVEL` | `info` | Sidecar log level. |
+
+Compose maps these onto the sidecar's own env (`EMBEDDING_PROVIDER` / `EMBEDDING_MODEL` / `EMBEDDING_BASE_URL`); the vector store is fixed to `CHROMADB_URL=http://chromadb:8000`. The sidecar bootstraps its RAG collection (`KB_RAG_COLLECTION`, default `codebase`) at boot — a fresh, never-indexed deployment reports **configured** (retrieval just returns nothing until content is indexed). With no vector-store env at all, the sidecar degrades to its `not_configured` stubs instead of crashing. The `ollama` service has **no host port mapping** — its API is unauthenticated and must stay internal to `tamma-net`; the model persists in the `tamma-ollama-data` volume, so the pull cost is first-boot-only.
 
 ### Cranl (optional; activates per-tenant provisioning)
 

--- a/wiki/Epics/Epic-18-User-Auth.md
+++ b/wiki/Epics/Epic-18-User-Auth.md
@@ -1,6 +1,6 @@
 # Epic 18: End-User Auth & Registration
 
-**Status:** Partially implemented — 18-4 done (non-migration slices completed 2026-07-05); 18-2/18-5 in progress; 18-1/18-3/18-6 drafted; 18-7/18-8 scoped 2026-04-21
+**Status:** Partially implemented — 18-4 nearly done (non-migration slices landed 2026-07-05; jsonb install-settings migration lane outstanding); 18-2/18-5 in progress; 18-1/18-3/18-6 drafted; 18-7/18-8 scoped 2026-04-21
 **Stories:** 8 (18-1 through 18-8)
 **Layer:** Layer 3 (Platform Ops)
 **Depends on:** Epic 16 (unified auth), Epic 17 (tenant model), Epic 1.5 (Fastify API + GitHub App)
@@ -278,7 +278,7 @@ sequenceDiagram
 | 18-1 Registration + Email Verification | Drafted | Waits on Story 29 for hardened secret rotation of email-verification HMAC |
 | 18-2 Login + Session Mgmt | **In Progress** | Dual auth (email+password + GitHub OAuth) + refresh rotation |
 | 18-3 Organisation/Tenant Creation | Drafted | `OrgEndpoints.cs` already carries the full hierarchy-respecting mutation set |
-| **18-4 GitHub App Install Onboarding** | **Done** (2026-04-21; non-migration slices completed 2026-07-05) | Status endpoint, state-encoded install redirect, webhook + callback linking, repo selection. 2026-07-05 added the remaining non-migration slices: `PATCH /api/v1/onboarding/repos/{installationId}/{repoId}` toggles a connected repo's `IsActive` flag (AC4, emitting `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS`), and an onboarding-complete endpoint (AC6/AC7) that emits `ONBOARDING.COMPLETED.SUCCESS` — idempotent via the event stream (a prior completion event is returned, not re-emitted); there is no persisted "onboarding complete" column, the append-only DCB stream is the source of truth |
+| **18-4 GitHub App Install Onboarding** | **In Progress** (core landed 2026-04-21; non-migration slices completed 2026-07-05; jsonb install-settings migration lane outstanding) | Status endpoint, state-encoded install redirect, webhook + callback linking, repo selection. 2026-07-05 added the remaining non-migration slices: `PATCH /api/v1/onboarding/repos/{installationId}/{repoId}` toggles a connected repo's `IsActive` flag (AC4, emitting `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS`), and an onboarding-complete endpoint (AC6/AC7) that emits `ONBOARDING.COMPLETED.SUCCESS` — idempotent via the event stream (a prior completion event is returned, not re-emitted); there is no persisted "onboarding complete" column, the append-only DCB stream is the source of truth |
 | 18-5 Dashboard Shell (`dash.tamma.dev`) | **In Progress** | React SPA scaffold + layout + projects + settings routes |
 | 18-6 Password Reset | Drafted | Reuses the email outbox + token lifecycle |
 | **18-7 Tenant-admin User Mgmt API gaps** | Planned (14h, added 2026-04-21) | Resend invite, tenant-scoped audit endpoint, `TENANT.MEMBER_ROLE_CHANGED.SUCCESS` event |

--- a/wiki/Epics/Epic-18-User-Auth.md
+++ b/wiki/Epics/Epic-18-User-Auth.md
@@ -1,6 +1,6 @@
 # Epic 18: End-User Auth & Registration
 
-**Status:** Partially implemented — 18-4 just landed; 18-5 in progress; 18-1/18-2/18-3/18-6 drafted; 18-7/18-8 scoped 2026-04-21
+**Status:** Partially implemented — 18-4 done (non-migration slices completed 2026-07-05); 18-2/18-5 in progress; 18-1/18-3/18-6 drafted; 18-7/18-8 scoped 2026-04-21
 **Stories:** 8 (18-1 through 18-8)
 **Layer:** Layer 3 (Platform Ops)
 **Depends on:** Epic 16 (unified auth), Epic 17 (tenant model), Epic 1.5 (Fastify API + GitHub App)
@@ -111,7 +111,7 @@ ONBOARDING.COMPLETED.SUCCESS event
 | Component | Source | Story | Role |
 |-----------|--------|-------|------|
 | **AuthEndpoints (C#)** | `Tamma.Api/Endpoints/AuthEndpoints.cs` | 18-1, 18-2, 18-6 | Register, login, logout, verify-email, reset-password, refresh |
-| **OnboardingEndpoints** | `Tamma.Api/Endpoints/OnboardingEndpoints.cs` | 18-4 | Status, install-github, install-callback, repo selection, first-run |
+| **OnboardingEndpoints** | `Tamma.Api/Endpoints/OnboardingEndpoints.cs` | 18-4 | Status, install-github, install-callback, repo selection, repo activate/deactivate, onboarding-complete |
 | **OrgEndpoints** | `Tamma.Api/Endpoints/OrgEndpoints.cs` | 18-3, 18-7 | Create tenant, list members, invite, change role, remove, transfer ownership, audit |
 | **PasswordService** | `Tamma.Api/Auth/PasswordService.cs` | 18-1 | Argon2id hashing (m=64MB, t=3, p=4) |
 | **PasswordStrengthValidator** | `Tamma.Api/Auth/PasswordStrengthValidator.cs` | 18-1 | zxcvbn-style rule: min 12 chars, not in common-passwords list |
@@ -278,7 +278,7 @@ sequenceDiagram
 | 18-1 Registration + Email Verification | Drafted | Waits on Story 29 for hardened secret rotation of email-verification HMAC |
 | 18-2 Login + Session Mgmt | **In Progress** | Dual auth (email+password + GitHub OAuth) + refresh rotation |
 | 18-3 Organisation/Tenant Creation | Drafted | `OrgEndpoints.cs` already carries the full hierarchy-respecting mutation set |
-| **18-4 GitHub App Install Onboarding** | **Done** (2026-04-21) | Status endpoint, state-encoded install redirect, webhook + callback linking, repo activation, first-run stub |
+| **18-4 GitHub App Install Onboarding** | **Done** (2026-04-21; non-migration slices completed 2026-07-05) | Status endpoint, state-encoded install redirect, webhook + callback linking, repo selection. 2026-07-05 added the remaining non-migration slices: `PATCH /api/v1/onboarding/repos/{installationId}/{repoId}` toggles a connected repo's `IsActive` flag (AC4, emitting `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS`), and an onboarding-complete endpoint (AC6/AC7) that emits `ONBOARDING.COMPLETED.SUCCESS` — idempotent via the event stream (a prior completion event is returned, not re-emitted); there is no persisted "onboarding complete" column, the append-only DCB stream is the source of truth |
 | 18-5 Dashboard Shell (`dash.tamma.dev`) | **In Progress** | React SPA scaffold + layout + projects + settings routes |
 | 18-6 Password Reset | Drafted | Reuses the email outbox + token lifecycle |
 | **18-7 Tenant-admin User Mgmt API gaps** | Planned (14h, added 2026-04-21) | Resend invite, tenant-scoped audit endpoint, `TENANT.MEMBER_ROLE_CHANGED.SUCCESS` event |
@@ -329,4 +329,4 @@ Story 18-8 ships the UI — members page, pending-invites section, transfer-owne
 
 ---
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-07-15_

--- a/wiki/Epics/Epic-2-Autonomous-Loop.md
+++ b/wiki/Epics/Epic-2-Autonomous-Loop.md
@@ -1,6 +1,6 @@
 # Epic 2: Autonomous Development Loop
 
-**Status:** Near Complete (13/20 done; 3 drafted for workflow redesign; 4 ready-for-dev)
+**Status:** Near Complete (14/20 done — 2-14 landed 2026-07-05; 2-15/2-16 ready-for-dev; 2-17..2-20 drafted for workflow redesign)
 **Stories:** 20 (2-1 through 2-20)
 **Tech Spec:** [tech-spec-epic-2.md](https://github.com/meywd/tamma/blob/main/docs/stories/epic-2/tech-spec-epic-2.md)
 **Retrospective:** Completed
@@ -43,7 +43,8 @@ The TypeScript mirror (`packages/orchestrator/src/engine.ts` — `TammaEngine`) 
 | `TammaEngine` (TS mirror) | In-process engine for CLI mode | `packages/orchestrator/src/engine.ts` | Done |
 | Intelligent provider selection | Route task to best provider by task type + cost + availability | `packages/providers/src/provider-chain.ts` | Done (2-12) |
 | Prompt engineering | Per-role prompt library + A/B testing scaffold | `packages/providers/src/agent-prompt-registry.ts` | Done (2-13) |
-| Issue decomposition engine | Break large issue into task graph | `docs/stories/epic-2/story-2-14/`, `story-2-15`, `story-2-16` | Ready-for-dev |
+| `IssueDecompositionWorkflow` | Break a complex issue into an ordered, dependency-declared sub-task set via mediated LLM; `DECOMPOSITION.*` events | `Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs`, `Tamma.Activities/Decomposition/*` | Done (2-14) |
+| Task dependency graph + incremental sequencing | Full graph-based dependency resolution / execution | `docs/stories/epic-2/story-2-15/`, `story-2-16` | Ready-for-dev |
 
 ## Class diagram
 
@@ -183,10 +184,11 @@ Every activity auto-emits `{activity}.{action}.{status}` events to the event sto
 - 33 Elsa workflow files in `Tamma.ElsaServer/Workflows/`, backed by ~150 activity classes in `Tamma.Activities/`.
 - Priority-based selection (2-20) — `SelectWorkItemActivity` has 3 outcomes (Selected / NothingFound / NeedsTriage) and ranks across issues, security alerts (Dependabot + CodeQL), failed CI on main, stale PRs.
 - `TammaEngine` TypeScript mirror for CLI mode — same pipeline, in-process.
+- **Issue Decomposition (2-14)** — landed 2026-07-05 as `IssueDecompositionWorkflow` (post-pivot architecture). Gathers codebase/prior-art context by reusing `DispatchWorkflow("context-gathering")`, then decomposes the issue via the mediated `llm-call` path (role `senior_developer` / action `decompose-issue` — the engine holds no LLM credential) into an ORDERED set of sub-tasks, each with rationale, definition-of-done, sizing, complexity, and declared prerequisite dependencies. Parsing is fail-closed (empty/unparseable/no-subtasks → `DECOMPOSITION.FAILED` + error terminal, never a fabricated breakdown). Emits `DECOMPOSITION.STARTED / CONTEXT_GATHERED / COMPLETED / FAILED` DCB events. Decomposition is autonomous — the AC7 "human approval before executing sub-tasks" is a downstream orchestration concern of the parent flow.
 
 **Ready for dev:**
 
-- 2-14 Issue Decomposition Engine, 2-15 Task Dependency Mapping, 2-16 Incremental Task Sequencing — context XMLs exist; partial support via `TaskCreationWorkflow` but full graph-based dependency resolution not implemented.
+- 2-15 Task Dependency Mapping, 2-16 Incremental Task Sequencing — context XMLs exist; 2-14's workflow declares per-sub-task prerequisite dependencies, but full graph-based dependency resolution / incremental execution is not implemented.
 
 **Drafted (workflow optimization wave 2):**
 

--- a/wiki/Epics/Epic-21-Marketing-Dashboard.md
+++ b/wiki/Epics/Epic-21-Marketing-Dashboard.md
@@ -1,15 +1,15 @@
 # Epic 21: Marketing Site & User Dashboard
 
-**Status:** Partially Implemented (Midnight Ocean marketing redesign live on tamma.dev; 4 stories still drafted/in-progress)
+**Status:** Partially Implemented (Midnight Ocean marketing redesign live on tamma.dev; 21-4 Repos & Workflow Runs landed 2026-07-05; 3 stories still drafted/in-progress)
 **Stories:** 5 (21-1 through 21-5)
-**Estimated Effort:** 128 hours (20 delivered; ~108 remaining)
+**Estimated Effort:** 128 hours (52 delivered; ~76 remaining)
 **Packages:** `apps/marketing-site`, `apps/wiki-site`, `packages/dashboard`
 
 ## Overview
 
 Epic 21 is the public-facing half of the Tamma SaaS. It pairs a marketing site at `tamma.dev` (acquisition funnel: hero, pricing, docs, blog, legal) with a user-facing dashboard at `app.tamma.dev/user/*` (self-service: repos, runs, settings, billing). Together they serve every visitor who has not yet signed up, every user managing their own workflows, and every tenant-admin managing organization billing.
 
-The marketing landing page is live — the Midnight Ocean redesign ships as a Cloudflare Worker running vanilla HTML/CSS with a `/api/signup` endpoint backed by Cloudflare KV. The wiki is live at `wiki.tamma.dev`. The pricing page, docs section, user-dashboard repos view, user-dashboard settings/billing view, and Stripe checkout are all still planned.
+The marketing landing page is live — the Midnight Ocean redesign ships as a Cloudflare Worker running vanilla HTML/CSS with a `/api/signup` endpoint backed by Cloudflare KV. The wiki is live at `wiki.tamma.dev`. The Repos & Workflow Runs dashboard pages landed 2026-07-05 (21-4). The pricing page, docs section, user-dashboard settings/billing view, and Stripe checkout are still planned.
 
 The admin dashboard at `app.tamma.dev` already exists (Epic 5 / Epic 16) and hosts settings, agents, provider health, knowledge-base management, and — as of 2026-04-22 — the Story 27-4 prompt store admin UI. The user dashboard lives in the **same** React SPA under a `/user/*` route prefix so both surfaces share auth, layout, and the `tamma_session` JWT cookie.
 
@@ -29,17 +29,17 @@ wiki.tamma.dev  (Cloudflare Worker — wiki-site, Epic 25)
 
 app.tamma.dev   (Hetzner VPS — packages/dashboard React SPA)
   /                     Admin shell (KB, agents, settings, prompts, health)
-  /user/repos           Connected repositories                    (21-4 planned)
-  /user/runs            Workflow run history + SSE live status    (21-4 planned)
-  /user/runs/:runId     Event timeline, logs, 14-step progress    (21-4 planned)
+  /repos                Connected repositories                    (21-4 done — shipped without the /user prefix)
+  /runs                 Workflow run history                      (21-4 done)
+  /runs/:runId          DCB event timeline + run detail           (21-4 done)
   /user/settings        Profile, org, API keys                    (21-5 planned)
   /user/billing         Subscription, invoices, Stripe portal     (21-5 planned)
 
-api.tamma.dev   (Fastify on VPS)
-  /api/v1/repos         User-scoped repo CRUD
-  /api/v1/runs          Workflow run list + detail
-  /api/v1/events/stream SSE for live run status
-  /webhooks/stripe      Stripe checkout / invoice webhooks
+api.tamma.dev   (Tamma.Api — ASP.NET Core Minimal API)
+  /api/v1/repos         Tenant-scoped connected repos (over github_installations)   (21-4 done)
+  /api/v1/runs          Workflow run list over the DCB run events                   (21-4 done)
+  /api/v1/runs/:runId   Single run's event/log detail                               (21-4 done)
+  /webhooks/stripe      Stripe checkout / invoice webhooks        (21-2 planned)
 ```
 
 All three public surfaces share the root domain `*.tamma.dev` with Cloudflare Full SSL and origin certificates. The SPA and the marketing site share the `tamma_session` JWT cookie on `.tamma.dev`.
@@ -144,8 +144,8 @@ The production landing page (`public/index.html`) has:
 1. **Prospect lands on tamma.dev** and sees Midnight Ocean hero, features, how-it-works, and "Get started free" CTA. Submitting the email form POSTs to `api/signup` which writes to Cloudflare KV with a 5-per-hour IP rate limit. (Live today.)
 2. **Prospect browses docs at tamma.dev/docs** — getting-started, CLI reference, API reference, GitHub App setup. (21-3 in progress; see Epic 25 for the separate wiki surface.)
 3. **Prospect picks a plan on tamma.dev/pricing**, clicks "Subscribe", is redirected into Stripe Checkout, returns to `app.tamma.dev/user/repos` with a verified session and a provisioned tenant. (21-2 planned.)
-4. **Logged-in user opens `/user/repos`** to see their connected GitHub repositories, click "View Runs" on a repo, "Pause" a repo, or "Disconnect" one with a confirm dialog. (21-4 planned.)
-5. **Logged-in user opens `/user/runs`**, filters by repo + status + date range, and clicks a row to open the run detail with the DCB event timeline, the 14-step orchestrator progress, logs, and PR link. Live-running workflows pulse in the list via SSE. (21-4 planned.)
+4. **Logged-in user opens `/repos`** to see the tenant's connected repositories (built over `github_installations`). The page is read-only; "Add repository" and repo activate/deactivate reuse the existing onboarding flow at `/onboarding` (see Epic 18 story 18-4). (21-4 shipped 2026-07-05.)
+5. **Logged-in user opens `/runs`**, filters by status, and clicks a row to open `/runs/:runId` with the run's DCB event/log timeline. (21-4 shipped 2026-07-05 — read-only over the DCB run events; SSE live-pulse not yet wired.)
 6. **Logged-in user manages settings** at `/user/settings`: profile name, org name, personal API keys (create, name, revoke). (21-5 planned.)
 7. **Tenant owner manages billing** at `/user/billing`: current plan, usage metrics, invoice history, change plan, and "Open Stripe Portal" for card updates. (21-5 planned.)
 8. **Admin user still sees the existing admin shell** (knowledge base, agents, prompts, health) — user routes are additive, no existing surface breaks.
@@ -192,7 +192,7 @@ The SPA at `app.tamma.dev` is served by Nginx from the shared VPS; the marketing
 | 21-1 | Marketing Landing Page (Midnight Ocean) | P0 | 20h | Done |
 | 21-2 | Pricing Page + Stripe Checkout | P1 | 24h | Drafted |
 | 21-3 | Documentation Site | P1 | 28h | In Progress (wiki live via Epic 25; marketing-side docs pending) |
-| 21-4 | User Dashboard — Repos & Workflow Runs | P0 | 32h | Drafted |
+| 21-4 | User Dashboard — Repos & Workflow Runs | P0 | 32h | Done (2026-07-05) |
 | 21-5 | User Dashboard — Settings & Billing | P1 | 24h | Drafted |
 
 ## Dependencies
@@ -219,8 +219,9 @@ The SPA at `app.tamma.dev` is served by Nginx from the shared VPS; the marketing
 ## Current state
 
 - **Live**: marketing site at tamma.dev with Midnight Ocean redesign (hero, features, how-it-works, 6-feature grid, 4-step flow, CTA, dark mode, Lighthouse >= 90). Email signup backed by Cloudflare KV with IP rate limiting. Full SEO metadata (Open Graph, Twitter, JSON-LD). wiki.tamma.dev also live via Epic 25. Admin dashboard at app.tamma.dev already hosts `/admin/prompts` (Epic 27 Story 27-4 landed 2026-04-22).
+- **Landed 2026-07-05 (21-4)**: tenant-facing **Repos & Workflow Runs** pages in the shared dashboard SPA — `ReposPage` (`/repos`, over `github_installations`), `RunsPage` (`/runs`, status filter + shared `DataTable`), `RunDetailPage` (`/runs/:runId`, single run's DCB event/log detail), plus a "Workspace" sidebar section. Backed by new C# `ReposRunsEndpoints` in `Tamma.Api`: `GET /api/v1/repos`, `GET /api/v1/runs`, `GET /api/v1/runs/{runId}` — member-visible, every read tenant-scoped (null tenant fails closed 404). Drift from the plan: routes ship at `/repos` + `/runs` (no `/user/*` prefix) inside the existing admin shell, the API is `Tamma.Api` (not Fastify), and SSE live status is not yet wired.
 - **In progress**: documentation site — marketing docs section scope still planned; the standalone wiki at wiki.tamma.dev (Epic 25) covers public documentation today.
-- **Drafted**: pricing page with Stripe Checkout (21-2), user dashboard repos + runs (21-4), user dashboard settings + billing (21-5). All three are additive — no existing admin surface breaks.
+- **Drafted**: pricing page with Stripe Checkout (21-2) and user dashboard settings + billing (21-5). Both are additive — no existing admin surface breaks.
 - **Deferred**: blog / changelog (will likely land inside the wiki site rather than marketing-site to avoid duplicating markdown renderers).
 
 ## See also
@@ -238,4 +239,4 @@ The SPA at `app.tamma.dev` is served by Nginx from the shared VPS; the marketing
 
 ---
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-07-15_

--- a/wiki/Epics/Epic-23-System-Monitoring.md
+++ b/wiki/Epics/Epic-23-System-Monitoring.md
@@ -1,9 +1,9 @@
 # Epic 23: System Monitoring & Observability Dashboard
 
-**Status:** Drafted — 12 stories, 26 task plans, implementation-ready. No dashboard/API code yet shipped; 23-1/23-6/23-9/23-11/23-12 track related in-flight work on existing infrastructure.
+**Status:** In build-out — 8/12 stories shipped 2026-07-04/05 (23-1..23-6, 23-8, 23-12); 23-7/23-9/23-10 still placeholder pages; 23-11's drafted Fastify plugin superseded by per-story C# endpoints
 **Stories:** 12 (23-1 through 23-12)
 **Task plans:** 26 detailed implementation breakdowns
-**Packages:** `@tamma/api` (new `routes/monitoring/*`), `@tamma/dashboard` (new `pages/monitoring/*`), `@tamma/shared`
+**Packages:** `@tamma/dashboard` (`pages/monitoring/*`, `components/monitoring/*`, `hooks/monitoring/*`) + C# `Tamma.Api` endpoints (the drafted `@tamma/api` Fastify `routes/monitoring/*` plugin was not built)
 
 ## Overview
 
@@ -11,7 +11,7 @@ Epic 23 is production-grade monitoring for every surface Tamma owns: the HTTP AP
 
 The epic is strictly **additive** — it reads from existing data sources (Pino structured logs, health-check endpoints, the DCB event stream, the `ICostTracker`, OpenSearch, `EngineRegistry`, `HealthService`, `DiagnosticsService`, and the KB analytics routes) and delivers the consolidated operator console at `app.tamma.dev/monitoring/*`. No new external dependencies are introduced.
 
-The frontend is a new "Monitoring" section of the existing React dashboard (`packages/dashboard/`). The backend is a new Fastify plugin at `packages/api/src/routes/monitoring/*`. Both are gated by the `settings:view` permission so only admin/owner see them.
+The frontend is a new "Monitoring" section of the existing React dashboard (`packages/dashboard/src/pages/monitoring/*` with shared primitives in `components/monitoring/*` and hooks in `hooks/monitoring/*`) — this shipped as drafted. The backend did **not** ship as the drafted Fastify plugin: the pages instead compose existing `Tamma.Api` (C#) endpoints plus new per-story ones (`GET /api/v1/runs/summary` for the workflow monitor, deep provider-diagnostics aggregations on `ProviderEndpoints`, `GET /api/admin/monitoring/infrastructure` for infra metrics). Tenant-facing reads are tenant-scoped and fail closed on a null tenant; the infrastructure endpoint is platform-owner-only.
 
 ## Architecture
 
@@ -180,20 +180,20 @@ Admin browser          React Monitoring          Fastify /monitoring   HealthSer
 
 ## Stories
 
-| # | Story | Task plans | Description |
-|---|-------|-----------:|-------------|
-| 23-1 | System Health Dashboard (Overview) | 2 | Service grid, dependency graph, error/request/latency rates |
-| 23-2 | Agent Monitor (Realtime) | 2 | Per-role provider chains, cost, rate limits, key validation |
-| 23-3 | Event Store Explorer | 2 | Search/filter/timeline/replay/export |
-| 23-4 | Configuration Audit | 2 | Sources, validation, diffs vs defaults, change history |
-| 23-5 | Workflow Monitor | 2 | Active/historical instances, Gantt, queue depth |
-| 23-6 | Provider Diagnostics (Deep) | 2 | Latency histograms, token analytics, error classification, cost compare, call logs |
-| 23-7 | Log Explorer (OpenSearch) | 2 | Live tail, Lucene search, saved searches, alerts |
-| 23-8 | Infrastructure Monitor | 2 | PostgreSQL, RabbitMQ, ChromaDB, OpenSearch, Docker metrics |
-| 23-9 | Knowledge Base Monitor | 2 | Vector DB, embeddings, RAG freshness, MCP connections |
-| 23-10 | Security & Access Audit | 2 | Logins, sessions, API keys, rate limits, suspicious activity |
-| 23-11 | Monitoring API Foundation | 3 | Route registration, SSE helpers, aggregators (foundation) |
-| 23-12 | Dashboard Navigation & Layout | 3 | Sidebar, shared layout, primitives, hooks |
+| # | Story | Task plans | Description | Status |
+|---|-------|-----------:|-------------|--------|
+| 23-1 | System Health Dashboard (Overview) | 2 | Service grid, dependency graph, error/request/latency rates | Done (2026-07-05) |
+| 23-2 | Agent Monitor (Realtime) | 2 | Per-role provider chains, cost, rate limits, key validation | Done (2026-07-05) |
+| 23-3 | Event Store Explorer | 2 | Search/filter/timeline/replay/export | Done (2026-07-05) |
+| 23-4 | Configuration Audit | 2 | Sources, validation, diffs vs defaults, change history | Done (2026-07-05) |
+| 23-5 | Workflow Monitor | 2 | Active/historical instances, Gantt, queue depth | Done (2026-07-05) |
+| 23-6 | Provider Diagnostics (Deep) | 2 | Latency histograms, token analytics, error classification, cost compare, call logs | Done (2026-07-05) |
+| 23-7 | Log Explorer (OpenSearch) | 2 | Live tail, Lucene search, saved searches, alerts | Placeholder page |
+| 23-8 | Infrastructure Monitor | 2 | PostgreSQL, RabbitMQ, ChromaDB, OpenSearch, Docker metrics | Done (2026-07-05) |
+| 23-9 | Knowledge Base Monitor | 2 | Vector DB, embeddings, RAG freshness, MCP connections | Placeholder page |
+| 23-10 | Security & Access Audit | 2 | Logins, sessions, API keys, rate limits, suspicious activity | Placeholder page |
+| 23-11 | Monitoring API Foundation | 3 | Route registration, SSE helpers, aggregators (foundation) | Superseded (per-story C# endpoints instead) |
+| 23-12 | Dashboard Navigation & Layout | 3 | Sidebar, shared layout, primitives, hooks | Done (2026-07-04) |
 
 **Total:** 26 task plans across 12 stories.
 
@@ -256,10 +256,22 @@ Admin browser          React Monitoring          Fastify /monitoring   HealthSer
 
 ## Current state
 
-- **Drafted**: all 12 stories with 26 task plans committed to `docs/stories/epic-23/`. Every screen ties back to an existing data source or a well-defined new API endpoint.
-- **Partial in-flight**: 23-1 (system health), 23-6 (provider diagnostics), 23-9 (KB monitor), 23-11 (API foundation), 23-12 (nav+layout) have in-repo work on the underlying data sources (`HealthService`, `DiagnosticsService`, `provider-health.ts`, KB routes) but no monitoring-specific API routes or dashboard pages exist yet — `packages/api/src/routes/monitoring/` and `packages/dashboard/src/pages/monitoring/` both empty.
-- **Not started**: 23-2, 23-3, 23-4, 23-5, 23-7, 23-8, 23-10 — still pure design.
-- **No external dependencies added**: the epic deliberately reuses PostgreSQL, OpenSearch, RabbitMQ, ChromaDB, and in-memory stores.
+**Landed (2026-07-04/05):**
+
+- **23-12 Navigation & Layout foundation** (2026-07-04) — sidebar "Monitoring" section, `MonitoringLayout` shell, the full shared-primitive set (`StatusBadge`, `MetricCard`, `MetricGrid`, `TimeSeriesChart` — hand-rolled SVG, no chart lib — `DataTable`, `EmptyState`, `ErrorBanner`, `ProgressRing`, `LatencyBar`), the three hooks (`useMonitoringSSE` with exponential-backoff reconnect, `useAutoRefresh` with visibility gating, `useTimeRange` with URL persistence), `monitoring-nav.ts` with all 10 routes, an overview page, and placeholder stubs for every screen.
+- **23-1 System Health** — `SystemHealthPage` + `useSystemHealth` composing the *existing* health / diagnostics / event sources into the service grid and rate views (no new backend).
+- **23-2 Agent Monitor (realtime)** — `AgentMonitorPage` showing active agents with a live tool-loop tail via `useRunStreamTail` over the existing Story 32-23 run-stream endpoint.
+- **23-3 Event Store Explorer** — `EventExplorerPage` + `useEventQuery` + `EventDetailPanel`: search / filter / detail over the DCB store through the Story 4-7 event query API.
+- **23-4 Configuration Audit** — `ConfigAuditPage` + `useConfigAudit`: effective configuration plus change history.
+- **23-5 Workflow Monitor** — `WorkflowMonitorPage` + `useWorkflowMonitor` over a new backend slice: `GET /api/v1/runs/summary` (`ReposRunsEndpoints`) backed by `WorkflowRepository.WorkflowInstanceSummary` — workflow instances, statuses, durations.
+- **23-6 Provider Diagnostics (deep)** — `ProviderDiagnosticsPage` + `useProviderDiagnostics` over a new `DiagnosticsService` / `DiagnosticsRepository` (latency / error / cost aggregations) exposed via `ProviderEndpoints`. A same-day fix made the endpoint **fail closed on a null tenant** (no cross-tenant economics fan-out on the `SettingsView` policy), clamped the max query window, and UTC-normalized date bounds.
+- **23-8 Infrastructure Monitor** — `InfrastructureMonitorPage` + `useInfrastructureMonitor` over a new lightweight `GET /api/admin/monitoring/infrastructure` endpoint (`InfrastructureMetricsService`: runtime, disk, dependency health) gated by the `PlatformOwnerAccess` policy.
+
+**Placeholder pages (design only):** 23-7 Log Explorer, 23-9 Knowledge Base Monitor, 23-10 Security & Access Audit — routes and stubs exist via 23-12, no data wiring yet.
+
+**Drift from the draft:** the backend shipped as C# `Tamma.Api` endpoints (existing + the three new slices above) rather than the drafted Fastify `packages/api/src/routes/monitoring/*` plugin — so 23-11's `MonitoringAggregator` / `MetricsCollector` / `SseHelpers` foundation was not built as specced; the architecture diagram above reflects the original draft.
+
+**No external dependencies added**: the epic deliberately reuses PostgreSQL, OpenSearch, RabbitMQ, ChromaDB, and in-memory stores.
 
 ## See also
 
@@ -277,4 +289,4 @@ Admin browser          React Monitoring          Fastify /monitoring   HealthSer
 
 ---
 
-_Last updated: 2026-04-22_
+_Last updated: 2026-07-15_

--- a/wiki/Epics/Epic-3-Quality-Gates.md
+++ b/wiki/Epics/Epic-3-Quality-Gates.md
@@ -1,6 +1,6 @@
 # Epic 3: Quality Gates & Intelligence Layer
 
-**Status:** Near Complete (8/12 done; 3-4..3-7 drafted)
+**Status:** Complete (12/12 done — intelligence-gate stories 3-4..3-7 landed 2026-07-04/05 as standalone Elsa sub-workflows)
 **Stories:** 12 (3-1 through 3-12)
 **MVP Critical:** All 12 stories
 **Tech Spec:** [tech-spec-epic-3.md](https://github.com/meywd/tamma/blob/main/docs/stories/epic-3/tech-spec-epic-3.md)
@@ -19,7 +19,7 @@ Quality gates sit **around** loop steps, not inside them. Each gate is an Elsa w
 
 The TypeScript `@tamma/gates` package implements the **permission side** (layered on top, also consumed by Epic 6): `PermissionEnforcer` evaluates each tool/command request from an agent against a per-agent / per-project policy and returns allow / deny / require_approval. `PermissionResolver` merges global + project + agent-specific policies. Violations route to `ViolationRecorder` and `ViolationAlerter`.
 
-Intelligence gates (ambiguity detection, complexity assessment, research, multi-option design) live as LLM-backed activities inside `ContextGatheringWorkflow` and `PlanGenerationWorkflow` — they run before code generation, not after. The outputs (ambiguity score, complexity estimate, knowledge-gap queue) become workflow variables that later stages read.
+Intelligence gates (ambiguity detection, clarifying questions, complexity assessment, research, multi-option design) landed as **standalone Elsa sub-workflows** — `AmbiguityScoringWorkflow`, `ClarifyingQuestionsWorkflow`, `AssessmentWorkflow`, `ResearchWorkflow`, `DesignProposalWorkflow` — that a parent flow dispatches before code generation, not after. They share one skeleton: (optionally) gather context by reusing `DispatchWorkflow("context-gathering")` → call the LLM through the mediated `DispatchWorkflow("llm-call")` path (the engine holds no LLM credential) → parse the response **fail-closed** (empty/unparseable output emits a LOUD `*.FAILED` event and routes to an error terminal — never a fabricated result) → emit typed DCB events and set outputs (score, report, proposal) that the parent reads.
 
 ## Components
 
@@ -41,10 +41,10 @@ Intelligence gates (ambiguity detection, complexity assessment, research, multi-
 | `PermissionEnforcer` | Per-agent / per-project tool + command policy evaluation | `packages/gates/src/permissions/permission-enforcer.ts` | Done |
 | `PermissionResolver` | Merge global → project → agent policies | `packages/gates/src/permissions/permission-resolver.ts` | Done |
 | `ViolationRecorder` + `ViolationAlerter` | Capture + alert on permission violations | `packages/gates/src/violations/` | Done |
-| Research activities | Generate research queries, call web / docs, classify findings | `docs/stories/epic-3/story-3-4/` | Drafted |
-| Clarifying questions | LLM generates questions for ambiguous requirements | `docs/stories/epic-3/story-3-5/` | Drafted |
-| Ambiguity detection | Score issue body 0-100, branch workflow on threshold | `docs/stories/epic-3/story-3-6/` | Drafted |
-| Multi-option design | Generate 2-3 design proposals for complex features | `docs/stories/epic-3/story-3-7/` | Drafted |
+| `ResearchWorkflow` | Gather codebase/prior-art context, synthesize a ranked confidence-scored research report via mediated LLM; `RESEARCH.*` events | `Tamma.ElsaServer/Workflows/ResearchWorkflow.cs`, `Tamma.Activities/Research/*` | Done (3-4) |
+| `ClarifyingQuestionsWorkflow` | LLM generates questions for ambiguous requirements + secure resume endpoint; `CLARIFY.*` events | `Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs` | Done (3-5) |
+| `AmbiguityScoringWorkflow` | Score requirement ambiguity 0..1 via mediated LLM, fail-closed parse, threshold policy routes to clarification; `AMBIGUITY.*` events | `Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs`, `Tamma.Activities/Ambiguity/*` | Done (3-6) |
+| `DesignProposalWorkflow` | Generate multi-alternative design proposal, deliver to issue, suspend on approval bookmark, secure resume; `DESIGN.*` events | `Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs`, `Tamma.Activities/Design/*` | Done (3-7) |
 | Agent performance monitoring | Track per-provider / per-task success + latency + cost | `packages/providers/src/provider-health.ts` | Done (3-10) |
 | Cost-aware AI usage | Budget limits (daily/weekly/monthly), alerts, emergency halt | `packages/cost-monitor/src/*` | Done (3-11) |
 | Task complexity assessment | LLM-scored complexity → route to appropriate agent | `Tamma.Activities/Assessment/*` | Done (3-12) |
@@ -183,20 +183,17 @@ SingleIssueCycle  CiWithDebugRetry   DebuggingWorkflow   AI Agent   GitHub      
 - **Agent performance monitoring** (3-10) — `provider-health.ts` tracks success / latency / cost per provider.
 - **Cost-aware usage** (3-11) — `@tamma/cost-monitor` package with tracker, limit manager, alert manager, pricing config, budget reports.
 - **Task complexity assessment** (3-12) — `Tamma.Activities/Assessment/*` (skill profile, complexity classification, question generation).
-
-**Drafted:**
-
-- 3-4 Research Capability for Unfamiliar Concepts — story brief + context XML; activity not yet landed.
-- 3-5 Clarifying Questions for Ambiguous Requirements — story brief exists; partial overlap with `Assessment` activities.
-- 3-6 Ambiguity Detection Scoring — scoring approach defined; not wired into `ContextGatheringWorkflow` yet.
-- 3-7 Multi-Option Design Proposals — story brief exists; not yet a standalone activity.
+- **Research capability** (3-4, landed 2026-07-05) — `ResearchWorkflow`: context-gathering reuse → mediated `llm-call` (role `product_owner` / action `research`, with a dedicated structured-findings prompt template in `SystemPrompts`) → fail-closed parse into a ranked, confidence-scored findings report. Emits `RESEARCH.STARTED / CONTEXT_GATHERED / COMPLETED / FAILED`. Autonomous — no human gate.
+- **Clarifying questions** (3-5, landed 2026-07-04) — `ClarifyingQuestionsWorkflow` with a secure resume endpoint; generates questions via mediated LLM and suspends until answers arrive (`CLARIFY.*` events).
+- **Ambiguity scoring** (3-6, landed 2026-07-05) — `AmbiguityScoringWorkflow`: mediated `llm-call` (role `product_owner` / action `score-ambiguity`) produces a 0..1 score + typed itemised breakdown; fail-closed parse (out-of-range score → `AMBIGUITY.FAILED`); pure `AmbiguityThresholds` policy (default 0.5, caller-overridable, clamped to [0,1]) routes score ≥ threshold to clarification (`AMBIGUITY.CLARIFICATION_TRIGGERED`) vs proceed (`AMBIGUITY.BELOW_THRESHOLD`).
+- **Multi-option design proposals** (3-7, landed 2026-07-05) — `DesignProposalWorkflow`: mediated `llm-call` (role `architect` / action `plan-system-design`) generates a proposal with multiple alternatives + trade-off analysis, delivers it to the issue, suspends on an approval bookmark with a durable SLA timeout, and resumes via the secure `DesignResumeEndpoint` (in both `Tamma.Api` and the Elsa server). Emits `DESIGN.PROPOSAL.GENERATED / DELIVERED / APPROVED / REJECTED / FAILED` and `DESIGN.REVIEW.TIMED_OUT`.
 
 **Drift from briefs:**
 
 - The original Epic 3 put "escalation workflow" as a single story (3-3). Actual implementation spreads across `BlockerDiagnosisWorkflow` (stalled agents), `CiWithDebugRetryWorkflow` / `TddWithDebugRetryWorkflow` retry-exhaustion paths, and `EscalateToSeniorActivity`. Wiki page now reflects the fuller structure.
 - Story 3-9 "security scanning" is more developed than the brief: in addition to SAST integration, the `Security/` activities subtree provides a full runtime gate (ActionGate + ContentSanitizer + ProviderAllowlist). This work landed partly under Epic 11 scope.
 - The 3-11 cost-monitoring package lives at `packages/cost-monitor/` rather than inside `@tamma/gates` — it's structurally closer to Epic 6.
-- Some tracking docs mark ambiguity detection (3-6) as Done; the wiki lists Drafted because the scoring activity is not yet wired into the production `ContextGatheringWorkflow` — only research prototypes exist.
+- The intelligence gates (3-4..3-7) landed as **standalone dispatchable sub-workflows** rather than activities embedded inside `ContextGatheringWorkflow` / `PlanGenerationWorkflow` as the briefs sketched. Ambiguity scoring uses a 0..1 decimal score with a 0.5 default clarify threshold, not the brief's 0-100 scale with >70/>90 bands; a parent flow wires the `decision="clarify"` output to `ClarifyingQuestionsWorkflow`.
 
 ## See also
 
@@ -212,7 +209,8 @@ SingleIssueCycle  CiWithDebugRetry   DebuggingWorkflow   AI Agent   GitHub      
   - [Epic 11: Security](Epic-11-Security.md) — broader security epic.
 - **Code paths:**
   - `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebuggingWorkflow.cs`, `BlockerDiagnosisWorkflow.cs`, `CiWithDebugRetryWorkflow.cs`, `TddWithDebugRetryWorkflow.cs`.
-  - `apps/tamma-elsa/src/Tamma.Activities/Debug/`, `Blocker/`, `Security/`, `Assessment/`.
+  - `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs`, `ClarifyingQuestionsWorkflow.cs`, `AmbiguityScoringWorkflow.cs`, `DesignProposalWorkflow.cs` — intelligence gates (3-4..3-7).
+  - `apps/tamma-elsa/src/Tamma.Activities/Debug/`, `Blocker/`, `Security/`, `Assessment/`, `Research/`, `Ambiguity/`, `Design/`.
   - `packages/gates/src/permissions/`, `packages/gates/src/violations/`.
   - `packages/cost-monitor/src/` (cost-aware usage).
   - `packages/providers/src/provider-health.ts` (agent performance monitoring).

--- a/wiki/Epics/Epic-3-Quality-Gates.md
+++ b/wiki/Epics/Epic-3-Quality-Gates.md
@@ -1,6 +1,6 @@
 # Epic 3: Quality Gates & Intelligence Layer
 
-**Status:** Complete (12/12 done — intelligence-gate stories 3-4..3-7 landed 2026-07-04/05 as standalone Elsa sub-workflows)
+**Status:** Near Complete (12/13 done — intelligence-gate stories 3-4..3-7 landed 2026-07-04/05 as standalone Elsa sub-workflows; 3-13 intelligent test-execution pipeline still ready-for-dev)
 **Stories:** 12 (3-1 through 3-12)
 **MVP Critical:** All 12 stories
 **Tech Spec:** [tech-spec-epic-3.md](https://github.com/meywd/tamma/blob/main/docs/stories/epic-3/tech-spec-epic-3.md)

--- a/wiki/Epics/Epic-4-Event-Sourcing.md
+++ b/wiki/Epics/Epic-4-Event-Sourcing.md
@@ -1,6 +1,6 @@
 # Epic 4: Event Sourcing & Audit Trail
 
-**Status:** Near Complete (6/8 done; 4-2 in progress; 4-8 drafted)
+**Status:** Near Complete (7/8 done; 4-2 in progress; 4-8 black-box replay landed 2026-07-05 as an API endpoint)
 **Stories:** 8 (4-1 through 4-8)
 **Tech Spec:** [tech-spec-epic-4.md](https://github.com/meywd/tamma/blob/main/docs/stories/epic-4/tech-spec-epic-4.md)
 
@@ -18,7 +18,7 @@ Events flow through three layers. At the bottom, `Tamma.Activities.Core.TammaAct
 
 The middle layer is the **query API** (Story 4-7): `GET /api/v1/events?since=&until=&type=&correlationId=&issueNumber=` returns chronologically-ordered pages (default 100 events). The `TenantDbContext` applies a row-level-security filter per tenant so operators querying across tenants only see their own data.
 
-The top layer is **replay** (Story 4-8, drafted): `tamma replay --correlation-id <id>` streams the event sequence for a given workflow, optionally in interactive step-by-step mode, and renders an HTML report. Replay doesn't re-execute activities — it reconstructs the state machine by projecting events, so a bug can be reproduced exactly without a live provider connection.
+The top layer is **replay** (Story 4-8, landed 2026-07-05): `GET /api/engine/runs/{correlationId}/replay?upTo={seq|timestamp}&from={seq}` reconstructs a run's point-in-time state as a **pure, deterministic left-fold** over the run's ordered DCB event slice (`ReplayReconstructor` — no I/O, no clock, no re-execution, no writes). `upTo` slices by sequence number or ISO-8601 timestamp (omitted = whole run; a point before the run began is a valid empty-state view, not a 404); `from` adds a `ReplayDelta` diff of everything after that point. The read is tenant-scoped and fails closed — a null tenant or another tenant's correlationId returns 404, never leaked events.
 
 ## Components
 
@@ -37,10 +37,10 @@ The top layer is **replay** (Story 4-8, drafted): `tamma replay --correlation-id
 | `@tamma/events` package | Placeholder — full TS DCB impl not landed | `packages/events/src/index.ts` | Stub |
 | Issue-selection events | `ISSUE.SELECTED.SUCCESS`, `ISSUE.ANALYZED.SUCCESS` | emitted by `SelectWorkItemActivity`, `ValidateWorkItemActivity` | Done (4-3) |
 | AI-provider events | `AI.REQUEST.*`, `AI.RESPONSE.*`, token usage, cost | emitted by `InstrumentedAgentProvider`, `InstrumentedLlmProvider` | Done (4-4) |
-| Code / Git events | `CODE.GENERATED.*`, `COMMIT.CREATED.*`, `BRANCH.CREATED.*`, `PR.CREATED.*`, `PR.MERGED.*` | emitted from `CreateBranchActivity`, `CreatePullRequestActivity`, `MergePullRequestActivity` | Done (4-5) |
+| Code / Git events | `CODE.GENERATED.*`, `CODE.REFACTORED.*`, `COMMIT.CREATED.*`, `BRANCH.CREATED.*`, `PR.CREATED.*`, `PR.MERGED.*` | `Tamma.Activities/TDD/CodeEvents.cs`, `CommitEvents.cs` + `WriteTestsActivity`, `WriteImplementationActivity`, `ApplyRefactoringActivity`, `CommitChangesActivity`; plus `CreateBranchActivity`, `CreatePullRequestActivity`, `MergePullRequestActivity` | Done (4-5) |
 | Approval / escalation events | `APPROVAL.REQUESTED`, `APPROVAL.PROVIDED`, `ESCALATION.TRIGGERED`, `ESCALATION.RESOLVED` | emitted from `WaitForPlanApprovalActivity`, `EscalateToSeniorActivity` | Done (4-6) |
-| Replay command | `tamma replay --correlation-id ...` | Drafted | Drafted (4-8) |
-| HTML export | Formatted replay report | Drafted | Drafted (4-8) |
+| Replay endpoint | `GET /api/engine/runs/{correlationId}/replay` — point-in-time reconstruction via pure fold | `Tamma.Api/Services/Engine/Replay/*` (`ReplayReconstructor`, `ReplayService`, `ReplayModels`), `Tamma.Api/Endpoints/EngineEndpoints.cs` | Done (4-8) |
+| Replay CLI / HTML export | `tamma replay --correlation-id ...` interactive mode + formatted report | Drafted | Drafted (4-8 follow-on) |
 
 ## Class diagram
 
@@ -168,7 +168,7 @@ Elsa Workflow                TammaActivity             IEventRepository       Po
 
 - **Compliance officer** wants **to prove a PR was merged only after human approval**: query `/api/v1/events?prId=456&type=APPROVAL.PROVIDED` → confirm event exists → query same PR for `PR.MERGED.SUCCESS` → confirm the approval timestamp is before the merge timestamp.
 - **Incident responder** wants **to reconstruct the state of a failing issue at 14:32:07**: query `/api/v1/events?issueNumber=123&until=2026-04-22T14:32:07Z` → project the event sequence into state → identify which retry attempt was running, what provider was selected, what tokens were spent.
-- **Developer debugging a flaky bug** wants **to replay events exactly**: `tamma replay --correlation-id <workflow-id> --interactive` → step through each event → see the exact prompt sent, the exact response received, the exact fix applied → diagnose without re-running cost-bearing AI calls (Story 4-8, drafted).
+- **Developer debugging a flaky bug** wants **to replay events exactly**: `GET /api/engine/runs/<correlationId>/replay?upTo=<seq>` → the pure fold reconstructs the run's state at that exact event → see which step was running, what succeeded/failed and the recorded payloads → diagnose without re-running cost-bearing AI calls (Story 4-8; a `from=` param adds a delta diff between two points).
 - **Cost auditor** wants **monthly AI spend by provider**: query `?type=AI.RESPONSE.SUCCESS&since=<start-of-month>` → sum `data.usage.cost` grouped by `tags.provider` → cross-check against cost-monitor storage.
 - **Platform admin** wants **to see everything a specific user did this week**: query `?userId=<uuid>&since=<7-days-ago>` → timeline of their actions across issues, PRs, approvals — all from the one table, no joins.
 - **Plugin developer** wants **to add a custom event type**: set `EventType = "PLUGIN.MY_ACTION.SUCCESS"` on the activity class + set tags — no schema migration needed; the JSONB columns accept arbitrary shapes.
@@ -195,13 +195,14 @@ Elsa Workflow                TammaActivity             IEventRepository       Po
 - Event store (partial, 4-2) — EF / PostgreSQL path via `EventRepository`. The brief picked Emmett; actual impl is EF + Postgres with the same shape.
 - Issue-selection + analysis events (4-3) — emitted by `SelectWorkItemActivity`, `ValidateWorkItemActivity`.
 - AI-provider events (4-4) — `InstrumentedAgentProvider` and `InstrumentedLlmProvider` decorators in `@tamma/providers` capture request/response with token usage.
-- Code + Git events (4-5) — `CreateBranchActivity`, `CreatePullRequestActivity`, `MergePullRequestActivity` all emit through `TammaActivity` base class.
+- Code + Git events (4-5) — completed 2026-07-05: the TDD activities (`WriteTestsActivity`, `WriteImplementationActivity`, `ApplyRefactoringActivity`, `CommitChangesActivity`) now emit typed `CODE.GENERATED.SUCCESS/FAILED`, `CODE.REFACTORED.SUCCESS/FAILED` (with an `operation` tag: implementation / testing / refactoring) and `COMMIT.CREATED.SUCCESS/FAILED` events via `TDD/CodeEvents.cs` + `CommitEvents.cs`, alongside the existing branch/PR/merge events from `CreateBranchActivity`, `CreatePullRequestActivity`, `MergePullRequestActivity`.
 - Approval + escalation events (4-6) — `WaitForPlanApprovalActivity`, `EscalateToSeniorActivity`.
-- Event query API (4-7) — `GET /api/v1/events` endpoints in `Tamma.Api/Endpoints/Events/`.
+- Event query API (4-7) — `GET /api/v1/events` endpoints in `Tamma.Api/Endpoints/Events/`; `IEventRepository.ListByCorrelationIdAsync` returns a run's full ordered event slice (with an empty-tenant guard added in the 2026-07-05 read-endpoint hardening).
+- Black-box replay (4-8) — landed 2026-07-05: `ReplayReconstructor` (pure deterministic fold over the DCB event slice) + `ReplayService` + `GET /api/engine/runs/{correlationId}/replay`. Tenant-scoped, read-only, supports `upTo` (sequence or timestamp) point-in-time views and `from` delta diffs. A follow-up hardening pass (same day) added UTC date-bound normalization, `from > upTo` → 400 validation, and bounded run-event fetches.
 
 **Stubbed / drafted:**
 
-- 4-8 Black-Box Replay — story brief exists; replay command not implemented.
+- 4-8 CLI surface (`tamma replay --interactive`) and the HTML report export are not implemented — replay shipped as the API endpoint above.
 - `@tamma/events` TypeScript package is a placeholder. `@tamma/shared/event-store.ts` ships `InMemoryEventStore` for the CLI path.
 
 **Drift from briefs:**
@@ -209,6 +210,7 @@ Elsa Workflow                TammaActivity             IEventRepository       Po
 - The original 4-2 picked Emmett as the event-store library. Actual implementation uses EF Core + PostgreSQL directly — same DCB shape (single stream + JSONB tags), different plumbing. This matches the broader "single source of truth in C# / Elsa" project decision.
 - The brief references `workflowVersion` metadata; implementation uses Elsa's workflow version concept rather than a hand-rolled metadata field, and adds `activityId` + `workflowInstanceId` to every event automatically via `TammaActivity`.
 - Epic 10 Story 10-3 is where the production event store actually landed; Epic 4 stories 4-1..4-7 are the *spec*. The overlap is documented but the work lives in the Epic 10 tree.
+- The 4-8 brief described replay as a CLI command with interactive stepping and HTML export; what shipped is an HTTP endpoint over a pure reconstruction core (`ReplayReconstructor`) — same "project events, never re-execute" semantics, different surface.
 - Retention policy (brief mentions 6 months hot + 2 years archival) is not yet enforced — retention story is implicit in Epic 10 ops scope.
 
 ## See also
@@ -226,5 +228,7 @@ Elsa Workflow                TammaActivity             IEventRepository       Po
   - `apps/tamma-elsa/src/Tamma.Data/Repositories/EventRepository.cs` — EF Core event store.
   - `apps/tamma-elsa/src/Tamma.Activities/Core/TammaActivity.cs` — auto-emission base class.
   - `apps/tamma-elsa/src/Tamma.Api/Endpoints/Events/` — query API.
+  - `apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/` — black-box replay (4-8).
+  - `apps/tamma-elsa/src/Tamma.Activities/TDD/CodeEvents.cs`, `CommitEvents.cs` — code/git event coverage (4-5).
   - `packages/shared/src/event-store.ts` — TS interface + in-memory impl.
   - `packages/providers/src/instrumented-agent-provider.ts`, `instrumented-llm-provider.ts` — AI event instrumentation.

--- a/wiki/Epics/Epic-6-Context-Knowledge.md
+++ b/wiki/Epics/Epic-6-Context-Knowledge.md
@@ -1,8 +1,8 @@
 # Epic 6: Context & Knowledge Management
 
-**Status:** Near Complete (9/10 done; 6-2 in progress)
+**Status:** Near Complete (9/10 done; 6-2 in progress — production KB/RAG sidecar wired to a real vector store + self-hosted Ollama embeddings, 2026-07-05/06)
 **Stories:** 10 (6-1 through 6-10) — plus 6-11 (drafted)
-**Packages:** `@tamma/intelligence`, `@tamma/mcp-client`, `@tamma/cost-monitor`, `@tamma/gates`, `@tamma/scrum-master`, `@tamma/dashboard`, `@tamma/api`
+**Packages:** `@tamma/intelligence`, `@tamma/intelligence-server` (sidecar), `@tamma/mcp-client`, `@tamma/cost-monitor`, `@tamma/gates`, `@tamma/scrum-master`, `@tamma/dashboard`, `@tamma/api`
 
 ## Overview
 
@@ -44,6 +44,8 @@ Knowledge base entries live separately from code chunks. `KnowledgeService` mana
 | Pre-task checker | Queries knowledge base before agent execution | `packages/intelligence/src/knowledge-base/pre-task-checker.ts` | Done |
 | Matchers | Keyword, pattern, semantic, relevance ranking | `packages/intelligence/src/knowledge-base/matchers/` | Done |
 | **Knowledge-base UI** | Dashboard pages for index / vector / RAG / MCP / context / analytics | `packages/dashboard/src/pages/knowledge-base/` | Done (6-6) |
+| **Intelligence sidecar composition root** | Env-driven wiring of a real vector store (ChromaDB/pgvector) + embedder + RAG pipeline into the KB sidecar; graceful degrade to `not_configured` when no env is set | `packages/intelligence-server/src/env-composition.ts`, `server.ts` | Done (2026-07-05) |
+| **Self-hosted embeddings (Ollama)** | Local `nomic-embed-text` (768-dim) model server in Docker Compose — KB/RAG embeddings with no OpenAI key or per-token cost | `docker/docker-compose.yml`, `docker-compose.prod.yml` (`ollama` service) | Done (2026-07-05) |
 | **LLM Cost Monitor** | `CostTracker`, `LimitManager`, `AlertManager`, pricing config, storage | `packages/cost-monitor/src/*` | Done (6-7) |
 | **Agent Permissions** | `PermissionEnforcer`, `PermissionResolver`, violations | `packages/gates/src/permissions/`, `violations/` | Done (6-8) |
 | **Scrum Master** | Plan / approve / implement / review / learn loop orchestration | `packages/scrum-master/src/*` | Done (6-10) |
@@ -215,10 +217,13 @@ Elsa workflow      ContextAggregator    RAGPipeline    IVectorStore   KnowledgeS
 - **Agent Permissions** (6-8) — enforcer + resolver + defaults + violation recorder + alerter.
 - **Agent Knowledge Base** (6-9) — recommendations / prohibitions / learnings with 4 matcher types.
 - **Scrum Master** (6-10) — full service with supervisor, approval workflow, learning capture, agent coordinator.
+- **Production sidecar wiring** (2026-07-05/06) — the `intelligence-server` KB/RAG sidecar's composition root (`env-composition.ts`) now builds a **real** `@tamma/intelligence` vector store (ChromaDB preferred, pgvector fallback) + embedding service + RAG pipeline from environment variables, replacing the `not_configured` stubs whenever a store is configured (unconfigured deployments still boot and degrade gracefully). The RAG collection is bootstrapped at composition time (created empty at the embedder's dimensions if missing) so a fresh, never-indexed deployment boots `configured` instead of `not_configured`.
+- **Self-hosted embeddings** (2026-07-05) — Docker Compose now runs a local **Ollama** service serving `nomic-embed-text` (768-dim); the model is pulled once into a persisted volume on first boot and the sidecar's Ollama embedder initializes config-only, so embeddings run with **no OpenAI key and no per-token cost**.
+- **Prod-image hardening** (2026-07-05) — the sidecar imports `EmbeddingService` via the narrow `@tamma/intelligence/embedding` subpath instead of the `/indexer` barrel (which transitively value-imported the `typescript` devDependency and crash-looped the `--prod`-pruned Docker image); guarded by a prod-import-graph test + a prod-pruned boot smoke test, plus a Dockerfile fix.
 
 **In progress:**
 
-- 6-2 Vector Database Integration — 5 adapters (ChromaDB, pgvector, Pinecone, Qdrant, Weaviate) exist; production uses ChromaDB; some adapters need integration tests.
+- 6-2 Vector Database Integration — 5 adapters (ChromaDB, pgvector, Pinecone, Qdrant, Weaviate) exist; production uses ChromaDB (wired end-to-end via the sidecar composition root above); some adapters need integration tests.
 
 **Drift from briefs:**
 
@@ -239,6 +244,8 @@ Elsa workflow      ContextAggregator    RAGPipeline    IVectorStore   KnowledgeS
   - [Epic 27: Prompt Store](Epic-27-Prompt-Store.md) — prompt template injection of knowledge.
 - **Code paths:**
   - `packages/intelligence/src/` — indexer, vector store, RAG, knowledge base, context aggregator.
+  - `packages/intelligence-server/src/env-composition.ts` — sidecar composition root (real vector store + embedder + RAG from env).
+  - `docker/docker-compose.yml`, `docker/docker-compose.prod.yml` — `ollama` service for self-hosted embeddings.
   - `packages/mcp-client/src/` — MCP client.
   - `packages/cost-monitor/src/` — cost tracking + limits + alerts.
   - `packages/gates/src/permissions/` — agent permissions.

--- a/wiki/Event-Schema-and-Catalog.md
+++ b/wiki/Event-Schema-and-Catalog.md
@@ -64,7 +64,7 @@ Rules the codebase holds to:
 - **`*.FAILED` / `*.REJECTED` are loud** — a failed operation is always its own audit row, never a silent success. `DeployEvents.IsFailureType` is the pattern: catalogs expose a helper that classifies which types are failures so no code path can report a false success.
 - **Aggregate prefixes are stable** — dashboards, the audit prefix-query (`TENANT.MEMBER` matches every `TENANT.MEMBER_*`), and alert rules key off them.
 
-As of this writing the source defines **363 distinct event-type constants across 62 aggregate prefixes** (grep of `const string … = "AGGREGATE.ACTION…"` under `apps/tamma-elsa/src`, migrations excluded). [§10](#10-event-catalog) enumerates them by domain.
+As of this writing the source defines **365 distinct event-type constants across 62 aggregate prefixes** (grep of `const string … = "AGGREGATE.ACTION…"` under `apps/tamma-elsa/src`, migrations excluded). [§10](#10-event-catalog) enumerates them by domain.
 
 ---
 
@@ -313,7 +313,7 @@ The Epic-2/3 assessment sub-workflows (2026-07): each mirrors the same skeleton 
 | Secret access/rotation (inline) | `SECRET.READ/WRITE/REVEAL`, `SECRET.ROTATE.STARTED/SUCCESS/FAILED`, `SECRET.MIGRATED.SUCCESS/SKIPPED/FAILED`, `SECRET.VERSION.RETIRED/REVOKED`, and the `SECRET.ROTATION.*` saga family (`REQUESTED`, `STAGED`, `SWITCHED`, `ACTIVATED`, `RETIRE_SCHEDULED`, `RETIRED`, `COMPLETED`, `FAILED`, `REJECTED`, `PROBE.SUCCESS/FAILED`, `PUSH.SUCCESS/FAILED`, `POOL.DRAINED`, `COMPENSATION.STARTED/SUCCESS/FAILED`, `ROLLBACK.ROLE_DISABLED`, `CRANL.ENV_PUSHED/RELOAD_TRIGGERED/RATE_LIMIT_HIT`) |
 | KEK rotation (inline) | `SECRETS.KEK.ROTATION.STARTED/COMPLETED/FAILED` |
 
-> This is a representative map, not a line-by-line dump of all 363 constants — the giant `SECRET.ROTATION.*` saga family is summarized. The catalog **classes** named above are the authoritative source; grep `apps/tamma-elsa/src` for the exact current set.
+> This is a representative map, not a line-by-line dump of all 365 constants — the giant `SECRET.ROTATION.*` saga family is summarized. The catalog **classes** named above are the authoritative source; grep `apps/tamma-elsa/src` for the exact current set.
 
 ---
 

--- a/wiki/Event-Schema-and-Catalog.md
+++ b/wiki/Event-Schema-and-Catalog.md
@@ -1,6 +1,6 @@
 # Event Schema & Catalog (Epic 4 — Story 4-1)
 
-_Last updated: 2026-07-04._
+_Last updated: 2026-07-15._
 
 This page is the maintainable reference for Tamma's **DCB (Dynamic Consistency Boundary)** event schema and the catalog of event **types** the running system emits. It is the shipped answer to [Story 4-1: Event Schema Design](https://github.com/meywd/tamma/blob/main/docs/stories/epic-4/story-4-1/4-1-event-schema-design.md) — re-based on the **current C# stack**. The original brief sketched a TypeScript `BaseEvent`/`Emmett` design; production landed on a custom EF Core implementation. Where the two differ, this page describes what the code actually does and maps it back to the story's acceptance criteria in [§9](#9-acceptance-criteria--shipped-schema).
 
@@ -19,7 +19,8 @@ Every claim here is grounded in a file you can open. Pair it with [Architecture]
 | Workflow event model + emitter | `apps/tamma-elsa/src/Tamma.Activities/Core/TammaActivity.cs` (`TammaEvent`, `TammaEventEmitter`) |
 | Engine drain ingestion | `apps/tamma-elsa/src/Tamma.Api/Endpoints/EngineEndpoints.cs` (`POST /api/engine/events`) |
 | Time-travel read | `EngineEndpoints.GetHistory` → `GET /api/engine/history` (Story 4-7) |
-| Event-type catalogs | `**/*Events.cs` (24 classes) + `**/*EventTypes.cs` (18 classes) + inline audit catalogs |
+| Event-type catalogs | `**/*Events.cs` (33 classes) + `**/*EventTypes.cs` (21 classes) + inline audit catalogs |
+| Black-box replay (fold + endpoint) | `apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/{ReplayReconstructor,ReplayService,ReplayModels}.cs` → `GET /api/engine/runs/{correlationId}/replay` (Story 4-8) |
 
 **Two physical streams, one logical model.** Tenant-scoped events live in each tenant's `t_<hex>.domain_events` table (schema-per-tenant isolation). Platform-lifecycle events that have no tenant (`TenantId == null` — e.g. `TENANT.PROVISIONED.SUCCESS`, `EMAIL.QUEUED.SUCCESS`) live in the control-plane `platform_events` table and are projected back into `DomainEvent` shape on read so callers see one model. See the class comment on `EventRepository` for the routing matrix (Story 28-1 Decision #2).
 
@@ -63,7 +64,7 @@ Rules the codebase holds to:
 - **`*.FAILED` / `*.REJECTED` are loud** — a failed operation is always its own audit row, never a silent success. `DeployEvents.IsFailureType` is the pattern: catalogs expose a helper that classifies which types are failures so no code path can report a false success.
 - **Aggregate prefixes are stable** — dashboards, the audit prefix-query (`TENANT.MEMBER` matches every `TENANT.MEMBER_*`), and alert rules key off them.
 
-As of this writing the source defines **324 distinct event-type constants across 54 aggregate prefixes** (grep of `const string … = "AGGREGATE.ACTION…"` under `apps/tamma-elsa/src`, migrations excluded). [§10](#10-event-catalog) enumerates them by domain.
+As of this writing the source defines **363 distinct event-type constants across 62 aggregate prefixes** (grep of `const string … = "AGGREGATE.ACTION…"` under `apps/tamma-elsa/src`, migrations excluded). [§10](#10-event-catalog) enumerates them by domain.
 
 ---
 
@@ -91,6 +92,11 @@ Common tags (not every event sets every tag):
 | `agentId` / `agentVersion` | Which agent + config version ran | `AgentTrailTags.Build` |
 | `promptRef` | **Reference** to the prompt (never the prompt body — AC6 of Story 32-6) | Agent trail |
 | `iteration` | Loop iteration counter | Agent trail |
+| `sessionId` | Unguessable per-run session id of an assessment/TDD sub-workflow run | Research / Ambiguity / Clarify / Design / Decomposition emit activities, TDD `CodeEvents`/`CommitEvents` |
+| `storyId` | Story being implemented by the TDD cycle | TDD `CodeEvents`/`CommitEvents` builders |
+| `operation` | Code-change discriminator: `implementation` / `testing` / `refactoring` | `CodeEvents` (Story 4-5) |
+| `branch` / `sha` | Git branch / commit SHA of an atomic TDD commit (`sha` on success only) | `CommitEvents.BuildCreated` |
+| `channel` | Delivery channel for questions / design proposals (e.g. the issue) | Clarify / Design emit activities |
 | `credentialSource` | Which credential plane served the call (platform vs BYOK) | Agent trail |
 | `billing_mode` | `platform` vs `byok` — lets metering split billable from non-billable with no join | `BillingModeEvents` (Story 35-2) |
 | `stripeEventId` / `eventType` / `stripeObjectId` | Stripe webhook forensics (no body leaked) | Billing webhook projections |
@@ -158,10 +164,20 @@ From the `domain_events` block in `TammaModelConfiguration.cs`:
 | Tenant audit log (prefix-match, cursor) | `ListByTenantAsync` | `GET /api/v1/orgs/{tenantId}/audit` (Story 18-7; `MemberAccess`) |
 | Per-agent action trail (Tags JSONB predicates) | `QueryAgentTrailAsync` | agent endpoints (Story 32-6) |
 | Run existence / replay by correlation id | `ExistsByCorrelationIdAsync` / `ListByCorrelationIdAsync` | run-tap (Story 32-23) |
+| Black-box replay — point-in-time state reconstruction (pure fold, read-only) | `ListByCorrelationIdAsync(maxEvents)` → `ReplayService` / `ReplayReconstructor` | `GET /api/engine/runs/{correlationId}/replay?upTo={seq\|timestamp}&from={seq}` (Story 4-8; `WorkflowsView`) |
 | Platform-lifecycle scan (tenant-less) | `QueryAsync(tenantId: null, type: prefix)` | admin, via `platform_events` |
 | Audit-chain integrity | — | `GET /api/v1/orgs/{tenantId}/audit/verify`, `GET /api/v1/admin/audit/verify`, `POST /api/v1/admin/audit/checkpoint` |
 
 Pagination and replay page on `SequenceNumber` (immune to same-millisecond `CreatedAt` collisions); the exact `total` on a trail read is opt-in (`includeTotal`) because it is an unbounded `COUNT(*)` over the audit stream.
+
+**Black-box replay (Story 4-8).** `ReplayReconstructor` is a **pure, deterministic left-fold** over a run's ordered event slice — no I/O, no clock, no Elsa runtime, no writes; the same slice always yields the same `ReplayResult`. It categorizes events into AI decisions, code changes, approval points and errors, derives the step reached + terminal status, and (with `from`) returns a `ReplayDelta` diff of two folds. Tenant-scoped and null-tenant fail-closed: no resolved tenant or a foreign/unknown `correlationId` → `404` (no IDOR). An `upTo` before the run began is a known-but-empty state (`200`, `eventsReplayed = 0`).
+
+**Read-endpoint hardening (2026-07)** — defensive fixes shared by the replay + run-detail reads:
+
+- **UTC-pinned timestamp bounds**: a timestamp `upTo` is parsed with `AssumeUniversal | AdjustToUniversal` — an offset-less ISO-8601 string is pinned to UTC (never treated as server-local) and an explicit offset is converted, so the boundary is the same instant on every host.
+- **`from > upTo` is a loud `400`** (`ReplayRangeException` → BadRequest), not a silent `200` with a meaningless empty delta. Bad/non-positive `upTo`/`from` values are also `400`.
+- **Bounded run-event fetch**: `ListByCorrelationIdAsync(tenantId, correlationId, maxEvents)` fetches `maxEvents + 1` to detect overflow; replay caps at **10,000 events** (`ReplayService.MaxReplayEvents`) and a run over the cap returns the capped oldest-first slice with `truncated: true` — no silent drop, no unbounded materialisation.
+- **Empty-tenant guard**: `ListByCorrelationIdAsync` throws on `Guid.Empty` (parity with `QueryEventsAsync` / `QueryAgentTrailAsync`), so an unresolved tenant can never widen a read.
 
 ---
 
@@ -172,7 +188,7 @@ The Story 4-1 brief was written against an aspirational TypeScript `BaseEvent`. 
 | Story 4-1 AC | Shipped realization |
 |---|---|
 | **AC1** base fields `eventId, timestamp, eventType, actorType, actorId, payload, metadata` | `Id`, `CreatedAt` (+ `Tags.emittedAt`), `Type`, **actor lives in `Tags`** (`userId` / `eventSource` / `provider`) rather than dedicated `actorType`/`actorId` columns, `Data` = payload, `Metadata`. |
-| **AC2** types for issue selection, AI req/resp, code changes, Git ops, approvals, escalations, errors | Shipped as the ADL, `AGENT`/`LLM`, `GIT`, `MERGE_APPROVAL`/`DEPLOY.PRODUCTION`, `*.ESCALATED`, and `*.FAILED` families — see [§10](#10-event-catalog). |
+| **AC2** types for issue selection, AI req/resp, code changes, Git ops, approvals, escalations, errors | Shipped as the ADL, `AGENT`/`LLM`, `GIT`, `CODE`/`COMMIT` (Story 4-5 closed the code-change/commit gaps), `MERGE_APPROVAL`/`DEPLOY.PRODUCTION`, `*.ESCALATED`, and `*.FAILED` families — see [§10](#10-event-catalog). |
 | **AC3** schema versioning | `Metadata.workflowVersion` + append-only new types (no in-place event edits). |
 | **AC4** correlation ids linking related events | `Tags.correlationId` (workflow-instance id), backed by an expression index; `ListByCorrelationIdAsync` returns a whole run in order. |
 | **AC5** schema validated (JSON Schema / Protobuf) | Realized as **type-safe C# catalog constants** (`*Events.cs` / `*EventTypes.cs`) + the `TammaEvent → DomainEvent` projection + a build-time guardrail (`TAMMA001`). No runtime JSON-Schema validator ships. |
@@ -202,7 +218,19 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | `TriageEvents` | `TRIAGE.PANEL.STARTED/COMPLETED/PARTIAL/FAILED` |
 | `TriagePoDecisionEvents` | `TRIAGE.PO_DECISION.STARTED/COMPLETED/FAILED/SKIPPED` |
 
-### 10.2 Quality gates, testing, debugging (`Tamma.Activities/{Testing,Review,Blocker,Debug}`)
+### 10.2 Assessment, research & design workflows (`Tamma.Activities/{Research,Ambiguity,Clarify,Design,Decomposition}`)
+
+The Epic-2/3 assessment sub-workflows (2026-07): each mirrors the same skeleton (gather context → mediated `llm-call` → fail-closed parse → emit) and emits through a dedicated `Emit*EventActivity`. Common tags: `sessionId`, `issueId`, `tenantId` (empty/single-user → platform-scope, `TenantId` null); each catalog exposes a `StatusForEvent` helper so the `.FAILED` terminal is always a loud error-status row, never a false success.
+
+| Catalog | Event types |
+|---|---|
+| `ResearchEvents` (Story 3.4, `research` workflow) | `RESEARCH.STARTED`, `RESEARCH.CONTEXT_GATHERED`, `RESEARCH.COMPLETED` (data: `findingCount`, `confidence`), `RESEARCH.FAILED` |
+| `ClarifyEvents` (Story 3.5, `clarifying-questions` workflow) | `CLARIFY.QUESTIONS.GENERATED/DELIVERED/FAILED`, `CLARIFY.ANSWERS.RECEIVED/TIMED_OUT`, `CLARIFY.REQUIREMENTS.CLARIFIED`, `CLARIFY.INCORPORATION.FAILED` (tags add `channel`; data: `questionCount`, `detail`) |
+| `AmbiguityEvents` (Story 3.6, `ambiguity-scoring` workflow) | `AMBIGUITY.STARTED`, `AMBIGUITY.SCORED`, `AMBIGUITY.CLARIFICATION_TRIGGERED`, `AMBIGUITY.BELOW_THRESHOLD`, `AMBIGUITY.FAILED` (data: `score` 0..1, `ambiguityCount`, `confidence`, `threshold`, `detail`) |
+| `DesignEvents` (Story 3.7, `design-proposal` workflow) | `DESIGN.PROPOSAL.GENERATED/DELIVERED/APPROVED/REJECTED`, `DESIGN.PROPOSAL.FAILED`, `DESIGN.REVIEW.TIMED_OUT` (both loud error-status; tags add `channel`; data: `alternativeCount`, `reviewer`, `detail`) |
+| `DecompositionEvents` (Story 2.14, `issue-decomposition` workflow) | `DECOMPOSITION.STARTED`, `DECOMPOSITION.CONTEXT_GATHERED`, `DECOMPOSITION.COMPLETED` (data: `subtaskCount`), `DECOMPOSITION.FAILED` |
+
+### 10.3 Quality gates, testing, debugging & TDD code/commit audit (`Tamma.Activities/{Testing,Review,Blocker,Debug,TDD}`)
 
 | Catalog | Event types |
 |---|---|
@@ -210,8 +238,12 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | `CodeReviewEvents` | `CODE_REVIEW.PR_CREATED.SUCCESS/FAILED`, `CODE_REVIEW.GUIDANCE_DELIVERED.SUCCESS/FAILED`, `CODE_REVIEW.ITERATION.STARTED`, `CODE_REVIEW.MERGED.SUCCESS/FAILED`, `CODE_REVIEW.ESCALATED`, `CODE_REVIEW.FAILED` |
 | `BlockerEvents` | `BLOCKER.DIAGNOSED.SUCCESS/FAILED`, `BLOCKER.RESOLUTION_ATTEMPTED`, `BLOCKER.PROGRESS_DETECTED`, `BLOCKER.PROGRESS_TIMED_OUT`, `BLOCKER.ESCALATED`, `BLOCKER.RESOLVED`, `BLOCKER.TIMED_OUT` |
 | `DebugEvents` | `DEBUG.SESSION.STARTED`, `DEBUG.DIAGNOSIS.SUCCESS/FAILED`, `DEBUG.HYPOTHESIS.SELECTED`, `DEBUG.FIX.ATTEMPTED`, `DEBUG.TESTS.PASSED/FAILED`, `DEBUG.REGRESSION_TEST.INVALID`, `DEBUG.RESOLVED.SUCCESS`, `DEBUG.ESCALATED.FAILED` |
+| `CodeEvents` (Story 4-5 AC1, `Tamma.Activities/TDD`) | `CODE.GENERATED.SUCCESS/FAILED` (RED test authoring + GREEN implementation, told apart by the `operation` tag: `testing` / `implementation`), `CODE.REFACTORED.SUCCESS/FAILED` (REFACTOR phase, `operation=refactoring`). Tags: `storyId`, `sessionId`, `operation`; data: `operation`, `source: "ai_generated"`, `files`, `fileCount`, optional `testCount`, failure `reason`. Emitted by `WriteTestsActivity` / `WriteImplementationActivity` / `ApplyRefactoringActivity`; `IsFailureType` classifies the loud FAILED types. |
+| `CommitEvents` (Story 4-5 AC2, `Tamma.Activities/TDD`) | `COMMIT.CREATED.SUCCESS/FAILED` — the atomic TDD commit (`CommitChangesActivity`), fired on all three edges (no-files, engine-callback result, exception). Tags: `storyId`, `sessionId`, `branch`, `repository` (+ `sha` on success); data: `sha`, `message`, `branch`, `fileCount`, `files`, failure `reason`. |
 
-### 10.3 Agents, LLM & tools (`Tamma.Api/Services/{Agents,AgentDispatch}`, `Billing/BillingModeEvents`)
+> Story 4-5's coverage pass confirmed branch / PR / merge / release git operations were **already** covered (`BranchEvents`, `PrEvents`, `MergeEvents`, `DeployEvents` + the server-side `GitEventTypes` `GIT.*` family in [§10.5](#105-integrations-tammaapiservicesgitcijiraemailnotifications)) — `CODE.*` and `COMMIT.*` fill the two gaps so every code change and git operation the loop makes is a DCB event. `CODE.GENERATED.FAILED` is the emitter that fulfils the `SensitiveActionCatalog` code of the same name.
+
+### 10.4 Agents, LLM & tools (`Tamma.Api/Services/{Agents,AgentDispatch}`, `Billing/BillingModeEvents`)
 
 | Catalog | Event types |
 |---|---|
@@ -226,7 +258,7 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 
 > **On "BYOK":** there is no `PRICING.BYOK.*` event type. BYOK is represented as the **`billing_mode` tag** (`byok` vs `platform`) on `LLM.CALL.*`, plus `PROVIDER_KEY.CHANGED.SUCCESS` when a tenant sets/clears its own key. Metering splits billable from non-billable off that tag with no join.
 
-### 10.4 Integrations (`Tamma.Api/Services/{Git,Ci,Jira,Email,Notifications}`)
+### 10.5 Integrations (`Tamma.Api/Services/{Git,Ci,Jira,Email,Notifications}`)
 
 | Catalog | Event types |
 |---|---|
@@ -236,7 +268,7 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | `EmailEventTypes` | `EMAIL.QUEUED.SUCCESS`, `EMAIL.SENT.SUCCESS`, `EMAIL.SENT.FAILED` |
 | `NotificationSlackEventTypes` | `NOTIFICATION.SLACK.SENT.SUCCESS`, `NOTIFICATION.SLACK.SEND.FAILED` |
 
-### 10.5 Config: prompts, conventions, providers, credentials
+### 10.6 Config: prompts, conventions, providers, credentials
 
 | Catalog | Event types |
 |---|---|
@@ -246,7 +278,7 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | Config-change audit (inline) | `PROVIDER_CHAIN.CHANGED.SUCCESS`, `PROVIDER_KEY.CHANGED.SUCCESS`, `INTEGRATION_CREDENTIAL.CHANGED.SUCCESS`, `SANITIZATION_RULE.CHANGED.SUCCESS`, `BUDGET.CONFIG.CHANGED.SUCCESS` |
 | `PricingEventTypes` (+ inline) | `PRICING.MARGIN.UPDATED`, `PRICING.MARGIN.NO_POLICY`, `PRICING.UNKNOWN_MODEL` |
 
-### 10.6 Billing & plans (`Tamma.Api/Services/{Billing,Pricing}`)
+### 10.7 Billing & plans (`Tamma.Api/Services/{Billing,Pricing}`)
 
 | Catalog | Event types |
 |---|---|
@@ -256,21 +288,22 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | `PlanAssignmentEventTypes` | `TENANT.PLAN.CHANGED`, `TENANT.PLAN.CANCELLED`, `PLAN.UPDATED` |
 | `EntitlementEventTypes` | `ENTITLEMENT.RESOLVED.SUCCESS`, `ENTITLEMENT.RESOLVED.FAILED` |
 
-### 10.7 Analytics (`Tamma.Activities/Analytics`, `Tamma.Api/Services/Analytics`)
+### 10.8 Analytics (`Tamma.Activities/Analytics`, `Tamma.Api/Services/Analytics`)
 
 | Catalog | Event types |
 |---|---|
 | `AnalyticsRollupEvents` | `ANALYTICS.ROLLUP.TENANT_COMPLETED/TENANT_SKIPPED/TENANT_FAILED`, `ANALYTICS.ROLLUP.PLATFORM_COMPLETED`, `ANALYTICS.ROLLUP.HOUR_COMPLETED`, `ANALYTICS.ROLLUP.DIMENSIONAL_LAG`, `ANALYTICS.PURGE.HOURLY/FAILED/USAGE_HOURLY/USAGE_HOURLY_FAILED`, `ANALYTICS.COMPACT.DAILY` |
 | `CostAnalyticsEvents` | `ANALYTICS.COST.BUDGET_PROJECTED_EXCEEDED` |
 
-### 10.8 Tenancy, provisioning & platform (`Tamma.Activities/TenantLifecycle`, `Tamma.Platforms`)
+### 10.9 Tenancy, onboarding, provisioning & platform (`Tamma.Activities/TenantLifecycle`, `Tamma.Platforms`, `Tamma.Api/Endpoints/OnboardingEndpoints.cs`)
 
 | Catalog | Event types |
 |---|---|
 | `TenantLifecycleEvents` | `TENANT.PROVISIONING_REQUESTED`, `TENANT.PROVISION.STEP_STARTED/STEP_COMPLETED/STEP_FAILED`, `TENANT.CREATED.SUCCESS`, `TENANT.PROVISIONED.SUCCESS`, `TENANT.PROVISION.FAILED`, `TENANT.DELETE.REQUESTED/STARTED/STEP_STARTED/STEP_COMPLETED/STEP_FAILED/STEP_SKIPPED/ABORTED/FAILED`, `TENANT.DELETED.SUCCESS`, `TENANT.DELETE_CANCELLED` |
 | `PlatformInstallationEventTypes` (in `PlatformInstallationEvents.cs`) | `PLATFORM.INSTALLATION.CONNECTED.SUCCESS`, `PLATFORM.INSTALLATION.DISCONNECTED.SUCCESS`, `TENANT.SWITCH_ORG.SUCCESS` |
+| Onboarding (Story 18-4, inline in `OnboardingEndpoints.cs`) | `REPO.ACTIVATED.SUCCESS` / `REPO.DEACTIVATED.SUCCESS` — a connected repo's `IsActive` flag flipped via `PATCH /api/v1/onboarding/repos/{installationId}/{repoId}` (idempotent: a no-op flip emits nothing; tags: `tenantId`, `userId`; data: `installationId`, `repoId`, `repoFullName`, `active`). `ONBOARDING.COMPLETED.SUCCESS` — the first-run milestone via `POST /api/v1/onboarding/complete`; the append-only event **is** the record (no persisted flag column), idempotent via `GetLastByTypeAsync` (tags: `tenantId`, `userId`; data: `installationCount`, `activeRepoCount`, `completedAt`). |
 
-### 10.9 Auth, audit, security & secrets (`Tamma.Core/Audit`, `Tamma.Api/Services/{Audit,Secrets}`, `Tamma.Activities/SecretsRotation`)
+### 10.10 Auth, audit, security & secrets (`Tamma.Core/Audit`, `Tamma.Api/Services/{Audit,Secrets}`, `Tamma.Activities/SecretsRotation`)
 
 | Catalog | Event types |
 |---|---|
@@ -280,7 +313,7 @@ Grouped by domain. Each group cites its catalog class; the listed strings are th
 | Secret access/rotation (inline) | `SECRET.READ/WRITE/REVEAL`, `SECRET.ROTATE.STARTED/SUCCESS/FAILED`, `SECRET.MIGRATED.SUCCESS/SKIPPED/FAILED`, `SECRET.VERSION.RETIRED/REVOKED`, and the `SECRET.ROTATION.*` saga family (`REQUESTED`, `STAGED`, `SWITCHED`, `ACTIVATED`, `RETIRE_SCHEDULED`, `RETIRED`, `COMPLETED`, `FAILED`, `REJECTED`, `PROBE.SUCCESS/FAILED`, `PUSH.SUCCESS/FAILED`, `POOL.DRAINED`, `COMPENSATION.STARTED/SUCCESS/FAILED`, `ROLLBACK.ROLE_DISABLED`, `CRANL.ENV_PUSHED/RELOAD_TRIGGERED/RATE_LIMIT_HIT`) |
 | KEK rotation (inline) | `SECRETS.KEK.ROTATION.STARTED/COMPLETED/FAILED` |
 
-> This is a representative map, not a line-by-line dump of all 324 constants — the giant `SECRET.ROTATION.*` saga family is summarized. The catalog **classes** named above are the authoritative source; grep `apps/tamma-elsa/src` for the exact current set.
+> This is a representative map, not a line-by-line dump of all 363 constants — the giant `SECRET.ROTATION.*` saga family is summarized. The catalog **classes** named above are the authoritative source; grep `apps/tamma-elsa/src` for the exact current set.
 
 ---
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -67,33 +67,22 @@ Tamma is an **autonomous development platform** designed to achieve **70%+ auton
 
 ## Current Status
 
-**Phase:** Active Implementation — `feat/auth-foundation` branch (PR #328)
-**Branch status:** 85+ commits ahead of `main`, CI green, **1817 tests passing**, PR mergeable
-**Deployment:** VPS at 204.168.131.39 (Hetzner CPX42, 16GB) with Docker Compose stack
-**Domains:** app.tamma.dev, api.tamma.dev, elsa.tamma.dev, wiki.tamma.dev, tamma.dev (Cloudflare DNS, Full SSL)
-**Last Audit:** 2026-04-20 senior code review (18 findings; 4 merge-blockers closed)
-**Epic Count:** **31 epics** (1–26 original plus 28–31, 33 new)
+**Phase:** Active development on `main` — Epic 23 monitoring-dashboard buildout, Epic 3 assessment workflows, Epic 4 event capture + black-box replay
+**Stack:** C#/.NET 8 backend (30+ Elsa workflows + `Tamma.Api` Minimal API) on PostgreSQL 17; TypeScript `intelligence-server` sidecar (KB/RAG) + React dashboards
+**KB/RAG:** sidecar wired to a real vector store with self-hosted embeddings via local Ollama (`nomic-embed-text`) — no external embedding API required
+**Deployment:** Hetzner VPS via Docker Compose (qa-tag–gated deploys); wiki site live at wiki.tamma.dev
+**Epic Count:** epics 1–31 plus 32/34–38 (agents, pricing, billing, analytics, audit) tracked in `docs/sprint-status.yaml`; Epic 33 deferred
 
-### Recent Progress (auth-foundation sprint, 2026-04-18 → 2026-04-21)
+### Recent Progress (main-branch development, 2026-07-04 → 2026-07-15)
 
-- **Epic 19 complete** -- all 4 stories (19-2 / 19-3 / 19-4 / 19-5) landed. `IAgentExecutor` with `LocalExecutor` (CLI) + `GitHubActionsExecutor` (SaaS). `WebhookSignalRegistry` for resumable webhook-mode monitoring (tenant-scoped via `install:{id}:` prefix after review finding 5). TS `execute-agent` CLI command in `packages/cli/` for `LocalExecutor` shell-out. 4 MB artifact cap + string clamps after review finding 6. See [Agent Dispatch](Agent-Dispatch).
-- **Code review (2026-04-20)** -- 18 findings identified; 4 merge-blockers closed (`c404b51` audit downgrade, `b76ea79` 19-6 follow-up story, `9160db1` webhook tenant-scoping, `aab36e3` NULL-tenant RLS drop, `ced59bc` artifact size cap). Phase-3 RLS audit markers downgraded to "scaffold only — not live" since no endpoints actually inject `TammaAppDbContext` yet. See [Port Audit](Port-Audit).
-- **Dependabot bumps** -- `System.Text.Json` 8.0.0 → 8.0.6, `MailKit` 4.15.1 → 4.16.0. Both NuGet vulnerabilities closed.
-- **Connection-string resolver fix** -- `appsettings.json` `TammaDb` default cleared; new `ConnectionStringResolver` uses `IsNullOrWhiteSpace` fallback. Fixes deploy-to-VPS regression where empty default values were preferred over env-provided ones.
-- **Marketing site live** -- Midnight Ocean redesign deployed to `tamma.dev` via wrangler (Cloudflare Worker).
-- **Wave-2 impl-plan campaign** -- 39 new impl plans written across Epic 9 (9-12), Epic 12 (12-5a/b/d), Epic 18 (18-4, 18-5), Epic 19-6 follow-up, Epic 28 (28-1..28-12 + 28-13 blocker), Epic 29 (10 stories), Epic 30 (10 stories). ~800h of planned work catalogued.
-- **New epics scoped** -- **Epic 29** Platform Secret Management (10 stories, 166h, Layer 4), **Epic 30** Pluggable Tenant Infrastructure Provisioning (10 stories, 216h, Layer 5), **Epic 31** Multi Git Platform Support (10 core + 2 deferred, ~228h), **Epic 33** Per-Tenant Identity Providers (deferred stub). Briefs + impl plans live under `docs/stories/epic-{29..33}/`.
-- **Epic 18 extensions** -- stories 18-7 (tenant-admin user-mgmt API gaps) and 18-8 (tenant-admin UI). Backend mostly exists; these close the thin gaps + add the UI.
-- **Research docs** -- `docs/stories/research/secret-management-and-multi-backend-provisioning-2026.md` and `docs/stories/research/multi-git-platform-2026.md` (2025–2026 citations).
-- **TS → C# port audit** -- 196 per-finding notes across 8 scopes; **118 findings landed** this sprint. Notes live in `docs/audit/port-gaps/<scope>/NNN-*.md`. See [Port Audit](Port-Audit).
-- **Phase-3 dual-connection RLS scaffolding** -- `TammaDb` + `TammaAppDb` split committed. Runtime wiring of `TammaAppDbContext` deferred to story 19-6 (the real RLS wiring follow-up). See [Deployment](Deployment#phase-3-rls-runbook).
-- **Octokit GitHub App client** (github/all 11 findings) -- `OctokitGitHubAppClient` using installation-scoped JWTs. `NullGitHubAppClient` seam when `GitHub:AppId` absent.
-- **Libsodium secrets provisioner** -- `LibsodiumGitHubSecretsProvisioner` encrypts GitHub Actions repository secrets via `Sodium.Core` sealed boxes.
-- **TammaEngine SSE lifecycle** (engine/012) -- in-process `InMemoryEngineLifecycleBus` + SSE endpoints `/api/engine/events/state`, `/api/engine/events/logs`. Tenant-scoped fanout; 15-second heartbeats.
-- **Redis-backed distributed rate limit** (auth/014) -- `IDistributedRateLimitBackend` with Lua `INCR + EXPIRE`; activated by `ConnectionStrings:Redis`.
-- **Cranl per-tenant provisioner** -- `CranlTenantProvisioner`; admin endpoint `POST /api/admin/tenants/{id}/provision`. `NullTenantProvisioner` is the default — no external resources are minted until `Cranl:ApiKey` + `Cranl:OrganizationId` set (tenant placement stays on the central pool).
-- **Content sanitizer port (~360 LoC)** -- C# port of the TS `ContentSanitizer` with prompt-injection detection, zero-width removal, NFKD normalisation.
-- **Mobile-responsive wiki nav** -- 2026-04-19 fix: side nav hides on mobile with hamburger toggle (commit `365ef54`).
+- **Epic 23 monitoring dashboard — 8 of 12 stories landed** -- 23-12 nav/layout/shared primitives (foundation), 23-1 System Health overview, 23-2 Agent Monitor (realtime tool-loop tail), 23-3 Event Store Explorer (over the 4-7 query API), 23-4 Configuration Audit, 23-5 Workflow Monitor, 23-6 Provider Diagnostics (latency/error/cost aggregations + fail-closed tenant fix), 23-8 Infrastructure Monitor (runtime/disk/dependency health).
+- **Epic 3 assessment workflows** -- 3-4 ResearchWorkflow + research action/prompt template (`RESEARCH.*` events, structured findings), 3-6 ambiguity scoring (mediated LLM, fail-closed parse, `AMBIGUITY.*` events), 3-7 DesignProposalWorkflow (approval gate + secure resume, `DESIGN.*` events).
+- **Epic 4 audit trail** -- 4-5 DCB event coverage for code changes & git operations; 4-8 black-box replay (point-in-time state reconstruction via a pure fold over the DCB event slice); read-endpoint hardening fix (UTC date bounds, bounded fetches, empty-tenant guard).
+- **Epic 2-14 issue decomposition** -- IssueDecompositionWorkflow: mediated LLM, ordered sub-tasks with dependencies, `DECOMPOSITION.*` events.
+- **Epic 18-4 onboarding slices** -- repo activate/deactivate endpoint + first-run `ONBOARDING.COMPLETED` event (non-migration slices; the install-settings migration slice remains open).
+- **Epic 21-4 user dashboard** -- Repos & Workflow Runs pages over installations + DCB run events.
+- **Epic 6 KB/RAG** -- sidecar composition root wired to a real vector store (`createVectorStoreFromEnv`/`RagPipeline`), self-hosted embeddings via local Ollama (`nomic-embed-text`), RAG collection bootstrap so the sidecar boots configured, plus prod-image fixes.
+- **Docs** -- CLAUDE.md stack-reality corrections: the active backend is C#/.NET 8 + Elsa; the TS toolchain notes now apply only to the legacy `packages/*`, the sidecar, and the dashboards.
 
 ### Completed Epics (13)
 
@@ -117,10 +106,10 @@ Tamma is an **autonomous development platform** designed to achieve **70%+ auton
 |------|------|------|-----------|
 | Epic 1 | Foundation & Core Infrastructure | 10/15 | 2 in progress, 3 ready |
 | Epic 1.5 | Infrastructure & Deployment | 9/10 | Kubernetes deployment in progress |
-| Epic 2 | Autonomous Development Loop | 13/20 | Priority work item selection + issue decomposition |
-| Epic 3 | Quality Gates & Intelligence | 8/12 | 4 drafted |
-| Epic 4 | Event Sourcing & Audit Trail | 6/8 | PostgreSQL backend in progress |
-| Epic 6 | Context & Knowledge Management | 10/11 | Vector DB stubs |
+| Epic 2 | Autonomous Development Loop | 14/20 | Provider selection, dependency mapping + sequencing, prompt overhauls |
+| Epic 3 | Quality Gates & Intelligence | 11/13 | Clarifying-questions workflow + intelligent test pipeline |
+| Epic 4 | Event Sourcing & Audit Trail | 7/8 | Event store backend selection in progress |
+| Epic 6 | Context & Knowledge Management | 10/11 | Vector DB provider stubs (sidecar now live w/ Ollama embeddings) |
 | Epic 7 | Mentorship Workflow | 8/9 | TDD sub-workflow in progress |
 
 ### Newly Scoped (this sprint)
@@ -133,13 +122,14 @@ Tamma is an **autonomous development platform** designed to achieve **70%+ auton
 | Epic 31 | Multi Git Platform Support | 10 core + 2 optional | 4 + 5 | Briefs only |
 | Epic 33 | Per-Tenant IdP (deferred) | — | post-launch | Forward-looking stub |
 
-### Partially Implemented (4)
+### Partially Implemented (5)
 
 | Epic | Name | Done | In Progress | Drafted |
 |------|------|------|-------------|---------|
 | Epic 5 | Observability Dashboard & Docs | 4 | 3 | 7 |
-| Epic 18 | End-User Auth & Registration | 1 | 2 | 2 (+ 18-7 / 18-8 new) |
-| Epic 21 | Marketing Site & User Dashboard | 1 | 1 | 3 |
+| Epic 18 | End-User Auth & Registration | 4 | 3 | 1 (18-8 UI) |
+| Epic 21 | Marketing Site & User Dashboard | 2 | 0 | 2 (21-1/21-2 superseded by repo extraction) |
+| Epic 23 | System Monitoring Dashboard | 8 | 0 | 3 (23-11 superseded by C# port) |
 | Epic 26 | Project Management & Triage | 0 | 1 | 3 |
 
 ## Getting Started
@@ -164,4 +154,4 @@ All technical documentation is maintained in the [/docs](https://github.com/meyw
 
 ---
 
-_Last updated: 2026-04-21 (auth-foundation sprint + Wave-2 planning sync) | Maintained by: meywd_
+_Last updated: 2026-07-15 (main-branch sync: Epic 23 monitoring pages, Epic 3 assessment workflows, Epic 4 capture + replay, Epic 6 KB/RAG + Ollama) | Maintained by: meywd_

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -107,7 +107,7 @@ Tamma is an **autonomous development platform** designed to achieve **70%+ auton
 | Epic 1 | Foundation & Core Infrastructure | 10/15 | 2 in progress, 3 ready |
 | Epic 1.5 | Infrastructure & Deployment | 9/10 | Kubernetes deployment in progress |
 | Epic 2 | Autonomous Development Loop | 14/20 | Provider selection, dependency mapping + sequencing, prompt overhauls |
-| Epic 3 | Quality Gates & Intelligence | 11/13 | Clarifying-questions workflow + intelligent test pipeline |
+| Epic 3 | Quality Gates & Intelligence | 12/13 | Intelligent test-execution pipeline (3-13) |
 | Epic 4 | Event Sourcing & Audit Trail | 7/8 | Event store backend selection in progress |
 | Epic 6 | Context & Knowledge Management | 10/11 | Vector DB provider stubs (sidecar now live w/ Ollama embeddings) |
 | Epic 7 | Mentorship Workflow | 8/9 | TDD sub-workflow in progress |

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -35,7 +35,8 @@ Service names, images, and internal ports are from `docker/docker-compose.yml`. 
 | `postgres` | `postgres:17-alpine` | Data, DCB events, ELSA state | 5432 | `pg_isready -U $POSTGRES_USER` | 2G / 2 cpu |
 | `rabbitmq` | `rabbitmq:3.13-management-alpine` | Message broker | 5672 / 15672 | `rabbitmq-diagnostics check_running` | 512M / 1 cpu |
 | `chromadb` | `chromadb/chroma:1.5.8` | Vector store (RAG) | 8000 | HTTP probe of `/api/v2/heartbeat` | 1G / 1 cpu |
-| `intelligence-server` | built (`packages/intelligence-server`) | TS Fastify sidecar for `/api/kb/*` | 4100 | `curl -fsS http://localhost:4100/health` | — |
+| `ollama` | `ollama/ollama:0.31.1` | Local embedding server (`nomic-embed-text`, 768-dim) for KB/RAG — no OpenAI key/cost. **No host port** (unauthenticated API, internal-only) | 11434 | `ollama list \| grep nomic-embed-text` (ops visibility only — deliberately not a `service_healthy` gate) | 2G / 2 cpu |
+| `intelligence-server` | built (`packages/intelligence-server`) | TS Fastify sidecar for `/api/kb/*` — real ChromaDB vector store + Ollama embeddings wired via env | 4100 | `curl -fsS http://localhost:4100/health` | — |
 | `elsa-server` | built (`apps/tamma-elsa/…/Tamma.ElsaServer`) | ELSA .NET 8 workflow engine | 5000 | `curl -f http://localhost:5000/health` | 1G / 1 cpu |
 | `elsa-studio` | built (`Tamma.Studio`) | Blazor WASM designer (nginx) | 80 | — | 128M |
 | `tamma-api` | built (`Tamma.Api`) | Consolidated **C#** REST API | 3100 | `curl -f http://localhost:3100/api/health` | 768M / 1 cpu |
@@ -46,7 +47,9 @@ Service names, images, and internal ports are from `docker/docker-compose.yml`. 
 | `opensearch` | `opensearchproject/opensearch:2.19.0` | Log aggregation (profile `observability`) | 9200 | cluster-health green/yellow | 3G / 2 cpu |
 | `opensearch-dashboards` | `…/opensearch-dashboards:2.19.0` | Log viz (profile `observability`) | 5601 | `/api/status` probe | 1.5G |
 
-Network: `tamma-net` (bridge). Volumes: `tamma-pg-data`, `tamma-rmq-data`, `tamma-chroma-data`, `tamma-engine-workdir`, `tamma-os-data`.
+Network: `tamma-net` (bridge). Volumes: `tamma-pg-data`, `tamma-rmq-data`, `tamma-chroma-data`, `tamma-ollama-data`, `tamma-engine-workdir`, `tamma-os-data`.
+
+The `ollama` entrypoint serves, waits for the API, pulls `nomic-embed-text` (~60s, first boot only — the model persists in `tamma-ollama-data`), then keeps serving. The sidecar's Ollama embedder initializes config-only (network-free), so `intelligence-server` waits on ollama with `service_started` — it boots and reports **configured** without blocking on the pull. An embed call landing inside the first-boot pull window gets a model-not-found from Ollama; the next call after the pull succeeds (nothing embeds at boot — RAG indexing is on-demand). The sidecar also creates its RAG collection (`codebase`) on an empty ChromaDB at boot, so a fresh deployment is fully configured rather than `not_configured`.
 
 Note: `tamma-api` is the **C# .NET 8** API (built from `Tamma.Api/Dockerfile`, port 3100, health `/api/health`). The consolidation onto a single C# API already happened — an older separate `tamma-api-dotnet` service no longer exists.
 
@@ -58,6 +61,8 @@ Services start in dependency layers so an in-flight upgrade never races its own 
 Layer 1:  postgres  rabbitmq  chromadb          (wait: healthy)
 Layer 2:  elsa-server                            (wait: /health)
 Layer 3:  tamma-api                              (wait: /api/health)
+          └─ pulls up ollama + intelligence-server via depends_on
+             (intelligence-server: chromadb healthy + ollama started)
 Layer 4:  tamma-engine  tamma-dashboard  elsa-studio
           oauth2-proxy  nginx-proxy
 ```
@@ -94,6 +99,8 @@ Copy `docker/.env.example` to `docker/.env` and fill it in. Config uses ASP.NET 
 | `DASHBOARD_URL` | `https://app.tamma.dev` |
 
 **Optional (commented in `.env.example`, shown with defaults):** `POSTGRES_USER=tamma`, `POSTGRES_DB=tamma`, `RABBITMQ_USER=tamma`, `RABBITMQ_PASSWORD=tamma`, `LOG_LEVEL=info`, plus the OpenSearch block (`OPENSEARCH_URL`, `OPENSEARCH_ENABLED`, `LOG_INDEX_PREFIX`).
+
+**KB/RAG embeddings (optional overrides; defaults in compose, absent from `.env.example`):** `INTELLIGENCE_EMBEDDING_PROVIDER=ollama`, `INTELLIGENCE_EMBEDDING_MODEL=nomic-embed-text`, `INTELLIGENCE_EMBEDDING_BASE_URL=http://ollama:11434`, `INTELLIGENCE_LOG_LEVEL=info`. The defaults run embeddings fully self-hosted on the in-stack `ollama` service — no OpenAI key required. To use a cloud provider instead, set `INTELLIGENCE_EMBEDDING_PROVIDER=openai` plus an API key. See [Deployment → KB / RAG sidecar embeddings](Deployment#kb--rag-sidecar-embeddings-optional-overrides-defaults-to-local-ollama).
 
 For the full env-var reference — including the least-privilege `TammaAppDb` role, Redis, Cranl provisioning, SMTP, and tenant-backup keys — see [Deployment](Deployment#core-environment-variables). Two variables consumed in production but **absent** from `.env.example`: `TAMMA_APP_DB_PASSWORD` (activates the least-privilege `tamma_app` DB role) and `CRANL_ENCRYPTION_KEY` (only when Cranl provisioning is enabled).
 
@@ -140,7 +147,7 @@ docker compose \
   --env-file ../.env up -d
 ```
 
-`docker-compose.prod.yml` applies per-service memory/CPU limits and exposes only `nginx-proxy` on 80/443 — every other service is reachable through the proxy. Budget: ~6.8 GB without observability, ~11.8 GB with it (fits the 16 GB VPS).
+`docker-compose.prod.yml` applies per-service memory/CPU limits and exposes only `nginx-proxy` on 80/443 — every other service is reachable through the proxy. Budget (sum of limits, not reservations): ~8.8 GB without observability (includes the 2G ollama cap), ~13.4 GB with it — fits the 16 GB VPS, but don't run observability + ollama on a 16 GB box without headroom care.
 
 ## Health checks
 
@@ -151,7 +158,10 @@ docker compose \
 | `GET /health/live` | tamma-api | Liveness only (no dependency checks). |
 | `GET /health/ready` | tamma-api | Readiness — checks tagged `ready` (Postgres, KEK, least-privilege role). |
 | `GET /health` | elsa-server (5000) | ELSA engine health. |
-| `GET /health` | intelligence-server (4100) | KB sidecar health. |
+| `GET /health` | intelligence-server (4100) | KB sidecar health. A fresh stack boots **configured** (the RAG collection is auto-created on an empty ChromaDB); only a stack with no vector-store env degrades to `not_configured` stubs. |
+| `GET /api/admin/monitoring/infrastructure` | tamma-api (3100) | Platform-owner infra-metrics snapshot: .NET runtime, CPU/memory/uptime, disks, and dependency connectivity (Postgres, ELSA, RabbitMQ, ChromaDB, OpenSearch). Backs the dashboard's Infrastructure Monitor page. |
+
+The `ollama` container healthcheck (`ollama list | grep nomic-embed-text`) passes only once the model is present — it exists for ops visibility and is deliberately **not** used as a `service_healthy` dependency gate (that would block deploys on the one-time model pull).
 
 Public surface (through nginx): `https://api.tamma.dev/api/health`, `https://app.tamma.dev/`, `https://elsa.tamma.dev/health` (the ELSA `/health` route is proxied unauthenticated).
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -39,7 +39,7 @@ Review-finding cross-reference: see [Port Audit → Code review (2026-04-20)](Po
 | **Epic 1** | Foundation & Core Infrastructure | 15 | 10 | Near Complete |
 | **Epic 1.5** | Infrastructure & Deployment | 10 | 9 | Near Complete (K8s in progress) |
 | **Epic 2** | Autonomous Development Loop | 20 | 14 | Near Complete (2-14 decomposition landed 2026-07) |
-| **Epic 3** | Quality Gates & Intelligence | 13 | 11 | Near Complete (3-4/3-6/3-7 landed 2026-07) |
+| **Epic 3** | Quality Gates & Intelligence | 13 | 12 | Near Complete (3-4/3-5/3-6/3-7 landed 2026-07; 3-13 remains) |
 | **Epic 4** | Event Sourcing & Audit Trail | 8 | 7 | Near Complete (4-5 capture + 4-8 replay landed 2026-07) |
 | **Epic 5** | Observability Dashboard & Docs | 14 | 4 | Partially Implemented |
 | **Epic 6** | Context & Knowledge Management | 10 | 9 | Near Complete (KB/RAG sidecar live w/ local Ollama embeddings, 2026-07) |
@@ -148,7 +148,7 @@ Completed / Near Complete:
   Epic 1   (Foundation)              [NEAR COMPLETE - 10/15]
   Epic 1.5 (Infrastructure)          [NEAR COMPLETE - 9/10]
   Epic 2   (Autonomous Loop)         [NEAR COMPLETE - 14/20 — 2-14 decomposition landed 2026-07]
-  Epic 3   (Quality Gates)           [NEAR COMPLETE - 11/13 — 3-4/3-6/3-7 landed 2026-07]
+  Epic 3   (Quality Gates)           [NEAR COMPLETE - 12/13 — 3-4/3-5/3-6/3-7 landed 2026-07]
   Epic 4   (Event Sourcing)          [NEAR COMPLETE - 7/8 — 4-5 capture + 4-8 replay landed 2026-07]
   Epic 6   (Context & Knowledge)     [NEAR COMPLETE - 9/10 — KB/RAG sidecar live w/ Ollama embeddings]
   Epic 7   (Mentorship Workflow)     [NEAR COMPLETE - 8/9]

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -2,7 +2,7 @@
 
 Comprehensive roadmap covering **33 epics** from foundation through SaaS platform, including five newly scoped epics from the 2026-04-20/21 planning sweep (Epics 28, 29, 30, 31, 33). _(Epics 27 and 32 are now defined; previous roadmap text marking them "reserved" was stale.)_
 
-_Last audited: 2026-04-21 (auth-foundation sprint + Wave-2 planning + prioritization)._
+_Last audited: 2026-07-15 (main-branch sync: Epic 23 monitoring pages, Epic 3 assessment workflows, Epic 4 capture + replay, 2-14 decomposition, 18-4 onboarding slices, 21-4 dashboard pages, Epic 6 KB/RAG + Ollama)._
 
 ## Prioritization (Wave A → D)
 
@@ -38,11 +38,11 @@ Review-finding cross-reference: see [Port Audit → Code review (2026-04-20)](Po
 |------|------|---------|------|--------|
 | **Epic 1** | Foundation & Core Infrastructure | 15 | 10 | Near Complete |
 | **Epic 1.5** | Infrastructure & Deployment | 10 | 9 | Near Complete (K8s in progress) |
-| **Epic 2** | Autonomous Development Loop | 20 | 13 | Near Complete |
-| **Epic 3** | Quality Gates & Intelligence | 12 | 8 | Near Complete |
-| **Epic 4** | Event Sourcing & Audit Trail | 8 | 6 | Near Complete |
+| **Epic 2** | Autonomous Development Loop | 20 | 14 | Near Complete (2-14 decomposition landed 2026-07) |
+| **Epic 3** | Quality Gates & Intelligence | 13 | 11 | Near Complete (3-4/3-6/3-7 landed 2026-07) |
+| **Epic 4** | Event Sourcing & Audit Trail | 8 | 7 | Near Complete (4-5 capture + 4-8 replay landed 2026-07) |
 | **Epic 5** | Observability Dashboard & Docs | 14 | 4 | Partially Implemented |
-| **Epic 6** | Context & Knowledge Management | 10 | 9 | Near Complete |
+| **Epic 6** | Context & Knowledge Management | 10 | 9 | Near Complete (KB/RAG sidecar live w/ local Ollama embeddings, 2026-07) |
 | **Epic 7** | Autonomous Mentorship Workflow | 9 | 8 | Near Complete |
 | **Epic 8** | Distribution & Installation | 8 | 8 | Completed |
 | **Epic 9** | Config-Driven Multi-Agent Management | 11 | 11 | Completed |
@@ -54,12 +54,12 @@ Review-finding cross-reference: see [Port Audit → Code review (2026-04-20)](Po
 | **Epic 15** | Observability & Log Aggregation | 1 | 1 | Completed |
 | **Epic 16** | Unified Auth, User Management & Admin | 6 | 6 | Completed |
 | **Epic 17** | Multi-Tenancy Foundation | 5 | 0 | Drafted |
-| **Epic 18** | End-User Auth & Registration | 5 (+ 18-7, 18-8) | 1 | Partially Implemented |
+| **Epic 18** | End-User Auth & Registration | 5 (+ 18-6/18-7/18-8) | 4 | Partially Implemented (18-4 onboarding slices landed 2026-07; 18-4 still in progress) |
 | **Epic 19** | GitHub App Agent Dispatch | 6 | 5 | **Completed** (19-6 follow-up drafted) |
 | **Epic 20** | Billing & Payments | 5 | 0 | Drafted |
-| **Epic 21** | Marketing Site & User Dashboard | 5 | 1 | Partially (Midnight Ocean live) |
+| **Epic 21** | Marketing Site & User Dashboard | 5 | 2 | Partially (21-4 Repos & Runs pages landed 2026-07; marketing site extracted to standalone repo) |
 | **Epic 22** | CLI Mode Preservation | 5 | 0 | Drafted |
-| **Epic 23** | System Monitoring & Observability Dashboard | 12 | 0 | Drafted (26 task plans) |
+| **Epic 23** | System Monitoring & Observability Dashboard | 12 | 8 | In Progress — 23-1..23-6, 23-8, 23-12 landed 2026-07; 23-7/23-9/23-10 remain (23-11 superseded) |
 | **Epic 24** | Realtime Voice Conversation | 7 | 1 | Drafted (24 task plans) |
 | **Epic 25** | Documentation & Wiki Site | 1 | 1 | Completed |
 | **Epic 26** | Project Management & Triage | 4 | 0 | Drafted |
@@ -147,7 +147,10 @@ Beyond the numbered findings, Epic 31 closes the "GitHub-hard-coding" design-int
 Completed / Near Complete:
   Epic 1   (Foundation)              [NEAR COMPLETE - 10/15]
   Epic 1.5 (Infrastructure)          [NEAR COMPLETE - 9/10]
-  Epic 6   (Context & Knowledge)     [NEAR COMPLETE - 9/10]
+  Epic 2   (Autonomous Loop)         [NEAR COMPLETE - 14/20 — 2-14 decomposition landed 2026-07]
+  Epic 3   (Quality Gates)           [NEAR COMPLETE - 11/13 — 3-4/3-6/3-7 landed 2026-07]
+  Epic 4   (Event Sourcing)          [NEAR COMPLETE - 7/8 — 4-5 capture + 4-8 replay landed 2026-07]
+  Epic 6   (Context & Knowledge)     [NEAR COMPLETE - 9/10 — KB/RAG sidecar live w/ Ollama embeddings]
   Epic 7   (Mentorship Workflow)     [NEAR COMPLETE - 8/9]
   Epic 8   (Distribution)            [COMPLETED]
   Epic 9   (Multi-Agent Management)  [COMPLETED]
@@ -158,18 +161,21 @@ Completed / Near Complete:
   Epic 15  (Log Aggregation)         [COMPLETED]
   Epic 16  (Unified Auth & Admin)    [COMPLETED]
   Epic 19  (Agent Dispatch)          [COMPLETED - 19-6 follow-up drafted]
-  Epic 21  (Marketing Site)          [PARTIAL - landing live]
+  Epic 21  (Marketing/User Dashboard) [PARTIAL - 21-4 Repos & Runs pages live]
   Epic 25  (Wiki Site)               [COMPLETED]
 
+In progress:
+  Epic 18  (End-User Auth)           [4 done — 18-4 onboarding slices landed 2026-07, still in progress]
+  Epic 23  (Monitoring Dashboard)    [IN PROGRESS - 8/12 pages landed 2026-07]
+
 Active planning (Wave-2):
-  Epic 18  (End-User Auth)           [1 done + 18-7/18-8 new]
   Epic 28  (Database-per-Tenant)     [NEW - briefs + 12 plans]
   Epic 29  (Secret Management)       [NEW - briefs + 10 plans]
   Epic 30  (Multi-Tenant Provisioning) [NEW - briefs + 10 plans]
   Epic 31  (Multi Git Platform)      [NEW - briefs only]
 
 Drafted / Future:
-  Epic 2-5, 10, 17, 20, 22-24, 26
+  Epic 5, 10, 17, 20, 22, 24, 26
   Epic 33  (Per-Tenant IdP)          [DEFERRED STUB - trigger-gated]
 ```
 

--- a/wiki/Stories.md
+++ b/wiki/Stories.md
@@ -60,7 +60,7 @@ Each story includes:
 
 ---
 
-## Epic 2: Autonomous Development Loop (Near Complete -- 13/20 Done)
+## Epic 2: Autonomous Development Loop (Near Complete -- 14/20 Done)
 
 | Story | Title | Status |
 |-------|-------|--------|
@@ -77,7 +77,7 @@ Each story includes:
 | 2-11 | Auto-Next Issue Selection | Done |
 | 2-12 | Intelligent Provider Selection | Done |
 | 2-13 | Prompt Engineering Optimization | Done |
-| 2-14 | Issue Decomposition Engine | Ready for Dev |
+| 2-14 | Issue Decomposition Engine | Done |
 | 2-15 | Task Dependency Mapping | Ready for Dev |
 | 2-16 | Incremental Task Sequencing | Ready for Dev |
 | 2-17 | Context Gathering Redesign | Drafted |
@@ -89,17 +89,17 @@ Each story includes:
 
 ---
 
-## Epic 3: Quality Gates & Intelligence (Near Complete -- 8/12 Done)
+## Epic 3: Quality Gates & Intelligence (Near Complete -- 11/12 Done)
 
 | Story | Title | Status |
 |-------|-------|--------|
 | 3-1 | Build Automation Gate Implementation | Done |
 | 3-2 | Test Execution Gate Implementation | Done |
 | 3-3 | Escalation Workflow Implementation | Done |
-| 3-4 | Research Workflow Implementation | Drafted |
+| 3-4 | Research Workflow Implementation | Done |
 | 3-5 | Clarifying Questions Workflow Implementation | Drafted |
-| 3-6 | Ambiguity Scoring Implementation | Drafted |
-| 3-7 | Design Proposal Workflow Implementation | Drafted |
+| 3-6 | Ambiguity Scoring Implementation | Done |
+| 3-7 | Design Proposal Workflow Implementation | Done |
 | 3-8 | Static Analysis Gate Implementation | Done |
 | 3-9 | Security Scanning Gate Implementation | Done |
 | 3-10 | Agent Performance Monitoring | Done |
@@ -110,7 +110,7 @@ Each story includes:
 
 ---
 
-## Epic 4: Event Sourcing & Audit Trail (Near Complete -- 6/8 Done)
+## Epic 4: Event Sourcing & Audit Trail (Near Complete -- 7/8 Done)
 
 | Story | Title | Status |
 |-------|-------|--------|
@@ -121,7 +121,7 @@ Each story includes:
 | 4-5 | Event Capture - Code Changes & Git Operations | Done |
 | 4-6 | Event Capture - Approvals & Escalations | Done |
 | 4-7 | Event Query API for Time-Travel | Done |
-| 4-8 | Black-Box Replay for Debugging | Drafted |
+| 4-8 | Black-Box Replay for Debugging | Done |
 
 [Detailed Breakdown](Epics/Epic-4-Event-Sourcing) | [Story Files](https://github.com/meywd/tamma/tree/main/docs/stories/epic-4)
 
@@ -153,6 +153,8 @@ Dashboard exists at `@tamma/dashboard` with admin, settings, and knowledge base 
 ---
 
 ## Epic 6: Context & Knowledge Management (Near Complete -- 10/11 Done)
+
+2026-07 update: the KB/RAG `intelligence-server` sidecar is now wired to a real vector store (`createVectorStoreFromEnv`/`RagPipeline`), with self-hosted embeddings via local Ollama (`nomic-embed-text`) and RAG collection bootstrap so the sidecar boots configured.
 
 | Story | Title | Package | Status |
 |-------|-------|---------|--------|
@@ -357,7 +359,7 @@ Engine exists as an imperative state machine (`packages/orchestrator/src/engine.
 | 18-1 | User Registration & Email Verification | Drafted |
 | 18-2 | User Login & Session Management | In Progress |
 | 18-3 | Organization/Tenant Creation | Drafted |
-| 18-4 | GitHub App Installation Onboarding | Done |
+| 18-4 | GitHub App Installation Onboarding | In Progress (non-migration slices landed 2026-07: repo activate/deactivate + `ONBOARDING.COMPLETED`) |
 | 18-5 | User-Facing Dashboard Shell | In Progress |
 
 [Detailed Breakdown](Epics/Epic-18-User-Auth) | [Story Files](https://github.com/meywd/tamma/tree/main/docs/stories/epic-18)
@@ -394,14 +396,14 @@ Engine exists as an imperative state machine (`packages/orchestrator/src/engine.
 
 ## Epic 21: Marketing Site & User Dashboard (Partially Implemented)
 
-Marketing site exists at `apps/marketing-site/` with Midnight Ocean redesign. Wiki site at `apps/wiki-site/`. User dashboard not yet implemented.
+Marketing site extracted to a standalone repo (Midnight Ocean redesign). Wiki site at `apps/wiki-site/`. User dashboard (`packages/dashboard-user`) now has Repos & Workflow Runs pages (21-4, landed 2026-07).
 
 | Story | Title | Status |
 |-------|-------|--------|
-| 21-1 | Marketing Landing Page | Done |
+| 21-1 | Marketing Landing Page | Done (site extracted to standalone repo) |
 | 21-2 | Pricing Page + Stripe Checkout | Drafted |
 | 21-3 | Documentation Site | In Progress |
-| 21-4 | User Dashboard -- Repos & Workflow Runs | Drafted |
+| 21-4 | User Dashboard -- Repos & Workflow Runs | Done |
 | 21-5 | User Dashboard -- Settings & Billing | Drafted |
 
 [Detailed Breakdown](Epics/Epic-21-Marketing-Dashboard) | [Story Files](https://github.com/meywd/tamma/tree/main/docs/stories/epic-21)
@@ -422,24 +424,24 @@ Marketing site exists at `apps/marketing-site/` with Midnight Ocean redesign. Wi
 
 ---
 
-## Epic 23: System Monitoring & Observability Dashboard (Drafted -- 26 Task Plans)
+## Epic 23: System Monitoring & Observability Dashboard (In Progress -- 8/12 Done)
 
-All 12 stories now have detailed implementation-ready task plan breakdowns.
+Eight monitoring pages landed on `main` in 2026-07: the nav/layout foundation (23-12) plus System Health, Agent Monitor, Event Store Explorer, Configuration Audit, Workflow Monitor, Provider Diagnostics, and Infrastructure Monitor.
 
 | Story | Title | Task Plans | Status |
 |-------|-------|------------|--------|
-| 23-1 | System Health Dashboard (Overview) | 2 | Planned |
-| 23-2 | Agent Monitor (Realtime) | 2 | Planned |
-| 23-3 | Event Store Explorer | 2 | Planned |
-| 23-4 | Configuration Audit | 2 | Planned |
-| 23-5 | Workflow Monitor | 2 | Planned |
-| 23-6 | Provider Diagnostics (Deep) | 2 | Planned |
+| 23-1 | System Health Dashboard (Overview) | 2 | Done |
+| 23-2 | Agent Monitor (Realtime) | 2 | Done |
+| 23-3 | Event Store Explorer | 2 | Done |
+| 23-4 | Configuration Audit | 2 | Done |
+| 23-5 | Workflow Monitor | 2 | Done |
+| 23-6 | Provider Diagnostics (Deep) | 2 | Done |
 | 23-7 | Log Explorer (OpenSearch) | 2 | Planned |
-| 23-8 | Infrastructure Monitor | 2 | Planned |
+| 23-8 | Infrastructure Monitor | 2 | Done |
 | 23-9 | Knowledge Base Monitor | 2 | Planned |
 | 23-10 | Security & Access Audit | 2 | Planned |
-| 23-11 | Monitoring API Foundation | 3 | Planned |
-| 23-12 | Dashboard Navigation & Layout | 3 | Planned |
+| 23-11 | Monitoring API Foundation | 3 | Superseded (C# `Tamma.Api` port replaced the TS Fastify foundation) |
+| 23-12 | Dashboard Navigation & Layout | 3 | Done |
 
 [Detailed Breakdown](Epics/Epic-23-System-Monitoring) | [Story Files](https://github.com/meywd/tamma/tree/main/docs/stories/epic-23)
 
@@ -633,8 +635,8 @@ Stories progress through the following stages:
 | Total epics | 33 (Epic 32 skipped) |
 | Epics completed | 10 (8, 9, 11, 13, 14, 15, 16, 19, 21 — landing page only, 25) |
 | Epics near complete | 8 (1, 1.5, 2, 3, 4, 6, 7, 12) |
-| Epics partially implemented | 5 (5, 17, 18, 21, 22) |
-| Epics drafted | 5 (10, 20, 23, 24, 26) |
+| Epics partially implemented | 6 (5, 17, 18, 21, 22, 23) |
+| Epics drafted | 4 (10, 20, 24, 26) |
 | Epics newly scoped (Wave-2) | 5 (27, 28, 29, 30, 31) + 1 deferred (33) |
 | Detailed task plans (Epic 23) | 26 |
 | Detailed task plans (Epic 24) | 24 |

--- a/wiki/Stories.md
+++ b/wiki/Stories.md
@@ -89,7 +89,7 @@ Each story includes:
 
 ---
 
-## Epic 3: Quality Gates & Intelligence (Near Complete -- 11/12 Done)
+## Epic 3: Quality Gates & Intelligence (Near Complete -- 12/13 Done)
 
 | Story | Title | Status |
 |-------|-------|--------|
@@ -97,7 +97,7 @@ Each story includes:
 | 3-2 | Test Execution Gate Implementation | Done |
 | 3-3 | Escalation Workflow Implementation | Done |
 | 3-4 | Research Workflow Implementation | Done |
-| 3-5 | Clarifying Questions Workflow Implementation | Drafted |
+| 3-5 | Clarifying Questions Workflow Implementation | Done (landed 2026-07-04: `ClarifyingQuestionsWorkflow` + secure resume endpoint, `CLARIFY.*` events) |
 | 3-6 | Ambiguity Scoring Implementation | Done |
 | 3-7 | Design Proposal Workflow Implementation | Done |
 | 3-8 | Static Analysis Gate Implementation | Done |
@@ -105,6 +105,7 @@ Each story includes:
 | 3-10 | Agent Performance Monitoring | Done |
 | 3-11 | Cost-Aware AI Usage | Done |
 | 3-12 | Task Complexity Assessment | Done |
+| 3-13 | Intelligent Test Execution Pipeline | Ready for Dev |
 
 [Detailed Breakdown](Epics/Epic-3-Quality-Gates) | [Story Files](https://github.com/meywd/tamma/tree/main/docs/stories/epic-3)
 

--- a/wiki/Usage-and-Configuration.md
+++ b/wiki/Usage-and-Configuration.md
@@ -1,6 +1,6 @@
 # Usage & Configuration
 
-How to run Tamma and configure its behaviour: the two operating modes and their entry points, the CLI commands, the per-repo `.tamma/config.json`, convention templates, the prompt-override store, provider/platform configuration, and BYOK (bring-your-own-key).
+How to run Tamma and configure its behaviour: the two operating modes and their entry points, the CLI commands, the per-repo `.tamma/config.json`, convention templates, the prompt-override store, provider/platform and KB/RAG configuration, and BYOK (bring-your-own-key).
 
 Related: [Installation & Setup](Installation) · [API Reference](API-Reference) · [Architecture](Architecture) · [Prompt Store (Epic 27)](Epics/Epic-27-Prompt-Store).
 
@@ -151,6 +151,16 @@ Provider health/diagnostics endpoints live under `/api/providers/*`; settings un
 ### Git platforms
 
 GitHub is the live platform (Octokit App client, activated by `GitHub:AppId` + `GitHub:PrivateKey` env — see [GitHub Integration](GitHub-Integration)). Gitea / Forgejo / GitLab drivers are covered by [Multi Git Platform](Multi-Git-Platform); their inbound webhooks are documented in [API Reference → Webhooks](API-Reference#webhooks).
+
+### KB / RAG (knowledge base)
+
+The C# API's `/api/kb/*` endpoints proxy to the **`intelligence-server` sidecar**, whose composition root (`packages/intelligence-server/src/env-composition.ts`) builds a real vector store + embedder from env:
+
+- **Vector store:** ChromaDB via `CHROMADB_URL` (or `CHROMADB_HOST`/`CHROMADB_PORT`), or pgvector via `KB_PGVECTOR_CONNECTION_STRING` / `PGVECTOR_URL` / `VECTOR_DB_URL`; force a backend with `KB_VECTOR_STORE` (alias `VECTOR_STORE_PROVIDER`). In the Docker stack this is wired to the in-stack ChromaDB.
+- **Embeddings:** in the Docker stack these default to **local Ollama `nomic-embed-text`** (768-dim) — `EMBEDDING_PROVIDER=ollama`, `EMBEDDING_BASE_URL=http://ollama:11434` — so KB vector search and RAG run **with no OpenAI key or per-token cost**. A cloud provider is opt-in: `EMBEDDING_PROVIDER=openai` + `OPENAI_API_KEY` (or `EMBEDDING_API_KEY`), `EMBEDDING_MODEL` to pick the model. (Outside the compose stack, the sidecar's bare default provider is `openai`, which needs a key.)
+- **Collection bootstrap:** the RAG collection (`KB_RAG_COLLECTION`, fallback `KB_INDEX_COLLECTION`, default `codebase`) is **created automatically at boot** if missing (at the embedder's dimensions), so a fresh, never-indexed deployment reports **configured** — retrieval simply returns nothing until content is indexed. Only when no vector-store env is set at all do the KB endpoints degrade to `not_configured` stubs; a store that is configured but unreachable degrades to stubs at boot rather than crashing.
+
+The compose-level knobs (`INTELLIGENCE_EMBEDDING_PROVIDER/MODEL/BASE_URL`) are documented in [Deployment → KB / RAG sidecar embeddings](Deployment#kb--rag-sidecar-embeddings-optional-overrides-defaults-to-local-ollama).
 
 ## BYOK — bring your own key
 

--- a/wiki/Workflow-Ambiguity-Scoring.md
+++ b/wiki/Workflow-Ambiguity-Scoring.md
@@ -1,0 +1,169 @@
+---
+title: "Workflow: Ambiguity Scoring"
+---
+
+**Definition ID:** `ambiguity-scoring`
+**Class:** `AmbiguityScoringWorkflow`
+**Source:** `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs`
+
+## Purpose
+
+The Ambiguity Scoring workflow (Story 3.6) quantifies how ambiguous/underspecified a requirement is: a 0..1 score plus a typed, itemised breakdown with specific recommendations, produced via the MEDIATED `llm-call` path (role=`product_owner`, action=`score-ambiguity`; the engine holds no LLM credential). It then applies a caller-supplied threshold policy to DECIDE whether clarification should be triggered before implementation proceeds, and emits every transition as an `AMBIGUITY.*` DCB event.
+
+Scoring is AUTONOMOUS — there is no human gate/bookmark. The workflow itself does not dispatch clarification: it exposes a `decision` output (`clarify` when score >= threshold, else `proceed`) that a parent flow uses to route into the sibling [Clarifying Questions](/workflows/clarifying-questions) workflow. It reuses the [Research](/workflows/research) / [Assessment](/workflows/assessment) skeleton (llm-call → parse → fail-closed gate + error terminal).
+
+## Flow Diagram
+
+```
++------------------+
+| Read Inputs      |
+| (requirement,    |
+|  context,        |
+|  threshold)      |
++--------+---------+
+         |
+         v
++------------------+
+| Emit AMBIGUITY.  |
+| STARTED          |
++--------+---------+
+         |
+         v
++------------------+
+| Score Ambiguity  |
+| (llm-call:       |
+|  product_owner/  |
+|  score-ambiguity)|
++--------+---------+
+         |
+         v
++------------------+
+| Parse Ambiguity  |
+| (fail-closed)    |
++--------+---------+
+         |
+         v
++------------------+
+| Ambiguity LLM OK?|
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit AMBIGUITY.  |
+| AMBIGUITY| | FAILED (LOUD)    |
+| .SCORED  | +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | Ambiguity Error  |
+| Compute  |   | (Finish)         |
+| Decision |   +------------------+
+| (score >=|
+| threshold|
+|  ?)      |
++----+-----+
+     |
+     v
++------------------+
+| Should Clarify?  |
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++-----------+ +-----------+
+| Emit      | | Emit      |
+| CLARIFI-  | | BELOW_    |
+| CATION_   | | THRESHOLD |
+| TRIGGERED | |           |
++-----+-----+ +-----+-----+
+      |             |
+      +------+------+
+             |
+             v
+      +------------------+
+      | Set Output       |
+      | Result           |
+      +--------+---------+
+               |
+               v
+      +------------------+
+      | Expose Output    |
+      | (score, decision,|
+      |  assessment)     |
+      +------------------+
+```
+
+## Threshold Policy
+
+`AmbiguityThresholds` is a pure, unit-testable policy:
+
+- **Default** clarify threshold: `0.5` (used when the caller supplies none).
+- A positive caller threshold is clamped to `[0, 1]`; a value <= 0 is treated as "unset" and falls back to the default (a threshold of exactly 0 would make every requirement — including a perfectly clear one — trigger clarification).
+- Decision: `score >= threshold` → `clarify`; otherwise `proceed`.
+
+## Sub-Workflows Dispatched
+
+| Workflow | Wait? | Purpose |
+|----------|-------|---------|
+| `llm-call` | Yes | Scoring — role=`product_owner`, action=`score-ambiguity`, tools disabled |
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `sessionId` | Guid | Session identifier (a new one is minted if empty) |
+| `issueId` | string | Issue identifier |
+| `requirement` | string | The requirement text to score |
+| `context` | string | Optional supporting context findings |
+| `threshold` | double | Clarify threshold (0..1; <= 0 or unset → default 0.5) |
+| `tenantId` | string | Tenant id (GUID string, or empty in single-user mode) |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `sessionId` | string | Session identifier |
+| `status` | string | `scored` on success |
+| `score` | double | Ambiguity score (0..1) |
+| `ambiguityCount` | int | Number of itemised ambiguities |
+| `confidence` | double | The model's confidence in the assessment (0..1) |
+| `threshold` | double | The effective (resolved) threshold |
+| `decision` | string | `clarify` or `proceed` |
+| `assessment` | string | The serialized `AmbiguityAssessment` JSON (`{}` on failure) |
+
+## Events Emitted
+
+| Event | Status | When |
+|-------|--------|------|
+| `AMBIGUITY.STARTED` | success | Scoring begins |
+| `AMBIGUITY.SCORED` | success | A valid assessment was parsed (carries score, item count, confidence; the score is nullable event data so a genuine 0.0 is recorded) |
+| `AMBIGUITY.CLARIFICATION_TRIGGERED` | success | Score met/exceeded the threshold — decision=`clarify` |
+| `AMBIGUITY.BELOW_THRESHOLD` | success | Score below the threshold — decision=`proceed` |
+| `AMBIGUITY.FAILED` | error (LOUD) | The scoring `llm-call` failed or output was unparseable/out-of-range — never a fabricated score |
+
+## Fail-Closed Parsing
+
+`AmbiguityParsing.ParseAssessment` returns `null` (routing to the error terminal) on empty output, no JSON, a missing/out-of-range score, or a missing rationale. Empty-shell breakdown items are dropped; item `type` is normalized onto `vague` / `missing` / `contradictory` / `implicit` (else `unspecified`) and `severity` onto `low` / `medium` / `high`. An empty breakdown with score near 0 is a VALID result — it means "clear requirement", not a failure.
+
+## Assessment Shape
+
+```json
+{
+  "score": 0.7,
+  "confidence": 0.85,
+  "rationale": "Why the requirement scored this way (load-bearing)",
+  "ambiguities": [
+    {
+      "type": "missing",
+      "description": "No error-handling behaviour specified",
+      "severity": "high",
+      "recommendation": "Ask which failures must be retried vs surfaced"
+    }
+  ]
+}
+```
+
+---
+
+_See also: [Clarifying Questions](/workflows/clarifying-questions) | [Research](/workflows/research) | [LLM Call](/workflows/llm-call) | [Workflows Index](/workflows)_

--- a/wiki/Workflow-Clarifying-Questions.md
+++ b/wiki/Workflow-Clarifying-Questions.md
@@ -1,0 +1,185 @@
+---
+title: "Workflow: Clarifying Questions"
+---
+
+**Definition ID:** `clarifying-questions`
+**Class:** `ClarifyingQuestionsWorkflow`
+**Source:** `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs`
+
+## Purpose
+
+The Clarifying Questions workflow (Story 3.5) resolves requirement ambiguity with a human in the loop. Given an ambiguous issue/requirement it generates clarifying questions via the MEDIATED `llm-call` path (role=`product_owner`, action=`clarify-requirements`; the engine holds no LLM credential), DELIVERS them to the issue via the mediated git seam, SUSPENDS on a bookmark awaiting the human answers (with a durable SLA timeout), then RESUMES via the secure resume endpoint and incorporates the answers — a second `llm-call` — into a disambiguated requirement. Every transition is emitted as a `CLARIFY.*` DCB event.
+
+It reuses the [Assessment](/workflows/assessment) skeleton (llm-call → deliver → bookmark-wait → analyze/resume, fail-closed gates + error terminal), and is the clarification target that [Ambiguity Scoring](/workflows/ambiguity-scoring) routes to (a parent flow dispatches this workflow on the `decision="clarify"` output).
+
+## Flow Diagram
+
+```
++------------------+
+| Read Inputs      |
+| (requirement,    |
+|  ambiguity       |
+|  context)        |
++--------+---------+
+         |
+         v
++------------------+
+| Generate         |
+| Clarifying       |
+| Questions        |
+| (llm-call:       |
+|  product_owner/  |
+|  clarify-        |
+|  requirements)   |
++--------+---------+
+         |
+         v
++------------------+
+| Parse Questions  |
+| (fail-closed)    |
++--------+---------+
+         |
+         v
++------------------+
+| Questions OK?    |
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit CLARIFY.    |
+| CLARIFY. | | QUESTIONS.FAILED |
+| QUESTIONS| | (LOUD)           |
+| GENERATED| +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | LLM Call Error   |
+| Deliver  |   | (Finish)         |
+| Questions|   +------------------+
+| (git     |
+|  seam)   |
++----+-----+
+     |
+     v
++------------------+
+| Emit CLARIFY.    |
+| QUESTIONS.       |
+| DELIVERED        |
++--------+---------+
+         |
+         v
++------------------+
+| Wait For Answers |
+| (bookmark +      |
+|  durable SLA)    |
++--+------------+--+
+Answered       Timeout
+   |              |
+   v              v
++----------+ +------------------+
+| Store    | | Set Timeout      |
+| Answers  | | Result           |
++----+-----+ +--------+---------+
+     |                |
+     v                v
++----------+ +------------------+
+| Emit     | | Emit CLARIFY.    |
+| ANSWERS. | | ANSWERS.TIMED_OUT|
+| RECEIVED | | (LOUD)           |
++----+-----+ +--------+---------+
+     |                |
+     v                v
++----------+ +------------------+
+| Incorpo- | | Expose Timeout   |
+| rate     | | Output           |
+| Answers  | +------------------+
+| (llm-    |
+|  call)   |
++----+-----+
+     |
+     v
++------------------+
+| Incorporation OK?|
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit CLARIFY.    |
+| REQUIRE- | | INCORPORATION.   |
+| MENTS.   | | FAILED (LOUD)    |
+| CLARIFIED| +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | LLM Call Error   |
+| Expose   |   | (Finish)         |
+| Output   |   +------------------+
++----------+
+```
+
+## Bookmark Points
+
+| Bookmark | Activity | Waits For | Outcomes |
+|----------|----------|-----------|----------|
+| `clarify-answers-{tenant}-{session}` | `WaitForClarifyingAnswersActivity` | Human answers via the secure resume endpoint, or the durable answer SLA (`Clarify:AnswerTimeoutMinutes`, default 4320 = 3 days) | `Answered`, `Timeout` |
+
+The SLA is a durable `DelayFor` bookmark (EF-persisted, re-armed by `Elsa.Scheduling` after a host restart), so an unanswered question set terminates as a real `Timeout` even across restarts.
+
+## Secure Resume
+
+- Public API: `POST /api/adl/clarify/resume` (`WorkflowsManage` policy — SaaS member-role users get 403), which forwards to the engine's `ClarifyResumeEndpoint`.
+- One canonical bookmark-name builder is shared by the suspend and resume sides; the tenant id is server-derived and folded into the bookmark name, so a cross-tenant resume attempt 404s (no IDOR). 0 matching bookmarks → 404; more than 1 → 409.
+
+## Sub-Workflows Dispatched
+
+| Workflow | Wait? | Purpose |
+|----------|-------|---------|
+| `llm-call` | Yes | Question generation — role=`product_owner`, action=`clarify-requirements`, tools disabled |
+| `llm-call` | Yes | Answer incorporation — same role/action, folding the human answers into a disambiguated requirement |
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `sessionId` | Guid | Session identifier (a new one is minted if empty) |
+| `issueId` | string | Issue identifier |
+| `requirement` | string | The ambiguous requirement text |
+| `repository` | string | Repository slug (owner/repo) for the issue-comment delivery |
+| `issueNumber` | int | Issue number for the issue-comment delivery |
+| `ambiguityContext` | string | Optional ambiguity context (e.g. the scoring breakdown) |
+| `tenantId` | string | Tenant id (GUID string, or empty in single-user mode) |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `sessionId` | string | Session identifier |
+| `status` | string | `clarified` or `timed_out` |
+| `clarifiedRequirement` | string | The disambiguated requirement JSON (success path) |
+| `resolved` | bool | Whether the ambiguity was resolved |
+
+## Events Emitted
+
+| Event | Status | When |
+|-------|--------|------|
+| `CLARIFY.QUESTIONS.GENERATED` | success | A non-empty question set was parsed |
+| `CLARIFY.QUESTIONS.DELIVERED` | success | Questions delivered to the issue |
+| `CLARIFY.ANSWERS.RECEIVED` | success | Human answers arrived via the resume endpoint |
+| `CLARIFY.REQUIREMENTS.CLARIFIED` | success | Answers incorporated into a disambiguated requirement |
+| `CLARIFY.QUESTIONS.FAILED` | error (LOUD) | Question-generation `llm-call` failed or output was unparseable |
+| `CLARIFY.INCORPORATION.FAILED` | error (LOUD) | Incorporation `llm-call` failed or output was unparseable |
+| `CLARIFY.ANSWERS.TIMED_OUT` | error (LOUD) | Answer SLA expired with no response |
+
+## Delivery Channels
+
+`DeliverClarifyingQuestionsActivity` posts the questions as an issue comment via the mediated git seam (`PATCH /api/v1/git/{repo}/issues/{n}`; the per-tenant git token is resolved API-side — the engine holds no git credential). When no issue coordinates are supplied it falls back to `api` mode (the questions are already durable in workflow state).
+
+## Fail-Closed Parsing
+
+`ClarifyParsing` mirrors the other Epic-3 parsers: `ParseQuestions` yields an empty list (→ error terminal) when nothing parseable is found; `ParseClarification` returns `null` when the clarified-requirement field is missing/empty. The workflow never proceeds with fabricated questions or a fabricated clarification.
+
+---
+
+_See also: [Ambiguity Scoring](/workflows/ambiguity-scoring) | [Design Proposal](/workflows/design-proposal) | [Assessment](/workflows/assessment) | [LLM Call](/workflows/llm-call) | [Workflows Index](/workflows)_

--- a/wiki/Workflow-Design-Proposal.md
+++ b/wiki/Workflow-Design-Proposal.md
@@ -1,0 +1,183 @@
+---
+title: "Workflow: Design Proposal"
+---
+
+**Definition ID:** `design-proposal`
+**Class:** `DesignProposalWorkflow`
+**Source:** `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs`
+
+## Purpose
+
+The Design Proposal workflow (Story 3.7) generates a technical design PROPOSAL for a complex requirement — a summary, multiple design alternatives with trade-off analysis, a recommendation, and a constraint evaluation — via the MEDIATED `llm-call` path (role=`architect`, action=`plan-system-design`; the engine holds no LLM credential). It DELIVERS the proposal to the issue via the mediated git seam, SUSPENDS on a bookmark awaiting a human approve/reject review decision (with a durable SLA timeout), then RESUMES via the secure resume endpoint and finalises: approved designs hand off to implementation, rejected designs capture the reviewer's feedback.
+
+`DESIGN.*` DCB events are emitted at every transition so the design decision is fully auditable; proposals are versioned in workflow state + events (no dedicated table) and feed the Epic-32 learning loop. It reuses the [Clarifying Questions](/workflows/clarifying-questions) / [Assessment](/workflows/assessment) skeleton (llm-call → deliver → bookmark-wait → resume, fail-closed gates + error terminal).
+
+## Flow Diagram
+
+```
++------------------+
+| Read Inputs      |
+| (requirement,    |
+|  constraints,    |
+|  conventions)    |
++--------+---------+
+         |
+         v
++------------------+
+| Generate Design  |
+| Proposal         |
+| (llm-call:       |
+|  architect/plan- |
+|  system-design)  |
++--------+---------+
+         |
+         v
++------------------+
+| Parse Proposal   |
+| (fail-closed)    |
++--------+---------+
+         |
+         v
++------------------+
+| Proposal LLM OK? |
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit DESIGN.     |
+| DESIGN.  | | PROPOSAL.FAILED  |
+| PROPOSAL.| | (LOUD)           |
+| GENERATED| +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | LLM Call Error   |
+| Deliver  |   | (Finish)         |
+| Design   |   +------------------+
+| Proposal |
+| (git     |
+|  seam)   |
++----+-----+
+     |
+     v
++------------------+
+| Emit DESIGN.     |
+| PROPOSAL.        |
+| DELIVERED        |
++--------+---------+
+         |
+         v
++------------------+
+| Wait For Design  |
+| Approval         |
+| (bookmark +      |
+|  durable SLA)    |
++--+------+-----+--+
+   |      |     |
+Approved Rejected Timeout
+   |      |     |
+   v      v     v
++------+ +------+ +----------+
+| Store| | Store| | Set      |
+| Appr.| | Rej. | | Timeout  |
++--+---+ +--+---+ | Result   |
+   |        |     +----+-----+
+   v        v          |
++------+ +------+      v
+| Emit | | Emit | +----------+
+| APPR-| | REJ- | | Emit     |
+| OVED | | ECTED| | REVIEW.  |
++--+---+ +--+---+ | TIMED_OUT|
+   |        |     +----+-----+
+   v        v          |
++------+ +------+      v
+| Set  | | Set  | +----------+
+| Appr.| | Rej. | | Expose   |
+| Rslt.| | Rslt.| | Timeout  |
++--+---+ +--+---+ | Output   |
+   |        |     +----------+
+   v        v
++------+ +------+
+|Expose| |Expose|
+|Appr. | |Rej.  |
+|Output| |Output|
++------+ +------+
+```
+
+## Bookmark Points
+
+| Bookmark | Activity | Waits For | Outcomes |
+|----------|----------|-----------|----------|
+| `design-approval-{tenant}-{session}` | `WaitForDesignApprovalActivity` | Reviewer approve/reject decision via the secure resume endpoint, or the durable review SLA (`Design:ReviewTimeoutMinutes`, default 4320 = 3 days) | `Approved`, `Rejected`, `Timeout` |
+
+The SLA is a durable `DelayFor` bookmark (EF-persisted, re-armed by `Elsa.Scheduling` after a host restart), so a never-reviewed proposal terminates as a real `Timeout` even across restarts. Whichever path resumes first completes the activity; Elsa burns the remaining bookmark.
+
+## Secure Resume
+
+- Public API: `POST /api/adl/design/resume` (`AdlEndpoints.ResumeDesign`, `WorkflowsManage` policy — SaaS member-role users get 403), which forwards to the engine's `DesignResumeEndpoint` (`/elsa/api/adl/design/resume`).
+- One canonical bookmark-name builder is shared by the suspend and resume sides; the tenant id is server-derived and folded into the bookmark name, so a cross-tenant resume attempt simply 404s (no IDOR). 0 matching bookmarks → 404; more than 1 → 409.
+- The reviewer identity is derived from the authenticated principal (non-forgeable), and the `Approved` flag is read via the tolerant `ResumeInput.AsBool` coercion so a serialized rejection is never mis-read as an approval.
+
+## Sub-Workflows Dispatched
+
+| Workflow | Wait? | Purpose |
+|----------|-------|---------|
+| `llm-call` | Yes | Proposal generation — role=`architect`, action=`plan-system-design`, tools disabled |
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `sessionId` | Guid | Session identifier (a new one is minted if empty) |
+| `issueId` | string | Issue identifier |
+| `requirement` | string | The complex requirement to design for |
+| `repository` | string | Repository slug (owner/repo) for the issue-comment delivery |
+| `issueNumber` | int | Issue number for the issue-comment delivery |
+| `constraints` | string | Technical/business constraints to evaluate against |
+| `conventions` | string | Repo conventions injected into the prompt |
+| `tenantId` | string | Tenant id (GUID string, or empty in single-user mode) |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `sessionId` | string | Session identifier |
+| `status` | string | `approved`, `rejected`, or `timed_out` |
+| `designProposal` | string | The serialized `DesignProposal` JSON (approved/rejected paths) |
+| `approved` | bool | Whether the reviewer approved the design |
+
+## Events Emitted
+
+| Event | Status | When |
+|-------|--------|------|
+| `DESIGN.PROPOSAL.GENERATED` | success | A valid proposal was parsed (carries the alternative count) |
+| `DESIGN.PROPOSAL.DELIVERED` | success | Proposal delivered to the issue (carries the channel) |
+| `DESIGN.PROPOSAL.APPROVED` | success | Reviewer approved (carries feedback) |
+| `DESIGN.PROPOSAL.REJECTED` | success | Reviewer rejected (feedback captured for revision) |
+| `DESIGN.PROPOSAL.FAILED` | error (LOUD) | The generation `llm-call` failed or output was unparseable — never a fabricated design a reviewer would then approve |
+| `DESIGN.REVIEW.TIMED_OUT` | error (LOUD) | Review SLA expired with no reviewer decision |
+
+## Delivery Channels
+
+`DeliverDesignProposalActivity` posts the proposal as a formatted review comment on the issue via the mediated git seam (`PATCH /api/v1/git/{repo}/issues/{n}`; the per-tenant git token is resolved API-side — the engine holds no git credential). Channel is `issue-comment` when repository + issue number are supplied; otherwise it falls back to `api` mode (the proposal is already durable in workflow state and the `DESIGN.PROPOSAL.GENERATED` event).
+
+## Proposal Shape
+
+```json
+{
+  "summary": "High-level summary of the recommended design (load-bearing)",
+  "alternatives": [
+    { "name": "Option A", "tradeoffs": "..." },
+    { "name": "Option B", "tradeoffs": "..." }
+  ],
+  "recommendation": "Why the winning alternative wins",
+  "constraintEvaluation": "How the proposal fares against the supplied constraints"
+}
+```
+
+`DesignParsing.ParseProposal` fails closed (returns `null`) when the load-bearing `summary` cannot be recovered.
+
+---
+
+_See also: [LLM Call](/workflows/llm-call) | [Clarifying Questions](/workflows/clarifying-questions) | [Merge Approval](/workflows/merge-approval) | [Workflows Index](/workflows)_

--- a/wiki/Workflow-Issue-Decomposition.md
+++ b/wiki/Workflow-Issue-Decomposition.md
@@ -1,0 +1,170 @@
+---
+title: "Workflow: Issue Decomposition"
+---
+
+**Definition ID:** `issue-decomposition`
+**Class:** `IssueDecompositionWorkflow`
+**Source:** `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs`
+
+## Purpose
+
+The Issue Decomposition workflow (Story 2.14) breaks a complex issue/requirement into an ORDERED set of smaller, implementable sub-tasks — each with a stable id, title, description, acceptance criteria, an effort estimate (hours), a complexity bucket, and declared `dependsOn` prerequisite edges. It gathers codebase/prior-art context by reusing the `context-gathering` sub-workflow, then decomposes via the MEDIATED `llm-call` path (role=`senior_developer`, action=`decompose-issue`) — the engine holds no LLM credential. Every transition is emitted as a `DECOMPOSITION.*` DCB event.
+
+The sub-task output shape (`IssueDecomposition` — ordered sub-tasks with ids + `dependsOn` edges) is the input contract for Story 2.15 (dependency mapping) and Story 2.16 (sequencing).
+
+Decomposition is AUTONOMOUS — there is no in-workflow human gate/bookmark. Human approval before executing decomposed tasks is a downstream orchestration concern: a parent flow presents the emitted sub-task set for approval before dispatching implementation.
+
+## Flow Diagram
+
+```
++------------------+
+| Read Inputs      |
+| (issueId, title, |
+|  repo, tenant)   |
++--------+---------+
+         |
+         v
++------------------+
+| Emit             |
+| DECOMPOSITION.   |
+| STARTED          |
++--------+---------+
+         |
+         v
++------------------+
+| Gather Context   |
+| (context-        |
+|  gathering)      |
++--------+---------+
+         |
+         v
++------------------+
+| Store Context    |
+| Result           |
++--------+---------+
+         |
+         v
++------------------+
+| Emit             |
+| DECOMPOSITION.   |
+| CONTEXT_GATHERED |
++--------+---------+
+         |
+         v
++------------------+
+| Decompose Issue  |
+| (llm-call:       |
+|  senior_developer|
+|  /decompose-     |
+|  issue)          |
++--------+---------+
+         |
+         v
++------------------+
+| Parse            |
+| Decomposition    |
+| (fail-closed)    |
++--------+---------+
+         |
+         v
++------------------+
+| Decomposition    |
+| LLM OK?          |
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit             |
+| DECOMPO- | | DECOMPOSITION.   |
+| SITION.  | | FAILED (LOUD)    |
+| COMPLETED| +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | Decomposition    |
+| Set      |   | Error (Finish)   |
+| Output   |   +------------------+
+| Result   |
++----+-----+
+     |
+     v
++------------------+
+| Expose Output    |
+| (decomposition,  |
+|  subtaskCount)   |
++------------------+
+```
+
+## Sub-Workflows Dispatched
+
+| Workflow | Wait? | Purpose |
+|----------|-------|---------|
+| `context-gathering` | Yes | Multi-role codebase/prior-art scan; scope/dependency signal informs the complexity assessment |
+| `llm-call` | Yes | Decomposition — role=`senior_developer`, action=`decompose-issue`, tools disabled |
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `sessionId` | Guid | Session identifier (a new one is minted if empty) |
+| `issueId` | string | Issue identifier |
+| `issueTitle` | string | Issue title (wrapped into a minimal work-item JSON when no `workItemJson` is supplied) |
+| `repository` | string | Repository identifier |
+| `issueNumber` | int | Issue number |
+| `workItemJson` | string | Work item JSON (preferred over `issueTitle` when present) |
+| `tenantId` | string | Tenant id (GUID string, or empty in single-user mode) |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `sessionId` | string | Session identifier |
+| `status` | string | `completed` on success |
+| `decomposition` | string | The serialized `IssueDecomposition` JSON (`{}` on failure) |
+| `subtaskCount` | int | Number of usable sub-tasks recovered |
+| `contextIds` | string | Context IDs JSON array from context gathering |
+
+## Events Emitted
+
+| Event | Status | When |
+|-------|--------|------|
+| `DECOMPOSITION.STARTED` | success | Decomposition begins |
+| `DECOMPOSITION.CONTEXT_GATHERED` | success | Context-gathering sub-workflow returned |
+| `DECOMPOSITION.COMPLETED` | success | A valid decomposition was parsed (carries the sub-task count) |
+| `DECOMPOSITION.FAILED` | error (LOUD) | The `llm-call` failed or output was empty/unparseable — never a false success |
+
+## Fail-Closed Parsing
+
+`DecompositionParsing.ParseDecomposition` returns `null` (routing to the error terminal — no fabricated breakdown) on:
+
+1. Empty/unparseable LLM output
+2. Missing/empty `summary` (the rationale is load-bearing — it records how the breakdown preserves the parent issue's intent)
+3. Zero usable sub-tasks
+
+It also cleans the sub-task set: shell (empty) sub-tasks and duplicate-id sub-tasks are dropped, `dependsOn` references are pruned to ids that exist in the same decomposition, and self-references are removed. Complexity labels are normalized onto the closed `low`/`medium`/`high` set (unknown labels fold to `medium`).
+
+## Sub-Task Shape
+
+```json
+{
+  "summary": "How the breakdown preserves the parent intent",
+  "subtasks": [
+    {
+      "id": "ST-1",
+      "title": "...",
+      "description": "...",
+      "acceptanceCriteria": "...",
+      "estimateHours": 4,
+      "complexity": "medium",
+      "dependsOn": []
+    }
+  ]
+}
+```
+
+Sub-tasks live in DCB events + workflow state only — there is no dedicated table.
+
+---
+
+_See also: [Context Gathering](/workflows/context-gathering) | [LLM Call](/workflows/llm-call) | [Research](/workflows/research) | [Workflows Index](/workflows)_

--- a/wiki/Workflow-Research.md
+++ b/wiki/Workflow-Research.md
@@ -1,0 +1,161 @@
+---
+title: "Workflow: Research"
+---
+
+**Definition ID:** `research`
+**Class:** `ResearchWorkflow`
+**Source:** `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs`
+
+## Purpose
+
+The Research workflow (Story 3.4) autonomously investigates an issue/topic — typically when ambiguity is detected in a requirement. It gathers codebase/prior-art context by reusing the `context-gathering` sub-workflow, then synthesizes the gathered context into a ranked, confidence-scored research report via the MEDIATED `llm-call` path (role=`product_owner`, action=`research`) — the engine holds no LLM credential. Results are emitted as `RESEARCH.*` DCB events so the research is stored and linked to the originating issue for traceability.
+
+Research is AUTONOMOUS — there is no human gate/bookmark. Requirement ambiguity itself is resolved by the sibling [Clarifying Questions](/workflows/clarifying-questions) workflow; research just investigates and reports. It mirrors the [Assessment](/workflows/assessment) skeleton (gather-context → llm-call → parse → fail-closed gate + error terminal).
+
+## Flow Diagram
+
+```
++------------------+
+| Read Inputs      |
+| (topic, issueId, |
+|  repo, tenant)   |
++--------+---------+
+         |
+         v
++------------------+
+| Emit RESEARCH.   |
+| STARTED          |
++--------+---------+
+         |
+         v
++------------------+
+| Gather Context   |
+| (context-        |
+|  gathering)      |
++--------+---------+
+         |
+         v
++------------------+
+| Store Context    |
+| Result           |
++--------+---------+
+         |
+         v
++------------------+
+| Emit RESEARCH.   |
+| CONTEXT_GATHERED |
++--------+---------+
+         |
+         v
++------------------+
+| Synthesize       |
+| Research         |
+| (llm-call:       |
+|  product_owner/  |
+|  research)       |
++--------+---------+
+         |
+         v
++------------------+
+| Parse Research   |
+| (fail-closed)    |
++--------+---------+
+         |
+         v
++------------------+
+| Research LLM OK? |
++--+------------+--+
+  YES            NO
+   |              |
+   v              v
++----------+ +------------------+
+| Emit     | | Emit RESEARCH.   |
+| RESEARCH.| | FAILED (LOUD)    |
+| COMPLETED| +--------+---------+
++----+-----+          |
+     |                v
+     v         +------------------+
++----------+   | Research Error   |
+| Set      |   | (Finish)         |
+| Output   |   +------------------+
+| Result   |
++----+-----+
+     |
+     v
++------------------+
+| Expose Output    |
+| (report,         |
+|  findingCount,   |
+|  confidence)     |
++------------------+
+```
+
+## Sub-Workflows Dispatched
+
+| Workflow | Wait? | Purpose |
+|----------|-------|---------|
+| `context-gathering` | Yes | Multi-role codebase/prior-art scan (same reuse as Assessment) |
+| `llm-call` | Yes | Synthesis — role=`product_owner`, action=`research`, tools disabled |
+
+## Inputs
+
+| Input | Type | Description |
+|-------|------|-------------|
+| `sessionId` | Guid | Session identifier (a new one is minted if empty) |
+| `issueId` | string | Issue identifier |
+| `topic` | string | Research topic/question (wrapped into a minimal work-item JSON when no `workItemJson` is supplied) |
+| `repository` | string | Repository identifier |
+| `issueNumber` | int | Issue number |
+| `workItemJson` | string | Work item JSON (preferred over `topic` when present) |
+| `tenantId` | string | Tenant id (GUID string, or empty in single-user mode) |
+
+## Outputs
+
+| Output | Type | Description |
+|--------|------|-------------|
+| `sessionId` | string | Session identifier |
+| `status` | string | `completed` on success |
+| `report` | string | The serialized `ResearchReport` JSON (`{}` on failure) |
+| `findingCount` | int | Number of findings recovered |
+| `confidence` | double | Overall confidence (0..1) across the findings |
+| `contextIds` | string | Context IDs JSON array from context gathering |
+
+## Events Emitted
+
+| Event | Status | When |
+|-------|--------|------|
+| `RESEARCH.STARTED` | success | Investigation begins |
+| `RESEARCH.CONTEXT_GATHERED` | success | Context-gathering sub-workflow returned |
+| `RESEARCH.COMPLETED` | success | A valid ranked report was parsed (carries finding count + confidence) |
+| `RESEARCH.FAILED` | error (LOUD) | The synthesis `llm-call` failed or output was empty/unparseable — never a false success |
+
+## Fail-Closed Parsing
+
+`ResearchParsing.ParseReport` returns `null` (routing to the error terminal — no fabricated report) on empty/unparseable output, a missing summary, or zero findings. Recovered findings are ranked most-relevant-first (relevance desc, then confidence desc).
+
+## Report Shape
+
+The dedicated system prompt template (`SystemPrompts.ResearchBody`, taxonomy pair `product_owner`/`research`) emits exactly the JSON the parser recovers:
+
+```json
+{
+  "topic": "...",
+  "summary": "...",
+  "findings": [
+    {
+      "title": "...",
+      "summary": "...",
+      "relevance": 0.9,
+      "confidence": 0.8,
+      "citations": ["src/foo.cs", "docs/bar.md"]
+    }
+  ],
+  "overallConfidence": 0.85
+}
+```
+
+The report lives in DCB events + workflow state only — there is no dedicated table.
+
+---
+
+_See also: [Context Gathering](/workflows/context-gathering) | [LLM Call](/workflows/llm-call) | [Ambiguity Scoring](/workflows/ambiguity-scoring) | [Clarifying Questions](/workflows/clarifying-questions) | [Workflows Index](/workflows)_

--- a/wiki/Workflows.md
+++ b/wiki/Workflows.md
@@ -2,7 +2,7 @@
 
 Tamma uses [ELSA Workflows](https://elsa-workflows.github.io/elsa-core/) (C# .NET 8) as its orchestration engine. All workflows are **code-first** (defined in C# classes extending `WorkflowBase`) and rendered as visual flowcharts in ELSA Studio.
 
-This page is the index for all 30 workflows in the system.
+This page is the index for the 35 development-orchestration workflows in the system. Five additional platform/operations workflows (tenant provisioning, secret rotation, analytics rollup) are listed [at the end](#platform--operations-workflows) without dedicated pages — see [Multi-Tenant Provisioning](Multi-Tenant-Provisioning) for the tenant lifecycle ones.
 
 ## Workflow Inventory
 
@@ -38,6 +38,11 @@ This page is the index for all 30 workflows in the system.
 | 28 | **Triage Context Gathering** | `triage-context-gathering` | Gather context for triage: code usage, deps, CVE, changelog | [Details](Workflow-Triage-Context-Gathering) |
 | 29 | **Triage Panel Review** | `triage-panel-review` | 4-role panel reviews item for triage (security/dev/devops/qa) | [Details](Workflow-Triage-Panel-Review) |
 | 30 | **Triage PO Decision** | `triage-po-decision` | PO makes final triage decision based on panel review | [Details](Workflow-Triage-PO-Decision) |
+| 31 | **Issue Decomposition** | `issue-decomposition` | Decompose a complex issue into ordered sub-tasks with dependencies via mediated LLM | [Details](Workflow-Issue-Decomposition) |
+| 32 | **Research** | `research` | Autonomous investigation: context gathering + ranked, confidence-scored research report | [Details](Workflow-Research) |
+| 33 | **Ambiguity Scoring** | `ambiguity-scoring` | Score requirement ambiguity (0..1 + itemised breakdown), threshold decides clarify vs proceed | [Details](Workflow-Ambiguity-Scoring) |
+| 34 | **Clarifying Questions** | `clarifying-questions` | LLM-generated clarifying questions, human answers via bookmark, incorporate into clarified requirement | [Details](Workflow-Clarifying-Questions) |
+| 35 | **Design Proposal** | `design-proposal` | Generate design proposal (alternatives + trade-offs), deliver to issue, human approve/reject gate | [Details](Workflow-Design-Proposal) |
 
 ## Dependency Diagram
 
@@ -104,6 +109,27 @@ Mentorship (independent top-level)
   +-- Debugging
         +-- LLM Call
         +-- Testing Pipeline
+
+Requirement-intelligence sub-workflows (Epics 2/3 — dispatched on demand by a parent flow)
+  |
+  +-- Ambiguity Scoring (autonomous, no bookmark)
+  |     +-- LLM Call (product_owner/score-ambiguity)
+  |     +-- decision output: "clarify" → parent dispatches Clarifying Questions;
+  |         "proceed" → parent continues
+  +-- Clarifying Questions
+  |     +-- LLM Call (product_owner/clarify-requirements — generate questions)
+  |     +-- WaitForClarifyingAnswers (bookmark + durable SLA, blocks)
+  |     +-- LLM Call (product_owner/clarify-requirements — incorporate answers)
+  +-- Research (autonomous, no bookmark)
+  |     +-- Context Gathering
+  |     +-- LLM Call (product_owner/research)
+  +-- Issue Decomposition (autonomous, no bookmark)
+  |     +-- Context Gathering
+  |     +-- LLM Call (senior_developer/decompose-issue)
+  +-- Design Proposal
+        +-- LLM Call (architect/plan-system-design)
+        +-- Deliver Design Proposal (mediated git seam, issue comment)
+        +-- WaitForDesignApproval (bookmark + durable SLA, blocks)
 ```
 
 ## Versioning
@@ -134,6 +160,8 @@ Several workflows pause and wait for external events (human approval, CI results
 - **Code Review** -- `MonitorReviewActivity` and `WaitForFixesActivity` pause for PR events
 - **Assessment** -- `WaitForResponseActivity` pauses for junior developer response
 - **Blocker Diagnosis** -- `DetectProgressActivity` and `EscalateToSeniorActivity` pause for progress/senior input
+- **Clarifying Questions** -- `WaitForClarifyingAnswersActivity` pauses for human answers (durable SLA timeout, resumed via `POST /api/adl/clarify/resume`)
+- **Design Proposal** -- `WaitForDesignApprovalActivity` pauses for the reviewer's approve/reject decision (durable SLA timeout, resumed via `POST /api/adl/design/resume`)
 
 ### Security
 
@@ -142,6 +170,20 @@ All workflows that construct LLM prompts from user-supplied data (issue titles, 
 ### Code Index Updates
 
 Workflows that modify code files (`TDD Cycle`, `Testing Pipeline`, `Review Fix`, `Debugging`) fire `UpdateCodeIndexActivity` after commits to keep the vector DB code index current.
+
+## Platform / Operations Workflows
+
+Five further Elsa workflows run platform plumbing rather than the development loop. They live in the same `Workflows/` folder but have no dedicated wiki pages:
+
+| Workflow | Definition ID | Description |
+|----------|---------------|-------------|
+| **Create Tenant** | `create-tenant` | Provision a new tenant: placement + role + schema + migration + encrypted creds + activate |
+| **Delete Tenant** | `delete-tenant` | Tear down a tenant: mark deleting, evict pool, backup, drop schema + role (continue-on-error; triggered via `TenantDeleteRequestedTrigger`) |
+| **Clean Up Failed Tenant** | `clean-up-failed-tenant` | Operator-triggered best-effort teardown for a tenant in a damaged state (triggered via `TenantCleanupRequestedTrigger`) |
+| **Rotate Secret** | `rotate-secret` | Generic secret-rotation saga: mint → push → probe → activate → retire (postgres/cranl/hmac/generic-http handlers) |
+| **Hourly Analytics Rollup** | `hourly-analytics-rollup` | Rolls `platform_events` + per-tenant `domain_events` into `platform_analytics_hourly` (armed by `HourlyAnalyticsRollupScheduler`) |
+
+See [Multi-Tenant Provisioning](Multi-Tenant-Provisioning) for the tenant lifecycle context.
 
 ---
 


### PR DESCRIPTION
## Summary

Syncs the wiki (and therefore wiki.tamma.dev, which builds from `wiki/**` + `docs/stories/**` on merge to `main`) and status docs with everything merged since the last wiki sync on 2026-07-04 (`070252c..main`, PRs #452–#473). All claims were verified against the actual commit diffs and C# sources, not just commit messages.

### What changed

**New workflow pages** (grounded in the Elsa workflow sources, existing page conventions):
- `Workflow-Issue-Decomposition.md` (2-14), `Workflow-Research.md` (3-4), `Workflow-Ambiguity-Scoring.md` (3-6), `Workflow-Design-Proposal.md` (3-7), `Workflow-Clarifying-Questions.md` (3-5, landed 2026-07-04 with no page)
- `Workflows.md`: inventory 30 → 35 dev workflows, requirement-intelligence cluster in the dependency diagram, new Platform/Operations section for the 5 previously-uncounted ops workflows

**Event catalog** (`Event-Schema-and-Catalog.md`): new RESEARCH.*, CLARIFY.*, AMBIGUITY.*, DESIGN.*, DECOMPOSITION.* families; Story 4-5 CODE.*/COMMIT.* rows; 18-4 REPO.ACTIVATED/DEACTIVATED + ONBOARDING.COMPLETED; 4-8 replay endpoint + 2026-07 read-endpoint hardening; recounted totals (365 event types / 62 prefixes)

**API reference**: infra-metrics endpoint (23-8), repos & runs endpoints (21-4/23-5), event query API (4-7), black-box replay (4-8), provider diagnostics deep endpoint + fail-closed hardening (23-6), onboarding endpoints (18-4), KB sidecar status — every route verified against `Program.cs` wiring

**Epic pages** (2, 3, 4, 6, 18, 21, 23): story statuses updated with drift notes where shipped work diverges from the original briefs; Epic 3 at 12/13 (only 3-13 outstanding), Epic 23 at 8/12 shipped

**Status docs**: `Home.md` (stale April status replaced with verified current state + dated 2026-07 progress), `Roadmap.md`, `Stories.md`, `docs/sprint-status.yaml` (stories marked done with commit evidence; 18-4 deliberately kept in-progress since only the non-migration slices landed — the jsonb install-settings migration lane is still outstanding)

**Ops docs**: `Deployment.md` / `Installation.md` / `Usage-and-Configuration.md` — ollama service (nomic-embed-text, no OpenAI key), intelligence-server wiring, updated memory budgets, `INTELLIGENCE_EMBEDDING_*` env vars, RAG collection bootstrap

**Self-review fixes** (`2e2a380`): story 3-5 (ClarifyingQuestionsWorkflow, landed 2026-07-04 in `12a8468`) corrected from drafted → done; Epic 3 counts aligned to 12/13 across all pages (added the missing 3-13 row to Stories.md); 18-4 status aligned to In Progress everywhere; event-type total corrected 363 → 365.

### Verification

- `pnpm --filter @tamma/wiki-site sync-content` — 867 files synced; workflow metadata generator reports 35 inventory / 40 total workflows, matching the updated counts
- `pnpm --filter @tamma/wiki-site typecheck` — clean
- `pnpm --filter @tamma/wiki-site build` — succeeds; all 5 new workflow pages present in the site content output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d