### PR TITLE
feat(39-3): Document Types Batch 1 — Decomposition, Findings, AmbiguityAssessment, Clarification

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentExample.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentExample.cs
@@ -6,4 +6,28 @@ namespace Tamma.Core.Documents;
 /// drift test); examples feed contract rendering and are self-checked against the
 /// type's own <see cref="IDocumentType.Validate"/>.
 /// </summary>
-public sealed record DocumentExample(string Name, bool IsValid, string PayloadJson);
+/// <param name="Name">A stable, human-readable example name.</param>
+/// <param name="IsValid">Whether the example is expected to pass <see cref="IDocumentType.Validate"/>.</param>
+/// <param name="PayloadJson">The example payload JSON.</param>
+/// <param name="ExpectedViolationCodes">
+/// For an invalid example, the EXACT set of violation codes
+/// <see cref="IDocumentType.Validate"/> must emit for this payload (Story 39-3
+/// Design Decision D9 — additive over the 39-2 record). Empty for valid examples;
+/// the registry drift loop asserts the emitted codes match this set exactly.
+/// </param>
+public sealed record DocumentExample(
+    string Name,
+    bool IsValid,
+    string PayloadJson,
+    IReadOnlyList<string> ExpectedViolationCodes)
+{
+    /// <summary>
+    /// Convenience overload for examples that declare no expected codes (all valid
+    /// examples, and pre-39-3 call sites) — defaults <see cref="ExpectedViolationCodes"/>
+    /// to empty.
+    /// </summary>
+    public DocumentExample(string name, bool isValid, string payloadJson)
+        : this(name, isValid, payloadJson, Array.Empty<string>())
+    {
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeRegistry.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/DocumentTypeRegistry.cs
@@ -1,4 +1,5 @@
 using Tamma.Core;
+using Tamma.Core.Documents.Types;
 
 namespace Tamma.Core.Documents;
 
@@ -18,12 +19,18 @@ namespace Tamma.Core.Documents;
 /// </summary>
 public static class DocumentTypeRegistry
 {
-    // The compile-time registration list. EMPTY at 39-2 by design (D3):
-    //   39-3 appends +4 IDocumentType implementations (bumps the count pin 0 -> 4)
+    // The compile-time registration list.
+    //   39-3 appends +4 IDocumentType implementations (bumps the count pin 0 -> 4)  <-- DONE
     //   39-4 appends the remaining +6 (bumps the count pin 4 -> 10)
     // and each shrinks the WorkflowInterfaceGraphTests PendingImplementations
     // ratchet accordingly.
-    private static readonly IReadOnlyList<IDocumentType> s_registrations = Array.Empty<IDocumentType>();
+    private static readonly IReadOnlyList<IDocumentType> s_registrations = new IDocumentType[]
+    {
+        new DecompositionDocumentType(),
+        new FindingsDocumentType(),
+        new AmbiguityAssessmentDocumentType(),
+        new ClarificationDocumentType(),
+    };
 
     private static readonly IReadOnlyDictionary<string, IDocumentType> s_index =
         BuildIndex(s_registrations);

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Types/AmbiguityAssessment.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Types/AmbiguityAssessment.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Types;
+
+/// <summary>
+/// The canonical ambiguity-type vocabulary (Design Decision D5 — strict closed
+/// set, exactly the members <c>AmbiguityParsing</c> enumerates today, including
+/// <c>unspecified</c>). Synonym folding becomes producer-side normalization at
+/// 39-13. Shipped as a <c>[Wire]</c> enum per the <c>AgentAction</c> pattern.
+/// </summary>
+public enum AmbiguityCategory
+{
+    [Wire("vague")] Vague,
+    [Wire("missing")] Missing,
+    [Wire("contradictory")] Contradictory,
+    [Wire("implicit")] Implicit,
+    [Wire("unspecified")] Unspecified,
+}
+
+/// <summary>
+/// The canonical ambiguity-severity vocabulary (Design Decision D5). Shipped as a
+/// <c>[Wire]</c> enum.
+/// </summary>
+public enum AmbiguitySeverity
+{
+    [Wire("low")] Low,
+    [Wire("medium")] Medium,
+    [Wire("high")] High,
+}
+
+/// <summary>
+/// One detected ambiguity — the typed analogue of the legacy
+/// <c>Tamma.Activities.Ambiguity.Models.AmbiguityItem</c> (Design Decision D2:
+/// wire shape verbatim).
+/// </summary>
+public sealed record AmbiguityConcern
+{
+    [JsonPropertyName("type")] public string Type { get; init; } = "";
+    [JsonPropertyName("description")] public string Description { get; init; } = "";
+    [JsonPropertyName("severity")] public string Severity { get; init; } = "";
+    [JsonPropertyName("recommendation")] public string Recommendation { get; init; } = "";
+}
+
+/// <summary>
+/// The structured ambiguity assessment for a requirement: a quantitative
+/// <see cref="Score"/> ∈ [0,1], a <see cref="Rationale"/>, the scorer's
+/// <see cref="Confidence"/>, and the itemised <see cref="Ambiguities"/> breakdown
+/// (which may legitimately be empty for a clear requirement).
+///
+/// <para><see cref="Score"/> is <c>required</c>: an assessment whose whole point
+/// is the score must carry one, so an absent score fails loud at the
+/// deserialization boundary (mirrors the baseline fail-closed on a missing
+/// score).</para>
+/// </summary>
+public sealed record AmbiguityAssessment
+{
+    [JsonPropertyName("score")] public required decimal Score { get; init; }
+    [JsonPropertyName("rationale")] public string Rationale { get; init; } = "";
+    [JsonPropertyName("confidence")] public decimal Confidence { get; init; }
+    [JsonPropertyName("ambiguities")] public IReadOnlyList<AmbiguityConcern> Ambiguities { get; init; } = [];
+}
+
+/// <summary>
+/// <see cref="IDocumentType"/> for the <c>ambiguity-assessment</c> document (Story
+/// 39-3 AC4). Enforces <c>score</c> ∈ [0,1], a closed typed ambiguity set, and a
+/// non-empty rationale — while treating a clear (low-score) assessment with an
+/// empty ambiguity list as valid.
+/// </summary>
+public sealed class AmbiguityAssessmentDocumentType : IDocumentType
+{
+    /// <summary>Payload could not be deserialized (absent/non-numeric score, or wrong types).</summary>
+    public const string MalformedPayload = "MALFORMED_PAYLOAD";
+
+    /// <summary>The <c>score</c> is outside [0,1] — rejected (parity with the baseline fail-closed).</summary>
+    public const string ScoreOutOfRange = "SCORE_OUT_OF_RANGE";
+
+    /// <summary>Baseline fail-closed: a score with no rationale is not auditable/actionable.</summary>
+    public const string MissingRationale = "MISSING_RATIONALE";
+
+    /// <summary>The <c>confidence</c> is outside [0,1] — rejected, not clamped (D6; baseline clamped).</summary>
+    public const string ConfidenceOutOfRange = "CONFIDENCE_OUT_OF_RANGE";
+
+    /// <summary>An ambiguity <c>type</c> outside the closed set — strict (D5; baseline normalized).</summary>
+    public const string UnknownAmbiguityType = "UNKNOWN_AMBIGUITY_TYPE";
+
+    /// <summary>An ambiguity <c>severity</c> outside the closed set — strict (D5; baseline normalized).</summary>
+    public const string UnknownSeverity = "UNKNOWN_SEVERITY";
+
+    /// <summary>An ambiguity item with no description is an empty shell.</summary>
+    public const string AmbiguityEmptyShell = "AMBIGUITY_EMPTY_SHELL";
+
+    public string Key => DocumentTypeKey.AmbiguityAssessment.ToWire();
+    public int SchemaVersion => 1;
+    public Type PayloadClrType => typeof(AmbiguityAssessment);
+
+    public DocumentValidationResult Validate(JsonElement payload)
+    {
+        AmbiguityAssessment? doc;
+        try
+        {
+            doc = payload.Deserialize<AmbiguityAssessment>(DocumentJson.Options);
+        }
+        catch (JsonException)
+        {
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload,
+                "The payload could not be parsed as an ambiguity assessment (a missing or non-numeric " +
+                "score fails here — the score is load-bearing)."));
+        }
+
+        if (doc is null)
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload deserialized to null."));
+
+        var violations = new List<DocumentViolation>();
+
+        if (doc.Score < 0m || doc.Score > 1m)
+            violations.Add(new DocumentViolation(
+                ScoreOutOfRange, $"score is {doc.Score} — the ambiguity score must be within [0, 1]."));
+
+        if (string.IsNullOrWhiteSpace(doc.Rationale))
+            violations.Add(new DocumentViolation(
+                MissingRationale, "The assessment has no rationale — a score with no rationale is not auditable."));
+
+        if (doc.Confidence < 0m || doc.Confidence > 1m)
+            violations.Add(new DocumentViolation(
+                ConfidenceOutOfRange, $"confidence is {doc.Confidence} — confidence must be within [0, 1]."));
+
+        // A clear requirement (low score) with an empty ambiguities list is valid (AC4).
+        var index = 0;
+        foreach (var concern in doc.Ambiguities ?? [])
+        {
+            index++;
+            var label = string.IsNullOrWhiteSpace(concern.Description) ? $"#{index}" : $"'{concern.Description}'";
+
+            if (string.IsNullOrWhiteSpace(concern.Description))
+                violations.Add(new DocumentViolation(
+                    AmbiguityEmptyShell, $"Ambiguity {label} has no description — it is an empty shell."));
+
+            if (!EnumWire<AmbiguityCategory>.TryParse(concern.Type ?? "", out _))
+                violations.Add(new DocumentViolation(
+                    UnknownAmbiguityType,
+                    $"Ambiguity {label} has type '{concern.Type}', which is not one of vague, missing, " +
+                    "contradictory, implicit, unspecified."));
+
+            if (!EnumWire<AmbiguitySeverity>.TryParse(concern.Severity ?? "", out _))
+                violations.Add(new DocumentViolation(
+                    UnknownSeverity,
+                    $"Ambiguity {label} has severity '{concern.Severity}', which is not one of low, medium, high."));
+        }
+
+        return violations.Count == 0
+            ? DocumentValidationResult.Valid()
+            : DocumentValidationResult.Invalid(violations.ToArray());
+    }
+
+    public string RenderContract() => Contract;
+
+    public IReadOnlyList<DocumentExample> Examples => s_examples;
+
+    // ── Contract + examples ──────────────────────────────────────────────────
+    // The quoted tokens below are pinned by ContractBindingTests.Bindings for the
+    // (product_owner, score-ambiguity) cell → AmbiguityParsing.ParseAssessment (8
+    // tokens): "score", "confidence", "rationale", "ambiguities", "type",
+    // "description", "severity", "recommendation".
+    private const string Contract =
+        """
+        Return ONLY a JSON object of this shape:
+        {
+          "score": 0.72,
+          "confidence": 0.8,
+          "rationale": "why the requirement scored this way",
+          "ambiguities": [
+            {
+              "type": "vague | missing | contradictory | implicit | unspecified",
+              "description": "what is unclear",
+              "severity": "low | medium | high",
+              "recommendation": "how to resolve it"
+            }
+          ]
+        }
+        Rules: "score" and "confidence" must be within [0, 1]; "rationale" is required;
+        each ambiguity "type" and "severity" must be from the closed sets above; the
+        "ambiguities" list may be empty for a genuinely clear requirement.
+        """;
+
+    private static readonly IReadOnlyList<DocumentExample> s_examples = new[]
+    {
+        new DocumentExample(
+            "valid-clear-requirement-empty-breakdown",
+            true,
+            """
+            { "score": 0.05, "confidence": 0.9, "rationale": "Fully specified with clear ACs.", "ambiguities": [] }
+            """),
+        new DocumentExample(
+            "invalid-out-of-range-and-unknown-type",
+            false,
+            """
+            {
+              "score": 1.5,
+              "confidence": 0.8,
+              "rationale": "Bad score and a bad label.",
+              "ambiguities": [
+                { "type": "unclear", "description": "vague wording", "severity": "high", "recommendation": "quantify it" }
+              ]
+            }
+            """,
+            new[] { ScoreOutOfRange, UnknownAmbiguityType }),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Clarification.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Clarification.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Types;
+
+/// <summary>
+/// The two phases of a clarification document (Design Decision D3 — one flat
+/// payload with a <c>phase</c> discriminator, NOT two types; the README's
+/// "Questions → Resolution" single row). Shipped as a <c>[Wire]</c> enum.
+/// </summary>
+public enum ClarificationPhase
+{
+    [Wire("questions")] Questions,
+    [Wire("resolution")] Resolution,
+}
+
+/// <summary>
+/// One resolution in the resolution phase: the clarified <see cref="Requirement"/>
+/// and the positional <see cref="QuestionId"/> (<c>Q-1</c>…<c>Q-n</c>) it resolves
+/// (Design Decision D3). Question identity is positional and derived, never stored
+/// on the question strings themselves.
+/// </summary>
+public sealed record QuestionResolution
+{
+    [JsonPropertyName("questionId")] public string QuestionId { get; init; } = "";
+    [JsonPropertyName("requirement")] public string Requirement { get; init; } = "";
+}
+
+/// <summary>
+/// One clarification document across both phases (Design Decision D3). The
+/// questions phase carries <see cref="Questions"/> (an array of strings, so the
+/// legacy <c>ClarifyParsing.ParseQuestions</c> still parses it); the resolution
+/// phase adds root-level <see cref="ClarifiedRequirement"/> /
+/// <see cref="RemainingAmbiguities"/> / <see cref="Resolved"/> (byte-compatible
+/// with <c>ClarifyParsing.ParseClarification</c>) plus the additive
+/// <see cref="Resolutions"/> array.
+/// </summary>
+public sealed record Clarification
+{
+    [JsonPropertyName("phase")] public string Phase { get; init; } = "";
+    [JsonPropertyName("questions")] public IReadOnlyList<string> Questions { get; init; } = [];
+    [JsonPropertyName("clarifiedRequirement")] public string? ClarifiedRequirement { get; init; }
+    [JsonPropertyName("resolutions")] public IReadOnlyList<QuestionResolution> Resolutions { get; init; } = [];
+    [JsonPropertyName("remainingAmbiguities")] public IReadOnlyList<string> RemainingAmbiguities { get; init; } = [];
+    [JsonPropertyName("resolved")] public bool Resolved { get; init; }
+}
+
+/// <summary>
+/// <see cref="IDocumentType"/> for the <c>clarification</c> document (Story 39-3
+/// AC5). Two-phase: the questions phase requires ≥1 open-ended question; the
+/// resolution phase requires a root-level clarified requirement and that every
+/// resolution reference a known question.
+///
+/// <para><b>Open-endedness rule (D4):</b> the baseline floor is ≥1 non-empty
+/// trimmed question. The deliberate tightening: a deterministic closed-question
+/// detector — a question that STARTS with a yes/no auxiliary (is/are/do/does/did/
+/// can/could/will/would/should/has/have/was/were) AND contains no interrogative
+/// word (what/why/how/when/where/which/who/whom/whose) AND no "or"-alternative is
+/// closed-form. <see cref="NoOpenQuestion"/> fires when ALL surviving questions
+/// are closed-form. A question mark is NOT consulted. This aligns the validator
+/// with what <c>product_owner/clarify-requirements.md</c> already instructs
+/// ("open-ended (not yes/no)").</para>
+/// </summary>
+public sealed class ClarificationDocumentType : IDocumentType
+{
+    /// <summary>Payload could not be deserialized into the typed shape.</summary>
+    public const string MalformedPayload = "MALFORMED_PAYLOAD";
+
+    /// <summary>The <c>phase</c> is not one of questions, resolution.</summary>
+    public const string UnknownPhase = "UNKNOWN_PHASE";
+
+    /// <summary>Questions phase: no open-ended question survives (zero questions, or all closed-form). D4.</summary>
+    public const string NoOpenQuestion = "NO_OPEN_QUESTION";
+
+    /// <summary>Questions phase: a question entry is empty / whitespace.</summary>
+    public const string EmptyQuestion = "EMPTY_QUESTION";
+
+    /// <summary>Resolution phase: the load-bearing root <c>clarifiedRequirement</c> is missing/empty.</summary>
+    public const string MissingClarifiedRequirement = "MISSING_CLARIFIED_REQUIREMENT";
+
+    /// <summary>Resolution phase: a resolution states no clarified requirement.</summary>
+    public const string EmptyResolution = "EMPTY_RESOLUTION";
+
+    /// <summary>Resolution phase: a resolution's questionId is outside Q-1…Q-n of the payload's questions.</summary>
+    public const string UnknownQuestionRef = "UNKNOWN_QUESTION_REF";
+
+    private static readonly IReadOnlySet<string> Auxiliaries = new HashSet<string>(StringComparer.Ordinal)
+    {
+        "is", "are", "do", "does", "did", "can", "could", "will", "would", "should", "has", "have", "was", "were",
+    };
+
+    private static readonly IReadOnlyList<string> Interrogatives = new[]
+    {
+        "what", "why", "how", "when", "where", "which", "who", "whom", "whose",
+    };
+
+    public string Key => DocumentTypeKey.Clarification.ToWire();
+    public int SchemaVersion => 1;
+    public Type PayloadClrType => typeof(Clarification);
+
+    public DocumentValidationResult Validate(JsonElement payload)
+    {
+        Clarification? doc;
+        try
+        {
+            doc = payload.Deserialize<Clarification>(DocumentJson.Options);
+        }
+        catch (JsonException)
+        {
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload could not be parsed as a clarification document."));
+        }
+
+        if (doc is null)
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload deserialized to null."));
+
+        if (!EnumWire<ClarificationPhase>.TryParse(doc.Phase ?? "", out var phase))
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                UnknownPhase, $"phase is '{doc.Phase}', which is not one of questions, resolution."));
+
+        var violations = new List<DocumentViolation>();
+        var questions = doc.Questions ?? [];
+
+        if (phase == ClarificationPhase.Questions)
+        {
+            if (questions.Any(q => string.IsNullOrWhiteSpace(q)))
+                violations.Add(new DocumentViolation(
+                    EmptyQuestion, "A question entry is empty — every question must be non-empty."));
+
+            var surviving = questions.Where(q => !string.IsNullOrWhiteSpace(q)).ToList();
+            if (surviving.Count == 0 || surviving.All(IsClosedForm))
+                violations.Add(new DocumentViolation(
+                    NoOpenQuestion,
+                    "The questions phase needs at least one open-ended (not yes/no) question — none survive."));
+        }
+        else // Resolution
+        {
+            if (string.IsNullOrWhiteSpace(doc.ClarifiedRequirement))
+                violations.Add(new DocumentViolation(
+                    MissingClarifiedRequirement,
+                    "The resolution phase has no clarifiedRequirement — the disambiguated requirement is load-bearing."));
+
+            var questionCount = questions.Count;
+            foreach (var resolution in doc.Resolutions ?? [])
+            {
+                if (string.IsNullOrWhiteSpace(resolution.Requirement))
+                    violations.Add(new DocumentViolation(
+                        EmptyResolution,
+                        $"Resolution for '{resolution.QuestionId}' states no clarified requirement."));
+
+                if (!IsKnownQuestionRef(resolution.QuestionId, questionCount))
+                    violations.Add(new DocumentViolation(
+                        UnknownQuestionRef,
+                        $"Resolution references '{resolution.QuestionId}', which is not a question in this " +
+                        $"document (expected Q-1…Q-{questionCount})."));
+            }
+        }
+
+        return violations.Count == 0
+            ? DocumentValidationResult.Valid()
+            : DocumentValidationResult.Invalid(violations.ToArray());
+    }
+
+    private static bool IsClosedForm(string question)
+    {
+        var text = question.Trim().ToLowerInvariant();
+        var firstWord = new string(text.TakeWhile(char.IsLetter).ToArray());
+        if (!Auxiliaries.Contains(firstWord))
+            return false;
+        if (Interrogatives.Any(w => ContainsWord(text, w)))
+            return false;
+        if (text.Contains(" or ", StringComparison.Ordinal))
+            return false;
+        return true;
+    }
+
+    private static bool ContainsWord(string text, string word)
+    {
+        var idx = 0;
+        while ((idx = text.IndexOf(word, idx, StringComparison.Ordinal)) >= 0)
+        {
+            var beforeOk = idx == 0 || !char.IsLetter(text[idx - 1]);
+            var afterPos = idx + word.Length;
+            var afterOk = afterPos >= text.Length || !char.IsLetter(text[afterPos]);
+            if (beforeOk && afterOk)
+                return true;
+            idx = afterPos;
+        }
+        return false;
+    }
+
+    private static bool IsKnownQuestionRef(string? questionId, int questionCount)
+    {
+        if (string.IsNullOrWhiteSpace(questionId))
+            return false;
+        if (!questionId.StartsWith("Q-", StringComparison.Ordinal))
+            return false;
+        if (!int.TryParse(questionId.AsSpan(2), out var n))
+            return false;
+        return n >= 1 && n <= questionCount;
+    }
+
+    public string RenderContract() => Contract;
+
+    public IReadOnlyList<DocumentExample> Examples => s_examples;
+
+    // ── Contract + examples ──────────────────────────────────────────────────
+    // The tokens below are pinned by ContractBindingTests.Bindings for the two
+    // clarify cells: (product_owner, clarify-requirements) → ParseQuestions pins the
+    // phrase "JSON array"; (product_owner, incorporate-answers) → ParseClarification
+    // pins "clarifiedRequirement", "remainingAmbiguities", "resolved".
+    private const string Contract =
+        """
+        A clarification document has a "phase" of either "questions" or "resolution".
+
+        QUESTIONS phase — return ONLY a JSON array of open-ended (not yes/no) question strings:
+        ["What is the target platform?", "Which auth model is expected?"]
+
+        RESOLUTION phase — return ONLY a JSON object of this shape:
+        {
+          "phase": "resolution",
+          "clarifiedRequirement": "the full disambiguated requirement text",
+          "resolutions": [ { "questionId": "Q-1", "requirement": "the clarified statement" } ],
+          "remainingAmbiguities": ["anything still unclear"],
+          "resolved": true
+        }
+        Rules: the questions phase needs at least one open-ended question; the resolution phase
+        needs a non-empty "clarifiedRequirement" and every "questionId" must reference a question
+        (Q-1…Q-n) in this document.
+        """;
+
+    private static readonly IReadOnlyList<DocumentExample> s_examples = new[]
+    {
+        new DocumentExample(
+            "valid-questions-phase",
+            true,
+            """
+            { "phase": "questions", "questions": ["What is the target platform?", "Which auth model is expected?"] }
+            """),
+        new DocumentExample(
+            "invalid-resolution-missing-requirement-and-bad-ref",
+            false,
+            """
+            {
+              "phase": "resolution",
+              "questions": ["What is the target platform?"],
+              "resolutions": [ { "questionId": "Q-9", "requirement": "web" } ]
+            }
+            """,
+            new[] { MissingClarifiedRequirement, UnknownQuestionRef }),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Decomposition.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Decomposition.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Types;
+
+/// <summary>
+/// The canonical complexity vocabulary for a decomposed task (Story 39-3, Design
+/// Decision D5 — strict closed label set, reject don't normalize). The legacy
+/// <c>SubtaskComplexities.Normalize</c> synonym folding becomes producer-side
+/// normalization at 39-13 migration time; this validator accepts ONLY the
+/// canonical wires. Shipped as a <c>[Wire]</c> enum per the <c>AgentAction</c>
+/// pattern.
+/// </summary>
+public enum TaskComplexity
+{
+    [Wire("low")] Low,
+    [Wire("medium")] Medium,
+    [Wire("high")] High,
+}
+
+/// <summary>
+/// One decomposed task — an immutable mirror of the legacy
+/// <c>Tamma.Activities.Decomposition.Models.Subtask</c> shape (Design Decision D2:
+/// wire shape verbatim). Every property carries an explicit
+/// <c>[JsonPropertyName]</c> (39-2 D8). New fields are only ever added; the old
+/// parser skips unknown fields.
+/// </summary>
+public sealed record DecompositionTask
+{
+    [JsonPropertyName("id")] public string Id { get; init; } = "";
+    [JsonPropertyName("title")] public string Title { get; init; } = "";
+    [JsonPropertyName("description")] public string Description { get; init; } = "";
+    [JsonPropertyName("acceptanceCriteria")] public string AcceptanceCriteria { get; init; } = "";
+    [JsonPropertyName("estimateHours")] public decimal EstimateHours { get; init; }
+    [JsonPropertyName("complexity")] public string Complexity { get; init; } = "medium";
+    [JsonPropertyName("dependsOn")] public IReadOnlyList<string> DependsOn { get; init; } = [];
+}
+
+/// <summary>
+/// The structured decomposition of a complex issue: an overview
+/// <see cref="Summary"/> (load-bearing — records how the breakdown preserves the
+/// parent intent) plus the implementable <see cref="Subtasks"/>. The typed
+/// analogue of the legacy <c>IssueDecomposition</c>; consumed downstream by
+/// Stories 2-15/2-16 (dependency mapping / sequencing).
+/// </summary>
+public sealed record Decomposition
+{
+    [JsonPropertyName("summary")] public string Summary { get; init; } = "";
+    [JsonPropertyName("subtasks")] public IReadOnlyList<DecompositionTask> Subtasks { get; init; } = [];
+}
+
+/// <summary>
+/// <see cref="IDocumentType"/> for the <c>decomposition</c> document (Story 39-3
+/// AC2). Enforces unique task ids, no dangling / self / cyclic <c>dependsOn</c>
+/// (naming the cycle members), per-task sizing within 2–8h, and a computable
+/// prerequisite order (topological order exists). Deliberate tightenings over the
+/// fail-closed baseline parser are enumerated in the story completion notes (AC6).
+/// </summary>
+public sealed class DecompositionDocumentType : IDocumentType
+{
+    /// <summary>Payload could not be deserialized into the typed shape (type mismatch on the wire).</summary>
+    public const string MalformedPayload = "MALFORMED_PAYLOAD";
+
+    /// <summary>Baseline fail-closed: a decomposition with no overview summary is not auditable.</summary>
+    public const string MissingSummary = "MISSING_SUMMARY";
+
+    /// <summary>Baseline fail-closed: a decomposition with no usable subtasks decomposed nothing.</summary>
+    public const string NoTasks = "NO_TASKS";
+
+    /// <summary>Baseline dropped shell tasks silently — now a loud violation. A task with no id.</summary>
+    public const string TaskMissingId = "TASK_MISSING_ID";
+
+    /// <summary>A task with neither a title nor a description is an empty shell.</summary>
+    public const string TaskEmptyShell = "TASK_EMPTY_SHELL";
+
+    /// <summary>Baseline kept the first of duplicate ids silently — now a loud violation.</summary>
+    public const string DuplicateTaskId = "DUPLICATE_TASK_ID";
+
+    /// <summary>Baseline pruned dangling refs silently — now a loud violation.</summary>
+    public const string DanglingDependsOn = "DANGLING_DEPENDS_ON";
+
+    /// <summary>Baseline pruned self-references silently — now a loud violation.</summary>
+    public const string SelfDependsOn = "SELF_DEPENDS_ON";
+
+    /// <summary>Cycle in the dependency graph — new (baseline deferred cycle detection to Story 2-15).</summary>
+    public const string CyclicDependsOn = "CYCLIC_DEPENDS_ON";
+
+    /// <summary>No topological order exists — the stable signal downstream sequencing (2-15/2-16) keys on.</summary>
+    public const string NoPrerequisiteOrder = "NO_PREREQUISITE_ORDER";
+
+    /// <summary>Per-task estimate outside the 2–8h rule — new (baseline only clamped negatives to 0).</summary>
+    public const string SizingOutOfRange = "SIZING_OUT_OF_RANGE";
+
+    /// <summary>Complexity outside {low, medium, high} — strict (baseline normalized synonyms). D5.</summary>
+    public const string UnknownComplexity = "UNKNOWN_COMPLEXITY";
+
+    private const decimal MinEstimateHours = 2m;
+    private const decimal MaxEstimateHours = 8m;
+
+    private static readonly DependencyGraphCodes GraphCodes = new(
+        DuplicateId: DuplicateTaskId,
+        DanglingDependency: DanglingDependsOn,
+        SelfDependency: SelfDependsOn,
+        Cyclic: CyclicDependsOn,
+        NoPrerequisiteOrder: NoPrerequisiteOrder);
+
+    public string Key => DocumentTypeKey.Decomposition.ToWire();
+    public int SchemaVersion => 1;
+    public Type PayloadClrType => typeof(Decomposition);
+
+    public DocumentValidationResult Validate(JsonElement payload)
+    {
+        Decomposition? doc;
+        try
+        {
+            doc = payload.Deserialize<Decomposition>(DocumentJson.Options);
+        }
+        catch (JsonException)
+        {
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload could not be parsed as a decomposition document."));
+        }
+
+        if (doc is null)
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload deserialized to null."));
+
+        var violations = new List<DocumentViolation>();
+
+        if (string.IsNullOrWhiteSpace(doc.Summary))
+            violations.Add(new DocumentViolation(
+                MissingSummary,
+                "The decomposition has no summary — the overview that records how the breakdown " +
+                "preserves the parent issue's intent is required."));
+
+        var subtasks = doc.Subtasks ?? [];
+        if (subtasks.Count == 0)
+            violations.Add(new DocumentViolation(
+                NoTasks, "The decomposition has no subtasks — nothing was actually decomposed."));
+
+        foreach (var task in subtasks)
+        {
+            var id = task.Id?.Trim() ?? "";
+            var label = string.IsNullOrWhiteSpace(id) ? "(no id)" : $"'{id}'";
+
+            if (string.IsNullOrWhiteSpace(id))
+                violations.Add(new DocumentViolation(
+                    TaskMissingId,
+                    "A subtask has no id — dependencies reference tasks by id, so every task must carry one."));
+
+            if (string.IsNullOrWhiteSpace(task.Title) && string.IsNullOrWhiteSpace(task.Description))
+                violations.Add(new DocumentViolation(
+                    TaskEmptyShell,
+                    $"Subtask {label} has neither a title nor a description — it is an empty shell."));
+
+            if (task.EstimateHours < MinEstimateHours || task.EstimateHours > MaxEstimateHours)
+                violations.Add(new DocumentViolation(
+                    SizingOutOfRange,
+                    $"Subtask {label} is estimated at {task.EstimateHours}h — each task must be sized " +
+                    $"within {MinEstimateHours}–{MaxEstimateHours}h inclusive."));
+
+            if (!EnumWire<TaskComplexity>.TryParse(task.Complexity ?? "", out _))
+                violations.Add(new DocumentViolation(
+                    UnknownComplexity,
+                    $"Subtask {label} has complexity '{task.Complexity}', which is not one of low, medium, high."));
+        }
+
+        var graphNodes = subtasks
+            .Where(t => !string.IsNullOrWhiteSpace(t.Id))
+            .Select(t => (Id: t.Id.Trim(), DependsOn: t.DependsOn ?? (IReadOnlyList<string>)[]))
+            .ToList();
+        violations.AddRange(DependencyGraphCheck.Check(graphNodes, GraphCodes));
+
+        return violations.Count == 0
+            ? DocumentValidationResult.Valid()
+            : DocumentValidationResult.Invalid(violations.ToArray());
+    }
+
+    public string RenderContract() => Contract;
+
+    public IReadOnlyList<DocumentExample> Examples => s_examples;
+
+    // ── Contract + examples ──────────────────────────────────────────────────
+    // The quoted tokens below are pinned by ContractBindingTests.Bindings for the
+    // (senior_developer, decompose-issue) cell → DecompositionParsing.ParseDecomposition
+    // (9 tokens): "summary", "subtasks", "id", "title", "description",
+    // "acceptanceCriteria", "estimateHours", "complexity", "dependsOn".
+    private const string Contract =
+        """
+        Return ONLY a JSON object of this shape:
+        {
+          "summary": "how the breakdown preserves the parent issue's intent",
+          "subtasks": [
+            {
+              "id": "ST-1",
+              "title": "short task title",
+              "description": "what the task delivers",
+              "acceptanceCriteria": "the definition of done",
+              "estimateHours": 4,
+              "complexity": "low | medium | high",
+              "dependsOn": ["ST-2"]
+            }
+          ]
+        }
+        Rules: every subtask needs a unique "id"; each "estimateHours" must be within 2–8h
+        inclusive; "complexity" must be one of low, medium, high; "dependsOn" may only
+        reference ids that exist in this document, with no self-dependency and no cycle.
+        """;
+
+    private static readonly IReadOnlyList<DocumentExample> s_examples = new[]
+    {
+        new DocumentExample(
+            "valid-two-task-chain",
+            true,
+            """
+            {
+              "summary": "Split rate limiting into middleware then config, preserving per-tenant protection.",
+              "subtasks": [
+                { "id": "ST-1", "title": "Token-bucket middleware", "description": "Limiter keyed by tenant id", "acceptanceCriteria": "over-limit requests get 429", "estimateHours": 6, "complexity": "medium", "dependsOn": [] },
+                { "id": "ST-2", "title": "Per-tenant config", "description": "Read the limit from tenant config", "acceptanceCriteria": "limit is configurable", "estimateHours": 4, "complexity": "low", "dependsOn": ["ST-1"] }
+              ]
+            }
+            """),
+        new DocumentExample(
+            "invalid-cycle-and-sizing",
+            false,
+            """
+            {
+              "summary": "Two mutually dependent tasks, one mis-sized.",
+              "subtasks": [
+                { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 6, "complexity": "low", "dependsOn": ["ST-2"] },
+                { "id": "ST-2", "title": "B", "description": "b", "estimateHours": 1, "complexity": "low", "dependsOn": ["ST-1"] }
+              ]
+            }
+            """,
+            new[] { SizingOutOfRange, CyclicDependsOn, NoPrerequisiteOrder }),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Types/DependencyGraphCheck.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Types/DependencyGraphCheck.cs
@@ -1,0 +1,218 @@
+namespace Tamma.Core.Documents.Types;
+
+/// <summary>
+/// The per-document-type violation code vocabulary the shared
+/// <see cref="DependencyGraphCheck"/> emits. Each document type that carries a
+/// dependency graph (Story 39-3 <c>Decomposition</c>, Story 39-4 <c>Plan</c>)
+/// supplies its OWN SCREAMING_SNAKE_CASE code strings so the shared checker keeps
+/// one implementation while every type keeps its own vocabulary (Design Decision
+/// D10 — codes are platform vocabulary).
+/// </summary>
+internal readonly record struct DependencyGraphCodes(
+    string DuplicateId,
+    string DanglingDependency,
+    string SelfDependency,
+    string Cyclic,
+    string NoPrerequisiteOrder);
+
+/// <summary>
+/// The single, shared dependency-graph checker (Story 39-3 step 2, Design
+/// Decision D10). Extracted UP FRONT so Story 39-4's <c>Plan</c> type reuses ONE
+/// copy of the cycle / dangling / self / duplicate / topological-order checks
+/// rather than minting a second implementation.
+///
+/// <para>
+/// The checks are pure over an <c>(id, dependsOn)</c> node list and return
+/// domain-phrased <see cref="DocumentViolation"/>s (never bare schema paths) so
+/// 39-9's repair ring can feed the message back to the model. The canonical
+/// example is the cycle path — <c>"Cyclic dependsOn: ST-2 -> ST-4 -> ST-2"</c>
+/// names the actual members.
+/// </para>
+///
+/// <para>
+/// Acyclicity ⟺ a topological order exists (Kahn's algorithm is the constructive
+/// proof). Rather than run Kahn separately, the DFS back-edge detection below is
+/// the equivalent decision procedure; when it finds a cycle it emits BOTH the
+/// naming <see cref="DependencyGraphCodes.Cyclic"/> code AND the stable
+/// <see cref="DependencyGraphCodes.NoPrerequisiteOrder"/> signal (D10) that
+/// downstream sequencing consumers (Stories 2-15/2-16) key on.
+/// </para>
+/// </summary>
+internal static class DependencyGraphCheck
+{
+    /// <summary>
+    /// Run the graph checks over <paramref name="nodes"/>, returning every
+    /// violation found (empty when the graph is a clean DAG with unique ids).
+    /// Nodes with an empty id are the caller's responsibility to flag (they are
+    /// not graph vertices); this checker only considers non-empty ids.
+    /// </summary>
+    internal static List<DocumentViolation> Check(
+        IReadOnlyList<(string Id, IReadOnlyList<string> DependsOn)> nodes,
+        DependencyGraphCodes codes)
+    {
+        var violations = new List<DocumentViolation>();
+
+        // ---- 1. duplicate ids (baseline kept-first — now loud) ------------------
+        var idCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var (id, _) in nodes)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                continue;
+            idCounts.TryGetValue(id, out var count);
+            idCounts[id] = count + 1;
+        }
+
+        foreach (var (id, count) in idCounts.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (count > 1)
+                violations.Add(new DocumentViolation(
+                    codes.DuplicateId,
+                    $"Duplicate task id '{id}' — task ids must be unique so dependencies are unambiguous."));
+        }
+
+        var idSet = new HashSet<string>(idCounts.Keys, StringComparer.Ordinal);
+
+        // Build the adjacency from the FIRST occurrence of each id (mirrors the
+        // baseline's keep-first behaviour) so a duplicate does not double the edges.
+        var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var order = new List<string>();
+        foreach (var (id, dependsOn) in nodes)
+        {
+            if (string.IsNullOrWhiteSpace(id) || adjacency.ContainsKey(id))
+                continue;
+            adjacency[id] = dependsOn?.Where(d => !string.IsNullOrWhiteSpace(d)).Select(d => d.Trim()).ToList()
+                            ?? new List<string>();
+            order.Add(id);
+        }
+
+        // ---- 2. self / dangling edges (baseline pruned — now loud) --------------
+        var reportedSelf = new HashSet<string>(StringComparer.Ordinal);
+        var reportedDangling = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in order)
+        {
+            foreach (var dep in adjacency[id])
+            {
+                if (string.Equals(dep, id, StringComparison.Ordinal))
+                {
+                    if (reportedSelf.Add(id))
+                        violations.Add(new DocumentViolation(
+                            codes.SelfDependency,
+                            $"Task '{id}' depends on itself — a task cannot be its own prerequisite."));
+                }
+                else if (!idSet.Contains(dep))
+                {
+                    if (reportedDangling.Add($"{id}->{dep}"))
+                        violations.Add(new DocumentViolation(
+                            codes.DanglingDependency,
+                            $"Task '{id}' depends on '{dep}', which is not a task in this document."));
+                }
+            }
+        }
+
+        // ---- 3. cycles over the CLEAN graph (self/dangling excluded) ------------
+        // Only real edges (both endpoints present, not self) can form a cycle, so
+        // self-loops and dangling refs above never manufacture a phantom cycle.
+        var clean = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var id in order)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var edges = new List<string>();
+            foreach (var dep in adjacency[id])
+            {
+                if (string.Equals(dep, id, StringComparison.Ordinal)) continue;
+                if (!idSet.Contains(dep)) continue;
+                if (!seen.Add(dep)) continue;
+                edges.Add(dep);
+            }
+            clean[id] = edges;
+        }
+
+        var cyclePath = FindCycle(order, clean);
+        if (cyclePath is not null)
+        {
+            violations.Add(new DocumentViolation(
+                codes.Cyclic,
+                $"Cyclic dependsOn: {string.Join(" -> ", cyclePath)}"));
+            violations.Add(new DocumentViolation(
+                codes.NoPrerequisiteOrder,
+                "No prerequisite order exists — the dependency graph has a cycle, so the tasks " +
+                "cannot be topologically sequenced."));
+        }
+
+        return violations;
+    }
+
+    /// <summary>
+    /// Iterative DFS with an explicit frame stack over the clean adjacency. On the
+    /// first back-edge (an edge into a node still on the active path) it walks the
+    /// path to render the cycle members, closing the loop back to the re-entered
+    /// node (e.g. <c>ST-2 -&gt; ST-4 -&gt; ST-2</c>). Returns <c>null</c> for a DAG.
+    /// </summary>
+    private static List<string>? FindCycle(
+        IReadOnlyList<string> order,
+        IReadOnlyDictionary<string, List<string>> adjacency)
+    {
+        const int Unvisited = 0, Active = 1, Finished = 2;
+        var state = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var id in order)
+            state[id] = Unvisited;
+
+        foreach (var root in order)
+        {
+            if (state[root] != Unvisited)
+                continue;
+
+            var stack = new Stack<Frame>();
+            var path = new List<string> { root };
+            state[root] = Active;
+            stack.Push(new Frame(root, adjacency[root]));
+
+            while (stack.Count > 0)
+            {
+                var frame = stack.Peek();
+                if (frame.Index < frame.Deps.Count)
+                {
+                    var dep = frame.Deps[frame.Index];
+                    frame.Index++;
+
+                    if (state[dep] == Unvisited)
+                    {
+                        state[dep] = Active;
+                        path.Add(dep);
+                        stack.Push(new Frame(dep, adjacency[dep]));
+                    }
+                    else if (state[dep] == Active)
+                    {
+                        // Back-edge into the active path: dep..current is the cycle.
+                        var startIndex = path.IndexOf(dep);
+                        var cycle = path.GetRange(startIndex, path.Count - startIndex);
+                        cycle.Add(dep); // close the loop
+                        return cycle;
+                    }
+                    // Finished node: a cross/forward edge, not a cycle — skip.
+                }
+                else
+                {
+                    state[frame.Node] = Finished;
+                    stack.Pop();
+                    path.RemoveAt(path.Count - 1);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private sealed class Frame
+    {
+        public Frame(string node, List<string> deps)
+        {
+            Node = node;
+            Deps = deps;
+        }
+
+        public string Node { get; }
+        public List<string> Deps { get; }
+        public int Index { get; set; }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Findings.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Types/Findings.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tamma.Core.Documents.Types;
+
+/// <summary>
+/// One synthesized research finding — the typed analogue of the legacy
+/// <c>Tamma.Activities.Research.Models.ResearchFinding</c> (Design Decision D2:
+/// wire shape verbatim). An optional additive <see cref="Rank"/> makes the
+/// ranking explicit; when absent, list order is the ranking (baseline behaviour).
+/// </summary>
+public sealed record Finding
+{
+    [JsonPropertyName("title")] public string Title { get; init; } = "";
+    [JsonPropertyName("summary")] public string Summary { get; init; } = "";
+    [JsonPropertyName("relevance")] public decimal Relevance { get; init; }
+    [JsonPropertyName("confidence")] public decimal Confidence { get; init; }
+    [JsonPropertyName("citations")] public IReadOnlyList<string> Citations { get; init; } = [];
+
+    /// <summary>Optional explicit rank. When present on ANY finding, it must be present on ALL, with no duplicates.</summary>
+    [JsonPropertyName("rank")] public int? Rank { get; init; }
+}
+
+/// <summary>
+/// A synthesized research report: an overview <see cref="Summary"/> plus the
+/// ranked, scored <see cref="Items"/>. The record member is <c>Items</c> (C#
+/// forbids a member named like its enclosing type) carrying
+/// <c>[JsonPropertyName("findings")]</c> so the wire shape matches the legacy
+/// <c>ResearchReport</c>.
+/// </summary>
+public sealed record Findings
+{
+    [JsonPropertyName("topic")] public string Topic { get; init; } = "";
+    [JsonPropertyName("summary")] public string Summary { get; init; } = "";
+    [JsonPropertyName("findings")] public IReadOnlyList<Finding> Items { get; init; } = [];
+    [JsonPropertyName("overallConfidence")] public decimal OverallConfidence { get; init; }
+}
+
+/// <summary>
+/// <see cref="IDocumentType"/> for the <c>findings</c> document (Story 39-3 AC3).
+/// Enforces cited evidence per finding, <c>relevance</c>/<c>confidence</c> ∈ [0,1]
+/// rejected (not clamped), and a ranking rule (explicit ranks or ordered with no
+/// duplicates). Deliberate tightenings over the baseline are enumerated in the
+/// completion notes (AC6).
+/// </summary>
+public sealed class FindingsDocumentType : IDocumentType
+{
+    /// <summary>Payload could not be deserialized into the typed shape.</summary>
+    public const string MalformedPayload = "MALFORMED_PAYLOAD";
+
+    /// <summary>Baseline fail-closed: a report with no overview summary is not actionable.</summary>
+    public const string MissingSummary = "MISSING_SUMMARY";
+
+    /// <summary>
+    /// Inherited baseline choice: <c>ResearchParsing</c> fails closed on an empty findings list,
+    /// so an empty list is a violation, NOT a valid "nothing found" (documented per AC3).
+    /// </summary>
+    public const string EmptyFindings = "EMPTY_FINDINGS";
+
+    /// <summary>A finding with neither a title nor a summary is an empty shell.</summary>
+    public const string FindingEmptyShell = "FINDING_EMPTY_SHELL";
+
+    /// <summary>A finding with no citations — AC3's evidence rule (tightening; baseline never required citations).</summary>
+    public const string MissingEvidence = "MISSING_EVIDENCE";
+
+    /// <summary>A finding <c>relevance</c> outside [0,1] — rejected, not clamped (D6).</summary>
+    public const string RelevanceOutOfRange = "RELEVANCE_OUT_OF_RANGE";
+
+    /// <summary>A <c>confidence</c> (per-finding or <c>overallConfidence</c>) outside [0,1] — rejected, not clamped (D6).</summary>
+    public const string ConfidenceOutOfRange = "CONFIDENCE_OUT_OF_RANGE";
+
+    /// <summary>Two findings carry the same explicit <c>rank</c>.</summary>
+    public const string DuplicateRank = "DUPLICATE_RANK";
+
+    /// <summary>Some findings carry an explicit <c>rank</c> and some do not — ranks must be all-or-nothing.</summary>
+    public const string PartialRanks = "PARTIAL_RANKS";
+
+    public string Key => DocumentTypeKey.Findings.ToWire();
+    public int SchemaVersion => 1;
+    public Type PayloadClrType => typeof(Findings);
+
+    public DocumentValidationResult Validate(JsonElement payload)
+    {
+        Findings? doc;
+        try
+        {
+            doc = payload.Deserialize<Findings>(DocumentJson.Options);
+        }
+        catch (JsonException)
+        {
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload could not be parsed as a findings document."));
+        }
+
+        if (doc is null)
+            return DocumentValidationResult.Invalid(new DocumentViolation(
+                MalformedPayload, "The payload deserialized to null."));
+
+        var violations = new List<DocumentViolation>();
+
+        if (string.IsNullOrWhiteSpace(doc.Summary))
+            violations.Add(new DocumentViolation(
+                MissingSummary, "The report has no summary — the overview of the research is required."));
+
+        if (doc.OverallConfidence < 0m || doc.OverallConfidence > 1m)
+            violations.Add(new DocumentViolation(
+                ConfidenceOutOfRange,
+                $"overallConfidence is {doc.OverallConfidence} — confidence must be within [0, 1]."));
+
+        var findings = doc.Items ?? [];
+        if (findings.Count == 0)
+        {
+            violations.Add(new DocumentViolation(
+                EmptyFindings,
+                "The report has no findings — the baseline research parser fails closed on an empty " +
+                "findings list, so an empty list is a violation, not a valid 'nothing found'."));
+        }
+
+        var index = 0;
+        foreach (var finding in findings)
+        {
+            index++;
+            var label = string.IsNullOrWhiteSpace(finding.Title) ? $"#{index}" : $"'{finding.Title}'";
+
+            if (string.IsNullOrWhiteSpace(finding.Title) && string.IsNullOrWhiteSpace(finding.Summary))
+                violations.Add(new DocumentViolation(
+                    FindingEmptyShell,
+                    $"Finding {label} has neither a title nor a summary — it is an empty shell."));
+
+            if ((finding.Citations ?? []).Count == 0)
+                violations.Add(new DocumentViolation(
+                    MissingEvidence,
+                    $"Finding {label} cites no evidence — every finding must reference at least one source."));
+
+            if (finding.Relevance < 0m || finding.Relevance > 1m)
+                violations.Add(new DocumentViolation(
+                    RelevanceOutOfRange,
+                    $"Finding {label} has relevance {finding.Relevance} — relevance must be within [0, 1]."));
+
+            if (finding.Confidence < 0m || finding.Confidence > 1m)
+                violations.Add(new DocumentViolation(
+                    ConfidenceOutOfRange,
+                    $"Finding {label} has confidence {finding.Confidence} — confidence must be within [0, 1]."));
+        }
+
+        AddRankViolations(findings, violations);
+
+        return violations.Count == 0
+            ? DocumentValidationResult.Valid()
+            : DocumentValidationResult.Invalid(violations.ToArray());
+    }
+
+    private static void AddRankViolations(IReadOnlyList<Finding> findings, List<DocumentViolation> violations)
+    {
+        var ranked = findings.Where(f => f.Rank.HasValue).ToList();
+        if (ranked.Count == 0)
+            return; // no explicit ranks — list order is the ranking (baseline parity).
+
+        if (ranked.Count != findings.Count)
+        {
+            violations.Add(new DocumentViolation(
+                PartialRanks,
+                "Some findings carry an explicit rank and some do not — either every finding is ranked " +
+                "or none are (list order is the ranking)."));
+            return;
+        }
+
+        var seen = new HashSet<int>();
+        var reported = false;
+        foreach (var value in ranked.Select(f => f.Rank!.Value))
+        {
+            if (!seen.Add(value) && !reported)
+            {
+                violations.Add(new DocumentViolation(
+                    DuplicateRank, $"Two findings share rank {value} — explicit ranks must be unique."));
+                reported = true;
+            }
+        }
+    }
+
+    public string RenderContract() => Contract;
+
+    public IReadOnlyList<DocumentExample> Examples => s_examples;
+
+    // ── Contract + examples ──────────────────────────────────────────────────
+    // The quoted tokens below are pinned by ContractBindingTests.Bindings for the
+    // (product_owner, research) cell → ResearchParsing.ParseReport (7 tokens):
+    // "summary", "findings", "title", "relevance", "confidence", "citations",
+    // "overallConfidence".
+    private const string Contract =
+        """
+        Return ONLY a JSON object of this shape:
+        {
+          "topic": "the question researched",
+          "summary": "overview of the synthesized research",
+          "findings": [
+            {
+              "title": "short finding headline",
+              "summary": "what was learned and why it matters",
+              "relevance": 0.9,
+              "confidence": 0.8,
+              "citations": ["src/File.cs", "https://example"]
+            }
+          ],
+          "overallConfidence": 0.85
+        }
+        Rules: every finding must cite at least one source in "citations"; "relevance" and
+        "confidence" (per finding and "overallConfidence") must be within [0, 1]; findings are
+        ranked by list order unless every finding carries a unique "rank".
+        """;
+
+    private static readonly IReadOnlyList<DocumentExample> s_examples = new[]
+    {
+        new DocumentExample(
+            "valid-two-findings",
+            true,
+            """
+            {
+              "topic": "per-tenant rate limiting",
+              "summary": "No limiter exists; a token-bucket keyed by tenant id is the lowest-risk introduction.",
+              "findings": [
+                { "title": "No existing limiter", "summary": "The API pipeline has no rate-limiting middleware.", "relevance": 0.95, "confidence": 0.9, "citations": ["src/Program.cs"] },
+                { "title": "Tenant id on context", "summary": "Every request already resolves a tenant id.", "relevance": 0.8, "confidence": 0.85, "citations": ["src/TenantContext.cs"] }
+              ],
+              "overallConfidence": 0.88
+            }
+            """),
+        new DocumentExample(
+            "invalid-no-evidence-and-out-of-range",
+            false,
+            """
+            {
+              "topic": "caching",
+              "summary": "Two problematic findings.",
+              "findings": [
+                { "title": "Uncited", "summary": "No citation here.", "relevance": 0.5, "confidence": 0.5, "citations": [] },
+                { "title": "Out of range", "summary": "Bad relevance.", "relevance": 1.5, "confidence": 0.5, "citations": ["a.cs"] }
+              ],
+              "overallConfidence": 0.7
+            }
+            """,
+            new[] { MissingEvidence, RelevanceOutOfRange }),
+    };
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/Types/BaselineSubsumptionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/Types/BaselineSubsumptionTests.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+using Tamma.Activities.Decomposition;
+using Tamma.Activities.Research;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Activities.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC6 — proves the typed validators SUBSUME the fail-closed baseline
+/// parsers. This suite lives in <c>Tamma.Activities.Tests</c> (Design Decision D7)
+/// because it references BOTH the OLD parsers (<c>Tamma.Activities</c>) and the NEW
+/// types (<c>Tamma.Core</c>); <c>Tamma.Core.Tests</c> stays dependency-light.
+///
+/// <para><b>Two kinds of negative (D8):</b></para>
+/// <list type="bullet">
+///   <item><b>JSON-shaped negatives</b> (missing summary, empty subtasks, out-of-range
+///   score, missing rationale, all-shell items) — valid JSON that the baseline parser
+///   returns null on; the typed path rejects them via a named <c>Validate</c> violation.</item>
+///   <item><b>Text-level negatives</b> ("no json here at all", "{ not valid json", empty,
+///   whitespace) — these can never REACH <c>Validate</c>: the 39-2 envelope boundary
+///   (<c>JsonDocument.Parse</c> / the payload deserialize) throws first. This suite
+///   asserts they throw at that boundary — a loud rejection, never a silent default.</item>
+/// </list>
+///
+/// <para>It also asserts the <b>lenient-spelling divergences</b>: inputs the baseline
+/// ACCEPTED by normalizing/pruning ("Trivial.", dangling ST-99, negative hours,
+/// uncited findings) now produce violations — each cites the completion-notes entry,
+/// making the AC6 divergence list executable.</para>
+/// </summary>
+[TestFixture]
+public class BaselineSubsumptionTests
+{
+    private static readonly DecompositionDocumentType Decomposition = new();
+    private static readonly FindingsDocumentType Findings = new();
+    private static readonly AmbiguityAssessmentDocumentType Ambiguity = new();
+
+    private static DocumentValidationResult Validate(IDocumentType type, string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return type.Validate(doc.RootElement);
+    }
+
+    // Copied fixture constants from the baseline *ParsingTests.cs (in-assembly reuse,
+    // per D7 — the parser tests live in this same project but are private constants).
+
+    // ── Decomposition JSON-shaped negatives (baseline → null) ────────────────
+    private const string NoSummary = """{ "subtasks": [ { "id": "ST-1", "title": "a" } ] }""";
+    private const string EmptySubtasks = """{ "summary": "s", "subtasks": [] }""";
+    private const string AllShells =
+        """{ "summary": "s", "subtasks": [ { "id": "", "title": "" }, { "id": "ST-1", "title": "", "description": "" } ] }""";
+
+    [Test]
+    public void Decomposition_json_negatives_rejected_by_both()
+    {
+        DecompositionParsing.ParseDecomposition(NoSummary).Should().BeNull("baseline floor");
+        Validate(Decomposition, NoSummary).IsValid.Should().BeFalse("typed path must also reject a missing summary");
+
+        DecompositionParsing.ParseDecomposition(EmptySubtasks).Should().BeNull("baseline floor");
+        Validate(Decomposition, EmptySubtasks).IsValid.Should().BeFalse("typed path must also reject empty subtasks");
+
+        DecompositionParsing.ParseDecomposition(AllShells).Should().BeNull("baseline floor");
+        Validate(Decomposition, AllShells).IsValid.Should().BeFalse("typed path must also reject all-shell subtasks");
+    }
+
+    // ── Research JSON-shaped negatives (baseline → null) ─────────────────────
+    private const string NoSummaryReport = """{ "findings": [ { "summary": "a" } ] }""";
+    private const string EmptyFindings = """{ "summary": "s", "findings": [] }""";
+    private const string AllShellFindings = """{ "summary": "s", "findings": [ { "title": "", "summary": "" } ] }""";
+
+    [Test]
+    public void Findings_json_negatives_rejected_by_both()
+    {
+        ResearchParsing.ParseReport(NoSummaryReport).Should().BeNull("baseline floor");
+        Validate(Findings, NoSummaryReport).IsValid.Should().BeFalse("typed path must also reject a missing summary");
+
+        ResearchParsing.ParseReport(EmptyFindings).Should().BeNull("baseline floor");
+        Validate(Findings, EmptyFindings).IsValid.Should().BeFalse("typed path must also reject empty findings");
+
+        ResearchParsing.ParseReport(AllShellFindings).Should().BeNull("baseline floor");
+        Validate(Findings, AllShellFindings).IsValid.Should().BeFalse("typed path must also reject all-shell findings");
+    }
+
+    // ── Ambiguity JSON-shaped negatives (baseline → null) ────────────────────
+    private const string NoScore = """{ "rationale": "r", "ambiguities": [] }""";
+    private const string BadScore = """{ "score": "high", "rationale": "r" }""";
+    private const string NoRationale = """{ "score": 0.5, "ambiguities": [] }""";
+
+    [TestCase("1.5")]
+    [TestCase("-0.2")]
+    [TestCase("42")]
+    public void Ambiguity_out_of_range_score_rejected_by_both(string raw)
+    {
+        var json = $$"""{ "score": {{raw}}, "rationale": "r" }""";
+        AmbiguityParsing.ParseAssessment(json).Should().BeNull("baseline floor");
+        Validate(Ambiguity, json).IsValid.Should().BeFalse("typed path must also reject an out-of-range score");
+    }
+
+    [Test]
+    public void Ambiguity_json_negatives_rejected_by_both()
+    {
+        AmbiguityParsing.ParseAssessment(NoScore).Should().BeNull("baseline floor");
+        Validate(Ambiguity, NoScore).IsValid.Should().BeFalse("typed path must also reject a missing score");
+
+        AmbiguityParsing.ParseAssessment(BadScore).Should().BeNull("baseline floor");
+        Validate(Ambiguity, BadScore).IsValid.Should().BeFalse("typed path must also reject a non-numeric score");
+
+        AmbiguityParsing.ParseAssessment(NoRationale).Should().BeNull("baseline floor");
+        Validate(Ambiguity, NoRationale).IsValid.Should().BeFalse("typed path must also reject a missing rationale");
+    }
+
+    // ── Text-level negatives: never reach Validate — throw at the JSON boundary (D8) ──
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("no json here at all")]
+    [TestCase("{ not valid json")]
+    public void Text_level_negatives_throw_at_the_json_boundary(string input)
+    {
+        // The baseline parsers fail closed (null) on these; in the typed pipeline the
+        // 39-2 boundary throws BEFORE any Validate is reached — a loud rejection.
+        DecompositionParsing.ParseDecomposition(input).Should().BeNull("baseline floor");
+
+        var act = () => JsonDocument.Parse(input);
+        act.Should().Throw<JsonException>(
+            "malformed / empty text cannot reach Validate — it fails loud at the JSON parse boundary (D8)");
+    }
+
+    // ── Lenient-spelling divergences: baseline ACCEPTED, typed path now REJECTS ──
+    // Each assertion cites its completion-notes.md divergence entry (AC6 executable).
+
+    [Test]
+    public void Divergence_strict_complexity_label()
+    {
+        // completion-notes: "Strict label sets" — baseline folds "Trivial." → low; typed rejects.
+        const string messy = """{ "summary": "s", "subtasks": [ { "id": "A", "title": "t", "complexity": "Trivial.", "estimateHours": 4 } ] }""";
+
+        DecompositionParsing.ParseDecomposition(messy).Should().NotBeNull("baseline accepts and folds the label");
+        Validate(Decomposition, messy).Violations.Select(v => v.Code)
+            .Should().Contain(DecompositionDocumentType.UnknownComplexity,
+                "completion-notes: strict label sets (senior_developer/decompose-issue)");
+    }
+
+    [Test]
+    public void Divergence_dangling_and_self_now_loud()
+    {
+        // completion-notes: "dangling/self/duplicate now loud" — baseline prunes silently.
+        const string withBadDeps =
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "a", "estimateHours": 4, "dependsOn": ["ST-1", "ST-99"] },
+              { "id": "ST-2", "title": "b", "estimateHours": 4, "dependsOn": ["ST-1", "ST-1"] }
+            ] }
+            """;
+
+        DecompositionParsing.ParseDecomposition(withBadDeps).Should().NotBeNull("baseline accepts and prunes edges");
+        var codes = Validate(Decomposition, withBadDeps).Violations.Select(v => v.Code).ToList();
+        codes.Should().Contain(DecompositionDocumentType.SelfDependsOn,
+            "completion-notes: self-dependency now loud (senior_developer/decompose-issue)");
+        codes.Should().Contain(DecompositionDocumentType.DanglingDependsOn,
+            "completion-notes: dangling dependency now loud (senior_developer/decompose-issue)");
+    }
+
+    [Test]
+    public void Divergence_negative_and_missing_hours_now_out_of_range()
+    {
+        // completion-notes: "sizing 2–8h" — baseline clamped negatives to 0 and called 2–8h a soft guide.
+        const string negativeHours = """{ "summary": "s", "subtasks": [ { "id": "A", "title": "t", "estimateHours": -4 } ] }""";
+
+        DecompositionParsing.ParseDecomposition(negativeHours).Should().NotBeNull("baseline accepts and clamps to 0");
+        Validate(Decomposition, negativeHours).Violations.Select(v => v.Code)
+            .Should().Contain(DecompositionDocumentType.SizingOutOfRange,
+                "completion-notes: 2–8h sizing rule (senior_developer/decompose-issue)");
+    }
+
+    [Test]
+    public void Divergence_evidence_required()
+    {
+        // completion-notes: "evidence required" — baseline never required citations.
+        const string uncited =
+            """{ "summary": "s", "findings": [ { "title": "F", "summary": "b", "relevance": 0.5, "confidence": 0.5 } ] }""";
+
+        ResearchParsing.ParseReport(uncited).Should().NotBeNull("baseline accepts a finding with no citations");
+        Validate(Findings, uncited).Violations.Select(v => v.Code)
+            .Should().Contain(FindingsDocumentType.MissingEvidence,
+                "completion-notes: evidence required (product_owner/research)");
+    }
+
+    [Test]
+    public void Divergence_ambiguity_confidence_rejected_not_clamped()
+    {
+        // completion-notes: "ranges rejected not clamped" — baseline CLAMPS ambiguity confidence.
+        const string highConf = """{ "score": 0.5, "confidence": 1.4, "rationale": "r" }""";
+
+        AmbiguityParsing.ParseAssessment(highConf).Should().NotBeNull("baseline accepts and clamps confidence");
+        Validate(Ambiguity, highConf).Violations.Select(v => v.Code)
+            .Should().Contain(AmbiguityAssessmentDocumentType.ConfidenceOutOfRange,
+                "completion-notes: confidence rejected not clamped (product_owner/score-ambiguity)");
+    }
+
+    [Test]
+    public void Divergence_strict_ambiguity_type_label()
+    {
+        // completion-notes: "label sets strict" — baseline folds "unclear" → vague; typed rejects.
+        const string unclear =
+            """{ "score": 0.5, "rationale": "r", "ambiguities": [ { "type": "unclear", "description": "d", "severity": "high" } ] }""";
+
+        AmbiguityParsing.ParseAssessment(unclear).Should().NotBeNull("baseline accepts and folds the label");
+        Validate(Ambiguity, unclear).Violations.Select(v => v.Code)
+            .Should().Contain(AmbiguityAssessmentDocumentType.UnknownAmbiguityType,
+                "completion-notes: strict label sets (product_owner/score-ambiguity)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/Types/RoundTripCompatibilityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/Types/RoundTripCompatibilityTests.cs
@@ -1,0 +1,308 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Ambiguity;
+using Tamma.Activities.Clarify;
+using Tamma.Activities.Core;
+using Tamma.Activities.Decomposition;
+using Tamma.Activities.Research;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+using TypedAmbiguity = Tamma.Core.Documents.Types.AmbiguityAssessment;
+using TypedClarification = Tamma.Core.Documents.Types.Clarification;
+using TypedDecomposition = Tamma.Core.Documents.Types.Decomposition;
+using TypedFindings = Tamma.Core.Documents.Types.Findings;
+
+namespace Tamma.Activities.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC7 — the 39-12/39-13 transition-window proof. For every fixture the
+/// baseline <c>*ParsingTests.cs</c> parse successfully, this suite: slices the JSON
+/// (the <see cref="JsonSlice"/> first-<c>{</c>/last-<c>}</c> idiom), deserializes into
+/// the TYPED payload (<see cref="DocumentJson.Options"/>), runs <c>Validate</c> and
+/// asserts either valid or EXACTLY the documented deliberate-tightening codes, then
+/// RE-SERIALIZES the typed payload and asserts the OLD parser still returns non-null
+/// with its key fields intact. Lives in <c>Tamma.Activities.Tests</c> (D7).
+/// </summary>
+[TestFixture]
+public class RoundTripCompatibilityTests
+{
+    private static readonly DecompositionDocumentType DecompositionType = new();
+    private static readonly FindingsDocumentType FindingsType = new();
+    private static readonly AmbiguityAssessmentDocumentType AmbiguityType = new();
+    private static readonly ClarificationDocumentType ClarificationType = new();
+
+    private static T DeserializeTyped<T>(string fixture)
+    {
+        var sliced = JsonSlice.ExtractObject(fixture);
+        sliced.Should().NotBeNull("the fixture must carry a JSON object to round-trip");
+        return JsonSerializer.Deserialize<T>(sliced!, DocumentJson.Options)!;
+    }
+
+    private static void AssertValidateCodes(IDocumentType type, string json, params string[] expectedCodes)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var result = type.Validate(doc.RootElement);
+        result.Violations.Select(v => v.Code).Distinct()
+            .Should().BeEquivalentTo(expectedCodes,
+                "the typed validator's verdict on this baseline fixture must match the documented set " +
+                "(empty = valid; otherwise exactly the deliberate tightenings)");
+        result.IsValid.Should().Be(expectedCodes.Length == 0);
+    }
+
+    // ── Decomposition fixtures ────────────────────────────────────────────────
+    private const string ValidDecomposition =
+        """
+        {
+          "summary": "Split the auth feature into a schema slice, an endpoint slice, and a UI slice.",
+          "subtasks": [
+            { "id": "ST-1", "title": "Add users table", "description": "schema + migration", "acceptanceCriteria": "applies cleanly", "estimateHours": 3, "complexity": "low", "dependsOn": [] },
+            { "id": "ST-2", "title": "Login endpoint", "description": "POST /login", "acceptanceCriteria": "200 + token", "estimateHours": 6, "complexity": "medium", "dependsOn": ["ST-1"] },
+            { "id": "ST-3", "title": "Login UI", "description": "form", "acceptanceCriteria": "user can log in", "estimateHours": 5, "complexity": "high", "dependsOn": ["ST-2"] }
+          ]
+        }
+        """;
+
+    private const string TemplateShapedDecomposition =
+        """
+        {
+          "summary": "Deliver rate limiting incrementally: middleware first, then config.",
+          "subtasks": [
+            { "id": "ST-1", "title": "Token-bucket middleware", "description": "limiter keyed by tenant id", "acceptanceCriteria": "over the limit → 429", "estimateHours": 6, "complexity": "medium", "dependsOn": [] },
+            { "id": "ST-2", "title": "Per-tenant config", "description": "read limit from config", "acceptanceCriteria": "configurable per tenant", "estimateHours": 4, "complexity": "low", "dependsOn": ["ST-1"] }
+          ]
+        }
+        """;
+
+    private const string MessyDecomposition =
+        """{ "summary": "s", "subtasks": [ { "id": "A", "title": "t", "complexity": "Trivial.", "estimateHours": -4 } ] }""";
+
+    private const string WithBadDepsDecomposition =
+        """
+        { "summary": "s", "subtasks": [
+          { "id": "ST-1", "title": "a", "dependsOn": ["ST-1", "ST-99"] },
+          { "id": "ST-2", "title": "b", "dependsOn": ["ST-1", "ST-1"] }
+        ] }
+        """;
+
+    private const string WithShellsDecomposition =
+        """
+        { "summary": "s", "subtasks": [
+          { "id": "", "title": "no id" },
+          { "id": "ST-1", "title": "", "description": "" },
+          { "id": "ST-2", "title": "real" },
+          { "id": "ST-2", "title": "duplicate id kept as first" }
+        ] }
+        """;
+
+    [Test]
+    public void Decomposition_valid_fixtures_round_trip()
+    {
+        foreach (var fixture in new[] { ValidDecomposition, TemplateShapedDecomposition })
+        {
+            AssertValidateCodes(DecompositionType, fixture);
+
+            var typed = DeserializeTyped<TypedDecomposition>(fixture);
+            var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+
+            var parsed = DecompositionParsing.ParseDecomposition(reserialized);
+            parsed.Should().NotBeNull("the old parser must still parse the re-serialized typed payload");
+            parsed!.Summary.Should().NotBeNullOrWhiteSpace();
+            parsed.Subtasks.Should().NotBeEmpty();
+        }
+    }
+
+    [Test]
+    public void Decomposition_tightening_fixtures_round_trip()
+    {
+        AssertValidateCodes(DecompositionType, MessyDecomposition,
+            DecompositionDocumentType.SizingOutOfRange, DecompositionDocumentType.UnknownComplexity);
+        AssertValidateCodes(DecompositionType, WithBadDepsDecomposition,
+            DecompositionDocumentType.SelfDependsOn, DecompositionDocumentType.DanglingDependsOn,
+            DecompositionDocumentType.SizingOutOfRange);
+        AssertValidateCodes(DecompositionType, WithShellsDecomposition,
+            DecompositionDocumentType.TaskMissingId, DecompositionDocumentType.TaskEmptyShell,
+            DecompositionDocumentType.DuplicateTaskId, DecompositionDocumentType.SizingOutOfRange);
+
+        // The old parser still recovers a non-null decomposition from each re-serialized payload.
+        foreach (var fixture in new[] { MessyDecomposition, WithBadDepsDecomposition, WithShellsDecomposition })
+        {
+            var typed = DeserializeTyped<TypedDecomposition>(fixture);
+            var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+            DecompositionParsing.ParseDecomposition(reserialized).Should().NotBeNull(
+                "even a fixture that trips a documented tightening must remain parseable by the old parser");
+        }
+    }
+
+    // ── Research (Findings) fixtures ──────────────────────────────────────────
+    private const string ValidReport =
+        """
+        {
+          "topic": "caching layer",
+          "summary": "Redis is the incumbent cache; no per-tenant isolation exists yet.",
+          "findings": [
+            { "title": "Low relevance", "summary": "Minor note", "relevance": 0.2, "confidence": 0.9, "citations": ["a.cs"] },
+            { "title": "High relevance", "summary": "Core finding", "relevance": 0.95, "confidence": 0.6, "citations": ["b.cs", "https://x"] },
+            { "title": "Mid relevance", "summary": "Secondary", "relevance": 0.5, "confidence": 0.8 }
+          ],
+          "overallConfidence": 0.77
+        }
+        """;
+
+    private const string TemplateShapedReport =
+        """
+        {
+          "topic": "per-tenant rate limiting",
+          "summary": "No rate limiter exists; a token-bucket keyed by tenant id is lowest-risk.",
+          "findings": [
+            { "title": "No existing limiter", "summary": "No rate-limiting middleware today.", "relevance": 0.95, "confidence": 0.9, "citations": ["src/Program.cs"] },
+            { "title": "Tenant id on context", "summary": "Every request resolves a tenant id.", "relevance": 0.8, "confidence": 0.85, "citations": ["src/TenantContext.cs"] }
+          ],
+          "overallConfidence": 0.88
+        }
+        """;
+
+    private const string NoOverallReport =
+        """
+        { "summary": "s", "findings": [
+          { "summary": "a", "relevance": 0.5, "confidence": 0.4 },
+          { "summary": "b", "relevance": 0.5, "confidence": 0.6 }
+        ] }
+        """;
+
+    private const string NoTopicReport = """{ "summary": "s", "findings": [ { "summary": "a" } ] }""";
+
+    private const string WithShellReport =
+        """
+        { "summary": "s", "findings": [
+          { "title": "", "summary": "" },
+          { "summary": "real finding" }
+        ] }
+        """;
+
+    [Test]
+    public void Findings_fixtures_round_trip()
+    {
+        // TemplateShapedReport cites every finding → valid; the others trip MISSING_EVIDENCE
+        // (evidence-required tightening) and withShell also FINDING_EMPTY_SHELL.
+        AssertValidateCodes(FindingsType, TemplateShapedReport);
+        AssertValidateCodes(FindingsType, ValidReport, FindingsDocumentType.MissingEvidence);
+        AssertValidateCodes(FindingsType, NoOverallReport, FindingsDocumentType.MissingEvidence);
+        AssertValidateCodes(FindingsType, NoTopicReport, FindingsDocumentType.MissingEvidence);
+        AssertValidateCodes(FindingsType, WithShellReport,
+            FindingsDocumentType.FindingEmptyShell, FindingsDocumentType.MissingEvidence);
+
+        foreach (var fixture in new[] { ValidReport, TemplateShapedReport, NoOverallReport, NoTopicReport, WithShellReport })
+        {
+            var typed = DeserializeTyped<TypedFindings>(fixture);
+            var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+            var parsed = ResearchParsing.ParseReport(reserialized, topic: "fallback");
+            parsed.Should().NotBeNull("the old parser must still parse the re-serialized typed payload");
+            parsed!.Summary.Should().NotBeNullOrWhiteSpace();
+            parsed.Findings.Should().NotBeEmpty();
+        }
+    }
+
+    // ── Ambiguity fixtures ────────────────────────────────────────────────────
+    private const string ValidAssessment =
+        """
+        {
+          "score": 0.72,
+          "confidence": 0.8,
+          "rationale": "Missing acceptance criteria and vague wording.",
+          "ambiguities": [
+            { "type": "missing", "description": "No acceptance criteria", "severity": "high", "recommendation": "Ask for measurable ACs" },
+            { "type": "Vague.", "description": "\"fast\" is not quantified", "severity": "medium", "recommendation": "Define a latency target" }
+          ]
+        }
+        """;
+
+    private const string TemplateShapedAssessment =
+        """
+        {
+          "score": 0.65,
+          "confidence": 0.75,
+          "rationale": "Omits the target platform and contradicts itself on auth.",
+          "ambiguities": [
+            { "type": "missing", "description": "Target platform is unstated.", "severity": "high", "recommendation": "Confirm the platform." },
+            { "type": "contradictory", "description": "'no login' but 'per-user history'.", "severity": "high", "recommendation": "Resolve whether accounts are required." },
+            { "type": "implicit", "description": "Assumes English-only.", "severity": "low", "recommendation": "Confirm i18n scope." }
+          ]
+        }
+        """;
+
+    private const string ClearAssessment =
+        """{ "score": 0.05, "confidence": 0.9, "rationale": "Fully specified with clear ACs.", "ambiguities": [] }""";
+
+    private const string ZeroAssessment = """{ "score": 0.0, "rationale": "Crystal clear." }""";
+    private const string NoConfAssessment = """{ "score": 0.4, "rationale": "Some gaps." }""";
+
+    [Test]
+    public void Ambiguity_fixtures_round_trip()
+    {
+        // ValidAssessment carries "Vague." (a synonym the baseline folds) → the strict
+        // typed validator reports UNKNOWN_AMBIGUITY_TYPE; the rest are clean.
+        AssertValidateCodes(AmbiguityType, ValidAssessment, AmbiguityAssessmentDocumentType.UnknownAmbiguityType);
+        AssertValidateCodes(AmbiguityType, TemplateShapedAssessment);
+        AssertValidateCodes(AmbiguityType, ClearAssessment);
+        AssertValidateCodes(AmbiguityType, ZeroAssessment);
+        AssertValidateCodes(AmbiguityType, NoConfAssessment);
+
+        foreach (var fixture in new[] { ValidAssessment, TemplateShapedAssessment, ClearAssessment, ZeroAssessment, NoConfAssessment })
+        {
+            var typed = DeserializeTyped<TypedAmbiguity>(fixture);
+            var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+            var parsed = AmbiguityParsing.ParseAssessment(reserialized);
+            parsed.Should().NotBeNull("the old parser must still parse the re-serialized typed payload");
+            parsed!.Rationale.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+
+    // ── Clarification fixtures (shaped per the two prompt templates) ──────────
+    private const string QuestionsClarification =
+        """
+        {
+          "phase": "questions",
+          "questions": ["What is the target platform?", "Which auth model is expected?"]
+        }
+        """;
+
+    private const string ResolutionClarification =
+        """
+        {
+          "phase": "resolution",
+          "clarifiedRequirement": "the full disambiguated requirement text",
+          "questions": ["What is the target platform?"],
+          "resolutions": [ { "questionId": "Q-1", "requirement": "web only" } ],
+          "remainingAmbiguities": ["anything still unclear"],
+          "resolved": true
+        }
+        """;
+
+    [Test]
+    public void Clarification_questions_phase_round_trips()
+    {
+        AssertValidateCodes(ClarificationType, QuestionsClarification);
+
+        var typed = DeserializeTyped<TypedClarification>(QuestionsClarification);
+        var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+
+        var questions = ClarifyParsing.ParseQuestions(reserialized);
+        questions.Should().HaveCount(2, "the old ParseQuestions must still recover the questions array");
+        questions.Should().Contain("What is the target platform?");
+    }
+
+    [Test]
+    public void Clarification_resolution_phase_round_trips()
+    {
+        AssertValidateCodes(ClarificationType, ResolutionClarification);
+
+        var typed = DeserializeTyped<TypedClarification>(ResolutionClarification);
+        var reserialized = JsonSerializer.Serialize(typed, DocumentJson.Options);
+
+        var clarification = ClarifyParsing.ParseClarification(reserialized);
+        clarification.Should().NotBeNull("the old ParseClarification must still parse the re-serialized payload");
+        clarification!.ClarifiedRequirement.Should().Be("the full disambiguated requirement text");
+        clarification.Resolved.Should().BeTrue();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeRegistryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentTypeRegistryTests.cs
@@ -21,16 +21,17 @@ public class DocumentTypeRegistryTests
     // -----------------------------------------------------------------------
 
     [Test]
-    public void All_registered_types_count_is_pinned_at_zero()
+    public void All_registered_types_count_is_pinned()
     {
-        // 39-2 ships the vocabulary (DocumentTypeKey, 10 members) but ZERO
-        // IDocumentType implementations — consciously (Design Decision D3). The
-        // implementations arrive later and bump this pin:
-        //   Story 39-3 registers +4  (0 -> 4)
+        // 39-2 shipped the vocabulary (DocumentTypeKey, 10 members) with ZERO
+        // IDocumentType implementations. The implementations arrive in stages and
+        // bump this pin consciously:
+        //   Story 39-3 registers +4  (0 -> 4)  <-- DONE (Decomposition, Findings,
+        //                                        AmbiguityAssessment, Clarification)
         //   Story 39-4 registers +6  (4 -> 10, matching the DocumentTypeKey count)
         // Same posture as RolePhaseMapTests' HaveCount(79): the number moving is a
         // conscious, reviewed edit here, never an accident.
-        DocumentTypeRegistry.All.Should().HaveCount(0);
+        DocumentTypeRegistry.All.Should().HaveCount(4);
     }
 
     // -----------------------------------------------------------------------
@@ -75,9 +76,22 @@ public class DocumentTypeRegistryTests
                 using var doc = JsonDocument.Parse(example.PayloadJson);
                 var result = type.Validate(doc.RootElement);
                 if (example.IsValid)
+                {
                     result.IsValid.Should().BeTrue($"valid example '{example.Name}' must pass {type.Key}.Validate");
+                    example.ExpectedViolationCodes.Should().BeEmpty(
+                        $"valid example '{example.Name}' declares no expected violation codes");
+                }
                 else
+                {
                     result.IsValid.Should().BeFalse($"invalid example '{example.Name}' must fail {type.Key}.Validate");
+
+                    // D9: an invalid example must emit EXACTLY its declared codes.
+                    example.ExpectedViolationCodes.Should().NotBeEmpty(
+                        $"invalid example '{example.Name}' must declare the codes it expects (D9)");
+                    result.Violations.Select(v => v.Code).Should().BeEquivalentTo(
+                        example.ExpectedViolationCodes,
+                        $"invalid example '{example.Name}' must emit exactly its ExpectedViolationCodes");
+                }
             }
         }
     }
@@ -96,11 +110,26 @@ public class DocumentTypeRegistryTests
     [Test]
     public void Resolve_valid_but_unimplemented_key_throws_not_registered()
     {
-        var byString = () => DocumentTypeRegistry.Resolve("decomposition");
+        // 'decomposition' is now registered by 39-3; use a still-unimplemented key
+        // (Plan — 39-4 scope) to exercise the NOT_REGISTERED fail-loud path.
+        var byString = () => DocumentTypeRegistry.Resolve("plan");
         byString.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.NOT_REGISTERED");
 
-        var byEnum = () => DocumentTypeRegistry.Resolve(DocumentTypeKey.Decomposition);
+        var byEnum = () => DocumentTypeRegistry.Resolve(DocumentTypeKey.Plan);
         byEnum.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.TYPE.NOT_REGISTERED");
+    }
+
+    [Test]
+    public void Registered_39_3_keys_resolve_to_their_implementations()
+    {
+        DocumentTypeRegistry.Resolve(DocumentTypeKey.Decomposition).PayloadClrType
+            .Should().Be(typeof(Tamma.Core.Documents.Types.Decomposition));
+        DocumentTypeRegistry.Resolve(DocumentTypeKey.Findings).PayloadClrType
+            .Should().Be(typeof(Tamma.Core.Documents.Types.Findings));
+        DocumentTypeRegistry.Resolve(DocumentTypeKey.AmbiguityAssessment).PayloadClrType
+            .Should().Be(typeof(Tamma.Core.Documents.Types.AmbiguityAssessment));
+        DocumentTypeRegistry.Resolve(DocumentTypeKey.Clarification).PayloadClrType
+            .Should().Be(typeof(Tamma.Core.Documents.Types.Clarification));
     }
 
     // -----------------------------------------------------------------------

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/AmbiguityAssessmentDocumentTypeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/AmbiguityAssessmentDocumentTypeTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC4 — domain rules for <see cref="AmbiguityAssessmentDocumentType"/>:
+/// score ∈ [0,1], closed typed set, and clear (low score) + empty ambiguities valid.
+/// </summary>
+[TestFixture]
+public class AmbiguityAssessmentDocumentTypeTests
+{
+    private static readonly AmbiguityAssessmentDocumentType Type = new();
+
+    private static DocumentValidationResult Validate(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return Type.Validate(doc.RootElement);
+    }
+
+    private static IEnumerable<string> Codes(DocumentValidationResult r) => r.Violations.Select(v => v.Code);
+
+    [Test]
+    public void Score_zero_is_valid()
+    {
+        var r = Validate("""{ "score": 0.0, "rationale": "Crystal clear." }""");
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Low_score_with_empty_ambiguities_is_valid()
+    {
+        var r = Validate(
+            """{ "score": 0.05, "confidence": 0.9, "rationale": "Fully specified.", "ambiguities": [] }""");
+
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [TestCase("1.5")]
+    [TestCase("-0.2")]
+    public void Out_of_range_score_is_reported(string score)
+    {
+        var r = Validate($$"""{ "score": {{score}}, "rationale": "r" }""");
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.ScoreOutOfRange);
+    }
+
+    [Test]
+    public void Missing_rationale_is_reported()
+    {
+        var r = Validate("""{ "score": 0.5, "ambiguities": [] }""");
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.MissingRationale);
+    }
+
+    [Test]
+    public void Out_of_range_confidence_is_rejected_not_clamped()
+    {
+        var r = Validate("""{ "score": 0.5, "confidence": 1.4, "rationale": "r" }""");
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.ConfidenceOutOfRange);
+    }
+
+    [Test]
+    public void Unknown_type_is_strict()
+    {
+        var r = Validate(
+            """
+            { "score": 0.5, "rationale": "r", "ambiguities": [
+              { "type": "unclear", "description": "vague", "severity": "high", "recommendation": "fix" }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.UnknownAmbiguityType);
+    }
+
+    [Test]
+    public void Unspecified_type_is_accepted_it_is_in_the_closed_set()
+    {
+        var r = Validate(
+            """
+            { "score": 0.5, "rationale": "r", "ambiguities": [
+              { "type": "unspecified", "description": "d", "severity": "low", "recommendation": "fix" }
+            ] }
+            """);
+
+        Codes(r).Should().NotContain(AmbiguityAssessmentDocumentType.UnknownAmbiguityType);
+    }
+
+    [Test]
+    public void Unknown_severity_is_strict()
+    {
+        var r = Validate(
+            """
+            { "score": 0.5, "rationale": "r", "ambiguities": [
+              { "type": "vague", "description": "d", "severity": "critical", "recommendation": "fix" }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.UnknownSeverity);
+    }
+
+    [Test]
+    public void Ambiguity_without_description_is_empty_shell()
+    {
+        var r = Validate(
+            """
+            { "score": 0.5, "rationale": "r", "ambiguities": [
+              { "type": "vague", "description": "", "severity": "low", "recommendation": "fix" }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(AmbiguityAssessmentDocumentType.AmbiguityEmptyShell);
+    }
+
+    [Test]
+    public void Missing_score_fails_at_the_deserialization_boundary()
+    {
+        // The score is load-bearing (required). Its absence fails loud as
+        // MALFORMED_PAYLOAD — the typed subsumption of the baseline fail-closed.
+        var r = Validate("""{ "rationale": "r", "ambiguities": [] }""");
+
+        r.IsValid.Should().BeFalse();
+        Codes(r).Should().Equal(new[] { AmbiguityAssessmentDocumentType.MalformedPayload });
+    }
+
+    [Test]
+    public void Non_numeric_score_is_malformed_payload()
+    {
+        var r = Validate("""{ "score": "high", "rationale": "r" }""");
+
+        r.IsValid.Should().BeFalse();
+        Codes(r).Should().Equal(new[] { AmbiguityAssessmentDocumentType.MalformedPayload });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/ClarificationDocumentTypeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/ClarificationDocumentTypeTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC5 — two-phase rules for <see cref="ClarificationDocumentType"/>:
+/// open-ended questions (D4) and resolution references.
+/// </summary>
+[TestFixture]
+public class ClarificationDocumentTypeTests
+{
+    private static readonly ClarificationDocumentType Type = new();
+
+    private static DocumentValidationResult Validate(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return Type.Validate(doc.RootElement);
+    }
+
+    private static IEnumerable<string> Codes(DocumentValidationResult r) => r.Violations.Select(v => v.Code);
+
+    [Test]
+    public void Questions_phase_with_one_open_question_is_valid()
+    {
+        var r = Validate("""{ "phase": "questions", "questions": ["What is the target platform?"] }""");
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Zero_questions_is_no_open_question()
+    {
+        var r = Validate("""{ "phase": "questions", "questions": [] }""");
+        Codes(r).Should().Contain(ClarificationDocumentType.NoOpenQuestion);
+    }
+
+    [Test]
+    public void All_closed_form_questions_is_no_open_question()
+    {
+        var r = Validate("""{ "phase": "questions", "questions": ["Is it fast?", "Should we ship?"] }""");
+        Codes(r).Should().Contain(ClarificationDocumentType.NoOpenQuestion);
+    }
+
+    [Test]
+    public void Mixed_set_with_one_open_question_is_valid()
+    {
+        // "Is it fast?" is closed-form; "What should we build?" is open — the
+        // conservative D4 rule fires only when ALL are closed.
+        var r = Validate(
+            """{ "phase": "questions", "questions": ["Is it fast?", "What should we build?"] }""");
+
+        Codes(r).Should().NotContain(ClarificationDocumentType.NoOpenQuestion);
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Closed_form_with_or_alternative_is_open()
+    {
+        // An "or"-alternative is not a simple yes/no — not closed-form.
+        var r = Validate(
+            """{ "phase": "questions", "questions": ["Should we use Redis or Postgres?"] }""");
+
+        Codes(r).Should().NotContain(ClarificationDocumentType.NoOpenQuestion);
+    }
+
+    [Test]
+    public void Empty_question_entry_is_reported()
+    {
+        var r = Validate(
+            """{ "phase": "questions", "questions": ["What is expected?", "  "] }""");
+
+        Codes(r).Should().Contain(ClarificationDocumentType.EmptyQuestion);
+    }
+
+    [Test]
+    public void Resolution_phase_without_clarified_requirement_is_reported()
+    {
+        var r = Validate(
+            """{ "phase": "resolution", "questions": ["What?"], "resolutions": [ { "questionId": "Q-1", "requirement": "web" } ] }""");
+
+        Codes(r).Should().Contain(ClarificationDocumentType.MissingClarifiedRequirement);
+    }
+
+    [Test]
+    public void Resolution_with_empty_requirement_is_reported()
+    {
+        var r = Validate(
+            """
+            { "phase": "resolution", "clarifiedRequirement": "the requirement", "questions": ["What?"],
+              "resolutions": [ { "questionId": "Q-1", "requirement": "" } ] }
+            """);
+
+        Codes(r).Should().Contain(ClarificationDocumentType.EmptyResolution);
+    }
+
+    [Test]
+    public void Resolution_referencing_unknown_question_is_reported()
+    {
+        var r = Validate(
+            """
+            { "phase": "resolution", "clarifiedRequirement": "the requirement",
+              "questions": ["Q1?", "Q2?", "Q3?"],
+              "resolutions": [ { "questionId": "Q-9", "requirement": "web" } ] }
+            """);
+
+        Codes(r).Should().Contain(ClarificationDocumentType.UnknownQuestionRef);
+    }
+
+    [Test]
+    public void Valid_resolution_phase_passes()
+    {
+        var r = Validate(
+            """
+            { "phase": "resolution", "clarifiedRequirement": "the full disambiguated requirement",
+              "questions": ["What is the target platform?"],
+              "resolutions": [ { "questionId": "Q-1", "requirement": "web only" } ],
+              "remainingAmbiguities": [], "resolved": true }
+            """);
+
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Bad_phase_is_unknown_phase()
+    {
+        var r = Validate("""{ "phase": "answers", "questions": ["What?"] }""");
+
+        r.IsValid.Should().BeFalse();
+        Codes(r).Should().Equal(new[] { ClarificationDocumentType.UnknownPhase });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/DecompositionDocumentTypeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/DecompositionDocumentTypeTests.cs
@@ -1,0 +1,215 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC2 — domain rules for <see cref="DecompositionDocumentType"/>:
+/// unique ids, no dangling / self / cyclic dependsOn (cycle path named), 2–8h
+/// sizing, and the stable NO_PREREQUISITE_ORDER signal.
+/// </summary>
+[TestFixture]
+public class DecompositionDocumentTypeTests
+{
+    private static readonly DecompositionDocumentType Type = new();
+
+    private static DocumentValidationResult Validate(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return Type.Validate(doc.RootElement);
+    }
+
+    private static IEnumerable<string> Codes(DocumentValidationResult r) => r.Violations.Select(v => v.Code);
+
+    [Test]
+    public void Valid_graph_passes()
+    {
+        var r = Validate(
+            """
+            {
+              "summary": "Split into two ordered tasks.",
+              "subtasks": [
+                { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4, "complexity": "low", "dependsOn": [] },
+                { "id": "ST-2", "title": "B", "description": "b", "estimateHours": 8, "complexity": "high", "dependsOn": ["ST-1"] }
+              ]
+            }
+            """);
+
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Inclusive_bounds_2h_and_8h_pass()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 2, "complexity": "low" },
+              { "id": "ST-2", "title": "B", "description": "b", "estimateHours": 8, "complexity": "low" }
+            ] }
+            """);
+
+        Codes(r).Should().NotContain(DecompositionDocumentType.SizingOutOfRange);
+    }
+
+    [Test]
+    public void Duplicate_id_is_reported()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4 },
+              { "id": "ST-1", "title": "B", "description": "b", "estimateHours": 4 }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.DuplicateTaskId);
+    }
+
+    [Test]
+    public void Dangling_dependency_names_the_missing_id()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4, "dependsOn": ["ST-99"] }
+            ] }
+            """);
+
+        r.Violations.Should().Contain(v =>
+            v.Code == DecompositionDocumentType.DanglingDependsOn && v.Message.Contains("ST-99"));
+    }
+
+    [Test]
+    public void Self_dependency_is_reported()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4, "dependsOn": ["ST-1"] }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.SelfDependsOn);
+        // A self-loop is excluded from the cycle graph — it is NOT a CYCLIC violation.
+        Codes(r).Should().NotContain(DecompositionDocumentType.CyclicDependsOn);
+    }
+
+    [Test]
+    public void Two_node_cycle_reports_path_and_no_prerequisite_order()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-2", "title": "A", "description": "a", "estimateHours": 4, "dependsOn": ["ST-4"] },
+              { "id": "ST-4", "title": "B", "description": "b", "estimateHours": 4, "dependsOn": ["ST-2"] }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.NoPrerequisiteOrder);
+        r.Violations.Should().Contain(v =>
+            v.Code == DecompositionDocumentType.CyclicDependsOn &&
+            v.Message.Contains("ST-2") && v.Message.Contains("ST-4") && v.Message.Contains("->"));
+    }
+
+    [Test]
+    public void Three_node_cycle_reports_cyclic_and_no_prerequisite_order()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4, "dependsOn": ["ST-2"] },
+              { "id": "ST-2", "title": "B", "description": "b", "estimateHours": 4, "dependsOn": ["ST-3"] },
+              { "id": "ST-3", "title": "C", "description": "c", "estimateHours": 4, "dependsOn": ["ST-1"] }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.CyclicDependsOn);
+        Codes(r).Should().Contain(DecompositionDocumentType.NoPrerequisiteOrder);
+    }
+
+    [TestCase("1.5")]
+    [TestCase("9")]
+    [TestCase("0")]
+    public void Estimate_outside_2_to_8_is_out_of_range(string hours)
+    {
+        var r = Validate(
+            $$"""
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": {{hours}} }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.SizingOutOfRange);
+    }
+
+    [Test]
+    public void Missing_estimate_defaults_to_zero_and_is_out_of_range()
+    {
+        var r = Validate(
+            """{ "summary": "s", "subtasks": [ { "id": "ST-1", "title": "A", "description": "a" } ] }""");
+
+        Codes(r).Should().Contain(DecompositionDocumentType.SizingOutOfRange);
+    }
+
+    [Test]
+    public void Unknown_complexity_is_strict()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "subtasks": [
+              { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4, "complexity": "Trivial." }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(DecompositionDocumentType.UnknownComplexity);
+    }
+
+    [Test]
+    public void Missing_summary_is_reported()
+    {
+        var r = Validate(
+            """{ "subtasks": [ { "id": "ST-1", "title": "A", "description": "a", "estimateHours": 4 } ] }""");
+
+        Codes(r).Should().Contain(DecompositionDocumentType.MissingSummary);
+    }
+
+    [Test]
+    public void Empty_subtasks_is_no_tasks()
+    {
+        var r = Validate("""{ "summary": "s", "subtasks": [] }""");
+        Codes(r).Should().Contain(DecompositionDocumentType.NoTasks);
+    }
+
+    [Test]
+    public void Empty_id_is_task_missing_id()
+    {
+        var r = Validate(
+            """{ "summary": "s", "subtasks": [ { "id": "", "title": "A", "description": "a", "estimateHours": 4 } ] }""");
+
+        Codes(r).Should().Contain(DecompositionDocumentType.TaskMissingId);
+    }
+
+    [Test]
+    public void Shell_task_is_reported()
+    {
+        var r = Validate(
+            """{ "summary": "s", "subtasks": [ { "id": "ST-1", "title": "", "description": "", "estimateHours": 4 } ] }""");
+
+        Codes(r).Should().Contain(DecompositionDocumentType.TaskEmptyShell);
+    }
+
+    [Test]
+    public void Type_mismatch_is_malformed_payload_not_a_throw()
+    {
+        // "subtasks" as a string is a wire type mismatch → deserialization fails →
+        // a single MALFORMED_PAYLOAD violation, never a throw out of Validate.
+        var r = Validate("""{ "summary": "s", "subtasks": "not-an-array" }""");
+
+        r.IsValid.Should().BeFalse();
+        Codes(r).Should().Equal(new[] { DecompositionDocumentType.MalformedPayload });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/FindingsDocumentTypeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/FindingsDocumentTypeTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC3 — domain rules for <see cref="FindingsDocumentType"/>: cited
+/// evidence, [0,1] ranges rejected (not clamped), ranking rule, and the inherited
+/// empty-findings-list baseline choice.
+/// </summary>
+[TestFixture]
+public class FindingsDocumentTypeTests
+{
+    private static readonly FindingsDocumentType Type = new();
+
+    private static DocumentValidationResult Validate(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return Type.Validate(doc.RootElement);
+    }
+
+    private static IEnumerable<string> Codes(DocumentValidationResult r) => r.Violations.Select(v => v.Code);
+
+    [Test]
+    public void Valid_report_with_citations_passes()
+    {
+        var r = Validate(
+            """
+            {
+              "topic": "t", "summary": "s",
+              "findings": [ { "title": "F", "summary": "body", "relevance": 0.9, "confidence": 0.8, "citations": ["a.cs"] } ],
+              "overallConfidence": 0.85
+            }
+            """);
+
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Finding_without_citations_is_missing_evidence()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "findings": [ { "title": "F", "summary": "body", "relevance": 0.5, "confidence": 0.5, "citations": [] } ] }
+            """);
+
+        Codes(r).Should().Contain(FindingsDocumentType.MissingEvidence);
+    }
+
+    [Test]
+    public void Out_of_range_relevance_and_confidence_are_rejected_not_clamped()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "findings": [ { "title": "F", "summary": "b", "relevance": 1.5, "confidence": -0.2, "citations": ["a.cs"] } ] }
+            """);
+
+        Codes(r).Should().Contain(FindingsDocumentType.RelevanceOutOfRange);
+        Codes(r).Should().Contain(FindingsDocumentType.ConfidenceOutOfRange);
+    }
+
+    [Test]
+    public void Out_of_range_overall_confidence_is_rejected()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "overallConfidence": 1.2,
+              "findings": [ { "title": "F", "summary": "b", "relevance": 0.5, "confidence": 0.5, "citations": ["a.cs"] } ] }
+            """);
+
+        Codes(r).Should().Contain(FindingsDocumentType.ConfidenceOutOfRange);
+    }
+
+    [Test]
+    public void Duplicate_explicit_ranks_are_reported()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "findings": [
+              { "title": "A", "summary": "a", "relevance": 0.5, "confidence": 0.5, "citations": ["a.cs"], "rank": 1 },
+              { "title": "B", "summary": "b", "relevance": 0.5, "confidence": 0.5, "citations": ["b.cs"], "rank": 1 }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(FindingsDocumentType.DuplicateRank);
+    }
+
+    [Test]
+    public void Some_but_not_all_ranks_is_partial_ranks()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "findings": [
+              { "title": "A", "summary": "a", "relevance": 0.5, "confidence": 0.5, "citations": ["a.cs"], "rank": 1 },
+              { "title": "B", "summary": "b", "relevance": 0.5, "confidence": 0.5, "citations": ["b.cs"] }
+            ] }
+            """);
+
+        Codes(r).Should().Contain(FindingsDocumentType.PartialRanks);
+    }
+
+    [Test]
+    public void No_ranks_at_all_is_valid_order_is_rank()
+    {
+        var r = Validate(
+            """
+            { "summary": "s", "findings": [
+              { "title": "A", "summary": "a", "relevance": 0.9, "confidence": 0.5, "citations": ["a.cs"] },
+              { "title": "B", "summary": "b", "relevance": 0.5, "confidence": 0.5, "citations": ["b.cs"] }
+            ] }
+            """);
+
+        Codes(r).Should().NotContain(FindingsDocumentType.PartialRanks);
+        Codes(r).Should().NotContain(FindingsDocumentType.DuplicateRank);
+        r.IsValid.Should().BeTrue(string.Join(", ", Codes(r)));
+    }
+
+    [Test]
+    public void Empty_findings_list_is_the_inherited_baseline_violation()
+    {
+        var r = Validate("""{ "summary": "s", "findings": [] }""");
+        Codes(r).Should().Contain(FindingsDocumentType.EmptyFindings);
+    }
+
+    [Test]
+    public void Missing_summary_is_reported()
+    {
+        var r = Validate(
+            """{ "findings": [ { "title": "F", "summary": "b", "relevance": 0.5, "confidence": 0.5, "citations": ["a.cs"] } ] }""");
+
+        Codes(r).Should().Contain(FindingsDocumentType.MissingSummary);
+    }
+
+    [Test]
+    public void Shell_finding_is_reported()
+    {
+        var r = Validate(
+            """{ "summary": "s", "findings": [ { "title": "", "summary": "", "relevance": 0.5, "confidence": 0.5, "citations": ["a.cs"] } ] }""");
+
+        Codes(r).Should().Contain(FindingsDocumentType.FindingEmptyShell);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/RenderContractTokenTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Types/RenderContractTokenTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Types;
+
+/// <summary>
+/// Story 39-3 AC8 — each type's <see cref="IDocumentType.RenderContract"/> output
+/// must carry every JSON token its prompt cells are bound to in
+/// <c>ContractBindingTests.Bindings</c> (Tamma.Activities.Tests), plus be
+/// deterministic (39-16 diffs it in CI).
+///
+/// <para>The binding map is private to <c>ContractBindingTests</c>, so the token
+/// lists are duplicated here DELIBERATELY (cross-referenced by comment). Story
+/// 39-16 later collapses this duplication by GENERATING the contract from the type
+/// — until then this pin is the guard that a contract does not drift out of the
+/// tokens the fail-closed parsers require.</para>
+/// </summary>
+[TestFixture]
+public class RenderContractTokenTests
+{
+    // (senior_developer, decompose-issue) → DecompositionParsing.ParseDecomposition (9 tokens)
+    private static readonly string[] DecompositionTokens =
+    {
+        "\"summary\"", "\"subtasks\"", "\"id\"", "\"title\"", "\"description\"",
+        "\"acceptanceCriteria\"", "\"estimateHours\"", "\"complexity\"", "\"dependsOn\"",
+    };
+
+    // (product_owner, research) → ResearchParsing.ParseReport (7 tokens)
+    private static readonly string[] FindingsTokens =
+    {
+        "\"summary\"", "\"findings\"", "\"title\"", "\"relevance\"",
+        "\"confidence\"", "\"citations\"", "\"overallConfidence\"",
+    };
+
+    // (product_owner, score-ambiguity) → AmbiguityParsing.ParseAssessment (8 tokens)
+    private static readonly string[] AmbiguityTokens =
+    {
+        "\"score\"", "\"confidence\"", "\"rationale\"", "\"ambiguities\"",
+        "\"type\"", "\"description\"", "\"severity\"", "\"recommendation\"",
+    };
+
+    // (product_owner, clarify-requirements) → ParseQuestions pins the phrase "JSON array";
+    // (product_owner, incorporate-answers) → ParseClarification pins the three object tokens.
+    private static readonly string[] ClarificationTokens =
+    {
+        "JSON array", "\"clarifiedRequirement\"", "\"remainingAmbiguities\"", "\"resolved\"",
+    };
+
+    [TestCaseSource(nameof(Cases))]
+    public void Contract_contains_every_bound_token(IDocumentType type, string[] tokens)
+    {
+        var contract = type.RenderContract();
+        foreach (var token in tokens)
+            contract.Should().Contain(token, $"{type.Key} contract must carry the bound token {token}");
+    }
+
+    [TestCaseSource(nameof(Cases))]
+    public void Contract_is_deterministic(IDocumentType type, string[] tokens)
+    {
+        _ = tokens;
+        var first = type.RenderContract();
+        type.RenderContract().Should().Be(first);
+    }
+
+    private static IEnumerable<TestCaseData> Cases()
+    {
+        yield return new TestCaseData(new DecompositionDocumentType(), DecompositionTokens).SetName("decomposition");
+        yield return new TestCaseData(new FindingsDocumentType(), FindingsTokens).SetName("findings");
+        yield return new TestCaseData(new AmbiguityAssessmentDocumentType(), AmbiguityTokens).SetName("ambiguity-assessment");
+        yield return new TestCaseData(new ClarificationDocumentType(), ClarificationTokens).SetName("clarification");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/WorkflowInterfaceGraphTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/WorkflowInterfaceGraphTests.cs
@@ -25,10 +25,9 @@ public class WorkflowInterfaceGraphTests
     /// </summary>
     private static readonly HashSet<DocumentTypeKey> PendingImplementations = new()
     {
-        DocumentTypeKey.Findings,
-        DocumentTypeKey.AmbiguityAssessment,
-        DocumentTypeKey.Clarification,
-        DocumentTypeKey.Decomposition,
+        // Findings, AmbiguityAssessment, Clarification, Decomposition were
+        // implemented + registered by Story 39-3 — removed from the ratchet. The
+        // remaining 6 land in Story 39-4.
         DocumentTypeKey.Plan,
         DocumentTypeKey.Design,
         DocumentTypeKey.Review,

--- a/docs/stories/epic-39/story-39-3/completion-notes.md
+++ b/docs/stories/epic-39/story-39-3/completion-notes.md
@@ -1,0 +1,71 @@
+# Completion Notes — Story 39-3: Document Types Batch 1
+
+Status: implemented (Decomposition, Findings, AmbiguityAssessment, Clarification).
+
+## AC6 — Deliberate divergences from the baseline parsers
+
+The four typed validators are **supersets** of the fail-closed baseline parsers:
+every input a baseline parser rejects, the typed `Validate` also rejects (proven by
+`BaselineSubsumptionTests`). Where a baseline parser was **lenient** (accepted a
+value by normalizing, pruning, or clamping it), the typed validator deliberately
+**tightens** and emits a violation instead. Each divergence below is asserted as a
+live test in `BaselineSubsumptionTests` (its `because` message cites this file), so a
+stale entry has a failing twin in CI.
+
+| # | Divergence | Baseline behaviour | Typed behaviour | Violation code | Affected prompt cell(s) |
+|---|---|---|---|---|---|
+| 1 | **Per-task sizing 2–8h** | `estimateHours` clamped `<0 → 0`; 2–8h was "a soft guide", never enforced | Rejected when outside **[2, 8]** inclusive (missing → 0 → rejected) | `SIZING_OUT_OF_RANGE` | `senior_developer/decompose-issue` |
+| 2 | **Dangling `dependsOn`** | Pruned silently | Loud violation naming the missing id | `DANGLING_DEPENDS_ON` | `senior_developer/decompose-issue` |
+| 3 | **Self `dependsOn`** | Pruned silently | Loud violation | `SELF_DEPENDS_ON` | `senior_developer/decompose-issue` |
+| 4 | **Duplicate task id** | Kept the first, dropped the rest silently | Loud violation naming the id | `DUPLICATE_TASK_ID` | `senior_developer/decompose-issue` |
+| 5 | **Dependency cycles** | Deferred to Story 2-15 (not detected) | Loud violation rendering the cycle path (`ST-2 -> ST-4 -> ST-2`) **plus** the stable `NO_PREREQUISITE_ORDER` signal | `CYCLIC_DEPENDS_ON`, `NO_PREREQUISITE_ORDER` | `senior_developer/decompose-issue` |
+| 6 | **Complexity label set** | `SubtaskComplexities.Normalize` folded synonyms (`"Trivial." → low`) and defaulted unknowns to `medium` | Strict closed set `{low, medium, high}` — reject, don't normalize (D5) | `UNKNOWN_COMPLEXITY` | `senior_developer/decompose-issue` |
+| 7 | **Evidence required (findings)** | `citations` read but never required | Every finding must cite ≥1 source | `MISSING_EVIDENCE` | `product_owner/research` |
+| 8 | **`relevance`/`confidence` ranges (findings)** | Read unchecked (no range enforcement) | Rejected when outside [0,1] — reject, don't clamp (D6) | `RELEVANCE_OUT_OF_RANGE`, `CONFIDENCE_OUT_OF_RANGE` | `product_owner/research` |
+| 9 | **Ambiguity `confidence` range** | **Clamped** to [0,1] | Rejected when outside [0,1] — reject, don't clamp (D6) | `CONFIDENCE_OUT_OF_RANGE` | `product_owner/score-ambiguity` |
+| 10 | **Ambiguity type label set** | `AmbiguityTypes.Normalize` folded synonyms (`"unclear" → vague`) and defaulted unknowns to `unspecified` | Strict closed set `{vague, missing, contradictory, implicit, unspecified}` (D5) | `UNKNOWN_AMBIGUITY_TYPE` | `product_owner/score-ambiguity` |
+| 11 | **Ambiguity severity label set** | `AmbiguitySeverities.Normalize` folded synonyms (`"critical" → high`) and defaulted unknowns to `medium` | Strict closed set `{low, medium, high}` (D5) | `UNKNOWN_SEVERITY` | `product_owner/score-ambiguity` |
+| 12 | **Open-endedness (clarification)** | `ParseQuestions` required only ≥1 non-empty question | ≥1 non-empty question **and** not-all-closed-form (deterministic yes/no-auxiliary detector, D4) | `NO_OPEN_QUESTION` | `product_owner/clarify-requirements` |
+
+### Producer-side reconciliation (Story 39-13)
+
+The strict label sets (divergences 6, 10, 11) do **not** regress live traffic: Story
+39-13 migration reuses the existing `SubtaskComplexities.Normalize` /
+`AmbiguityTypes.Normalize` / `AmbiguitySeverities.Normalize` helpers **producer-side**,
+before the typed payload is constructed, so synonyms are folded to the canonical wire
+before `Validate` ever sees them. The 39-9 repair ring is the designed consumer of the
+remaining tightenings (sizing, evidence, ranges).
+
+### Boundary mapping (D8)
+
+Text-level baseline negatives (`""`, `"   "`, `"no json here at all"`, `"{ not valid
+json"`) can never reach `Validate` — the 39-2 JSON boundary throws first
+(`BaselineSubsumptionTests.Text_level_negatives_throw_at_the_json_boundary`). JSON-shaped
+negatives (missing summary, empty subtasks, out-of-range score, missing rationale,
+all-shell items) map to named `Validate` violations. A payload whose wire **types** are
+wrong (e.g. a non-numeric `score`, a string where an array is expected) deserializes to a
+single `MALFORMED_PAYLOAD` violation — `AmbiguityAssessment.score` is `required`, so an
+absent score also fails loud there (subsuming the baseline fail-closed on a missing score).
+
+## Notable design choices
+
+- **`DependencyGraphCheck` extracted up front** (`Tamma.Core/Documents/Types/`) so Story
+  39-4's `Plan` reuses one copy of the cycle/dangling/self/topological checks (D10). Each
+  document type supplies its own SCREAMING_SNAKE_CASE code strings via `DependencyGraphCodes`.
+- **`DocumentExample.ExpectedViolationCodes`** added additively (D9); the registry drift loop
+  now asserts each invalid example emits **exactly** its declared codes.
+- **Clarification is one flat two-phase payload** with a `phase` discriminator (D3); `questions`
+  stays an array of strings so `ClarifyParsing.ParseQuestions` still parses it, and the resolution
+  phase keeps `clarifiedRequirement`/`remainingAmbiguities`/`resolved` at the root for
+  `ClarifyParsing.ParseClarification`.
+
+## Minor deviations from the implementation-plan sketches
+
+- Payload records use **non-`required`, defaulted** properties for domain-checked load-bearing
+  fields (`summary`, `subtasks`, `rationale`, task `id`, …) rather than `required` as the plan's
+  illustrative sketches showed — so a missing field yields the **named** domain violation the Test
+  Plan pins (`MISSING_SUMMARY`, `NO_TASKS`, `MISSING_RATIONALE`, `TASK_MISSING_ID`) instead of a
+  generic deserialization failure. The one intentional `required` is `AmbiguityAssessment.Score`,
+  where the plan wants an absent score to fail loud with no named code available (→ `MALFORMED_PAYLOAD`).
+- `RenderContractTokenTests` and the cross-parser suites live exactly where D7 places them
+  (`Tamma.Activities.Tests/Documents/Types/`); `Tamma.Core.Tests` gained **no** `ProjectReference`.


### PR DESCRIPTION
## What

Epic 39 **PR-B** (Wave 2, gated on 39-2 which is now on `main`) — the first four typed documents, each an immutable payload record + `IDocumentType` validator, registered in `DocumentTypeRegistry` (count pin **0 → 4**, WorkflowInterface ratchet **−4**).

## Types & domain rules

- **Decomposition** — unique task ids; dangling/self/**cyclic** `dependsOn` (the cycle *path* is rendered in the message); 2–8h sizing (inclusive); `NO_PREREQUISITE_ORDER` stable topo signal for downstream sequencing.
- **Findings** — every finding cites evidence; `relevance`/`confidence` ∈ [0,1] **rejected, not clamped**; all-or-none explicit ranking; empty findings list = the baseline's fail-closed choice.
- **AmbiguityAssessment** — `score` ∈ [0,1]; closed category/severity sets (`vague|missing|contradictory|implicit|unspecified`, `low|medium|high`); a clear requirement with an empty ambiguity list is valid.
- **Clarification** — one flat two-phase payload (`phase: questions|resolution`); open-endedness rule (all-closed-form questions → `NO_OPEN_QUESTION`); resolution references questions by position (`Q-n`).

## Design highlights

- **Shared `DependencyGraphCheck`** extracted up front (DFS back-edge cycle detection + rendered path) so 39-4's `Plan` reuses one implementation.
- `DocumentExample` gains an additive `ExpectedViolationCodes`; the registry drift loop now asserts each invalid example emits *exactly* those codes.
- Wire shapes are byte-compatible with the baseline parsers, so **`RenderContract()` tokens still satisfy `ContractBindingTests`** (undisturbed).

## Compatibility proof (kept where the old parsers live)

The cross-parser **subsumption** + **round-trip** suites are in `Tamma.Activities.Tests` (so `Tamma.Core.Tests` stays dependency-light / Docker-free — no new `ProjectReference`). They prove: every input the fail-closed parsers reject, the typed validators also reject; and every fixture the parsers accept re-serializes and re-parses through the **old** parser intact — the 39-12/39-13 transition-window guarantee. The **12 deliberate tightenings** over baseline (strict sizing, dangling/self/duplicate now loud, evidence required, reject-not-clamp, strict labels, open-endedness) are enumerated in `story-39-3/completion-notes.md`, each pinned by a live test.

## Constraints (AC9)

No parser deleted, no workflow rewired, no `.csproj`/`ProjectReference` change, no Agents files touched. Build clean; **229 `Tamma.Core.Tests` green + 25 filtered `Tamma.Activities.Tests` green** (no Docker).

## Deviations (in completion-notes)

1. Load-bearing payload fields are non-`required` defaulted so a missing field yields the *named* violation the Test Plan pins (not a generic deserialize failure); the one `required` is `AmbiguityAssessment.Score` → `MALFORMED_PAYLOAD` when absent.
2. `DependencyGraphCheck` uses iterative-DFS back-edge detection and ties `NO_PREREQUISITE_ORDER` to cycle presence (the Kahn equivalent) — same observable contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_