### PR TITLE
feat(39-2): Document Core — envelope, type registry, state machine, drift tests

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentEnvelope.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentEnvelope.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The immutable core document record (Story 39-2 AC1): identity, type, schema
+/// version, lineage, producer provenance, lifecycle state, timestamps, and the
+/// typed payload as JSON. Envelopes are values — a state transition produces a
+/// NEW envelope via <see cref="WithState"/> (Design Decision D10), never a
+/// mutation.
+///
+/// <para>
+/// Every property carries an explicit <c>[JsonPropertyName]</c> (Design Decision
+/// D8); serialize/deserialize through <see cref="DocumentJson.Options"/> so the
+/// wire contract is deliberate. Timestamps are truncated to millisecond
+/// precision at construction so JSON round-trips are exact.
+/// </para>
+/// </summary>
+public sealed record DocumentEnvelope
+{
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("schemaVersion")]
+    public required int SchemaVersion { get; init; }
+
+    [JsonPropertyName("issueId")]
+    public required string IssueId { get; init; }
+
+    [JsonPropertyName("correlationId")]
+    public required string CorrelationId { get; init; }
+
+    [JsonPropertyName("parentDocumentId")]
+    public Guid? ParentDocumentId { get; init; }
+
+    [JsonPropertyName("supersedesDocumentId")]
+    public Guid? SupersedesDocumentId { get; init; }
+
+    [JsonPropertyName("producedBy")]
+    public required DocumentProducer ProducedBy { get; init; }
+
+    [JsonPropertyName("state")]
+    public required DocumentState State { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("updatedAt")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+
+    [JsonPropertyName("payload")]
+    public required JsonElement Payload { get; init; }
+
+    /// <summary>
+    /// Mint a fresh <c>Draft</c> envelope with a UUID v7 identity. Timestamps are
+    /// set to <paramref name="now"/> (defaulting to UTC now), truncated to
+    /// millisecond precision.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.ENVELOPE.INVALID</c> for an empty <paramref name="issueId"/>
+    /// or <paramref name="correlationId"/> — the lineage anchor is mandatory.
+    /// </exception>
+    public static DocumentEnvelope CreateDraft(
+        DocumentTypeKey type,
+        int schemaVersion,
+        string issueId,
+        string correlationId,
+        DocumentProducer producedBy,
+        JsonElement payload,
+        Guid? parentDocumentId = null,
+        Guid? supersedesDocumentId = null,
+        DateTimeOffset? now = null)
+    {
+        if (string.IsNullOrWhiteSpace(issueId))
+            throw Invalid("issueId", "The issueId lineage anchor must not be empty.");
+        if (string.IsNullOrWhiteSpace(correlationId))
+            throw Invalid("correlationId", "The correlationId must not be empty.");
+
+        var timestamp = Truncate(now ?? DateTimeOffset.UtcNow);
+
+        return new DocumentEnvelope
+        {
+            Id = UuidV7.NewGuid(timestamp),
+            Type = type.ToWire(),
+            SchemaVersion = schemaVersion,
+            IssueId = issueId,
+            CorrelationId = correlationId,
+            ParentDocumentId = parentDocumentId,
+            SupersedesDocumentId = supersedesDocumentId,
+            ProducedBy = producedBy,
+            State = DocumentState.Draft,
+            CreatedAt = timestamp,
+            UpdatedAt = timestamp,
+            Payload = payload.Clone(),
+        };
+    }
+
+    /// <summary>
+    /// Return a NEW envelope in state <paramref name="next"/> (Design Decision
+    /// D10). The transition is validated by <see cref="DocumentStateMachine.AssertTransition"/>;
+    /// <c>UpdatedAt</c> advances to <paramref name="now"/> (default UTC now),
+    /// truncated to millisecond precision. The original instance is unchanged.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.STATE.ILLEGAL_TRANSITION</c> for an illegal transition.
+    /// </exception>
+    public DocumentEnvelope WithState(DocumentState next, DateTimeOffset? now = null)
+    {
+        DocumentStateMachine.AssertTransition(State, next);
+        return this with
+        {
+            State = next,
+            UpdatedAt = Truncate(now ?? DateTimeOffset.UtcNow),
+        };
+    }
+
+    private static DateTimeOffset Truncate(DateTimeOffset value)
+    {
+        var utc = value.ToUniversalTime();
+        return new DateTimeOffset(utc.Ticks - (utc.Ticks % TimeSpan.TicksPerMillisecond), TimeSpan.Zero);
+    }
+
+    private static TammaError Invalid(string field, string message) =>
+        new(
+            "DOCUMENT.ENVELOPE.INVALID",
+            message,
+            new Dictionary<string, object?> { ["field"] = field },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+
+    // ---------------------------------------------------------------------
+    // Value equality — the compiler-synthesized record equality would compare
+    // Payload (a JsonElement struct) by its default (non-value) semantics, so a
+    // round-tripped envelope would never equal its original. Override to compare
+    // the payload by canonical raw text; everything else by value.
+    // ---------------------------------------------------------------------
+
+    public bool Equals(DocumentEnvelope? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Id.Equals(other.Id)
+            && Type == other.Type
+            && SchemaVersion == other.SchemaVersion
+            && IssueId == other.IssueId
+            && CorrelationId == other.CorrelationId
+            && Nullable.Equals(ParentDocumentId, other.ParentDocumentId)
+            && Nullable.Equals(SupersedesDocumentId, other.SupersedesDocumentId)
+            && ProducedBy == other.ProducedBy
+            && State == other.State
+            && CreatedAt.Equals(other.CreatedAt)
+            && UpdatedAt.Equals(other.UpdatedAt)
+            && Payload.GetRawText() == other.Payload.GetRawText();
+    }
+
+    public override int GetHashCode() =>
+        HashCode.Combine(Id, Type, SchemaVersion, IssueId, CorrelationId, ProducedBy, State);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentExample.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentExample.cs
@@ -1,0 +1,9 @@
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// A named example payload for an <see cref="IDocumentType"/> (Story 39-2 AC3).
+/// Each type ships ≥1 valid and ≥1 invalid example (enforced by the registry
+/// drift test); examples feed contract rendering and are self-checked against the
+/// type's own <see cref="IDocumentType.Validate"/>.
+/// </summary>
+public sealed record DocumentExample(string Name, bool IsValid, string PayloadJson);

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentJson.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentJson.cs
@@ -1,0 +1,97 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The single canonical <see cref="JsonSerializerOptions"/> for document
+/// envelopes (Design Decision D8). Because every wire property carries an
+/// explicit <c>[JsonPropertyName]</c>, no naming policy is applied; the options
+/// only wire the two converters:
+/// <list type="bullet">
+/// <item><see cref="WireEnumJsonConverter{TEnum}"/> for <see cref="DocumentState"/>
+/// (serializes as its <c>[Wire]</c> string).</item>
+/// <item><see cref="MillisecondIso8601Converter"/> for timestamps
+/// (<c>yyyy-MM-ddTHH:mm:ss.fffZ</c>).</item>
+/// </list>
+/// Every caller serializes/deserializes through <see cref="Serialize"/> /
+/// <see cref="Deserialize"/> so the contract is uniform.
+/// </summary>
+public static class DocumentJson
+{
+    public static JsonSerializerOptions Options { get; } = Build();
+
+    private static JsonSerializerOptions Build()
+    {
+        var options = new JsonSerializerOptions
+        {
+            // Explicit [JsonPropertyName] everywhere makes any naming policy
+            // irrelevant (D8); leave it unset so nothing is inferred.
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        };
+        options.Converters.Add(new WireEnumJsonConverter<DocumentState>());
+        options.Converters.Add(new MillisecondIso8601Converter());
+        return options;
+    }
+
+    /// <summary>Serialize an envelope with the canonical options.</summary>
+    public static string Serialize(DocumentEnvelope envelope) =>
+        JsonSerializer.Serialize(envelope, Options);
+
+    /// <summary>Deserialize an envelope with the canonical options.</summary>
+    /// <exception cref="JsonException">
+    /// Missing required properties (e.g. <c>issueId</c>, <c>type</c>), an unknown
+    /// state wire string, or otherwise malformed JSON.
+    /// </exception>
+    public static DocumentEnvelope Deserialize(string json) =>
+        JsonSerializer.Deserialize<DocumentEnvelope>(json, Options)
+        ?? throw new JsonException("Document envelope JSON deserialized to null.");
+}
+
+/// <summary>
+/// Serializes a <c>[Wire]</c>-mapped enum as its canonical wire string, and reads
+/// it back case-sensitively. Throws <see cref="JsonException"/> on a non-wire
+/// string so a bad token fails loud on the boundary (D8).
+/// </summary>
+internal sealed class WireEnumJsonConverter<TEnum> : JsonConverter<TEnum>
+    where TEnum : struct, Enum
+{
+    public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var wire = reader.GetString();
+        if (wire is not null && EnumWire<TEnum>.TryParse(wire, out var value))
+            return value;
+
+        throw new JsonException($"Unknown wire value '{wire}' for enum {typeof(TEnum).Name}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(EnumWire<TEnum>.ToWire(value));
+}
+
+/// <summary>
+/// Serializes <see cref="DateTimeOffset"/> as UTC ISO 8601 with millisecond
+/// precision (<c>yyyy-MM-ddTHH:mm:ss.fffZ</c>) and parses it back to a UTC offset
+/// (D8).
+/// </summary>
+internal sealed class MillisecondIso8601Converter : JsonConverter<DateTimeOffset>
+{
+    private const string Format = "yyyy-MM-ddTHH:mm:ss.fffZ";
+
+    public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var text = reader.GetString();
+        if (text is null)
+            throw new JsonException("Expected an ISO 8601 timestamp string, got null.");
+
+        return DateTimeOffset.Parse(
+            text,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTimeOffset value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToUniversalTime().ToString(Format, CultureInfo.InvariantCulture));
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentLifecycleOutcome.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentLifecycleOutcome.cs
@@ -1,0 +1,55 @@
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The closed set of typed "unhandleable" lifecycle outcomes that force an
+/// escalation rather than a bare failure (Design Decision D5; consumed by Story
+/// 39-6). Each fires from a different lifecycle stage:
+/// <list type="bullet">
+/// <item><c>ValidationExhausted</c> — deterministic validation could not be
+/// satisfied within the repair-ring budget (fires from Draft).</item>
+/// <item><c>ReviewUndecidable</c> — the review panel could not reach a decision
+/// (fires from Validated).</item>
+/// <item><c>RoundsExhausted</c> — the review/revision rounds ran out (fires from
+/// Reviewed).</item>
+/// <item><c>AmbiguityAboveThreshold</c> — the input ambiguity score exceeded the
+/// autonomy threshold.</item>
+/// </list>
+/// Shipped here in <c>Tamma.Core/Documents</c> so 39-6 has a compile-time target;
+/// pinned by a drift test.
+/// </summary>
+public enum DocumentLifecycleOutcome
+{
+    [Wire("review-undecidable")]        ReviewUndecidable,
+    [Wire("ambiguity-above-threshold")] AmbiguityAboveThreshold,
+    [Wire("rounds-exhausted")]          RoundsExhausted,
+    [Wire("validation-exhausted")]      ValidationExhausted,
+}
+
+public static class DocumentLifecycleOutcomeExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="outcome"/>.</summary>
+    public static string ToWire(this DocumentLifecycleOutcome outcome) =>
+        EnumWire<DocumentLifecycleOutcome>.ToWire(outcome);
+
+    /// <summary>
+    /// Resolves a wire string to a <see cref="DocumentLifecycleOutcome"/>.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.OUTCOME.UNKNOWN</c> for null, empty, or unknown input.
+    /// </exception>
+    public static DocumentLifecycleOutcome Parse(string input)
+    {
+        if (!string.IsNullOrWhiteSpace(input) && EnumWire<DocumentLifecycleOutcome>.TryParse(input, out var outcome))
+            return outcome;
+
+        throw new TammaError(
+            "DOCUMENT.OUTCOME.UNKNOWN",
+            $"Unknown document lifecycle outcome: '{input}'. Valid outcomes: {string.Join(", ", Enum.GetValues<DocumentLifecycleOutcome>().Select(o => o.ToWire()))}.",
+            new Dictionary<string, object?> { ["input"] = input },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentProducer.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentProducer.cs
@@ -1,0 +1,109 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// Producer provenance for a <see cref="DocumentEnvelope"/> (Story 39-2 AC1;
+/// Design Decision D7). Records which agent role + action + workflow produced the
+/// document, expressed in exactly the <c>llm-call</c> dispatch vocabulary
+/// (<see cref="AgentRole"/> / <see cref="AgentAction"/> wire strings), never free
+/// strings.
+///
+/// <para>
+/// Every property carries an explicit <c>[JsonPropertyName]</c> (Design Decision
+/// D8) so the wire contract is deliberate, not an accident of C# naming.
+/// </para>
+/// </summary>
+public sealed record DocumentProducer
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("workflow")]
+    public required string WorkflowDefinitionId { get; init; }
+
+    /// <summary>
+    /// Validate and construct producer provenance. Role and action are parsed
+    /// strictly through the agent taxonomy (throw on unknown), the (action, role)
+    /// pair is asserted eligible via <see cref="RolePhaseMap.IsRoleEligibleForPhase"/>,
+    /// and the workflow id is validated structurally as a non-empty kebab token.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.PRODUCER.INVALID</c> for an unknown role/action, an
+    /// ineligible (role, action) pair, or a malformed workflow definition id.
+    /// </exception>
+    public static DocumentProducer Create(string role, string action, string workflowDefinitionId)
+    {
+        // Role + action must be canonical taxonomy wire strings. AgentRole/Action
+        // Parse throw ArgumentException on unknown; rethrow as the typed
+        // registry-facing error (D7).
+        string roleWire;
+        string actionWire;
+        try
+        {
+            roleWire = AgentRoleExtensions.Parse(role).ToWire();
+            actionWire = AgentActionExtensions.Parse(action).ToWire();
+        }
+        catch (ArgumentException ex)
+        {
+            throw new TammaError(
+                "DOCUMENT.PRODUCER.INVALID",
+                $"Invalid producer provenance: {ex.Message}",
+                new Dictionary<string, object?>
+                {
+                    ["role"] = role,
+                    ["action"] = action,
+                    ["workflow"] = workflowDefinitionId,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        // The (action, role) pair must be a taxonomy-valid cell. NOTE the param
+        // order: IsRoleEligibleForPhase(phase, role) — i.e. (action, role).
+        if (!RolePhaseMap.IsRoleEligibleForPhase(actionWire, roleWire))
+        {
+            throw new TammaError(
+                "DOCUMENT.PRODUCER.INVALID",
+                $"Invalid producer provenance: role '{roleWire}' is not eligible for action '{actionWire}'.",
+                new Dictionary<string, object?>
+                {
+                    ["role"] = roleWire,
+                    ["action"] = actionWire,
+                    ["workflow"] = workflowDefinitionId,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        // Tamma.Core cannot reference Tamma.ElsaServer to enumerate real
+        // DefinitionIds (dependency direction), so validate the workflow id
+        // structurally only (D7): non-empty kebab-case.
+        if (!KebabCase.IsKebab(workflowDefinitionId))
+        {
+            throw new TammaError(
+                "DOCUMENT.PRODUCER.INVALID",
+                $"Invalid producer provenance: workflow definition id '{workflowDefinitionId}' is not a valid kebab-case token.",
+                new Dictionary<string, object?>
+                {
+                    ["role"] = roleWire,
+                    ["action"] = actionWire,
+                    ["workflow"] = workflowDefinitionId,
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        return new DocumentProducer
+        {
+            Role = roleWire,
+            Action = actionWire,
+            WorkflowDefinitionId = workflowDefinitionId,
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentState.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentState.cs
@@ -1,0 +1,50 @@
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The document lifecycle states (Story 39-2 AC2). The legal transitions between
+/// them live in <see cref="DocumentStateMachine"/>; this enum is only the
+/// vocabulary. Each member carries its canonical wire string via <c>[Wire]</c>.
+///
+/// <para>
+/// <c>Accepted</c>, <c>Rejected</c>, and <c>Escalated</c> are terminal — they
+/// have no outbound transitions. A revision does not rewind a state; it mints a
+/// new envelope in the <c>SupersedesDocumentId</c> chain (Design Decision D4).
+/// </para>
+/// </summary>
+public enum DocumentState
+{
+    [Wire("draft")]     Draft,
+    [Wire("validated")] Validated,
+    [Wire("reviewed")]  Reviewed,
+    [Wire("accepted")]  Accepted,
+    [Wire("rejected")]  Rejected,
+    [Wire("escalated")] Escalated,
+}
+
+public static class DocumentStateExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="state"/>.</summary>
+    public static string ToWire(this DocumentState state) => EnumWire<DocumentState>.ToWire(state);
+
+    /// <summary>
+    /// Resolves a wire string to a <see cref="DocumentState"/> (case-sensitive).
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.STATE.UNKNOWN</c> for null, empty, or unknown input.
+    /// </exception>
+    public static DocumentState Parse(string input)
+    {
+        if (!string.IsNullOrWhiteSpace(input) && EnumWire<DocumentState>.TryParse(input, out var state))
+            return state;
+
+        throw new TammaError(
+            "DOCUMENT.STATE.UNKNOWN",
+            $"Unknown document state: '{input}'. Valid states: {string.Join(", ", Enum.GetValues<DocumentState>().Select(s => s.ToWire()))}.",
+            new Dictionary<string, object?> { ["input"] = input },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentStateMachine.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentStateMachine.cs
@@ -1,0 +1,88 @@
+using System.Collections.Frozen;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The data-driven document lifecycle state machine (Story 39-2 AC2/AC7). The
+/// legal-transition map (Design Decision D4) is the single enforcement seam the
+/// 39-6 lifecycle workflow consumes — written once, here.
+///
+/// <para>Legal map:</para>
+/// <list type="bullet">
+/// <item><c>Draft   → { Validated, Escalated }</c></item>
+/// <item><c>Validated → { Reviewed, Escalated }</c></item>
+/// <item><c>Reviewed → { Accepted, Rejected, Escalated }</c></item>
+/// <item><c>Accepted / Rejected / Escalated → ∅</c> (terminal)</item>
+/// </list>
+/// <c>Escalated</c> is reachable from every non-terminal state (D4): the typed
+/// unhandleable outcomes escalate with the full lineage attached rather than
+/// rejecting. A revision mints a NEW envelope in the supersedes chain, so no
+/// <c>Reviewed → Draft</c> rewind edge exists.
+/// </summary>
+public static class DocumentStateMachine
+{
+    private static readonly FrozenDictionary<DocumentState, FrozenSet<DocumentState>> s_legal =
+        new Dictionary<DocumentState, FrozenSet<DocumentState>>
+        {
+            [DocumentState.Draft]     = FreezeSet(DocumentState.Validated, DocumentState.Escalated),
+            [DocumentState.Validated] = FreezeSet(DocumentState.Reviewed, DocumentState.Escalated),
+            [DocumentState.Reviewed]  = FreezeSet(DocumentState.Accepted, DocumentState.Rejected, DocumentState.Escalated),
+            [DocumentState.Accepted]  = FrozenSet<DocumentState>.Empty,
+            [DocumentState.Rejected]  = FrozenSet<DocumentState>.Empty,
+            [DocumentState.Escalated] = FrozenSet<DocumentState>.Empty,
+        }.ToFrozenDictionary();
+
+    /// <summary>
+    /// The legal-transition map, exposed read-only for the 39-6 lifecycle
+    /// workflow to walk. Keyed by source state; the value is the set of legal
+    /// destination states (empty for terminals).
+    /// </summary>
+    public static IReadOnlyDictionary<DocumentState, FrozenSet<DocumentState>> LegalTransitions => s_legal;
+
+    /// <summary>
+    /// Whether <paramref name="from"/> → <paramref name="to"/> is a legal
+    /// transition. Non-throwing.
+    /// </summary>
+    public static bool CanTransition(DocumentState from, DocumentState to) =>
+        s_legal.TryGetValue(from, out var destinations) && destinations.Contains(to);
+
+    /// <summary>
+    /// Assert that <paramref name="from"/> → <paramref name="to"/> is legal.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.STATE.ILLEGAL_TRANSITION</c> — the message names BOTH
+    /// state wire strings (AC7).
+    /// </exception>
+    public static void AssertTransition(DocumentState from, DocumentState to)
+    {
+        if (CanTransition(from, to)) return;
+
+        var allowed = s_legal[from];
+        var allowedText = allowed.Count == 0
+            ? "none (terminal state)"
+            : string.Join(", ", allowed.Select(s => $"'{s.ToWire()}'"));
+
+        throw new TammaError(
+            "DOCUMENT.STATE.ILLEGAL_TRANSITION",
+            $"Illegal document state transition: '{from.ToWire()}' -> '{to.ToWire()}'. " +
+            $"Legal transitions from '{from.ToWire()}': {allowedText}.",
+            new Dictionary<string, object?>
+            {
+                ["from"] = from.ToWire(),
+                ["to"] = to.ToWire(),
+            },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="state"/> is terminal (has no legal outbound
+    /// transitions): <c>Accepted</c>, <c>Rejected</c>, or <c>Escalated</c>.
+    /// </summary>
+    public static bool IsTerminal(DocumentState state) =>
+        s_legal.TryGetValue(state, out var destinations) && destinations.Count == 0;
+
+    private static FrozenSet<DocumentState> FreezeSet(params DocumentState[] items) =>
+        new HashSet<DocumentState>(items).ToFrozenSet();
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeKey.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeKey.cs
@@ -1,0 +1,74 @@
+// NOTE: New Epic 39 code lands in the clean `Tamma.Core.Documents` namespace
+// (Design Decision D1). The `[Wire]` attribute + `EnumWire<T>` bidirectional
+// map live in the legacy `Tamma.Api.Services.Agents` namespace inside this same
+// Tamma.Core assembly (see the relocation NOTE atop Agents/EnumWire.cs), so this
+// file imports them explicitly rather than reimplementing the pattern.
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The closed, compile-time vocabulary of Epic 39 document types (README's
+/// 10-type table). Mirrors the <see cref="AgentRole"/> / <see cref="AgentAction"/>
+/// pattern: each member carries its canonical kebab-case wire string via
+/// <c>[Wire]</c> (Design Decision D2), and the set is count-pinned by a drift test.
+///
+/// <para>
+/// This enum is the vocabulary; the <see cref="DocumentTypeRegistry"/> maps keys
+/// to <see cref="IDocumentType"/> implementations (which arrive in 39-3/39-4).
+/// </para>
+/// </summary>
+public enum DocumentTypeKey
+{
+    [Wire("findings")]             Findings,
+    [Wire("ambiguity-assessment")] AmbiguityAssessment,
+    [Wire("clarification")]        Clarification,
+    [Wire("decomposition")]        Decomposition,
+    [Wire("plan")]                 Plan,
+    [Wire("design")]               Design,
+    [Wire("review")]               Review,
+    [Wire("triage-decision")]      TriageDecision,
+    [Wire("diagnosis")]            Diagnosis,
+    [Wire("test-spec")]            TestSpec,
+}
+
+public static class DocumentTypeKeyExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="key"/>.</summary>
+    public static string ToWire(this DocumentTypeKey key) => EnumWire<DocumentTypeKey>.ToWire(key);
+
+    /// <summary>
+    /// Resolves a wire string to a <see cref="DocumentTypeKey"/>. Case-sensitive
+    /// (ordinal) — non-canonical casing is rejected, not silently accepted.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.TYPE.UNKNOWN</c> if <paramref name="input"/> is null,
+    /// empty, or not a canonical wire string.
+    /// </exception>
+    public static DocumentTypeKey Parse(string input)
+    {
+        if (TryParse(input, out var key)) return key;
+
+        throw new TammaError(
+            "DOCUMENT.TYPE.UNKNOWN",
+            $"Unknown document type: '{input}'. Valid types: {string.Join(", ", Enum.GetValues<DocumentTypeKey>().Select(k => k.ToWire()))}.",
+            new Dictionary<string, object?> { ["input"] = input },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Non-throwing wire-string lookup. Returns <c>false</c> for null, empty, or
+    /// unknown input.
+    /// </summary>
+    public static bool TryParse(string? input, out DocumentTypeKey key)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            key = default;
+            return false;
+        }
+        return EnumWire<DocumentTypeKey>.TryParse(input, out key);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeRegistry.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeRegistry.cs
@@ -1,0 +1,141 @@
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The fail-loud, static, immutable document type registry (Story 39-2 AC4;
+/// Design Decision D3). Mirrors the <c>SystemPrompts</c> / <c>RolePhaseMap</c>
+/// facade shape: a pure <see cref="BuildIndex"/> core validates the registration
+/// list at static init (a bad registration refuses to load), and
+/// <see cref="Resolve(string)"/> never returns null or a silent default.
+///
+/// <para>
+/// The key→<see cref="IDocumentType"/> map ships EMPTY at 39-2 (registered count
+/// pinned at 0). Story 39-3 appends +4 implementations and 39-4 the remaining +6;
+/// each bump is a conscious edit to <see cref="s_registrations"/> plus the count
+/// pin in <c>DocumentTypeRegistryTests</c>.
+/// </para>
+/// </summary>
+public static class DocumentTypeRegistry
+{
+    // The compile-time registration list. EMPTY at 39-2 by design (D3):
+    //   39-3 appends +4 IDocumentType implementations (bumps the count pin 0 -> 4)
+    //   39-4 appends the remaining +6 (bumps the count pin 4 -> 10)
+    // and each shrinks the WorkflowInterfaceGraphTests PendingImplementations
+    // ratchet accordingly.
+    private static readonly IReadOnlyList<IDocumentType> s_registrations = Array.Empty<IDocumentType>();
+
+    private static readonly IReadOnlyDictionary<string, IDocumentType> s_index =
+        BuildIndex(s_registrations);
+
+    /// <summary>All registered document types (empty at 39-2).</summary>
+    public static IReadOnlyList<IDocumentType> All => s_registrations;
+
+    /// <summary>
+    /// The static workflow interface declarations (Design Decision D6), seeded
+    /// from the README document-type table mapped to real Elsa
+    /// <c>DefinitionId</c>s. Every entry is <c>Provisional</c> until reconciled
+    /// against the landed 39-1 audit. Keyed by <see cref="DocumentTypeKey"/>, so
+    /// no declaration can reference a type outside the vocabulary.
+    /// </summary>
+    public static IReadOnlyList<WorkflowDocumentInterface> WorkflowInterfaces { get; } = BuildSeed();
+
+    /// <summary>
+    /// Resolve a document type by its wire-string key.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.TYPE.UNKNOWN</c> if <paramref name="key"/> is not a
+    /// vocabulary wire string; code <c>DOCUMENT.TYPE.NOT_REGISTERED</c> if it is a
+    /// valid key with no registered implementation yet.
+    /// </exception>
+    public static IDocumentType Resolve(string key)
+    {
+        // Unknown wire string -> UNKNOWN (throws DOCUMENT.TYPE.UNKNOWN).
+        var typeKey = DocumentTypeKeyExtensions.Parse(key);
+        return Resolve(typeKey);
+    }
+
+    /// <summary>
+    /// Resolve a document type by its <see cref="DocumentTypeKey"/>.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.TYPE.NOT_REGISTERED</c> if no implementation is registered
+    /// for <paramref name="key"/> yet (39-3/39-4 pending).
+    /// </exception>
+    public static IDocumentType Resolve(DocumentTypeKey key)
+    {
+        var wire = key.ToWire();
+        if (s_index.TryGetValue(wire, out var type))
+            return type;
+
+        throw new TammaError(
+            "DOCUMENT.TYPE.NOT_REGISTERED",
+            $"Document type '{wire}' is a valid key but has no registered implementation yet " +
+            "(implementations land in Story 39-3/39-4).",
+            new Dictionary<string, object?> { ["key"] = wire },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// Pure core (PromptFileLoader.Build style): build the key→type index from a
+    /// registration list, validating each type. Test-drivable with fakes.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.TYPE.KEY_NOT_IN_VOCABULARY</c> if a type's <c>Key</c> is
+    /// not a <see cref="DocumentTypeKey"/> wire string; code
+    /// <c>DOCUMENT.TYPE.DUPLICATE_KEY</c> if two types share a key.
+    /// </exception>
+    internal static IReadOnlyDictionary<string, IDocumentType> BuildIndex(IEnumerable<IDocumentType> types)
+    {
+        var index = new Dictionary<string, IDocumentType>(StringComparer.Ordinal);
+        foreach (var type in types)
+        {
+            if (!DocumentTypeKeyExtensions.TryParse(type.Key, out var parsed))
+                throw new TammaError(
+                    "DOCUMENT.TYPE.KEY_NOT_IN_VOCABULARY",
+                    $"Document type key '{type.Key}' is not part of the DocumentTypeKey vocabulary.",
+                    new Dictionary<string, object?> { ["key"] = type.Key },
+                    retryable: false,
+                    severity: TammaErrorSeverity.Critical);
+
+            var wire = parsed.ToWire();
+            if (!index.TryAdd(wire, type))
+                throw new TammaError(
+                    "DOCUMENT.TYPE.DUPLICATE_KEY",
+                    $"Duplicate document type key '{wire}' — two IDocumentType implementations claim the same key.",
+                    new Dictionary<string, object?> { ["key"] = wire },
+                    retryable: false,
+                    severity: TammaErrorSeverity.Critical);
+        }
+        return index;
+    }
+
+    /// <summary>
+    /// The D6 provisional seed: README document-type table → real
+    /// <c>DefinitionId</c>s observed in <c>Tamma.ElsaServer/Workflows/</c>. All
+    /// entries <c>Provisional=true</c> pending the 39-1 audit. <c>Consumes</c> is
+    /// left empty until the audit supplies the verified consumer edges.
+    /// </summary>
+    private static IReadOnlyList<WorkflowDocumentInterface> BuildSeed()
+    {
+        var empty = Array.Empty<DocumentTypeKey>();
+        return new[]
+        {
+            new WorkflowDocumentInterface("research",           empty, DocumentTypeKey.Findings,            true),
+            new WorkflowDocumentInterface("ambiguity-scoring",  empty, DocumentTypeKey.AmbiguityAssessment, true),
+            new WorkflowDocumentInterface("clarifying-questions", empty, DocumentTypeKey.Clarification,      true),
+            new WorkflowDocumentInterface("issue-decomposition", empty, DocumentTypeKey.Decomposition,      true),
+            new WorkflowDocumentInterface("plan-generation",    empty, DocumentTypeKey.Plan,                true),
+            new WorkflowDocumentInterface("task-creation",      empty, DocumentTypeKey.Plan,                true),
+            new WorkflowDocumentInterface("design-proposal",    empty, DocumentTypeKey.Design,              true),
+            new WorkflowDocumentInterface("plan-review",        empty, DocumentTypeKey.Review,              true),
+            new WorkflowDocumentInterface("task-review",        empty, DocumentTypeKey.Review,              true),
+            new WorkflowDocumentInterface("code-review",        empty, DocumentTypeKey.Review,              true),
+            new WorkflowDocumentInterface("triage-po-decision", empty, DocumentTypeKey.TriageDecision,      true),
+            new WorkflowDocumentInterface("blocker-diagnosis",  empty, DocumentTypeKey.Diagnosis,           true),
+            new WorkflowDocumentInterface("debugging",          empty, DocumentTypeKey.Diagnosis,           true),
+            new WorkflowDocumentInterface("test-case-creation", empty, DocumentTypeKey.TestSpec,            true),
+        };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentValidationResult.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentValidationResult.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// A single deterministic-validation violation (Story 39-2 AC3). The interface
+/// between deterministic validation and the 39-9 LLM repair turn / 39-6 review
+/// notes: <see cref="Code"/> is a stable machine identifier (e.g.
+/// <c>DANGLING_DEPENDS_ON</c>); <see cref="Message"/> is domain-phrased for the
+/// model, never a bare schema path.
+/// </summary>
+public sealed record DocumentViolation(
+    [property: JsonPropertyName("code")]    string Code,
+    [property: JsonPropertyName("message")] string Message);
+
+/// <summary>
+/// The result of <see cref="IDocumentType.Validate"/> (Story 39-2 AC3): a valid
+/// flag plus the ordered violation list (empty when valid).
+/// </summary>
+public sealed record DocumentValidationResult(
+    [property: JsonPropertyName("isValid")]    bool IsValid,
+    [property: JsonPropertyName("violations")] IReadOnlyList<DocumentViolation> Violations)
+{
+    private static readonly IReadOnlyList<DocumentViolation> s_none = Array.Empty<DocumentViolation>();
+
+    /// <summary>A passing result with no violations.</summary>
+    public static DocumentValidationResult Valid() => new(true, s_none);
+
+    /// <summary>
+    /// A failing result carrying at least one violation.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.VALIDATION.EMPTY_INVALID</c> if no violations are
+    /// supplied — an invalid result without a reason is a programming error.
+    /// </exception>
+    public static DocumentValidationResult Invalid(params DocumentViolation[] violations)
+    {
+        if (violations is null || violations.Length == 0)
+            throw new TammaError(
+                "DOCUMENT.VALIDATION.EMPTY_INVALID",
+                "An invalid DocumentValidationResult must carry at least one violation.",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+
+        return new DocumentValidationResult(false, violations);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentsAssemblyInfo.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentsAssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// Exposes the Documents namespace's internal pure cores (notably
+// DocumentTypeRegistry.BuildIndex — Story 39-2 AC5d) to the drift-test project.
+// Declared here, in a source file under the story's allowed diff surface, rather
+// than in the csproj.
+[assembly: InternalsVisibleTo("Tamma.Core.Tests")]

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/IDocumentType.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/IDocumentType.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The contract every Epic 39 document type implements (Story 39-2 AC3;
+/// implementations arrive in 39-3/39-4). Binds a <see cref="DocumentTypeKey"/>
+/// wire string to executable validation, a deterministic prompt-contract
+/// renderer, and self-checking examples.
+/// </summary>
+public interface IDocumentType
+{
+    /// <summary>
+    /// The type's key — a <see cref="DocumentTypeKey"/> wire string (drift-tested
+    /// against the vocabulary by the registry).
+    /// </summary>
+    string Key { get; }
+
+    /// <summary>The payload schema version this type validates against.</summary>
+    int SchemaVersion { get; }
+
+    /// <summary>The CLR type the JSON payload deserializes to.</summary>
+    Type PayloadClrType { get; }
+
+    /// <summary>
+    /// Deterministically validate <paramref name="payload"/>, returning
+    /// domain-phrased violations (never bare schema paths) so 39-9's repair ring
+    /// can feed them back to the model.
+    /// </summary>
+    DocumentValidationResult Validate(JsonElement payload);
+
+    /// <summary>
+    /// Render the prompt-contract block describing the required output shape. MUST
+    /// be deterministic (stable ordering) — 39-16 diffs this output in CI.
+    /// </summary>
+    string RenderContract();
+
+    /// <summary>
+    /// The type's examples — ≥1 valid and ≥1 invalid (enforced by the registry
+    /// drift test), used by contract rendering and tests.
+    /// </summary>
+    IReadOnlyList<DocumentExample> Examples { get; }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/UuidV7.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/UuidV7.cs
@@ -1,0 +1,53 @@
+using System.Security.Cryptography;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// A minimal RFC 9562 UUID version 7 generator (Design Decision D9). net8 has no
+/// <c>Guid.CreateVersion7</c>, so document identities are minted here: a 48-bit
+/// big-endian Unix-millisecond timestamp prefix (time-ordered), the version
+/// nibble 7, the RFC 4122 variant bits, and a cryptographically random tail.
+///
+/// <para>
+/// The <see cref="Guid"/> is constructed big-endian so both its byte
+/// representation and its string form sort in creation order. If .NET is ever
+/// bumped to 9+, swap the body for <c>Guid.CreateVersion7</c> behind this same
+/// static surface.
+/// </para>
+/// </summary>
+public static class UuidV7
+{
+    /// <summary>Mint a new UUID v7 stamped with the current UTC time.</summary>
+    public static Guid NewGuid() => NewGuid(DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Mint a UUID v7 stamped with <paramref name="timestamp"/>. Overload exists
+    /// so the time-ordering property is deterministically testable.
+    /// </summary>
+    public static Guid NewGuid(DateTimeOffset timestamp)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+
+        // Bytes 0..5: 48-bit big-endian Unix-millisecond timestamp.
+        long unixMs = timestamp.ToUnixTimeMilliseconds();
+        bytes[0] = (byte)(unixMs >> 40);
+        bytes[1] = (byte)(unixMs >> 32);
+        bytes[2] = (byte)(unixMs >> 24);
+        bytes[3] = (byte)(unixMs >> 16);
+        bytes[4] = (byte)(unixMs >> 8);
+        bytes[5] = (byte)unixMs;
+
+        // Bytes 6..15: random.
+        RandomNumberGenerator.Fill(bytes[6..]);
+
+        // Version nibble 7 in the high nibble of byte 6.
+        bytes[6] = (byte)((bytes[6] & 0x0F) | 0x70);
+
+        // RFC 4122 variant (10xx) in the high bits of byte 8.
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+
+        // Construct big-endian so byte- and string-comparison are both
+        // time-ordered (net8's Guid(ReadOnlySpan<byte>, bool) ctor).
+        return new Guid(bytes, bigEndian: true);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/WorkflowDocumentInterface.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/WorkflowDocumentInterface.cs
@@ -1,0 +1,37 @@
+using System.Text.RegularExpressions;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// A static declaration of one producing workflow's document interface: which
+/// document type keys it <see cref="Consumes"/> and the single key it
+/// <see cref="Produces"/> (Story 39-2 AC4; Design Decision D6). Declarations are
+/// keyed by <see cref="DocumentTypeKey"/> enum members, so a declaration can
+/// never reference a type outside the compile-time vocabulary.
+///
+/// <para>
+/// <see cref="Provisional"/> is <c>true</c> until each edge is reconciled against
+/// the landed 39-1 workflow-io audit; the 39-1 PR (or a small follow-up) flips
+/// the flags off. Until then the seed is derived from the README document-type
+/// table mapped to real <c>DefinitionId</c>s observed in
+/// <c>Tamma.ElsaServer/Workflows/</c>.
+/// </para>
+/// </summary>
+public sealed record WorkflowDocumentInterface(
+    string WorkflowDefinitionId,
+    IReadOnlyList<DocumentTypeKey> Consumes,
+    DocumentTypeKey? Produces,
+    bool Provisional);
+
+/// <summary>
+/// Shared kebab-case validation for structural workflow-id / wire-token checks
+/// (Design Decision D7). Kept internal to the Documents namespace.
+/// </summary>
+internal static partial class KebabCase
+{
+    [GeneratedRegex("^[a-z0-9]+(-[a-z0-9]+)*$")]
+    private static partial Regex Pattern();
+
+    public static bool IsKebab(string? value) =>
+        !string.IsNullOrEmpty(value) && Pattern().IsMatch(value);
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentEnvelopeSerializationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentEnvelopeSerializationTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Wire-contract tests for <see cref="DocumentJson"/> (Story 39-2 AC6): the exact
+/// serialized property-name set, lossless round-trip, millisecond-ISO timestamp
+/// format, wire-string state, forward compatibility (unknown extra field), and
+/// strict rejection of missing required fields.
+/// </summary>
+[TestFixture]
+public class DocumentEnvelopeSerializationTests
+{
+    private static readonly Regex Iso8601Ms = new(@"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$");
+
+    private static DocumentEnvelope FullyPopulated()
+    {
+        using var doc = JsonDocument.Parse("{\"summary\":\"a decomposition\",\"count\":3}");
+        var producer = DocumentProducer.Create("senior_developer", "decompose-issue", "issue-decomposition");
+        return DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition,
+            schemaVersion: 2,
+            issueId: "issue-42",
+            correlationId: "corr-7",
+            producedBy: producer,
+            payload: doc.RootElement.Clone(),
+            parentDocumentId: UuidV7.NewGuid(),
+            supersedesDocumentId: UuidV7.NewGuid(),
+            now: DateTimeOffset.Parse("2026-07-21T12:34:56.789Z"));
+    }
+
+    [Test]
+    public void Serialized_property_names_are_the_exact_wire_contract()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var names = root.EnumerateObject().Select(p => p.Name).ToArray();
+        names.Should().BeEquivalentTo(new[]
+        {
+            "id", "type", "schemaVersion", "issueId", "correlationId",
+            "parentDocumentId", "supersedesDocumentId", "producedBy",
+            "state", "createdAt", "updatedAt", "payload",
+        });
+
+        var producedBy = root.GetProperty("producedBy");
+        producedBy.EnumerateObject().Select(p => p.Name)
+            .Should().BeEquivalentTo(new[] { "role", "action", "workflow" });
+    }
+
+    [Test]
+    public void State_serializes_as_its_wire_string_not_the_enum_name_or_number()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("state").GetString().Should().Be("draft");
+    }
+
+    [Test]
+    public void Timestamps_serialize_as_millisecond_iso8601_utc()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+
+        var createdAt = doc.RootElement.GetProperty("createdAt").GetString();
+        createdAt.Should().MatchRegex(Iso8601Ms.ToString());
+        createdAt.Should().Be("2026-07-21T12:34:56.789Z");
+    }
+
+    [Test]
+    public void Round_trip_loses_nothing()
+    {
+        var original = FullyPopulated();
+        var json = DocumentJson.Serialize(original);
+        var deserialized = DocumentJson.Deserialize(json);
+
+        deserialized.Should().Be(original);
+        // Payload compared explicitly via raw text (JsonElement has no value equality).
+        deserialized.Payload.GetRawText().Should().Be(original.Payload.GetRawText());
+    }
+
+    [Test]
+    public void Unknown_extra_field_is_tolerated_on_read()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+        // Inject a forward-compatible unknown field at the object root.
+        var withExtra = AddProperty(doc.RootElement, "futureField", w => w.WriteNumberValue(1));
+
+        var act = () => DocumentJson.Deserialize(withExtra);
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void Missing_required_issue_id_throws()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+        var stripped = StripProperty(doc.RootElement, "issueId");
+
+        var act = () => DocumentJson.Deserialize(stripped);
+        act.Should().Throw<JsonException>();
+    }
+
+    [Test]
+    public void Missing_required_type_throws()
+    {
+        var json = DocumentJson.Serialize(FullyPopulated());
+        using var doc = JsonDocument.Parse(json);
+        var stripped = StripProperty(doc.RootElement, "type");
+
+        var act = () => DocumentJson.Deserialize(stripped);
+        act.Should().Throw<JsonException>();
+    }
+
+    private static string AddProperty(JsonElement obj, string name, Action<Utf8JsonWriter> writeValue)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            foreach (var prop in obj.EnumerateObject())
+                prop.WriteTo(writer);
+            writer.WritePropertyName(name);
+            writeValue(writer);
+            writer.WriteEndObject();
+        }
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string StripProperty(JsonElement obj, string name)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            foreach (var prop in obj.EnumerateObject())
+            {
+                if (prop.NameEquals(name)) continue;
+                prop.WriteTo(writer);
+            }
+            writer.WriteEndObject();
+        }
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentEnvelopeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentEnvelopeTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Tests for the <see cref="DocumentEnvelope"/> core (Story 39-2 AC1 + the AC2
+/// enforcement seam): UUID v7 identity, strict producer provenance, lineage
+/// guards, and mutation-free state transitions.
+/// </summary>
+[TestFixture]
+public class DocumentEnvelopeTests
+{
+    private static JsonElement Payload(string json = "{\"ok\":true}")
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    private static DocumentProducer ValidProducer() =>
+        DocumentProducer.Create("senior_developer", "decompose-issue", "issue-decomposition");
+
+    private static DocumentEnvelope Draft() =>
+        DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, "issue-42", "corr-1", ValidProducer(), Payload());
+
+    // -----------------------------------------------------------------------
+    // Identity — UUID v7
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void CreateDraft_mints_a_version_7_id()
+    {
+        var envelope = Draft();
+        var bytes = envelope.Id.ToByteArray(bigEndian: true);
+        (bytes[6] >> 4).Should().Be(7, "the UUID version nibble must be 7");
+    }
+
+    [Test]
+    public void CreateDraft_ids_are_time_ordered()
+    {
+        var t1 = DateTimeOffset.UtcNow;
+        var t2 = t1.AddMilliseconds(5);
+
+        var first = DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, "i", "c", ValidProducer(), Payload(), now: t1);
+        var second = DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, "i", "c", ValidProducer(), Payload(), now: t2);
+
+        // Big-endian UUID v7 sorts in creation order both as string and bytes.
+        string.CompareOrdinal(first.Id.ToString(), second.Id.ToString()).Should().BeLessThan(0);
+    }
+
+    [Test]
+    public void CreateDraft_starts_in_draft_with_equal_timestamps()
+    {
+        var envelope = Draft();
+        envelope.State.Should().Be(DocumentState.Draft);
+        envelope.CreatedAt.Should().Be(envelope.UpdatedAt);
+    }
+
+    // -----------------------------------------------------------------------
+    // Lineage guards
+    // -----------------------------------------------------------------------
+
+    [Test]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void CreateDraft_throws_on_empty_issue_id(string issueId)
+    {
+        var act = () => DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, issueId, "corr-1", ValidProducer(), Payload());
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.ENVELOPE.INVALID");
+    }
+
+    [Test]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void CreateDraft_throws_on_empty_correlation_id(string correlationId)
+    {
+        var act = () => DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, "issue-42", correlationId, ValidProducer(), Payload());
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.ENVELOPE.INVALID");
+    }
+
+    // -----------------------------------------------------------------------
+    // Producer provenance — strict role/action, structural workflow id
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void Producer_Create_accepts_a_taxonomy_valid_triple()
+    {
+        var producer = DocumentProducer.Create("senior_developer", "decompose-issue", "issue-decomposition");
+        producer.Role.Should().Be("senior_developer");
+        producer.Action.Should().Be("decompose-issue");
+        producer.WorkflowDefinitionId.Should().Be("issue-decomposition");
+    }
+
+    [Test]
+    public void Producer_Create_throws_on_unknown_role()
+    {
+        var act = () => DocumentProducer.Create("wizard", "decompose-issue", "issue-decomposition");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.PRODUCER.INVALID");
+    }
+
+    [Test]
+    public void Producer_Create_throws_on_unknown_action()
+    {
+        var act = () => DocumentProducer.Create("senior_developer", "cast-spell", "issue-decomposition");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.PRODUCER.INVALID");
+    }
+
+    [Test]
+    public void Producer_Create_throws_on_ineligible_pair()
+    {
+        // tech_writer is not eligible for decompose-issue (a senior_developer action).
+        var act = () => DocumentProducer.Create("tech_writer", "decompose-issue", "issue-decomposition");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.PRODUCER.INVALID");
+    }
+
+    [Test]
+    public void Producer_Create_throws_on_malformed_workflow_id()
+    {
+        var act = () => DocumentProducer.Create("senior_developer", "decompose-issue", "Not Kebab");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.PRODUCER.INVALID");
+    }
+
+    // -----------------------------------------------------------------------
+    // Immutability + transition seam
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void WithState_returns_a_new_instance_leaving_the_original_unchanged()
+    {
+        var draft = DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, "i", "c", ValidProducer(), Payload(),
+            now: DateTimeOffset.UtcNow);
+
+        var validated = draft.WithState(DocumentState.Validated, now: draft.CreatedAt.AddMilliseconds(10));
+
+        ReferenceEquals(draft, validated).Should().BeFalse();
+        draft.State.Should().Be(DocumentState.Draft, "the original envelope must be unmutated");
+        validated.State.Should().Be(DocumentState.Validated);
+        validated.UpdatedAt.Should().BeAfter(draft.UpdatedAt);
+        validated.Id.Should().Be(draft.Id, "a state transition keeps the same identity");
+    }
+
+    [Test]
+    public void WithState_rejects_an_illegal_transition_naming_both_states()
+    {
+        var draft = Draft();
+        var act = () => draft.WithState(DocumentState.Accepted);
+        var error = act.Should().Throw<TammaError>().Which;
+        error.Code.Should().Be("DOCUMENT.STATE.ILLEGAL_TRANSITION");
+        error.Message.Should().Contain("draft").And.Contain("accepted");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentStateMachineTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentStateMachineTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// State machine + lifecycle-enum drift tests (Story 39-2 AC2/AC7, Design
+/// Decision D4/D5). Every legal transition allowed; a representative illegal set
+/// rejected with both state names in the message; terminals and enum shapes
+/// pinned.
+/// </summary>
+[TestFixture]
+public class DocumentStateMachineTests
+{
+    // ---------------------------------------------------------------------
+    // Enum shape pins (drift anchors)
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void DocumentState_has_exactly_six_members() =>
+        Enum.GetValues<DocumentState>().Length.Should().Be(6);
+
+    [TestCase(DocumentState.Draft, "draft")]
+    [TestCase(DocumentState.Validated, "validated")]
+    [TestCase(DocumentState.Reviewed, "reviewed")]
+    [TestCase(DocumentState.Accepted, "accepted")]
+    [TestCase(DocumentState.Rejected, "rejected")]
+    [TestCase(DocumentState.Escalated, "escalated")]
+    public void DocumentState_wire_strings_are_canonical(DocumentState state, string wire) =>
+        state.ToWire().Should().Be(wire);
+
+    [Test]
+    public void DocumentLifecycleOutcome_has_exactly_four_members() =>
+        // The 39-6 drift anchor: the closed outcome set (D5).
+        Enum.GetValues<DocumentLifecycleOutcome>().Length.Should().Be(4);
+
+    [TestCase(DocumentLifecycleOutcome.ReviewUndecidable, "review-undecidable")]
+    [TestCase(DocumentLifecycleOutcome.AmbiguityAboveThreshold, "ambiguity-above-threshold")]
+    [TestCase(DocumentLifecycleOutcome.RoundsExhausted, "rounds-exhausted")]
+    [TestCase(DocumentLifecycleOutcome.ValidationExhausted, "validation-exhausted")]
+    public void DocumentLifecycleOutcome_wire_strings_are_canonical(DocumentLifecycleOutcome outcome, string wire) =>
+        outcome.ToWire().Should().Be(wire);
+
+    // ---------------------------------------------------------------------
+    // Legal transitions — exhaustive over the declared map
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void Every_pair_in_the_legal_map_is_allowed()
+    {
+        foreach (var (from, destinations) in DocumentStateMachine.LegalTransitions)
+        {
+            foreach (var to in destinations)
+            {
+                DocumentStateMachine.CanTransition(from, to)
+                    .Should().BeTrue($"'{from.ToWire()}' -> '{to.ToWire()}' is in the legal map");
+
+                var assert = () => DocumentStateMachine.AssertTransition(from, to);
+                assert.Should().NotThrow();
+            }
+        }
+    }
+
+    [Test]
+    public void Legal_map_matches_the_D4_specification()
+    {
+        DocumentStateMachine.LegalTransitions[DocumentState.Draft]
+            .Should().BeEquivalentTo(new[] { DocumentState.Validated, DocumentState.Escalated });
+        DocumentStateMachine.LegalTransitions[DocumentState.Validated]
+            .Should().BeEquivalentTo(new[] { DocumentState.Reviewed, DocumentState.Escalated });
+        DocumentStateMachine.LegalTransitions[DocumentState.Reviewed]
+            .Should().BeEquivalentTo(new[] { DocumentState.Accepted, DocumentState.Rejected, DocumentState.Escalated });
+        DocumentStateMachine.LegalTransitions[DocumentState.Accepted].Should().BeEmpty();
+        DocumentStateMachine.LegalTransitions[DocumentState.Rejected].Should().BeEmpty();
+        DocumentStateMachine.LegalTransitions[DocumentState.Escalated].Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------------
+    // Illegal transitions — rejected, naming both states
+    // ---------------------------------------------------------------------
+
+    [Test]
+    [TestCase(DocumentState.Draft, DocumentState.Accepted)]
+    [TestCase(DocumentState.Draft, DocumentState.Reviewed)]
+    [TestCase(DocumentState.Draft, DocumentState.Rejected)]
+    [TestCase(DocumentState.Validated, DocumentState.Accepted)]
+    [TestCase(DocumentState.Validated, DocumentState.Draft)]
+    [TestCase(DocumentState.Reviewed, DocumentState.Draft)]
+    [TestCase(DocumentState.Accepted, DocumentState.Rejected)]
+    [TestCase(DocumentState.Accepted, DocumentState.Draft)]
+    [TestCase(DocumentState.Rejected, DocumentState.Escalated)]
+    [TestCase(DocumentState.Escalated, DocumentState.Accepted)]
+    // self-transitions
+    [TestCase(DocumentState.Draft, DocumentState.Draft)]
+    [TestCase(DocumentState.Reviewed, DocumentState.Reviewed)]
+    public void Illegal_transition_is_rejected_naming_both_states(DocumentState from, DocumentState to)
+    {
+        DocumentStateMachine.CanTransition(from, to).Should().BeFalse();
+
+        var act = () => DocumentStateMachine.AssertTransition(from, to);
+        var error = act.Should().Throw<TammaError>()
+            .Which;
+        error.Code.Should().Be("DOCUMENT.STATE.ILLEGAL_TRANSITION");
+        error.Message.Should().Contain(from.ToWire()).And.Contain(to.ToWire());
+    }
+
+    // ---------------------------------------------------------------------
+    // Terminals
+    // ---------------------------------------------------------------------
+
+    [Test]
+    public void Terminal_states_are_accepted_rejected_escalated()
+    {
+        var terminals = Enum.GetValues<DocumentState>()
+            .Where(DocumentStateMachine.IsTerminal)
+            .ToArray();
+
+        terminals.Should().BeEquivalentTo(new[]
+        {
+            DocumentState.Accepted, DocumentState.Rejected, DocumentState.Escalated,
+        });
+    }
+
+    [Test]
+    [TestCase(DocumentState.Draft)]
+    [TestCase(DocumentState.Validated)]
+    [TestCase(DocumentState.Reviewed)]
+    public void Non_terminal_states_are_not_terminal(DocumentState state) =>
+        DocumentStateMachine.IsTerminal(state).Should().BeFalse();
+
+    [Test]
+    public void Escalated_is_reachable_from_every_non_terminal_state()
+    {
+        // D4: the typed unhandleable outcomes escalate from different stages.
+        DocumentStateMachine.CanTransition(DocumentState.Draft, DocumentState.Escalated).Should().BeTrue();
+        DocumentStateMachine.CanTransition(DocumentState.Validated, DocumentState.Escalated).Should().BeTrue();
+        DocumentStateMachine.CanTransition(DocumentState.Reviewed, DocumentState.Escalated).Should().BeTrue();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeKeyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeKeyTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Drift tests for the <see cref="DocumentTypeKey"/> vocabulary (Story 39-2
+/// AC5b). Same posture as <c>AgentRoleTests</c>: count pin, per-member wire
+/// spelling, round-trip, and fail-loud on unknown wire strings.
+/// </summary>
+[TestFixture]
+public class DocumentTypeKeyTests
+{
+    [Test]
+    public void Has_exactly_ten_document_types() =>
+        // The README's 10-type table. Adding/removing a type is a conscious edit
+        // here AND to DocumentTypeRegistry's registration list (39-3 +4, 39-4 +6).
+        Enum.GetValues<DocumentTypeKey>().Length.Should().Be(10);
+
+    [TestCase(DocumentTypeKey.Findings, "findings")]
+    [TestCase(DocumentTypeKey.AmbiguityAssessment, "ambiguity-assessment")]
+    [TestCase(DocumentTypeKey.Clarification, "clarification")]
+    [TestCase(DocumentTypeKey.Decomposition, "decomposition")]
+    [TestCase(DocumentTypeKey.Plan, "plan")]
+    [TestCase(DocumentTypeKey.Design, "design")]
+    [TestCase(DocumentTypeKey.Review, "review")]
+    [TestCase(DocumentTypeKey.TriageDecision, "triage-decision")]
+    [TestCase(DocumentTypeKey.Diagnosis, "diagnosis")]
+    [TestCase(DocumentTypeKey.TestSpec, "test-spec")]
+    public void ToWire_returns_canonical_kebab_string(DocumentTypeKey key, string wire) =>
+        key.ToWire().Should().Be(wire);
+
+    [Test]
+    public void Roundtrip_holds_for_every_type()
+    {
+        foreach (var key in Enum.GetValues<DocumentTypeKey>())
+            DocumentTypeKeyExtensions.Parse(key.ToWire()).Should().Be(key);
+    }
+
+    [Test]
+    public void Parse_throws_typed_unknown_error_on_unknown()
+    {
+        var act = () => DocumentTypeKeyExtensions.Parse("not-a-type");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.UNKNOWN");
+    }
+
+    [Test]
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Parse_throws_typed_unknown_error_on_null_or_empty(string? input)
+    {
+        var act = () => DocumentTypeKeyExtensions.Parse(input!);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.UNKNOWN");
+    }
+
+    [Test]
+    public void Parse_is_case_sensitive()
+    {
+        // Wire strings are canonical lowercase kebab; non-canonical casing is rejected.
+        var act = () => DocumentTypeKeyExtensions.Parse("Findings");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.UNKNOWN");
+    }
+
+    [Test]
+    public void TryParse_returns_false_for_unknown_and_true_for_known()
+    {
+        DocumentTypeKeyExtensions.TryParse("nope", out _).Should().BeFalse();
+        DocumentTypeKeyExtensions.TryParse("findings", out var key).Should().BeTrue();
+        key.Should().Be(DocumentTypeKey.Findings);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeRegistryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeRegistryTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Drift tests for the <see cref="DocumentTypeRegistry"/> (Story 39-2 AC3/AC4/AC5).
+/// The registered-type count is pinned; the per-type contract checks are LIVE now
+/// (they iterate <see cref="DocumentTypeRegistry.All"/>, which is empty at 39-2
+/// and bites when 39-3/39-4 land); the fail-loud resolution + <c>BuildIndex</c>
+/// guards are exercised via small local fakes.
+/// </summary>
+[TestFixture]
+public class DocumentTypeRegistryTests
+{
+    // -----------------------------------------------------------------------
+    // (a) count pin
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void All_registered_types_count_is_pinned_at_zero()
+    {
+        // 39-2 ships the vocabulary (DocumentTypeKey, 10 members) but ZERO
+        // IDocumentType implementations — consciously (Design Decision D3). The
+        // implementations arrive later and bump this pin:
+        //   Story 39-3 registers +4  (0 -> 4)
+        //   Story 39-4 registers +6  (4 -> 10, matching the DocumentTypeKey count)
+        // Same posture as RolePhaseMapTests' HaveCount(79): the number moving is a
+        // conscious, reviewed edit here, never an accident.
+        DocumentTypeRegistry.All.Should().HaveCount(0);
+    }
+
+    // -----------------------------------------------------------------------
+    // (b) per-registered-type contract loop — LIVE, empty today, bites at 39-3
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void Every_registered_type_has_a_vocabulary_key_that_is_unique()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var type in DocumentTypeRegistry.All)
+        {
+            // Key must be a vocabulary wire string (throws if not).
+            var parsed = DocumentTypeKeyExtensions.Parse(type.Key);
+            parsed.ToWire().Should().Be(type.Key);
+            seen.Add(type.Key).Should().BeTrue($"key '{type.Key}' must be unique across registered types");
+        }
+    }
+
+    [Test]
+    public void Every_registered_type_renders_a_deterministic_non_empty_contract()
+    {
+        foreach (var type in DocumentTypeRegistry.All)
+        {
+            var first = type.RenderContract();
+            first.Should().NotBeNullOrWhiteSpace();
+            // Determinism: 39-16 diffs this in CI.
+            type.RenderContract().Should().Be(first);
+        }
+    }
+
+    [Test]
+    public void Every_registered_type_has_at_least_one_valid_and_one_invalid_self_checking_example()
+    {
+        foreach (var type in DocumentTypeRegistry.All)
+        {
+            type.Examples.Should().Contain(e => e.IsValid, $"{type.Key} needs a valid example");
+            type.Examples.Should().Contain(e => !e.IsValid, $"{type.Key} needs an invalid example");
+
+            foreach (var example in type.Examples)
+            {
+                using var doc = JsonDocument.Parse(example.PayloadJson);
+                var result = type.Validate(doc.RootElement);
+                if (example.IsValid)
+                    result.IsValid.Should().BeTrue($"valid example '{example.Name}' must pass {type.Key}.Validate");
+                else
+                    result.IsValid.Should().BeFalse($"invalid example '{example.Name}' must fail {type.Key}.Validate");
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // (c) fail-loud resolution
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void Resolve_unknown_wire_string_throws_unknown()
+    {
+        var act = () => DocumentTypeRegistry.Resolve("nope");
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.UNKNOWN");
+    }
+
+    [Test]
+    public void Resolve_valid_but_unimplemented_key_throws_not_registered()
+    {
+        var byString = () => DocumentTypeRegistry.Resolve("decomposition");
+        byString.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.NOT_REGISTERED");
+
+        var byEnum = () => DocumentTypeRegistry.Resolve(DocumentTypeKey.Decomposition);
+        byEnum.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.NOT_REGISTERED");
+    }
+
+    // -----------------------------------------------------------------------
+    // (d) BuildIndex fail-loud core, exercised with fakes
+    // -----------------------------------------------------------------------
+
+    [Test]
+    public void BuildIndex_accepts_distinct_vocabulary_keys()
+    {
+        var index = DocumentTypeRegistry.BuildIndex(new IDocumentType[]
+        {
+            new FakeDocumentType("findings"),
+            new FakeDocumentType("plan"),
+        });
+
+        index.Should().HaveCount(2);
+        index.Should().ContainKey("findings").And.ContainKey("plan");
+    }
+
+    [Test]
+    public void BuildIndex_throws_duplicate_key_on_collision()
+    {
+        var act = () => DocumentTypeRegistry.BuildIndex(new IDocumentType[]
+        {
+            new FakeDocumentType("findings"),
+            new FakeDocumentType("findings"),
+        });
+
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.DUPLICATE_KEY");
+    }
+
+    [Test]
+    public void BuildIndex_throws_key_not_in_vocabulary_for_bogus_key()
+    {
+        var act = () => DocumentTypeRegistry.BuildIndex(new IDocumentType[]
+        {
+            new FakeDocumentType("not-a-type"),
+        });
+
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.KEY_NOT_IN_VOCABULARY");
+    }
+
+    /// <summary>
+    /// Minimal local fake standing in for a 39-3/39-4 <see cref="IDocumentType"/>.
+    /// </summary>
+    private sealed class FakeDocumentType : IDocumentType
+    {
+        public FakeDocumentType(string key) => Key = key;
+
+        public string Key { get; }
+        public int SchemaVersion => 1;
+        public Type PayloadClrType => typeof(object);
+        public DocumentValidationResult Validate(JsonElement payload) => DocumentValidationResult.Valid();
+        public string RenderContract() => $"contract:{Key}";
+        public IReadOnlyList<DocumentExample> Examples => Array.Empty<DocumentExample>();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/WorkflowInterfaceGraphTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/WorkflowInterfaceGraphTests.cs
@@ -1,0 +1,116 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// The graph-walk build test over the static workflow interface declarations
+/// (Story 39-2 AC4; Design Decision D6). Same posture as
+/// <c>ContractBindingTests.KnownContractViolations</c>: a ratchet allowlist of
+/// not-yet-implemented type keys that may only shrink as 39-3/39-4 land.
+/// </summary>
+[TestFixture]
+public class WorkflowInterfaceGraphTests
+{
+    private static readonly Regex Kebab = new("^[a-z0-9]+(-[a-z0-9]+)*$");
+
+    /// <summary>
+    /// Type keys whose <see cref="IDocumentType"/> implementation is still pending
+    /// (39-3/39-4). Starts as ALL 10 vocabulary keys; may only SHRINK. When a key
+    /// becomes registered, it must be removed from this set — a stale entry (a
+    /// pending key that is now registered) fails <see cref="Pending_entry_is_not_already_registered"/>.
+    /// </summary>
+    private static readonly HashSet<DocumentTypeKey> PendingImplementations = new()
+    {
+        DocumentTypeKey.Findings,
+        DocumentTypeKey.AmbiguityAssessment,
+        DocumentTypeKey.Clarification,
+        DocumentTypeKey.Decomposition,
+        DocumentTypeKey.Plan,
+        DocumentTypeKey.Design,
+        DocumentTypeKey.Review,
+        DocumentTypeKey.TriageDecision,
+        DocumentTypeKey.Diagnosis,
+        DocumentTypeKey.TestSpec,
+    };
+
+    [Test]
+    public void Declared_edge_count_is_pinned()
+    {
+        // Adding/removing a workflow declaration is a conscious edit. The D6 seed
+        // maps the README document-type table onto real Elsa DefinitionIds
+        // (plan-generation + task-creation both produce 'plan'; plan-review /
+        // task-review / code-review all produce 'review'; blocker-diagnosis +
+        // debugging both produce 'diagnosis').
+        DocumentTypeRegistry.WorkflowInterfaces.Should().HaveCount(14);
+    }
+
+    [Test]
+    public void Every_workflow_definition_id_is_non_empty_kebab()
+    {
+        foreach (var iface in DocumentTypeRegistry.WorkflowInterfaces)
+        {
+            iface.WorkflowDefinitionId.Should().NotBeNullOrWhiteSpace();
+            Kebab.IsMatch(iface.WorkflowDefinitionId)
+                .Should().BeTrue($"'{iface.WorkflowDefinitionId}' must be kebab-case");
+        }
+    }
+
+    [Test]
+    public void Workflow_definition_ids_are_unique()
+    {
+        var ids = DocumentTypeRegistry.WorkflowInterfaces.Select(i => i.WorkflowDefinitionId).ToArray();
+        ids.Should().OnlyHaveUniqueItems();
+    }
+
+    [Test]
+    public void Every_declared_produces_key_is_registered_or_pending()
+    {
+        foreach (var iface in DocumentTypeRegistry.WorkflowInterfaces)
+        {
+            if (iface.Produces is not { } produced)
+                continue;
+
+            var isRegistered = IsRegistered(produced);
+            var isPending = PendingImplementations.Contains(produced);
+
+            (isRegistered || isPending).Should().BeTrue(
+                $"workflow '{iface.WorkflowDefinitionId}' produces '{produced.ToWire()}', " +
+                "which must either have a registered implementation or be listed in PendingImplementations");
+        }
+    }
+
+    [Test]
+    public void Pending_entry_is_not_already_registered()
+    {
+        // Ratchet: once a key is registered by 39-3/39-4, its stale PendingImplementations
+        // entry must be removed. A pending-yet-registered key fails here.
+        foreach (var key in PendingImplementations)
+        {
+            IsRegistered(key).Should().BeFalse(
+                $"'{key.ToWire()}' is registered now — remove it from PendingImplementations");
+        }
+    }
+
+    [Test]
+    public void All_seeded_declarations_are_provisional_until_the_39_1_audit_lands()
+    {
+        DocumentTypeRegistry.WorkflowInterfaces.Should().OnlyContain(i => i.Provisional);
+    }
+
+    private static bool IsRegistered(DocumentTypeKey key)
+    {
+        try
+        {
+            DocumentTypeRegistry.Resolve(key);
+            return true;
+        }
+        catch (TammaError)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## What

First implementation story of Epic 39 (**PR-A** in the execution plan) — **Story 39-2, Document Core**, the critical-path root that unblocks the entire epic. A new storage-free `Tamma.Core.Documents` namespace; no DB, no migrations, no endpoints, no Elsa activities (AC8).

## Delivered

- **`DocumentEnvelope`** — immutable `sealed record`: identity (UUID v7), `type`/`schemaVersion`, lineage (`issueId`, `correlationId`, `parent`/`supersedes`), `DocumentProducer` provenance, `DocumentState`, ms-precision timestamps, `JsonElement` payload. `CreateDraft` / `WithState` are the only construction/transition seams (mutation-free).
- **`UuidV7`** — RFC 9562 hand-roll (net8 has no `Guid.CreateVersion7`): 48-bit big-endian ms prefix + version-7 nibble + variant bits + random tail, constructed big-endian so byte- and string-order match creation order.
- **`DocumentState`** (6 members) + data-driven **`DocumentStateMachine`** — `Draft → Validated → Reviewed → Accepted/Rejected/Escalated`, `Escalated` reachable from every non-terminal, terminals closed; illegal transitions throw `DOCUMENT.STATE.ILLEGAL_TRANSITION` naming both states. Closed **`DocumentLifecycleOutcome`** enum (4) shipped here as the 39-6 drift anchor.
- **`DocumentTypeKey`** (10-member kebab-wire vocabulary) + fail-loud **`DocumentTypeRegistry`** — ships **empty** (registered-count pinned 0; +4 in 39-3, +6 in 39-4), distinguishes `DOCUMENT.TYPE.UNKNOWN` (bad key) vs `DOCUMENT.TYPE.NOT_REGISTERED` (valid key, no impl yet); `BuildIndex` fail-loud on duplicate/out-of-vocabulary keys.
- **`IDocumentType`** / `DocumentValidationResult` / `DocumentViolation` / `DocumentExample` contract; **`DocumentProducer`** validates role/action through the taxonomy + `RolePhaseMap` eligibility; **`WorkflowDocumentInterface`** seed (14 `Provisional` declarations mapped to real Elsa DefinitionIds) with a graph-walk drift test whose `PendingImplementations` ratchet starts at all 10 keys.
- **`DocumentJson`** — one canonical `JsonSerializerOptions`, explicit `[JsonPropertyName]` on every wire field, wire-enum + millisecond-ISO8601 converters; missing required `issueId`/`type` → `JsonException`, unknown fields tolerated.

## Tests

**170 NUnit + FluentAssertions tests, no Docker** — `DocumentTypeKeyTests`, `DocumentStateMachineTests`, `DocumentTypeRegistryTests`, `WorkflowInterfaceGraphTests`, `DocumentEnvelopeTests`, `DocumentEnvelopeSerializationTests`. Count pins, wire round-trips, fail-loud-on-unknown, immutability, serialization property-name pins — the `RolePhaseMapTests`/`AgentRoleTests` drift style. Build clean (0 warnings), 170/170 green.

## Notes / deviation

- One file beyond the 13 planned deliverables: `DocumentsAssemblyInfo.cs` (`[assembly: InternalsVisibleTo("Tamma.Core.Tests")]`) — the registry drift test exercises the `internal BuildIndex` pure core (AC5d), and the csproj is off-limits, so the attribute lives in a source file inside the allowed `Documents/` diff surface.
- The empty registry + `Provisional` interface seed are intentional per the plan (D3/D6); 39-3/39-4 bump the count pins and shrink the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_