### PR TITLE
feat(39-5): Acceptance Rules — configurable policy, autonomy dial, guardrails, admin API/UI

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/Permissions.cs
@@ -69,6 +69,15 @@ public static class Permissions
         // admin+owner reach. Single-user mode is unaffected — every signed-up
         // user is auto-owner of their personal tenant.
         ["pricing:manage"] = ["admin", "owner"],
+        // Story 39-5 — acceptance-rules management. Mirrors prompts:manage /
+        // conventions:manage: CLAUDE.md "Prompt Store Architecture / RBAC" (the
+        // acceptance-rules store follows the same tenant-scoped RBAC) requires
+        // PUT/DELETE of a tenant override to be reachable by tenant_owner OR
+        // tenant_admin (member → 403). The owner-only settings:manage would 403
+        // every tenant_admin, so the dedicated acceptance-rules:manage permission
+        // grants admin+owner reach. Single-user mode is unaffected — every
+        // signed-up user is auto-owner of their personal tenant.
+        ["acceptance-rules:manage"] = ["admin", "owner"],
     };
 
     public static bool HasPermission(string? role, string? permission)

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/AcceptanceRules/AcceptanceRulesDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/AcceptanceRules/AcceptanceRulesDtos.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Api.Dtos.AcceptanceRules;
+
+/// <summary>
+/// PUT body for <c>/api/acceptance-rules/{documentTypeKey}</c> (Story 39-5). The
+/// shape mirrors <see cref="AcceptanceRules"/>; <see cref="ToRules"/> maps it to
+/// the domain record which the service validates fail-loud (rejects out-of-range
+/// knobs and unknown taxonomy keys) before any write.
+/// </summary>
+public sealed record AcceptanceRulesUpsertRequest(
+    [property: JsonPropertyName("autonomyLevel")] int AutonomyLevel,
+    [property: JsonPropertyName("maxRevisionRounds")] int MaxRevisionRounds,
+    [property: JsonPropertyName("maxValidationRepairAttempts")] int MaxValidationRepairAttempts,
+    [property: JsonPropertyName("ambiguityEscalationThreshold")] double AmbiguityEscalationThreshold,
+    [property: JsonPropertyName("alwaysEscalate")] IReadOnlyList<EscalationClass>? AlwaysEscalate,
+    [property: JsonPropertyName("reviewerSelection")] ReviewerSelection ReviewerSelection,
+    [property: JsonPropertyName("decisionGuidance")] string DecisionGuidance,
+    [property: JsonPropertyName("routingGuidance")] string RoutingGuidance)
+{
+    /// <summary>Map to the domain record (unvalidated — the service calls <c>Validate()</c>).</summary>
+    public Tamma.Core.Documents.Policy.AcceptanceRules ToRules() => new()
+    {
+        AutonomyLevel = AutonomyLevel,
+        MaxRevisionRounds = MaxRevisionRounds,
+        MaxValidationRepairAttempts = MaxValidationRepairAttempts,
+        AmbiguityEscalationThreshold = AmbiguityEscalationThreshold,
+        AlwaysEscalate = AlwaysEscalate ?? Array.Empty<EscalationClass>(),
+        ReviewerSelection = ReviewerSelection,
+        DecisionGuidance = DecisionGuidance ?? string.Empty,
+        RoutingGuidance = RoutingGuidance ?? string.Empty,
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/AcceptanceRulesEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/AcceptanceRulesEndpoints.cs
@@ -1,0 +1,185 @@
+using System.Security.Claims;
+using Tamma.Api.Auth;
+using Tamma.Api.Dtos.AcceptanceRules;
+using Tamma.Api.Services.AcceptanceRules;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Minimal-API handlers for <c>/api/acceptance-rules</c> (Story 39-5 step 9). The
+/// heavy lifting lives in <see cref="AcceptanceRulesService"/>; DCB audit events
+/// are emitted from within its mutation methods (D12). Handlers branch on
+/// <see cref="ITammaModeProvider.Mode"/> + <see cref="ITenantContext"/> exactly
+/// like <c>PromptEndpoints</c>. The literal <c>base</c> segment addresses the
+/// principal base row (the dial).
+/// </summary>
+public static class AcceptanceRulesEndpoints
+{
+    // =======================================================================
+    // List — resolved rules for every document type + provenance
+    // =======================================================================
+
+    public static async Task<IResult> ListEffective(
+        AcceptanceRulesService store,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider,
+        ILoggerFactory loggerFactory)
+    {
+        try
+        {
+            IReadOnlyList<ResolvedAcceptanceRules> resolved;
+            if (modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid tenantId)
+                resolved = await store.ListEffectiveForTenantAsync(tenantId);
+            else if (tenantContext.TenantId is null)
+                // No tenant yet (bootstrap) — every type resolves to the shipped
+                // static default; no DB read needed. Mirror PromptEndpoints'
+                // "no overrides yet is a valid state" degradation.
+                resolved = DefaultsForAllTypes();
+            else
+                resolved = await store.ListEffectiveAsync(principal.GetUserId());
+            return Results.Ok(resolved);
+        }
+        catch (Exception ex) when (
+            ex is InvalidOperationException
+            || ex is Npgsql.NpgsqlException
+            || ex is Microsoft.EntityFrameworkCore.DbUpdateException)
+        {
+            loggerFactory.CreateLogger("AcceptanceRulesEndpoints.ListEffective").LogError(ex,
+                "ListEffective: returning shipped defaults because the per-tenant acceptance-rules store " +
+                "could not be queried (tenant={TenantId})", tenantContext.TenantId);
+            return Results.Ok(DefaultsForAllTypes());
+        }
+    }
+
+    // =======================================================================
+    // Defaults (read-only) — the shipped principal-base row
+    // =======================================================================
+
+    public static IResult GetDefaults() => Results.Ok(AcceptanceDefaults.Rules);
+
+    // =======================================================================
+    // Get resolved (one document type, or the literal `base` dial row)
+    // =======================================================================
+
+    public static async Task<IResult> GetResolved(
+        string documentTypeKey,
+        AcceptanceRulesService store,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var saas = modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid;
+
+        if (string.Equals(documentTypeKey, AcceptanceRulesService.BaseRowKeyLiteral, StringComparison.Ordinal))
+        {
+            var baseResolved = saas
+                ? await store.ResolveBaseForTenantAsync((Guid)tenantContext.TenantId!)
+                : await store.ResolveBaseAsync(principal.GetUserId());
+            return Results.Ok(baseResolved);
+        }
+
+        if (!Tamma.Core.Documents.DocumentTypeKeyExtensions.TryParse(documentTypeKey, out var type))
+            return Results.BadRequest(new { error = "Unknown document type", code = "DOCUMENT.TYPE.UNKNOWN", input = documentTypeKey });
+
+        var resolved = saas
+            ? await store.ResolveForTenantAsync((Guid)tenantContext.TenantId!, type)
+            : await store.ResolveAsync(principal.GetUserId(), type);
+        return Results.Ok(resolved);
+    }
+
+    // =======================================================================
+    // Upsert (AcceptanceRulesManage)
+    // =======================================================================
+
+    public static async Task<IResult> Upsert(
+        string documentTypeKey,
+        AcceptanceRulesUpsertRequest req,
+        AcceptanceRulesService store,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var userId = principal.GetUserId();
+        AcceptanceRules rules;
+        try
+        {
+            rules = req.ToRules();
+        }
+        catch (Exception ex)
+        {
+            return Results.BadRequest(new { error = ex.Message, code = "ACCEPTANCE_RULES.INVALID" });
+        }
+
+        try
+        {
+            if (modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid tenantId)
+                await store.UpsertForTenantAsync(tenantId, userId, documentTypeKey, rules);
+            else
+                await store.UpsertAsync(userId, documentTypeKey, rules);
+        }
+        catch (TammaError te)
+        {
+            // Out-of-range knob (ACCEPTANCE_RULES.INVALID) or unknown type key
+            // (DOCUMENT.TYPE.UNKNOWN) — both are caller errors → 400.
+            return Results.BadRequest(new { error = te.Message, code = te.Code });
+        }
+
+        // Return the freshly resolved rules (with provenance) for the type.
+        return await GetResolved(documentTypeKey, store, principal, tenantContext, modeProvider);
+    }
+
+    // =======================================================================
+    // Delete → reset to next tier (AcceptanceRulesManage)
+    // =======================================================================
+
+    public static async Task<IResult> Delete(
+        string documentTypeKey,
+        AcceptanceRulesService store,
+        ClaimsPrincipal principal,
+        ITenantContext tenantContext,
+        ITammaModeProvider modeProvider)
+    {
+        var userId = principal.GetUserId();
+        bool deleted;
+        try
+        {
+            if (modeProvider.Mode == TammaMode.SaaS && tenantContext.TenantId is Guid tenantId)
+                deleted = await store.DeleteForTenantAsync(tenantId, documentTypeKey);
+            else
+                deleted = await store.DeleteAsync(userId, documentTypeKey);
+        }
+        catch (TammaError te)
+        {
+            return Results.BadRequest(new { error = te.Message, code = te.Code });
+        }
+
+        if (!deleted)
+            return Results.NotFound(new { error = "Acceptance-rules override not found" });
+
+        return Results.Ok(new { message = "Acceptance-rules override deleted" });
+    }
+
+    // =======================================================================
+    // Helpers
+    // =======================================================================
+
+    private static IReadOnlyList<ResolvedAcceptanceRules> DefaultsForAllTypes()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var list = new List<ResolvedAcceptanceRules>();
+        foreach (var type in Enum.GetValues<Tamma.Core.Documents.DocumentTypeKey>())
+            list.Add(new ResolvedAcceptanceRules(
+                AcceptanceDefaults.For(type),
+                AcceptanceRulesSource.SystemDefault,
+                1,
+                type.ToWire(),
+                now));
+        return list;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -399,6 +399,16 @@ builder.Services.AddScoped<Tamma.Api.Middleware.ProxyHeaderAuthMiddleware>();
 // Hardening workstreams — ported from the deleted TS API services.
 // Each extension method owns its own service registrations.
 builder.Services.AddPromptStoreServices();
+// Story 39-5 — acceptance-rules resolver + events + tool factory. The service
+// implements IAcceptanceRulesResolver (consumed by the 39-17 tool factory and,
+// in later stories, the 39-6 workflow). The GetAcceptanceRulesTool itself is NOT
+// registered as an IToolExecutor (Design Decision D6) — the factory mints
+// principal-bound instances per tenant-agent session.
+builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.AcceptanceRulesEventsService>();
+builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.AcceptanceRulesService>();
+builder.Services.AddScoped<Tamma.Core.Documents.Policy.IAcceptanceRulesResolver>(
+    sp => sp.GetRequiredService<Tamma.Api.Services.AcceptanceRules.AcceptanceRulesService>());
+builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.GetAcceptanceRulesToolFactory>();
 builder.Services.AddProviderHealthServices();
 builder.Services.AddDiagnosticsServices();
 builder.Services.AddSanitizationServices();
@@ -1530,6 +1540,16 @@ if (!string.IsNullOrEmpty(jwtSecret))
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
             p.AddRequirements(new PermissionRequirement("pricing:manage"));
         });
+        // Story 39-5 — Acceptance Rules tenant-admin policy. Mirrors PromptManage
+        // exactly: PUT/DELETE of a tenant acceptance-rules override must be
+        // reachable by tenant_owner OR tenant_admin (admin+owner here); member-role
+        // callers hit 403. The owner-only SettingsManage would 403 every
+        // tenant_admin, so the dedicated AcceptanceRulesManage gate is used.
+        options.AddPolicy("AcceptanceRulesManage", p =>
+        {
+            p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
+            p.AddRequirements(new PermissionRequirement("acceptance-rules:manage"));
+        });
         options.AddPolicy("WorkflowsView", p =>
         {
             p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
@@ -1621,7 +1641,7 @@ else if (builder.Environment.IsDevelopment())
             .Build();
         // Register all named policies with permissive default
         foreach (var name in new[] { "AdminAccess", "OwnerAccess", "PlatformOwnerAccess", "MemberAccess", "SettingsView",
-            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "PricingManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
+            "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "PricingManage", "AcceptanceRulesManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
             "SelfOrApiKeysManage", "SelfOrUsersView", "AuthenticatedAny", "EngineServiceOnly" })
         {
             options.AddPolicy(name, p => p.AddRequirements(new Tamma.Api.Infrastructure.AllowAnonymousRequirement()));
@@ -2609,6 +2629,28 @@ var adminConventions = app.MapGroup("/api/admin/conventions").RequireAuthorizati
 adminConventions.MapPut("/{role}/{action}", ConventionStoreEndpoints.UpsertSystemDefault);
 adminConventions.MapDelete("/{role}/{action}", ConventionStoreEndpoints.DeleteSystemDefault);
 adminConventions.MapPost("/{role}/{action}/reset", ConventionStoreEndpoints.ResetSystemDefault);
+
+// ── Acceptance Rules (Story 39-5) ──
+// Configurable per-document-type acceptance policy (autonomy dial + bounds +
+// escalation + reviewer selection + guidance). RBAC parity with the prompt/
+// convention stores, with the SAME DELIBERATE read-gate deviation as the
+// convention store: reads use AuthenticatedAny (any authed tenant member) rather
+// than SettingsView (admin/owner) because AC7 requires reads for any tenant
+// member — the orchestrator + role-holders all need to see the effective rules,
+// not just admins. Writes are gated by AcceptanceRulesManage (tenant_owner/
+// tenant_admin; member → 403).
+//
+// Route ordering (mirrors prompt/convention stores): the specific literal route
+// (/defaults) MUST be registered BEFORE the parameterized /{documentTypeKey} so
+// "defaults" is not swallowed by the {documentTypeKey} route. The literal `base`
+// segment addresses the principal base row (the dial) and is handled inside
+// GetResolved / Upsert / Delete.
+var acceptanceRules = app.MapGroup("/api/acceptance-rules").RequireAuthorization("AuthenticatedAny");
+acceptanceRules.MapGet("/", AcceptanceRulesEndpoints.ListEffective);
+acceptanceRules.MapGet("/defaults", AcceptanceRulesEndpoints.GetDefaults);
+acceptanceRules.MapGet("/{documentTypeKey}", AcceptanceRulesEndpoints.GetResolved);
+acceptanceRules.MapPut("/{documentTypeKey}", AcceptanceRulesEndpoints.Upsert).RequireAuthorization("AcceptanceRulesManage");
+acceptanceRules.MapDelete("/{documentTypeKey}", AcceptanceRulesEndpoints.Delete).RequireAuthorization("AcceptanceRulesManage");
 
 // ── Settings / Config ──
 // Rate limit (finding 020): ConfigRead default for the group; ConfigWrite

--- a/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/AcceptanceRulesEventsService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/AcceptanceRulesEventsService.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.AcceptanceRules;
+
+/// <summary>
+/// Best-effort emitter of acceptance-rules DCB events (Story 39-5 Design Decision
+/// D12), mirroring <c>PromptEventsService</c>. Emission never throws to callers:
+/// if the event store is unavailable the error is logged and the originating
+/// mutation continues.
+/// </summary>
+public sealed class AcceptanceRulesEventsService
+{
+    public const string CreatedType = "ACCEPTANCE_RULES.CREATED.SUCCESS";
+    public const string UpdatedType = "ACCEPTANCE_RULES.UPDATED.SUCCESS";
+    public const string ResetType = "ACCEPTANCE_RULES.RESET.SUCCESS";
+
+    private readonly IEventRepository _events;
+    private readonly ILogger<AcceptanceRulesEventsService>? _logger;
+
+    public AcceptanceRulesEventsService(IEventRepository events, ILogger<AcceptanceRulesEventsService>? logger = null)
+    {
+        _events = events;
+        _logger = logger;
+    }
+
+    /// <summary>Emit <c>ACCEPTANCE_RULES.CREATED.SUCCESS</c>.</summary>
+    public Task EmitCreatedAsync(Guid? tenantId, Guid? userId, string documentTypeKey, int autonomyLevel, int version)
+        => EmitAsync(CreatedType, tenantId, userId, documentTypeKey, new Dictionary<string, object?>
+        {
+            ["documentTypeKey"] = documentTypeKey,
+            ["autonomyLevel"] = autonomyLevel,
+            ["version"] = version,
+        });
+
+    /// <summary>Emit <c>ACCEPTANCE_RULES.UPDATED.SUCCESS</c>.</summary>
+    public Task EmitUpdatedAsync(Guid? tenantId, Guid? userId, string documentTypeKey, int autonomyLevel, int version)
+        => EmitAsync(UpdatedType, tenantId, userId, documentTypeKey, new Dictionary<string, object?>
+        {
+            ["documentTypeKey"] = documentTypeKey,
+            ["autonomyLevel"] = autonomyLevel,
+            ["version"] = version,
+        });
+
+    /// <summary>Emit <c>ACCEPTANCE_RULES.RESET.SUCCESS</c> (override deleted → falls back to default).</summary>
+    public Task EmitResetAsync(Guid? tenantId, Guid? userId, string documentTypeKey)
+        => EmitAsync(ResetType, tenantId, userId, documentTypeKey, new Dictionary<string, object?>
+        {
+            ["documentTypeKey"] = documentTypeKey,
+        });
+
+    private async Task EmitAsync(
+        string type,
+        Guid? tenantId,
+        Guid? userId,
+        string documentTypeKey,
+        IReadOnlyDictionary<string, object?> data)
+    {
+        try
+        {
+            var tags = new Dictionary<string, string?>
+            {
+                ["documentTypeKey"] = documentTypeKey,
+            };
+            if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString();
+            if (userId is not null) tags["userId"] = userId.Value.ToString();
+
+            var metadata = new Dictionary<string, object?>
+            {
+                ["workflowVersion"] = "1.0.0",
+                ["eventSource"] = "system",
+            };
+
+            var evt = new DomainEvent
+            {
+                Type = type,
+                TenantId = tenantId,
+                Tags = JsonSerializer.Serialize(tags),
+                Metadata = JsonSerializer.Serialize(metadata),
+                Data = JsonSerializer.Serialize(data),
+            };
+
+            await _events.AppendAsync(evt);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex,
+                "Failed to emit acceptance-rules event {Type} for {DocumentTypeKey}",
+                type, documentTypeKey);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/AcceptanceRulesService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/AcceptanceRulesService.cs
@@ -1,0 +1,261 @@
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.AcceptanceRules;
+
+/// <summary>
+/// EF-backed <see cref="IAcceptanceRulesResolver"/> (Story 39-5 step 8, Design
+/// Decision D1/D2). Implements the three-tier, wholesale-row resolution per mode:
+/// <list type="number">
+///   <item>principal's per-type override row (documentTypeKey = key)</item>
+///   <item>principal's base override row (documentTypeKey NULL — the dial)</item>
+///   <item><see cref="AcceptanceDefaults.For"/> — the shipped static default</item>
+/// </list>
+/// mirroring <c>PromptStoreService</c>'s layer-walk + <c>ForTenant</c> split. Each
+/// stored row holds a COMPLETE, validated <see cref="AcceptanceRules"/> body;
+/// resolution picks the highest-precedence row wholesale (no field merge). Bodies
+/// are validated defensively on read (a corrupt row throws <see cref="TammaError"/>)
+/// and fail-loud on write. Mutations emit DCB events best-effort (D12).
+/// </summary>
+public sealed class AcceptanceRulesService : IAcceptanceRulesResolver
+{
+    private readonly IAcceptanceRulesRepository _repository;
+    private readonly AcceptanceRulesEventsService? _events;
+    private readonly TimeProvider _time;
+
+    public AcceptanceRulesService(
+        IAcceptanceRulesRepository repository,
+        AcceptanceRulesEventsService events,
+        TimeProvider? timeProvider = null)
+    {
+        _repository = repository;
+        _events = events;
+        _time = timeProvider ?? TimeProvider.System;
+    }
+
+    /// <summary>Test seam — construct without an events service.</summary>
+    internal AcceptanceRulesService(IAcceptanceRulesRepository repository, TimeProvider? timeProvider = null)
+    {
+        _repository = repository;
+        _events = null;
+        _time = timeProvider ?? TimeProvider.System;
+    }
+
+    // -----------------------------------------------------------------------
+    // Resolution (IAcceptanceRulesResolver)
+    // -----------------------------------------------------------------------
+
+    public async Task<ResolvedAcceptanceRules> ResolveAsync(
+        Guid? userId, DocumentTypeKey documentType, CancellationToken ct = default)
+    {
+        var key = documentType.ToWire();
+
+        var typeOverride = await _repository.GetAsync(userId, key);
+        if (typeOverride is not null)
+            return Materialize(typeOverride, AcceptanceRulesSource.TypeOverride, key);
+
+        var baseOverride = await _repository.GetAsync(userId, null);
+        if (baseOverride is not null)
+            return Materialize(baseOverride, AcceptanceRulesSource.PrincipalDefault, key);
+
+        return SystemDefault(documentType, key);
+    }
+
+    public async Task<ResolvedAcceptanceRules> ResolveForTenantAsync(
+        Guid tenantId, DocumentTypeKey documentType, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        var key = documentType.ToWire();
+
+        var typeOverride = await _repository.GetByTenantAsync(tenantId, key);
+        if (typeOverride is not null)
+            return Materialize(typeOverride, AcceptanceRulesSource.TypeOverride, key);
+
+        var baseOverride = await _repository.GetByTenantAsync(tenantId, null);
+        if (baseOverride is not null)
+            return Materialize(baseOverride, AcceptanceRulesSource.PrincipalDefault, key);
+
+        return SystemDefault(documentType, key);
+    }
+
+    /// <summary>
+    /// Resolve the PRINCIPAL BASE row (the deployment-wide dial): base override
+    /// if present, else the shipped <see cref="AcceptanceDefaults.Rules"/>. Serves
+    /// the literal <c>base</c> path segment.
+    /// </summary>
+    public async Task<ResolvedAcceptanceRules> ResolveBaseAsync(Guid? userId, CancellationToken ct = default)
+    {
+        var baseOverride = await _repository.GetAsync(userId, null);
+        if (baseOverride is not null)
+            return Materialize(baseOverride, AcceptanceRulesSource.PrincipalDefault, BaseRowKeyLiteral);
+        return BaseSystemDefault();
+    }
+
+    /// <summary>Tenant variant of <see cref="ResolveBaseAsync"/>.</summary>
+    public async Task<ResolvedAcceptanceRules> ResolveBaseForTenantAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+        var baseOverride = await _repository.GetByTenantAsync(tenantId, null);
+        if (baseOverride is not null)
+            return Materialize(baseOverride, AcceptanceRulesSource.PrincipalDefault, BaseRowKeyLiteral);
+        return BaseSystemDefault();
+    }
+
+    private ResolvedAcceptanceRules BaseSystemDefault() =>
+        new(
+            Rules: AcceptanceDefaults.Rules,
+            Source: AcceptanceRulesSource.SystemDefault,
+            Version: 1,
+            DocumentTypeKey: BaseRowKeyLiteral,
+            ResolvedAt: _time.GetUtcNow());
+
+    // -----------------------------------------------------------------------
+    // Listing (resolved-with-provenance for every document type)
+    // -----------------------------------------------------------------------
+
+    /// <summary>Resolve all 10 document types for a single-user principal (list endpoint).</summary>
+    public async Task<IReadOnlyList<ResolvedAcceptanceRules>> ListEffectiveAsync(Guid? userId, CancellationToken ct = default)
+    {
+        var list = new List<ResolvedAcceptanceRules>();
+        foreach (var type in Enum.GetValues<DocumentTypeKey>())
+            list.Add(await ResolveAsync(userId, type, ct));
+        return list;
+    }
+
+    /// <summary>Resolve all 10 document types for a SaaS tenant (list endpoint).</summary>
+    public async Task<IReadOnlyList<ResolvedAcceptanceRules>> ListEffectiveForTenantAsync(Guid tenantId, CancellationToken ct = default)
+    {
+        var list = new List<ResolvedAcceptanceRules>();
+        foreach (var type in Enum.GetValues<DocumentTypeKey>())
+            list.Add(await ResolveForTenantAsync(tenantId, type, ct));
+        return list;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutations
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Upsert a single-user override. <paramref name="documentTypeKey"/> null (or
+    /// the literal <c>base</c>, resolved by the endpoint) addresses the base row.
+    /// The rules are validated and the type key rejected fail-loud BEFORE any
+    /// repository touch (AC4).
+    /// </summary>
+    public async Task<(AcceptanceRulesOverride Entity, bool WasCreated)> UpsertAsync(
+        Guid? userId, string? documentTypeKey, Tamma.Core.Documents.Policy.AcceptanceRules rules)
+    {
+        var key = NormalizeAndValidateKey(documentTypeKey);
+        var validated = rules.Validate();
+
+        var (saved, wasCreated) = await _repository.UpsertAsync(new AcceptanceRulesOverride
+        {
+            UserId = userId,
+            TenantId = null,
+            DocumentTypeKey = key,
+            RulesJson = AcceptanceRulesJson.Serialize(validated),
+        }, userId);
+
+        await EmitMutationAsync(null, userId, saved, wasCreated, validated.AutonomyLevel);
+        return (saved, wasCreated);
+    }
+
+    /// <summary>Upsert a tenant-scoped override (SaaS). <paramref name="documentTypeKey"/> null = base row.</summary>
+    public async Task<(AcceptanceRulesOverride Entity, bool WasCreated)> UpsertForTenantAsync(
+        Guid tenantId, Guid? actingUserId, string? documentTypeKey, Tamma.Core.Documents.Policy.AcceptanceRules rules)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        var key = NormalizeAndValidateKey(documentTypeKey);
+        var validated = rules.Validate();
+
+        var (saved, wasCreated) = await _repository.UpsertAsync(new AcceptanceRulesOverride
+        {
+            UserId = null,
+            TenantId = tenantId,
+            DocumentTypeKey = key,
+            RulesJson = AcceptanceRulesJson.Serialize(validated),
+        }, actingUserId);
+
+        await EmitMutationAsync(tenantId, actingUserId, saved, wasCreated, validated.AutonomyLevel);
+        return (saved, wasCreated);
+    }
+
+    /// <summary>Delete a single-user override → fall back to the next tier. Emits RESET on success.</summary>
+    public async Task<bool> DeleteAsync(Guid? userId, string? documentTypeKey)
+    {
+        var key = NormalizeAndValidateKey(documentTypeKey);
+        var deleted = await _repository.DeleteAsync(userId, key);
+        if (deleted && _events is not null)
+            await _events.EmitResetAsync(null, userId, key ?? "base");
+        return deleted;
+    }
+
+    /// <summary>Delete a tenant-scoped override → fall back to the next tier. Emits RESET on success.</summary>
+    public async Task<bool> DeleteForTenantAsync(Guid tenantId, string? documentTypeKey)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+        var key = NormalizeAndValidateKey(documentTypeKey);
+        var deleted = await _repository.DeleteByTenantAsync(tenantId, key);
+        if (deleted && _events is not null)
+            await _events.EmitResetAsync(tenantId, null, key ?? "base");
+        return deleted;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /// <summary>The literal path segment addressing the principal base row.</summary>
+    public const string BaseRowKeyLiteral = "base";
+
+    /// <summary>
+    /// Normalize a raw key: null or the literal <c>base</c> → null (the base row);
+    /// otherwise parse it against the 39-2 registry (rejects a typo fail-loud, AC4).
+    /// </summary>
+    private static string? NormalizeAndValidateKey(string? raw)
+    {
+        if (raw is null) return null;
+        if (string.Equals(raw, BaseRowKeyLiteral, StringComparison.Ordinal)) return null;
+        // Throws TammaError DOCUMENT.TYPE.UNKNOWN on an unknown key.
+        return DocumentTypeKeyExtensions.Parse(raw).ToWire();
+    }
+
+    private ResolvedAcceptanceRules Materialize(AcceptanceRulesOverride row, AcceptanceRulesSource source, string key)
+    {
+        // Defensive validation on read (D3) — a corrupt row throws, never degrades.
+        var rules = AcceptanceRulesJson.Deserialize(row.RulesJson);
+        return new ResolvedAcceptanceRules(
+            Rules: rules,
+            Source: source,
+            Version: row.Version,
+            DocumentTypeKey: key,
+            ResolvedAt: _time.GetUtcNow());
+    }
+
+    private ResolvedAcceptanceRules SystemDefault(DocumentTypeKey type, string key) =>
+        new(
+            Rules: AcceptanceDefaults.For(type),
+            Source: AcceptanceRulesSource.SystemDefault,
+            Version: 1,
+            DocumentTypeKey: key,
+            ResolvedAt: _time.GetUtcNow());
+
+    private async Task EmitMutationAsync(
+        Guid? tenantId, Guid? actingUserId, AcceptanceRulesOverride saved, bool wasCreated, int autonomyLevel)
+    {
+        if (_events is null) return;
+        var key = saved.DocumentTypeKey ?? "base";
+        if (wasCreated)
+            await _events.EmitCreatedAsync(tenantId, actingUserId, key, autonomyLevel, saved.Version);
+        else
+            await _events.EmitUpdatedAsync(tenantId, actingUserId, key, autonomyLevel, saved.Version);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/GetAcceptanceRulesTool.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/AcceptanceRules/GetAcceptanceRulesTool.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Activities.LlmCall.Tools;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Api.Services.AcceptanceRules;
+
+/// <summary>
+/// The <c>get_acceptance_rules</c> tool (Story 39-5 AC3a, Design Decision D6): the
+/// 39-17 orchestrator agent calls it at decision time to read the effective rules
+/// for a document type. It implements the existing <see cref="IToolExecutor"/>
+/// seam but is PRINCIPAL-BOUND AT CONSTRUCTION and NOT globally DI-registered —
+/// registering it in the set <c>ResolveToolsActivity</c> discovers would inject it
+/// into every coding-agent tool loop. The 39-17 host constructs one per
+/// tenant-agent session via <see cref="GetAcceptanceRulesToolFactory"/>.
+///
+/// <para>The principal (<c>userId</c> XOR <c>tenantId</c>) comes from the SERVER
+/// at construction, NEVER from the LLM's <c>argumentsJson</c> — only
+/// <c>documentTypeKey</c> is an accepted argument (the <c>LlmCallWorkflow</c>
+/// conventions discipline). The output JSON is the same
+/// <see cref="ResolvedAcceptanceRules"/> the request embeds, serialized through
+/// the one canonical <see cref="AcceptanceRulesJson.Options"/> (AC3 byte-identity).</para>
+/// </summary>
+public sealed class GetAcceptanceRulesTool : IToolExecutor
+{
+    private readonly IAcceptanceRulesResolver _resolver;
+    private readonly Guid? _userId;
+    private readonly Guid? _tenantId;
+    private readonly ILogger<GetAcceptanceRulesTool>? _logger;
+
+    /// <summary>
+    /// Construct a principal-bound tool. Exactly one of <paramref name="userId"/>
+    /// / <paramref name="tenantId"/> should be set (single-user vs SaaS); the
+    /// factory enforces that.
+    /// </summary>
+    public GetAcceptanceRulesTool(
+        IAcceptanceRulesResolver resolver,
+        Guid? userId,
+        Guid? tenantId,
+        ILogger<GetAcceptanceRulesTool>? logger = null)
+    {
+        _resolver = resolver;
+        _userId = userId;
+        _tenantId = tenantId;
+        _logger = logger;
+    }
+
+    public string ToolName => "get_acceptance_rules";
+
+    public string Description =>
+        "Read the effective acceptance rules (autonomy level, revision/repair bounds, escalation criteria, " +
+        "reviewer selection, and decision/routing guidance) for a document type. Call this at decision time " +
+        "to decide whether to decide the acceptance yourself or assign it to a role.";
+
+    public Dictionary<string, object> InputSchema => new()
+    {
+        ["type"] = "object",
+        ["properties"] = new Dictionary<string, object>
+        {
+            ["documentTypeKey"] = new Dictionary<string, object>
+            {
+                ["type"] = "string",
+                ["description"] = "The document-type wire key (e.g. 'plan', 'design', 'review'). Optional; defaults to 'review'.",
+            },
+        },
+        ["required"] = Array.Empty<string>(),
+    };
+
+    public async Task<ToolExecutionResult> ExecuteAsync(
+        string toolCallId, string argumentsJson, CancellationToken cancellationToken = default)
+    {
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            // Only documentTypeKey is honored from the arguments. A principal
+            // smuggled into argumentsJson is IGNORED — the principal is bound at
+            // construction from the server (D6).
+            var typeKey = "review";
+            if (!string.IsNullOrWhiteSpace(argumentsJson))
+            {
+                var args = JsonSerializer.Deserialize<JsonElement>(argumentsJson);
+                if (args.ValueKind == JsonValueKind.Object
+                    && args.TryGetProperty("documentTypeKey", out var el)
+                    && el.ValueKind == JsonValueKind.String)
+                {
+                    typeKey = el.GetString() ?? "review";
+                }
+            }
+
+            if (!DocumentTypeKeyExtensions.TryParse(typeKey, out var documentType))
+            {
+                return Fail(toolCallId, sw,
+                    $"Unknown document type '{typeKey}'. Valid types: " +
+                    string.Join(", ", Enum.GetValues<DocumentTypeKey>().Select(k => k.ToWire())) + ".");
+            }
+
+            var resolved = _tenantId is { } tid && tid != Guid.Empty
+                ? await _resolver.ResolveForTenantAsync(tid, documentType, cancellationToken)
+                : await _resolver.ResolveAsync(_userId, documentType, cancellationToken);
+
+            var output = JsonSerializer.Serialize(resolved, AcceptanceRulesJson.Options);
+            return new ToolExecutionResult(toolCallId, ToolName, true, output, sw.ElapsedMilliseconds);
+        }
+        catch (Exception ex)
+        {
+            // Never throw — return a failure result (IToolExecutor contract).
+            _logger?.LogWarning(ex, "get_acceptance_rules failed for {ToolCallId}", toolCallId);
+            return Fail(toolCallId, sw, $"get_acceptance_rules failed: {ex.Message}");
+        }
+    }
+
+    private ToolExecutionResult Fail(string toolCallId, Stopwatch sw, string message) =>
+        new(toolCallId, ToolName, false, message, sw.ElapsedMilliseconds);
+}
+
+/// <summary>
+/// Constructs a principal-bound <see cref="GetAcceptanceRulesTool"/> for the
+/// 39-17 host (Design Decision D6). NOT added to the global
+/// <see cref="IToolExecutor"/> DI set — the host mounts one per tenant-agent
+/// session so the tool never leaks into a coding-agent tool loop.
+/// </summary>
+public sealed class GetAcceptanceRulesToolFactory
+{
+    private readonly IAcceptanceRulesResolver _resolver;
+    private readonly ILoggerFactory? _loggerFactory;
+
+    public GetAcceptanceRulesToolFactory(IAcceptanceRulesResolver resolver, ILoggerFactory? loggerFactory = null)
+    {
+        _resolver = resolver;
+        _loggerFactory = loggerFactory;
+    }
+
+    /// <summary>
+    /// Create a tool bound to a single-user principal (<paramref name="userId"/>)
+    /// or a SaaS tenant (<paramref name="tenantId"/>). Exactly one must be set.
+    /// </summary>
+    public GetAcceptanceRulesTool Create(Guid? userId = null, Guid? tenantId = null)
+    {
+        var hasUser = userId is { } u && u != Guid.Empty;
+        var hasTenant = tenantId is { } t && t != Guid.Empty;
+        if (hasUser == hasTenant)
+            throw new ArgumentException(
+                "Exactly one of userId / tenantId must be provided (single-user vs SaaS principal).");
+
+        return new GetAcceptanceRulesTool(
+            _resolver,
+            hasUser ? userId : null,
+            hasTenant ? tenantId : null,
+            _loggerFactory?.CreateLogger<GetAcceptanceRulesTool>());
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/ApprovalChannel.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/ApprovalChannel.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// The transport channel a decision arrives on (Story 39-5 step 3). A NEW enum
+/// OWNED BY 39-5: <see cref="Policy.AcceptanceGuardrails"/> types its gate
+/// context's decider channel on it (Tamma.Core cannot reference a type from
+/// 39-8's scope, so 39-5 defines it here). 39-8 CONSUMES it — it maps its
+/// server-derived resume principal onto these three values; it never redefines
+/// the type.
+///
+/// <list type="bullet">
+/// <item><c>orchestrator</c> — the 39-17 agent decided itself (the autonomous path).</item>
+/// <item><c>user</c> — a human decided via the 39-19 Task View / conversational surface.</item>
+/// <item><c>api</c> — a decision arrived over the programmatic API.</item>
+/// </list>
+///
+/// <para>The distinction is load-bearing for the guardrails: a <c>Reject</c> is
+/// human-only, so a reject arriving on the <c>orchestrator</c> channel is clamped
+/// to <c>Escalate(RejectRequiresHuman)</c>.</para>
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<ApprovalChannel>))]
+public enum ApprovalChannel
+{
+    [Wire("orchestrator")] Orchestrator,
+    [Wire("user")]         User,
+    [Wire("api")]          Api,
+}
+
+/// <summary><see cref="ApprovalChannel"/> wire helper.</summary>
+public static class ApprovalChannelExtensions
+{
+    public static string ToWire(this ApprovalChannel channel) => EnumWire<ApprovalChannel>.ToWire(channel);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceDecision.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceDecision.cs
@@ -1,0 +1,85 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The closed acceptor decision vocabulary (Story 39-5 AC2). Serialized
+/// polymorphically with a <c>kind</c> discriminator through
+/// <see cref="AcceptanceRulesJson.Options"/>; the derived-type set is closed —
+/// there is NO <c>AutoAccept</c> member, so the lifecycle cannot route around
+/// the orchestrator at the contract level (Design Decision D7).
+///
+/// <para><c>Reject</c> is HUMAN-ONLY (settled design review 2026-07-21): the
+/// orchestrator cannot reject without escalating. A <c>Reject</c> arriving on the
+/// <c>orchestrator</c> channel is clamped to <c>Escalate(RejectRequiresHuman)</c>
+/// by <see cref="AcceptanceGuardrails.Clamp"/>.</para>
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(Accept), "accept")]
+[JsonDerivedType(typeof(RequestRevision), "request-revision")]
+[JsonDerivedType(typeof(Reject), "reject")]
+[JsonDerivedType(typeof(Escalate), "escalate")]
+public abstract record AcceptanceDecision
+{
+    /// <summary>A final "yes" — the document is accepted and published.</summary>
+    public sealed record Accept : AcceptanceDecision;
+
+    /// <summary>Send the document back for another revision round with reviewer notes.</summary>
+    public sealed record RequestRevision(
+        [property: JsonPropertyName("notes")] string Notes) : AcceptanceDecision;
+
+    /// <summary>A final "no" → the document reaches the <c>Rejected</c> state. HUMAN-ONLY.</summary>
+    public sealed record Reject(
+        [property: JsonPropertyName("reason")] string Reason) : AcceptanceDecision;
+
+    /// <summary>Hand the decision up to a human via the 39-8 escalation surface.</summary>
+    public sealed record Escalate(
+        [property: JsonPropertyName("reason")] AcceptanceEscalationReason Reason,
+        [property: JsonPropertyName("detail")] string Detail) : AcceptanceDecision;
+}
+
+/// <summary>
+/// The closed set of reasons a decision escalates (Story 39-5 Design Decision
+/// D10 — EXACTLY 6 members, count-pinned). Two members map 1:1 onto 39-2's
+/// <see cref="DocumentLifecycleOutcome"/> via
+/// <see cref="AcceptanceEscalationReasonExtensions.ToLifecycleOutcome"/>; the
+/// other four are escalation-only and map to <c>null</c>.
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<AcceptanceEscalationReason>))]
+public enum AcceptanceEscalationReason
+{
+    [Wire("rounds-exhausted")]          RoundsExhausted,
+    [Wire("always-escalate-class")]     AlwaysEscalateClass,
+    [Wire("blocking-review-violation")] BlockingReviewViolation,
+    [Wire("ambiguity-above-threshold")] AmbiguityAboveThreshold,
+    [Wire("acceptor-judgment")]         AcceptorJudgment,
+    [Wire("reject-requires-human")]     RejectRequiresHuman,
+}
+
+/// <summary><see cref="AcceptanceEscalationReason"/> wire + lifecycle-outcome mapping (D10).</summary>
+public static class AcceptanceEscalationReasonExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="reason"/>.</summary>
+    public static string ToWire(this AcceptanceEscalationReason reason) =>
+        EnumWire<AcceptanceEscalationReason>.ToWire(reason);
+
+    /// <summary>
+    /// Maps an escalation reason to its terminal <see cref="DocumentLifecycleOutcome"/>,
+    /// or <c>null</c> when the reason is escalation-only (never a terminal
+    /// lifecycle state). Drift-pinned so 39-6 never string-matches (D10):
+    /// <list type="bullet">
+    /// <item><c>RoundsExhausted</c> → <see cref="DocumentLifecycleOutcome.RoundsExhausted"/></item>
+    /// <item><c>AmbiguityAboveThreshold</c> → <see cref="DocumentLifecycleOutcome.AmbiguityAboveThreshold"/></item>
+    /// <item><c>AlwaysEscalateClass</c> / <c>BlockingReviewViolation</c> /
+    ///   <c>AcceptorJudgment</c> / <c>RejectRequiresHuman</c> → <c>null</c></item>
+    /// </list>
+    /// </summary>
+    public static DocumentLifecycleOutcome? ToLifecycleOutcome(this AcceptanceEscalationReason reason) =>
+        reason switch
+        {
+            AcceptanceEscalationReason.RoundsExhausted => DocumentLifecycleOutcome.RoundsExhausted,
+            AcceptanceEscalationReason.AmbiguityAboveThreshold => DocumentLifecycleOutcome.AmbiguityAboveThreshold,
+            _ => null,
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceDefaults.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceDefaults.cs
@@ -1,0 +1,115 @@
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The static, shipped-in-code acceptance defaults (Story 39-5 AC5). A deployment
+/// with ZERO configuration behaves safely: autonomy 70 (the supervised baseline),
+/// conservative round bounds, no always-escalate classes, and sensible reviewer
+/// selection per type.
+///
+/// <para>Shared knobs are the same for every type; REVIEWER SELECTION is per-type
+/// (Design Decision D2 / step 2) so 39-14's PlanReview migration is
+/// behavior-preserving with zero config: the <c>plan</c> and <c>review</c> types
+/// default to a 7-role PANEL with a MAJORITY decision rule, while every other
+/// type defaults to a single <c>architect</c> reviewer with a UNANIMOUS rule.</para>
+///
+/// <para>The static constructor calls <see cref="AcceptanceRules.Validate"/> on
+/// every per-type default — an invalid default REFUSES to load (the fail-loud
+/// posture of <c>PromptFileLoader</c>). Every value here is pinned by
+/// <c>AcceptanceDefaultsDriftTests</c>.</para>
+/// </summary>
+public static class AcceptanceDefaults
+{
+    /// <summary>Shared autonomy default — the supervised baseline.</summary>
+    public const int DefaultAutonomyLevel = 70;
+
+    /// <summary>Shared revision-rounds default.</summary>
+    public const int DefaultMaxRevisionRounds = 2;
+
+    /// <summary>Shared validation-repair-attempts default.</summary>
+    public const int DefaultMaxValidationRepairAttempts = 2;
+
+    /// <summary>Shared ambiguity-escalation-threshold default.</summary>
+    public const double DefaultAmbiguityEscalationThreshold = 0.7;
+
+    private const string DefaultDecisionGuidance =
+        "Accept when the review approves with no blocking issues and the document satisfies its acceptance " +
+        "criteria. Request revision when the review raises addressable, non-blocking concerns within the round " +
+        "budget. Escalate when the review is undecidable, blocking issues remain after revision, the input " +
+        "ambiguity exceeds the threshold, or the decision requires a human judgment call.";
+
+    private const string DefaultRoutingGuidance =
+        "At the supervised baseline (autonomy 70) assign nearly every acceptance decision to a human role. As " +
+        "the autonomy level rises, decide more routine, unambiguous, fully-approved documents yourself and " +
+        "assign only the contested or high-impact ones. Always assign — never reject or hard-accept — anything " +
+        "you are not confident the rules unambiguously permit.";
+
+    /// <summary>
+    /// The 7-role plan/review panel roster (Design Decision D2 — pinned by the
+    /// drift test). Mirrors <c>PlanReviewWorkflow</c>'s roster (architect,
+    /// developer, tester, security, devops, product_owner, senior_developer);
+    /// <c>tech_writer</c> is intentionally excluded.
+    /// </summary>
+    public static IReadOnlyList<string> PanelRoster { get; } = new[]
+    {
+        AgentRole.Architect.ToWire(),
+        AgentRole.Developer.ToWire(),
+        AgentRole.Tester.ToWire(),
+        AgentRole.Security.ToWire(),
+        AgentRole.Devops.ToWire(),
+        AgentRole.ProductOwner.ToWire(),
+        AgentRole.SeniorDeveloper.ToWire(),
+    };
+
+    /// <summary>
+    /// The shared-knobs BASE row used for the principal-base tier — single
+    /// reviewer (<c>architect</c>), unanimous. <see cref="For"/> layers the
+    /// per-type reviewer default on top of these same knobs.
+    /// </summary>
+    public static AcceptanceRules Rules { get; }
+
+    private static readonly AcceptanceRules s_panelRules;
+
+    static AcceptanceDefaults()
+    {
+        Rules = new AcceptanceRules
+        {
+            AutonomyLevel = DefaultAutonomyLevel,
+            MaxRevisionRounds = DefaultMaxRevisionRounds,
+            MaxValidationRepairAttempts = DefaultMaxValidationRepairAttempts,
+            AmbiguityEscalationThreshold = DefaultAmbiguityEscalationThreshold,
+            AlwaysEscalate = Array.Empty<EscalationClass>(),
+            ReviewerSelection = new ReviewerSelection(
+                Mode: ReviewerMode.SingleReviewer,
+                ReviewerRole: AgentRole.Architect.ToWire(),
+                PanelRoles: Array.Empty<string>(),
+                Quorum: null,
+                DecisionRule: ReviewDecisionRule.Unanimous),
+            DecisionGuidance = DefaultDecisionGuidance,
+            RoutingGuidance = DefaultRoutingGuidance,
+        }.Validate();
+
+        s_panelRules = (Rules with
+        {
+            ReviewerSelection = new ReviewerSelection(
+                Mode: ReviewerMode.Panel,
+                ReviewerRole: null,
+                PanelRoles: PanelRoster,
+                Quorum: null,
+                DecisionRule: ReviewDecisionRule.Majority),
+        }).Validate();
+
+        // Fail loud if any per-type default is invalid.
+        foreach (var type in Enum.GetValues<DocumentTypeKey>())
+            _ = For(type);
+    }
+
+    /// <summary>
+    /// The per-type default: <c>plan</c> and <c>review</c> get the 7-role
+    /// majority panel; every other type gets the single-<c>architect</c>
+    /// unanimous base row.
+    /// </summary>
+    public static AcceptanceRules For(DocumentTypeKey type) =>
+        type is DocumentTypeKey.Plan or DocumentTypeKey.Review ? s_panelRules : Rules;
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceGuardrails.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceGuardrails.cs
@@ -1,0 +1,136 @@
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The projection of 39-4's review the guardrails read (Design Decision D8). It
+/// carries 39-4's <see cref="ReviewDecision"/> DIRECTLY (referenced from
+/// <c>Tamma.Core/Documents/Types/Review.cs</c> — <c>Approve | RequestChanges |
+/// NeedsDiscussion</c>), never a local shadow copy, plus whether any blocking
+/// (critical-severity) issue exists.
+/// </summary>
+public sealed record ReviewFacts(ReviewDecision Decision, bool HasBlockingIssues);
+
+/// <summary>
+/// Everything the pure guardrails need to gate one acceptor decision. The
+/// <see cref="DeciderChannel"/> is typed as <see cref="ApprovalChannel"/> — a
+/// <c>[Wire]</c> enum OWNED BY 39-5 (39-8 maps its server-derived resume
+/// transport onto it).
+/// </summary>
+public sealed record AcceptanceGateContext(
+    DocumentTypeKey DocumentType,
+    string? AgentActionWire,
+    ReviewFacts Review,
+    int RoundsUsed,
+    AcceptanceRules Rules,
+    ApprovalChannel DeciderChannel);
+
+/// <summary>
+/// The deterministic hard guardrails AROUND the acceptor's decision (Story 39-5
+/// AC8). PURE — no I/O, no Elsa, no configuration read. It validates and clamps a
+/// decision; it never makes one. <see cref="Clamp"/> can only pass a decision
+/// through or convert it to <see cref="AcceptanceDecision.Escalate"/> — it
+/// structurally cannot manufacture an <see cref="AcceptanceDecision.Accept"/>
+/// from a non-Accept input.
+/// </summary>
+public static class AcceptanceGuardrails
+{
+    /// <summary>
+    /// Pre-gate BEFORE any acceptor runs (AC8a): an always-escalate class match
+    /// short-circuits to <c>Escalate(AlwaysEscalateClass)</c>; a rounds-exhausted
+    /// state short-circuits to <c>Escalate(RoundsExhausted)</c>. Returns
+    /// <c>true</c> (with <paramref name="escalation"/> set) when the request must
+    /// escalate before an acceptor is even consulted.
+    /// </summary>
+    public static bool TryPreGate(AcceptanceGateContext ctx, out AcceptanceDecision.Escalate escalation)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        // Always-escalate class match (by document type or by agent action).
+        foreach (var cls in ctx.Rules.AlwaysEscalate)
+        {
+            var matched = cls.Kind switch
+            {
+                EscalationClassKind.DocumentType =>
+                    string.Equals(cls.Key, ctx.DocumentType.ToWire(), StringComparison.Ordinal),
+                EscalationClassKind.AgentAction =>
+                    ctx.AgentActionWire is not null &&
+                    string.Equals(cls.Key, ctx.AgentActionWire, StringComparison.Ordinal),
+                _ => false,
+            };
+            if (matched)
+            {
+                escalation = new AcceptanceDecision.Escalate(
+                    AcceptanceEscalationReason.AlwaysEscalateClass,
+                    $"Document/action class '{cls.Key}' ({cls.Kind.ToWire()}) is configured to always escalate.");
+                return true;
+            }
+        }
+
+        // Rounds exhausted.
+        if (ctx.RoundsUsed >= ctx.Rules.MaxRevisionRounds)
+        {
+            escalation = new AcceptanceDecision.Escalate(
+                AcceptanceEscalationReason.RoundsExhausted,
+                $"Revision rounds exhausted: {ctx.RoundsUsed} used of a {ctx.Rules.MaxRevisionRounds}-round budget.");
+            return true;
+        }
+
+        escalation = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Post-gate clamp AROUND the acceptor's <paramref name="proposed"/> decision
+    /// (AC8b):
+    /// <list type="bullet">
+    /// <item><c>Accept</c> for a review that is not <c>Approve</c> OR carries a
+    ///   blocking issue → <c>Escalate(BlockingReviewViolation)</c> (forged approval).</item>
+    /// <item><c>Reject</c> on the <c>orchestrator</c> channel →
+    ///   <c>Escalate(RejectRequiresHuman)</c> (reject is human-only).</item>
+    /// <item><c>RequestRevision</c> that would exceed the round budget →
+    ///   <c>Escalate(RoundsExhausted)</c>.</item>
+    /// <item>anything else → pass through unchanged.</item>
+    /// </list>
+    /// </summary>
+    public static AcceptanceDecision Clamp(AcceptanceDecision proposed, AcceptanceGateContext ctx)
+    {
+        ArgumentNullException.ThrowIfNull(proposed);
+        ArgumentNullException.ThrowIfNull(ctx);
+
+        switch (proposed)
+        {
+            case AcceptanceDecision.Accept:
+                if (ctx.Review.Decision != ReviewDecision.Approve || ctx.Review.HasBlockingIssues)
+                {
+                    return new AcceptanceDecision.Escalate(
+                        AcceptanceEscalationReason.BlockingReviewViolation,
+                        "Accept refused: the review is not a clean approval " +
+                        $"(decision={ctx.Review.Decision.ToWire()}, hasBlockingIssues={ctx.Review.HasBlockingIssues}).");
+                }
+                return proposed;
+
+            case AcceptanceDecision.Reject:
+                if (ctx.DeciderChannel == ApprovalChannel.Orchestrator)
+                {
+                    return new AcceptanceDecision.Escalate(
+                        AcceptanceEscalationReason.RejectRequiresHuman,
+                        "Reject refused on the orchestrator channel: rejection is human-only; escalate instead.");
+                }
+                return proposed;
+
+            case AcceptanceDecision.RequestRevision:
+                if (ctx.RoundsUsed + 1 > ctx.Rules.MaxRevisionRounds)
+                {
+                    return new AcceptanceDecision.Escalate(
+                        AcceptanceEscalationReason.RoundsExhausted,
+                        $"RequestRevision refused: another round would exceed the {ctx.Rules.MaxRevisionRounds}-round budget " +
+                        $"(rounds used={ctx.RoundsUsed}).");
+                }
+                return proposed;
+
+            default:
+                return proposed;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRequest.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRequest.cs
@@ -1,0 +1,103 @@
+using System.Text.Json.Serialization;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The payload the accept stage publishes on the workflow↔orchestrator channel
+/// (Story 39-5 AC2/AC3): the finished document, its <c>Review</c>, its lineage,
+/// the rounds used so far, the server-resolved rules (including the autonomy
+/// level and version), and the decision-session id the 39-8 gate resumes on.
+///
+/// <para>The rules are resolved SERVER-SIDE and embedded here for context + audit
+/// (the <see cref="ResolvedAcceptanceRules.Version"/> is what 39-6's decision
+/// event records the decision was made under). The caller never passes rules from
+/// the client — the same discipline as <c>LlmCallWorkflow</c>'s conventions
+/// resolution.</para>
+/// </summary>
+public sealed record AcceptanceRequest
+{
+    [JsonPropertyName("decisionSessionId")]
+    public required Guid DecisionSessionId { get; init; }
+
+    [JsonPropertyName("document")]
+    public required DocumentEnvelope Document { get; init; }
+
+    [JsonPropertyName("review")]
+    public required DocumentEnvelope Review { get; init; }
+
+    [JsonPropertyName("lineage")]
+    public required IReadOnlyList<DocumentEnvelope> Lineage { get; init; }
+
+    [JsonPropertyName("roundsUsed")]
+    public required int RoundsUsed { get; init; }
+
+    [JsonPropertyName("rules")]
+    public required ResolvedAcceptanceRules Rules { get; init; }
+
+    [JsonPropertyName("issueId")]
+    public required string IssueId { get; init; }
+}
+
+/// <summary>
+/// The ONLY way to build an <see cref="AcceptanceRequest"/> (Story 39-5 Design
+/// Decision D7). There is no autonomy-level branch and no accept/skip output:
+/// every request goes to the orchestrator over the channel, regardless of
+/// autonomy level. This makes "route around the orchestrator" unrepresentable at
+/// the contract level; 39-6 re-pins the same invariant at the workflow level.
+/// </summary>
+public static class AcceptanceRequestFactory
+{
+    /// <summary>
+    /// Build an orchestrator-bound acceptance request. Mints a fresh UUID v7
+    /// decision-session id. Rejects a <paramref name="review"/> envelope whose
+    /// type is not <c>review</c> (the request must carry the unified review
+    /// document, 39-4) and a negative <paramref name="roundsUsed"/>.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>ACCEPTANCE_REQUEST.INVALID</c> for a non-review review envelope,
+    /// an empty issue id, or a negative rounds count.
+    /// </exception>
+    public static AcceptanceRequest Create(
+        DocumentEnvelope document,
+        DocumentEnvelope review,
+        IReadOnlyList<DocumentEnvelope> lineage,
+        int roundsUsed,
+        ResolvedAcceptanceRules rules)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(review);
+        ArgumentNullException.ThrowIfNull(lineage);
+        ArgumentNullException.ThrowIfNull(rules);
+
+        var reviewKey = DocumentTypeKey.Review.ToWire();
+        if (!string.Equals(review.Type, reviewKey, StringComparison.Ordinal))
+            throw Invalid("review",
+                $"The review envelope must be of type '{reviewKey}'; got '{review.Type}'.");
+
+        if (string.IsNullOrWhiteSpace(document.IssueId))
+            throw Invalid("issueId", "The document envelope carries no issueId.");
+
+        if (roundsUsed < 0)
+            throw Invalid("roundsUsed", $"RoundsUsed must be non-negative; got {roundsUsed}.");
+
+        return new AcceptanceRequest
+        {
+            DecisionSessionId = UuidV7.NewGuid(),
+            Document = document,
+            Review = review,
+            Lineage = lineage,
+            RoundsUsed = roundsUsed,
+            Rules = rules,
+            IssueId = document.IssueId,
+        };
+    }
+
+    private static TammaError Invalid(string field, string message) =>
+        new(
+            "ACCEPTANCE_REQUEST.INVALID",
+            message,
+            new Dictionary<string, object?> { ["field"] = field },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRouting.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRouting.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The orchestrator's routing decision (Story 39-5 AC2): decide the acceptance
+/// itself, or assign it to a tenant ROLE (never an exact user — settled design
+/// review 2026-07-21; 39-20 resolves the role's audience). Serialized
+/// polymorphically with a <c>kind</c> discriminator through
+/// <see cref="AcceptanceRulesJson.Options"/>.
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(DecideSelf), "decide-self")]
+[JsonDerivedType(typeof(AssignToRole), "assign-to-role")]
+public abstract record AcceptanceRouting
+{
+    /// <summary>The orchestrator answers the <see cref="AcceptanceDecision"/> itself.</summary>
+    public sealed record DecideSelf : AcceptanceRouting;
+
+    /// <summary>
+    /// Address the decision to a tenant role. <see cref="RoleWire"/> is an
+    /// <see cref="AgentRole"/> wire string; <see cref="Basis"/> records the
+    /// visibility rule 39-20 intersects the role-holders with.
+    /// </summary>
+    public sealed record AssignToRole(
+        [property: JsonPropertyName("roleWire")] string RoleWire,
+        [property: JsonPropertyName("basis")] AssignmentBasis Basis) : AcceptanceRouting;
+}
+
+/// <summary>
+/// The visibility rule an assignment is intersected with (Story 39-5 AC2; 39-20
+/// consumes it): the issue initiator, or anyone with repo access.
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<AssignmentBasis>))]
+public enum AssignmentBasis
+{
+    [Wire("initiator")]  Initiator,
+    [Wire("repo-access")] RepoAccess,
+}
+
+/// <summary><see cref="AssignmentBasis"/> wire helper.</summary>
+public static class AssignmentBasisExtensions
+{
+    public static string ToWire(this AssignmentBasis basis) => EnumWire<AssignmentBasis>.ToWire(basis);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRules.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRules.cs
@@ -1,0 +1,239 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The configurable acceptance policy for a document type (Story 39-5 AC1). It
+/// expresses the autonomy dial (70–100), the revision/repair bounds, the
+/// escalation criteria (ambiguity threshold + always-escalate classes), the
+/// reviewer selection (single reviewer vs panel), and the two operator-authored
+/// guidance strings the orchestrator reads when it decides and routes.
+///
+/// <para>
+/// Every property carries an explicit <c>[JsonPropertyName]</c> (39-2 D8);
+/// serialize/deserialize through <see cref="AcceptanceRulesJson.Options"/> so the
+/// wire contract — including the <c>[Wire]</c> enum spellings — is deliberate.
+/// </para>
+///
+/// <para>
+/// <see cref="Validate"/> REJECTS out-of-range knobs and unknown taxonomy keys
+/// (Design Decision D4) — it never clamps. Validation runs both fail-loud on
+/// write and defensively on read so a corrupt row throws rather than silently
+/// degrading.
+/// </para>
+/// </summary>
+public sealed record AcceptanceRules
+{
+    /// <summary>How much the orchestrator decides itself (70 = supervised baseline, 100 = full auto). Validated 70–100.</summary>
+    [JsonPropertyName("autonomyLevel")]
+    public required int AutonomyLevel { get; init; }
+
+    /// <summary>Maximum review/revision rounds before <c>Escalate(RoundsExhausted)</c>. Validated 1–10.</summary>
+    [JsonPropertyName("maxRevisionRounds")]
+    public required int MaxRevisionRounds { get; init; }
+
+    /// <summary>Maximum deterministic validation-repair attempts. Validated 0–10.</summary>
+    [JsonPropertyName("maxValidationRepairAttempts")]
+    public required int MaxValidationRepairAttempts { get; init; }
+
+    /// <summary>Ambiguity score at/above which a request escalates. Validated [0,1].</summary>
+    [JsonPropertyName("ambiguityEscalationThreshold")]
+    public required double AmbiguityEscalationThreshold { get; init; }
+
+    /// <summary>Document/action classes that always short-circuit to <c>Escalate</c> before any acceptor runs.</summary>
+    [JsonPropertyName("alwaysEscalate")]
+    public required IReadOnlyList<EscalationClass> AlwaysEscalate { get; init; }
+
+    /// <summary>How reviewers are selected for 39-7 (single reviewer role or a panel + decision rule).</summary>
+    [JsonPropertyName("reviewerSelection")]
+    public required ReviewerSelection ReviewerSelection { get; init; }
+
+    /// <summary>Operator prose: what warrants acceptance, revision, escalation.</summary>
+    [JsonPropertyName("decisionGuidance")]
+    public required string DecisionGuidance { get; init; }
+
+    /// <summary>Operator prose: what the orchestrator must assign to a human at this autonomy level.</summary>
+    [JsonPropertyName("routingGuidance")]
+    public required string RoutingGuidance { get; init; }
+
+    /// <summary>
+    /// Enforce the D4 bounds and taxonomy validity, throwing
+    /// <c>ACCEPTANCE_RULES.INVALID</c> on any violation. Returns <c>this</c> for
+    /// fluent use. Called on every write AND on every read (defensive) so an
+    /// out-of-range or typo'd row fails loud, never silently degrades.
+    /// </summary>
+    /// <exception cref="TammaError">Code <c>ACCEPTANCE_RULES.INVALID</c>.</exception>
+    public AcceptanceRules Validate()
+    {
+        if (AutonomyLevel is < 70 or > 100)
+            throw Invalid(nameof(AutonomyLevel), $"AutonomyLevel must be within [70, 100]; got {AutonomyLevel}.");
+        if (MaxRevisionRounds is < 1 or > 10)
+            throw Invalid(nameof(MaxRevisionRounds), $"MaxRevisionRounds must be within [1, 10]; got {MaxRevisionRounds}.");
+        if (MaxValidationRepairAttempts is < 0 or > 10)
+            throw Invalid(nameof(MaxValidationRepairAttempts), $"MaxValidationRepairAttempts must be within [0, 10]; got {MaxValidationRepairAttempts}.");
+        if (double.IsNaN(AmbiguityEscalationThreshold) || AmbiguityEscalationThreshold is < 0.0 or > 1.0)
+            throw Invalid(nameof(AmbiguityEscalationThreshold), $"AmbiguityEscalationThreshold must be within [0, 1]; got {AmbiguityEscalationThreshold}.");
+
+        if (AlwaysEscalate is null)
+            throw Invalid(nameof(AlwaysEscalate), "AlwaysEscalate must not be null (use an empty list).");
+        foreach (var cls in AlwaysEscalate)
+        {
+            if (cls is null)
+                throw Invalid(nameof(AlwaysEscalate), "AlwaysEscalate entries must not be null.");
+            ValidateEscalationClass(cls);
+        }
+
+        if (ReviewerSelection is null)
+            throw Invalid(nameof(ReviewerSelection), "ReviewerSelection must not be null.");
+        ValidateReviewerSelection(ReviewerSelection);
+
+        if (DecisionGuidance is null)
+            throw Invalid(nameof(DecisionGuidance), "DecisionGuidance must not be null.");
+        if (RoutingGuidance is null)
+            throw Invalid(nameof(RoutingGuidance), "RoutingGuidance must not be null.");
+
+        return this;
+    }
+
+    private static void ValidateEscalationClass(EscalationClass cls)
+    {
+        if (string.IsNullOrWhiteSpace(cls.Key))
+            throw Invalid(nameof(AlwaysEscalate), "An always-escalate class carries an empty key.");
+
+        try
+        {
+            switch (cls.Kind)
+            {
+                case EscalationClassKind.DocumentType:
+                    DocumentTypeKeyExtensions.Parse(cls.Key);
+                    break;
+                case EscalationClassKind.AgentAction:
+                    AgentActionExtensions.Parse(cls.Key);
+                    break;
+                default:
+                    throw Invalid(nameof(AlwaysEscalate), $"Unknown escalation-class kind '{cls.Kind}'.");
+            }
+        }
+        catch (TammaError ex) when (ex.Code != "ACCEPTANCE_RULES.INVALID")
+        {
+            throw Invalid(nameof(AlwaysEscalate),
+                $"Always-escalate {cls.Kind.ToWire()} key '{cls.Key}' is not a known taxonomy vocabulary member.");
+        }
+        catch (ArgumentException)
+        {
+            throw Invalid(nameof(AlwaysEscalate),
+                $"Always-escalate {cls.Kind.ToWire()} key '{cls.Key}' is not a known taxonomy vocabulary member.");
+        }
+    }
+
+    private static void ValidateReviewerSelection(ReviewerSelection sel)
+    {
+        switch (sel.Mode)
+        {
+            case ReviewerMode.SingleReviewer:
+                if (string.IsNullOrWhiteSpace(sel.ReviewerRole))
+                    throw Invalid(nameof(ReviewerSelection), "A single-reviewer selection requires a ReviewerRole.");
+                ParseRole(sel.ReviewerRole!);
+                break;
+            case ReviewerMode.Panel:
+                if (sel.PanelRoles is null || sel.PanelRoles.Count == 0)
+                    throw Invalid(nameof(ReviewerSelection), "A panel selection requires a non-empty PanelRoles roster.");
+                foreach (var r in sel.PanelRoles) ParseRole(r);
+                if (sel.Quorum is { } q && (q < 1 || q > sel.PanelRoles.Count))
+                    throw Invalid(nameof(ReviewerSelection),
+                        $"Panel quorum {q} must be within [1, {sel.PanelRoles.Count}] (the roster size).");
+                break;
+            default:
+                throw Invalid(nameof(ReviewerSelection), $"Unknown reviewer mode '{sel.Mode}'.");
+        }
+    }
+
+    private static void ParseRole(string role)
+    {
+        try
+        {
+            AgentRoleExtensions.Parse(role);
+        }
+        catch (ArgumentException)
+        {
+            throw Invalid(nameof(ReviewerSelection), $"Reviewer role '{role}' is not a known agent role.");
+        }
+    }
+
+    private static TammaError Invalid(string field, string message) =>
+        new(
+            "ACCEPTANCE_RULES.INVALID",
+            message,
+            new Dictionary<string, object?> { ["field"] = field },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+}
+
+/// <summary>
+/// One always-escalate class: a taxonomy key interpreted per its
+/// <see cref="EscalationClassKind"/> (Story 39-5 AC1; the README's "whether
+/// breaking changes always escalate is acceptance-rules configuration, not a
+/// hardcoded rule"). <see cref="AcceptanceRules.Validate"/> parses
+/// <see cref="Key"/> against the matching registry.
+/// </summary>
+public sealed record EscalationClass(
+    [property: JsonPropertyName("kind")] EscalationClassKind Kind,
+    [property: JsonPropertyName("key")] string Key);
+
+/// <summary>Whether an <see cref="EscalationClass.Key"/> is a document-type or agent-action wire string.</summary>
+[JsonConverter(typeof(WireEnumJsonConverter<EscalationClassKind>))]
+public enum EscalationClassKind
+{
+    [Wire("document-type")] DocumentType,
+    [Wire("agent-action")]  AgentAction,
+}
+
+/// <summary>
+/// Reviewer selection for 39-7 (Story 39-5 AC1): a single reviewer role, or a
+/// panel with a roster + a <see cref="ReviewDecisionRule"/> (unanimous/majority)
+/// that 39-7 reads to resolve the panel verdict. <see cref="Quorum"/> is an
+/// optional numeric floor; the decision rule — not a bare number — expresses
+/// unanimous-vs-majority.
+/// </summary>
+public sealed record ReviewerSelection(
+    [property: JsonPropertyName("mode")] ReviewerMode Mode,
+    [property: JsonPropertyName("reviewerRole")] string? ReviewerRole,
+    [property: JsonPropertyName("panelRoles")] IReadOnlyList<string> PanelRoles,
+    [property: JsonPropertyName("quorum")] int? Quorum,
+    [property: JsonPropertyName("decisionRule")] ReviewDecisionRule DecisionRule);
+
+/// <summary>Single reviewer or a full panel.</summary>
+[JsonConverter(typeof(WireEnumJsonConverter<ReviewerMode>))]
+public enum ReviewerMode
+{
+    [Wire("single-reviewer")] SingleReviewer,
+    [Wire("panel")]           Panel,
+}
+
+/// <summary>How a panel's verdict is resolved (39-7 consumes this).</summary>
+[JsonConverter(typeof(WireEnumJsonConverter<ReviewDecisionRule>))]
+public enum ReviewDecisionRule
+{
+    [Wire("unanimous")] Unanimous,
+    [Wire("majority")]  Majority,
+}
+
+/// <summary><see cref="EscalationClassKind"/> wire helper.</summary>
+public static class EscalationClassKindExtensions
+{
+    public static string ToWire(this EscalationClassKind kind) => EnumWire<EscalationClassKind>.ToWire(kind);
+}
+
+/// <summary><see cref="ReviewerMode"/> wire helper.</summary>
+public static class ReviewerModeExtensions
+{
+    public static string ToWire(this ReviewerMode mode) => EnumWire<ReviewerMode>.ToWire(mode);
+}
+
+/// <summary><see cref="ReviewDecisionRule"/> wire helper.</summary>
+public static class ReviewDecisionRuleExtensions
+{
+    public static string ToWire(this ReviewDecisionRule rule) => EnumWire<ReviewDecisionRule>.ToWire(rule);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRulesJson.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/AcceptanceRulesJson.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// The single canonical <see cref="JsonSerializerOptions"/> for acceptance-rules
+/// payloads (mirrors 39-2's <c>DocumentJson</c> style). Every wire property
+/// carries an explicit <c>[JsonPropertyName]</c> and every closed enum a
+/// <c>[JsonConverter(WireEnumJsonConverter&lt;T&gt;)]</c>, so the options only
+/// need to (a) not infer a naming policy and (b) never write nulls implicitly.
+/// The polymorphic <see cref="AcceptanceDecision"/> / <see cref="AcceptanceRouting"/>
+/// hierarchies serialize via their <c>[JsonPolymorphic]</c> attributes.
+///
+/// <para>Persisted rows and the <c>get_acceptance_rules</c> tool output MUST go
+/// through this single serializer so the resolver payload and the embedded
+/// request payload are byte-identical (AC3).</para>
+/// </summary>
+public static class AcceptanceRulesJson
+{
+    public static JsonSerializerOptions Options { get; } = Build();
+
+    private static JsonSerializerOptions Build()
+    {
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            // Explicit [JsonPropertyName] everywhere; enums carry their own
+            // [JsonConverter]. Nothing to infer.
+            PropertyNamingPolicy = null,
+        };
+        return options;
+    }
+
+    /// <summary>Serialize an <see cref="AcceptanceRules"/> body with the canonical options.</summary>
+    public static string Serialize(AcceptanceRules rules) => JsonSerializer.Serialize(rules, Options);
+
+    /// <summary>
+    /// Deserialize an <see cref="AcceptanceRules"/> body and VALIDATE it
+    /// defensively (Design Decision D3 — a corrupt row throws, never silently
+    /// degrades).
+    /// </summary>
+    /// <exception cref="JsonException">Malformed JSON or a bad wire token.</exception>
+    /// <exception cref="Tamma.Core.TammaError">
+    /// Code <c>ACCEPTANCE_RULES.INVALID</c> for an out-of-range / unknown-key body.
+    /// </exception>
+    public static AcceptanceRules Deserialize(string json)
+    {
+        var rules = JsonSerializer.Deserialize<AcceptanceRules>(json, Options)
+            ?? throw new JsonException("Acceptance-rules JSON deserialized to null.");
+        return rules.Validate();
+    }
+
+    /// <summary>Serialize a <see cref="ResolvedAcceptanceRules"/> with the canonical options.</summary>
+    public static string SerializeResolved(ResolvedAcceptanceRules resolved) =>
+        JsonSerializer.Serialize(resolved, Options);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/IAcceptanceRulesResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/IAcceptanceRulesResolver.cs
@@ -1,0 +1,32 @@
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// Resolves the effective <see cref="ResolvedAcceptanceRules"/> for a principal +
+/// document type (Story 39-5 AC6). The MODEL + this interface live in
+/// <c>Tamma.Core</c> so 39-6 (Elsa process) and the 39-17 agent host can depend
+/// on them without a <c>Tamma.Api</c> reference; the EF-backed implementation
+/// (<c>AcceptanceRulesService</c>) lives in <c>Tamma.Api</c> (Design Decision D1).
+///
+/// <para>The <c>ForTenant</c> method name (rather than an overload on
+/// <c>Guid</c> vs <c>Guid?</c>) follows <c>PromptStoreService</c>'s
+/// overload-resolution rationale: a non-null <c>Guid</c> binds to BOTH a
+/// nullable and a non-nullable same-named overload, and the non-nullable always
+/// wins — which would silently route single-user callers onto the SaaS path.
+/// Distinct names keep the two surfaces unambiguous.</para>
+/// </summary>
+public interface IAcceptanceRulesResolver
+{
+    /// <summary>
+    /// Resolve for the single-user principal (<paramref name="userId"/>): per-type
+    /// user override → base user override → static default.
+    /// </summary>
+    Task<ResolvedAcceptanceRules> ResolveAsync(
+        Guid? userId, DocumentTypeKey documentType, CancellationToken ct = default);
+
+    /// <summary>
+    /// Resolve for the SaaS tenant (<paramref name="tenantId"/>): per-type tenant
+    /// override → base tenant override → static default. Never consults user rows.
+    /// </summary>
+    Task<ResolvedAcceptanceRules> ResolveForTenantAsync(
+        Guid tenantId, DocumentTypeKey documentType, CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/ResolvedAcceptanceRules.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Policy/ResolvedAcceptanceRules.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Core.Documents.Policy;
+
+/// <summary>
+/// Which layer produced a resolved rules row (Story 39-5 AC4/D2 three-tier
+/// resolution): a per-type principal override, a principal base override (the
+/// deployment-wide dial), or the shipped static default.
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<AcceptanceRulesSource>))]
+public enum AcceptanceRulesSource
+{
+    [Wire("system-default")]    SystemDefault,
+    [Wire("principal-default")] PrincipalDefault,
+    [Wire("type-override")]     TypeOverride,
+}
+
+/// <summary><see cref="AcceptanceRulesSource"/> wire helper.</summary>
+public static class AcceptanceRulesSourceExtensions
+{
+    public static string ToWire(this AcceptanceRulesSource source) => EnumWire<AcceptanceRulesSource>.ToWire(source);
+}
+
+/// <summary>
+/// The effective <see cref="AcceptanceRules"/> for a principal + document type,
+/// carrying its provenance and version (Story 39-5 AC3/AC6). The <c>Version</c>
+/// lets 39-6's decision event record which rules version the decision was made
+/// under.
+/// </summary>
+public sealed record ResolvedAcceptanceRules(
+    [property: JsonPropertyName("rules")] AcceptanceRules Rules,
+    [property: JsonPropertyName("source")] AcceptanceRulesSource Source,
+    [property: JsonPropertyName("version")] int Version,
+    [property: JsonPropertyName("documentTypeKey")] string DocumentTypeKey,
+    [property: JsonPropertyName("resolvedAt")] DateTimeOffset ResolvedAt);

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -155,6 +155,8 @@ public static class DependencyInjection
         // Tenant-scoped repositories (use ITenantDbContextFactory internally).
         services.AddScoped<IAgentConfigRepository, AgentConfigRepository>();
         services.AddScoped<IPromptRepository, PromptRepository>();
+        // Story 39-5 — tenant-resident acceptance-rules overrides.
+        services.AddScoped<IAcceptanceRulesRepository, AcceptanceRulesRepository>();
         services.AddScoped<IConventionRepository, ConventionRepository>();
         services.AddScoped<IProviderHealthRepository, ProviderHealthRepository>();
         services.AddScoped<IDiagnosticsRepository, DiagnosticsRepository>();

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/AcceptanceRulesOverride.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/AcceptanceRulesOverride.cs
@@ -1,0 +1,35 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// A stored acceptance-rules override row (Story 39-5 Design Decision D3),
+/// mirroring <see cref="PromptOverride"/>'s dual-scoping shape: single-user rows
+/// are keyed on <see cref="UserId"/> (tenant_id NULL), SaaS rows on
+/// <see cref="TenantId"/> (user_id NULL); the <c>principal_xor</c> CHECK enforces
+/// exactly-one. <see cref="DocumentTypeKey"/> NULL marks the PRINCIPAL BASE row
+/// (the deployment-wide dial); a non-null key marks a per-type override. The
+/// rules body is one <c>jsonb</c> column (<see cref="RulesJson"/>).
+/// </summary>
+public class AcceptanceRulesOverride
+{
+    public Guid Id { get; set; }
+    public Guid? UserId { get; set; }
+    public Guid? TenantId { get; set; }
+
+    /// <summary>Document-type wire key; NULL = the principal base row (the dial).</summary>
+    public string? DocumentTypeKey { get; set; }
+
+    /// <summary>The complete, validated <c>AcceptanceRules</c> body serialized via <c>AcceptanceRulesJson</c>.</summary>
+    public string RulesJson { get; set; } = null!;
+
+    /// <summary>Optimistic-concurrency / audit version; bumped on every upsert.</summary>
+    public int Version { get; set; } = 1;
+
+    /// <summary>User id that originally created the override.</summary>
+    public Guid? CreatedBy { get; set; }
+
+    /// <summary>User id of the most recent updater.</summary>
+    public Guid? UpdatedBy { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722011909_AddAcceptanceRulesOverrides.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722011909_AddAcceptanceRulesOverrides.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722011909_AddAcceptanceRulesOverrides")]
+    partial class AddAcceptanceRulesOverrides
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722011909_AddAcceptanceRulesOverrides.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722011909_AddAcceptanceRulesOverrides.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddAcceptanceRulesOverrides : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "acceptance_rules_overrides",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: true),
+                    DocumentTypeKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    RulesJson = table.Column<string>(type: "jsonb", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                    CreatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    UpdatedBy = table.Column<Guid>(type: "uuid", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_acceptance_rules_overrides", x => x.Id);
+                    table.CheckConstraint("ck_acceptance_rules_overrides_principal_xor", "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_acceptance_rules_overrides_UserId_TenantId_DocumentTypeKey",
+                table: "acceptance_rules_overrides",
+                columns: new[] { "UserId", "TenantId", "DocumentTypeKey" },
+                unique: true)
+                .Annotation("Npgsql:NullsDistinct", false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "acceptance_rules_overrides");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/AcceptanceRulesRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/AcceptanceRulesRepository.cs
@@ -1,0 +1,136 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Tenant-scoped acceptance-rules overrides (Story 39-5). Mirrors
+/// <see cref="PromptRepository"/> exactly: uses <see cref="ITenantDbContextFactory"/>
+/// for all reads/writes; the ambient <see cref="ITenantContext"/> MUST carry a
+/// tenant id (single-user users own a personal tenant DB, so both modes land in
+/// the same physical home). Single-user rows carry <c>user_id</c> (tenant_id
+/// NULL); SaaS rows carry <c>tenant_id</c> (user_id NULL); the DB
+/// <c>principal_xor</c> CHECK forces exactly-one. <c>documentTypeKey</c> NULL
+/// addresses the principal base row.
+/// </summary>
+public class AcceptanceRulesRepository(
+    ITenantDbContextFactory tenantDbFactory,
+    ITenantContext tenantContext) : IAcceptanceRulesRepository
+{
+    private Guid RequireTenantId() => tenantContext.TenantId
+        ?? throw new InvalidOperationException(
+            "AcceptanceRulesRepository requires an ambient tenant id. acceptance_rules_overrides " +
+            "is tenant-resident (mirrors prompt_overrides); system defaults resolve from in-code " +
+            "AcceptanceDefaults via AcceptanceRulesService, not from DB rows.");
+
+    // ───────────────────────── single-user mode ─────────────────────────
+
+    public async Task<AcceptanceRulesOverride?> GetAsync(Guid? userId, string? documentTypeKey)
+    {
+        var tid = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(tid);
+        return await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.UserId == userId && p.TenantId == default(Guid?)
+                && p.DocumentTypeKey == documentTypeKey);
+    }
+
+    public async Task<(AcceptanceRulesOverride Entity, bool WasCreated)> UpsertAsync(
+        AcceptanceRulesOverride entity, Guid? actingUserId = null)
+    {
+        var tid = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(tid);
+        return await UpsertInternal(db.AcceptanceRulesOverrides, () => db.SaveChangesAsync(), entity, actingUserId);
+    }
+
+    private static async Task<(AcceptanceRulesOverride Entity, bool WasCreated)> UpsertInternal(
+        DbSet<AcceptanceRulesOverride> set,
+        Func<Task<int>> save,
+        AcceptanceRulesOverride entity,
+        Guid? actingUserId)
+    {
+        // Match on BOTH user_id AND tenant_id AND the type key so single-user
+        // and SaaS rows for the same key don't collide. The principal_xor CHECK
+        // guarantees exactly one predicate picks the existing row.
+        var existing = await set.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p =>
+                p.UserId == entity.UserId && p.TenantId == entity.TenantId &&
+                p.DocumentTypeKey == entity.DocumentTypeKey);
+        if (existing is not null)
+        {
+            existing.RulesJson = entity.RulesJson;
+            existing.UpdatedAt = DateTime.UtcNow;
+            existing.Version += 1;
+            existing.UpdatedBy = actingUserId ?? entity.UserId;
+            await save();
+            return (existing, false);
+        }
+        entity.CreatedAt = DateTime.UtcNow;
+        entity.UpdatedAt = DateTime.UtcNow;
+        entity.Version = 1;
+        entity.CreatedBy = actingUserId ?? entity.UserId;
+        entity.UpdatedBy = actingUserId ?? entity.UserId;
+        set.Add(entity);
+        await save();
+        return (entity, true);
+    }
+
+    public async Task<bool> DeleteAsync(Guid? userId, string? documentTypeKey)
+    {
+        var tid = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(tid);
+        var row = await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.UserId == userId && p.TenantId == default(Guid?)
+                && p.DocumentTypeKey == documentTypeKey);
+        if (row is null) return false;
+        db.AcceptanceRulesOverrides.Remove(row);
+        await db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<List<AcceptanceRulesOverride>> ListAsync(Guid? userId)
+    {
+        var tid = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(tid);
+        return await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .Where(p => p.UserId == userId && p.TenantId == default(Guid?)).ToListAsync();
+    }
+
+    // ───────────────────────── SaaS mode ────────────────────────────────
+
+    public async Task<AcceptanceRulesOverride?> GetByTenantAsync(Guid tenantId, string? documentTypeKey)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+        var ambient = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(ambient);
+        return await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.TenantId == tenantId && p.UserId == default(Guid?)
+                && p.DocumentTypeKey == documentTypeKey);
+    }
+
+    public async Task<bool> DeleteByTenantAsync(Guid tenantId, string? documentTypeKey)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+        var ambient = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(ambient);
+        var row = await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(p => p.TenantId == tenantId && p.UserId == default(Guid?)
+                && p.DocumentTypeKey == documentTypeKey);
+        if (row is null) return false;
+        db.AcceptanceRulesOverrides.Remove(row);
+        await db.SaveChangesAsync();
+        return true;
+    }
+
+    public async Task<List<AcceptanceRulesOverride>> ListByTenantAsync(Guid tenantId)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+        var ambient = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(ambient);
+        return await db.AcceptanceRulesOverrides.IgnoreQueryFilters()
+            .Where(p => p.TenantId == tenantId && p.UserId == default(Guid?)).ToListAsync();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IAcceptanceRulesRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IAcceptanceRulesRepository.cs
@@ -1,0 +1,42 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Persistence seam for <c>acceptance_rules_overrides</c> (Story 39-5). Mirrors
+/// <see cref="IPromptRepository"/>'s dual-scoping surface: single-user rows are
+/// keyed on <c>UserId</c>, SaaS rows on <c>TenantId</c>; the DB
+/// <c>principal_xor</c> CHECK forces exactly-one. <c>documentTypeKey</c> NULL
+/// addresses the principal BASE row. The two surfaces are PARALLEL — no method
+/// silently joins both planes.
+/// </summary>
+public interface IAcceptanceRulesRepository
+{
+    // ───────────────────────── single-user mode ─────────────────────────
+
+    /// <summary>Read a single-user override (tenant_id IS NULL) for the given key (NULL key = base row).</summary>
+    Task<AcceptanceRulesOverride?> GetAsync(Guid? userId, string? documentTypeKey);
+
+    /// <summary>
+    /// Upsert an override. Returns the persisted entity and a flag: fresh insert
+    /// (<c>true</c>) vs update (<c>false</c>) — drives CREATED-vs-UPDATED event
+    /// emission. Routes on whichever of <see cref="AcceptanceRulesOverride.UserId"/>
+    /// / <see cref="AcceptanceRulesOverride.TenantId"/> is set.
+    /// </summary>
+    Task<(AcceptanceRulesOverride Entity, bool WasCreated)> UpsertAsync(
+        AcceptanceRulesOverride entity, Guid? actingUserId = null);
+
+    Task<bool> DeleteAsync(Guid? userId, string? documentTypeKey);
+    Task<List<AcceptanceRulesOverride>> ListAsync(Guid? userId);
+
+    // ───────────────────────── SaaS mode ────────────────────────────────
+
+    /// <summary>Read a tenant-scoped override (user_id IS NULL) for the given key (NULL key = base row).</summary>
+    Task<AcceptanceRulesOverride?> GetByTenantAsync(Guid tenantId, string? documentTypeKey);
+
+    /// <summary>Delete a tenant-scoped override. Returns false when no row matched.</summary>
+    Task<bool> DeleteByTenantAsync(Guid tenantId, string? documentTypeKey);
+
+    /// <summary>List every tenant-scoped override for <paramref name="tenantId"/>.</summary>
+    Task<List<AcceptanceRulesOverride>> ListByTenantAsync(Guid tenantId);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1537,6 +1537,41 @@ internal static class TammaModelConfiguration
             ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
         });
 
+        // ── AcceptanceRulesOverride ──
+        // Story 39-5: dual-scoping, mirrors PromptOverride exactly. Single-user
+        // rows carry user_id (tenant_id IS NULL); SaaS rows carry tenant_id
+        // (user_id IS NULL). The principal_xor CHECK enforces exactly-one.
+        // DocumentTypeKey NULL = the principal BASE row (the deployment-wide
+        // dial); a non-null key = a per-type override. The unique index covers
+        // BOTH principal keys + the type key with NULLS NOT DISTINCT (PG15+;
+        // production runs PG17) so the (null, tid, key) and (uid, null, key)
+        // row spaces are disjoint and the (principal, NULL-key) base rows dedupe.
+        modelBuilder.Entity<AcceptanceRulesOverride>(entity =>
+        {
+            entity.ToTable("acceptance_rules_overrides", t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_acceptance_rules_overrides_principal_xor",
+                    "(\"UserId\" IS NOT NULL AND \"TenantId\" IS NULL) " +
+                    "OR (\"UserId\" IS NULL AND \"TenantId\" IS NOT NULL)");
+            });
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasDefaultValueSql("gen_random_uuid()");
+            entity.Property(e => e.DocumentTypeKey).HasMaxLength(64);
+            entity.Property(e => e.RulesJson).IsRequired().HasColumnType("jsonb");
+            entity.Property(e => e.Version).HasDefaultValue(1);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+            entity.Property(e => e.UpdatedAt).HasDefaultValueSql("now()");
+
+            entity.HasIndex(e => new { e.UserId, e.TenantId, e.DocumentTypeKey })
+                .IsUnique()
+                .AreNullsDistinct(false)
+                .HasDatabaseName("IX_acceptance_rules_overrides_UserId_TenantId_DocumentTypeKey");
+
+            if (omitTenantIdColumn) entity.Ignore(e => e.TenantId);
+            ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
+        });
+
         // ── Convention ──
         // Story 27-8: two-tier convention store.
         //   tenant_id IS NULL  → system default (shipped by Tamma, seeded in 27-16)

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -51,6 +51,9 @@ public class TenantDbContext : DbContext
     // ── Tenant-scoped entities ──
     public DbSet<AgentConfig> AgentConfigs => Set<AgentConfig>();
     public DbSet<PromptOverride> PromptOverrides => Set<PromptOverride>();
+    // Story 39-5 — tenant-resident acceptance-rules overrides (dual-scoped like
+    // prompt_overrides: user_id in single-user mode, tenant_id in SaaS mode).
+    public DbSet<AcceptanceRulesOverride> AcceptanceRulesOverrides => Set<AcceptanceRulesOverride>();
     // Story 32-2 — SaaS tenant-keyed role→agent selections (the single-user
     // user-keyed rows live on the CP context). Same table shape, two homes.
     public DbSet<AgentRoleSelection> AgentRoleSelections => Set<AgentRoleSelection>();

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesEndpointsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesEndpointsTests.cs
@@ -1,0 +1,199 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Dtos.AcceptanceRules;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.AcceptanceRules;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.AcceptanceRules;
+
+/// <summary>
+/// Endpoint dispatch + RBAC-matrix tests for <see cref="AcceptanceRulesEndpoints"/>
+/// (Story 39-5 AC6, AC7). Mirrors <c>PromptEndpointsTenantAdminTests</c>: uses the
+/// EF-InMemory fixture and drives the endpoint delegates directly. HTTP-level 403
+/// enforcement rides the shared <c>AcceptanceRulesManage</c> policy — pinned via
+/// the permission matrix (the dev-mode permissive auth seam short-circuits named
+/// policies, exactly as documented for the prompt store).
+/// </summary>
+[TestFixture]
+public class AcceptanceRulesEndpointsTests
+{
+    private InMemoryDbFixture _fx = null!;
+    private AcceptanceRulesService _store = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _fx = new InMemoryDbFixture();
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var repo = new Tamma.Data.Repositories.AcceptanceRulesRepository(_fx.Factory, tc);
+        _store = new AcceptanceRulesService(repo);
+    }
+
+    [TearDown]
+    public async Task TearDown() => await _fx.DisposeAsync();
+
+    private static ClaimsPrincipal Principal(Guid userId, string? role = null)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, userId.ToString()) };
+        if (role is not null) claims.Add(new Claim(ClaimTypes.Role, role));
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"));
+    }
+
+    private static ITammaModeProvider Mode(TammaMode mode) => new StubModeProvider(mode);
+    private sealed class StubModeProvider(TammaMode mode) : ITammaModeProvider { public TammaMode Mode { get; } = mode; }
+
+    private static AcceptanceRulesUpsertRequest Req(int autonomy = 90)
+    {
+        var r = AcceptanceDefaults.Rules with { AutonomyLevel = autonomy };
+        return new AcceptanceRulesUpsertRequest(
+            r.AutonomyLevel, r.MaxRevisionRounds, r.MaxValidationRepairAttempts,
+            r.AmbiguityEscalationThreshold, r.AlwaysEscalate, r.ReviewerSelection,
+            r.DecisionGuidance, r.RoutingGuidance);
+    }
+
+    private static async Task<(int Status, string Body)> Exec(IResult result)
+    {
+        var services = new ServiceCollection().AddLogging().AddOptions().BuildServiceProvider();
+        var ctx = new DefaultHttpContext
+        {
+            RequestServices = services,
+            Response = { Body = new MemoryStream() },
+        };
+        await result.ExecuteAsync(ctx);
+        ctx.Response.Body.Position = 0;
+        var body = await new StreamReader(ctx.Response.Body).ReadToEndAsync();
+        return (ctx.Response.StatusCode, body);
+    }
+
+    // ── SaaS: admin PUT writes a tenant-keyed row ──
+
+    [Test]
+    public async Task Upsert_SaaS_writes_tenant_keyed_row()
+    {
+        var tenantId = Guid.NewGuid();
+        var tc = new TenantContext();
+        tc.SetTenantId(tenantId);
+        var admin = Principal(Guid.NewGuid(), "admin");
+
+        var result = await AcceptanceRulesEndpoints.Upsert(
+            "plan", Req(97), _store, admin, tc, Mode(TammaMode.SaaS));
+        (await Exec(result)).Status.Should().Be(StatusCodes.Status200OK);
+
+        var resolved = await _store.ResolveForTenantAsync(tenantId, DocumentTypeKey.Plan);
+        resolved.Source.Should().Be(AcceptanceRulesSource.TypeOverride);
+        resolved.Rules.AutonomyLevel.Should().Be(97);
+    }
+
+    // ── single-user: sole user writes a user-keyed row ──
+
+    [Test]
+    public async Task Upsert_SingleUser_writes_user_keyed_row_and_resolves()
+    {
+        var userId = Guid.NewGuid();
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var user = Principal(userId, "owner");
+
+        var result = await AcceptanceRulesEndpoints.Upsert(
+            "design", Req(85), _store, user, tc, Mode(TammaMode.SingleUser));
+        (await Exec(result)).Status.Should().Be(StatusCodes.Status200OK);
+
+        var resolved = await _store.ResolveAsync(userId, DocumentTypeKey.Design);
+        resolved.Source.Should().Be(AcceptanceRulesSource.TypeOverride);
+        resolved.Rules.AutonomyLevel.Should().Be(85);
+    }
+
+    // ── the `base` dial row ──
+
+    [Test]
+    public async Task Upsert_base_writes_principal_base_row()
+    {
+        var userId = Guid.NewGuid();
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var user = Principal(userId, "owner");
+
+        await Exec(await AcceptanceRulesEndpoints.Upsert(
+            "base", Req(80), _store, user, tc, Mode(TammaMode.SingleUser)));
+
+        // A type with no per-type override now resolves from the base row.
+        var resolved = await _store.ResolveAsync(userId, DocumentTypeKey.Findings);
+        resolved.Source.Should().Be(AcceptanceRulesSource.PrincipalDefault);
+        resolved.Rules.AutonomyLevel.Should().Be(80);
+    }
+
+    // ── validation + unknown-key → 400 ──
+
+    [Test]
+    public async Task Upsert_invalid_autonomy_is_400_with_code()
+    {
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var user = Principal(Guid.NewGuid(), "owner");
+
+        var (status, body) = await Exec(await AcceptanceRulesEndpoints.Upsert(
+            "plan", Req(150), _store, user, tc, Mode(TammaMode.SingleUser)));
+
+        status.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("ACCEPTANCE_RULES.INVALID");
+    }
+
+    [Test]
+    public async Task Upsert_unknown_type_key_is_400()
+    {
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var user = Principal(Guid.NewGuid(), "owner");
+
+        var (status, body) = await Exec(await AcceptanceRulesEndpoints.Upsert(
+            "not-a-type", Req(), _store, user, tc, Mode(TammaMode.SingleUser)));
+
+        status.Should().Be(StatusCodes.Status400BadRequest);
+        body.Should().Contain("DOCUMENT.TYPE.UNKNOWN");
+    }
+
+    // ── reads ──
+
+    [Test]
+    public async Task GetResolved_member_read_is_200()
+    {
+        var tc = new TenantContext();
+        tc.SetTenantId(Guid.NewGuid());
+        var member = Principal(Guid.NewGuid(), "member");
+
+        var (status, _) = await Exec(await AcceptanceRulesEndpoints.GetResolved(
+            "review", _store, member, tc, Mode(TammaMode.SaaS)));
+        status.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Test]
+    public async Task GetDefaults_is_read_only_200()
+    {
+        var (status, body) = await Exec(AcceptanceRulesEndpoints.GetDefaults());
+        status.Should().Be(StatusCodes.Status200OK);
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("autonomyLevel").GetInt32().Should().Be(70);
+    }
+
+    // ── RBAC matrix pin (AC7) ──
+
+    [Test]
+    public void AcceptanceRulesManage_permission_is_admin_and_owner_not_member()
+    {
+        Permissions.Matrix.Should().ContainKey("acceptance-rules:manage");
+        Permissions.HasPermission("owner", "acceptance-rules:manage").Should().BeTrue();
+        Permissions.HasPermission("admin", "acceptance-rules:manage").Should().BeTrue();
+        Permissions.HasPermission("member", "acceptance-rules:manage").Should().BeFalse();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesOverridesMigrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesOverridesMigrationTests.cs
@@ -1,0 +1,185 @@
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Data;
+using Tamma.Data.Pooling;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.AcceptanceRules;
+
+/// <summary>
+/// Story 39-5 AC6 (schema) — pin the <c>ck_acceptance_rules_overrides_principal_xor</c>
+/// CHECK and the <c>NULLS NOT DISTINCT</c> semantics of the dual-key unique index
+/// against a real Postgres instance, plus a jsonb round-trip through the real
+/// <c>RulesJson</c> column. EF-InMemory enforces neither CHECK constraints nor
+/// NULLS NOT DISTINCT, so a Postgres testcontainer is the only path.
+///
+/// <para>REQUIRES DOCKER to run (CI-verified). The migration under test is
+/// <c>AddAcceptanceRulesOverrides</c>; the fixture spins Postgres 17, runs the full
+/// tenant migration graph via <see cref="EfTenantDbMigrator"/>, then drives the
+/// table with raw SQL.</para>
+/// </summary>
+[TestFixture]
+[Category("Docker")]
+public class AcceptanceRulesOverridesMigrationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _connectionString = null!;
+
+    private const string SampleRules =
+        "{\"autonomyLevel\":70,\"maxRevisionRounds\":2,\"maxValidationRepairAttempts\":2," +
+        "\"ambiguityEscalationThreshold\":0.7,\"alwaysEscalate\":[]," +
+        "\"reviewerSelection\":{\"mode\":\"single-reviewer\",\"reviewerRole\":\"architect\"," +
+        "\"panelRoles\":[],\"quorum\":null,\"decisionRule\":\"unanimous\"}," +
+        "\"decisionGuidance\":\"d\",\"routingGuidance\":\"r\"}";
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("acceptance_rules_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _connectionString = _postgres.GetConnectionString();
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(_connectionString);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    [SetUp]
+    public async Task ClearTable()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand("TRUNCATE TABLE acceptance_rules_overrides;", conn);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Test]
+    public async Task PrincipalXor_accepts_user_row()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (@uid, NULL, 'plan', @rules::jsonb);
+            """, conn);
+        cmd.Parameters.AddWithValue("uid", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("rules", SampleRules);
+        (await cmd.ExecuteNonQueryAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task PrincipalXor_accepts_tenant_base_row_with_null_type_key()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (NULL, @tid, NULL, @rules::jsonb);
+            """, conn);
+        cmd.Parameters.AddWithValue("tid", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("rules", SampleRules);
+        (await cmd.ExecuteNonQueryAsync()).Should().Be(1);
+    }
+
+    [Test]
+    public async Task PrincipalXor_rejects_both_keys_set()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (@uid, @tid, 'plan', @rules::jsonb);
+            """, conn);
+        cmd.Parameters.AddWithValue("uid", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("tid", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("rules", SampleRules);
+
+        var ex = await FluentActions.Awaiting(() => cmd.ExecuteNonQueryAsync()).Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23514");
+        ex.Which.ConstraintName.Should().Be("ck_acceptance_rules_overrides_principal_xor");
+    }
+
+    [Test]
+    public async Task PrincipalXor_rejects_both_keys_null()
+    {
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (NULL, NULL, 'plan', @rules::jsonb);
+            """, conn);
+        cmd.Parameters.AddWithValue("rules", SampleRules);
+
+        var ex = await FluentActions.Awaiting(() => cmd.ExecuteNonQueryAsync()).Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23514");
+        ex.Which.ConstraintName.Should().Be("ck_acceptance_rules_overrides_principal_xor");
+    }
+
+    [Test]
+    public async Task UniqueIndex_NullsNotDistinct_rejects_duplicate_base_rows()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using (var insert1 = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (NULL, @tid, NULL, @rules::jsonb);
+            """, conn))
+        {
+            insert1.Parameters.AddWithValue("tid", tenantId);
+            insert1.Parameters.AddWithValue("rules", SampleRules);
+            await insert1.ExecuteNonQueryAsync();
+        }
+
+        await using var insert2 = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (NULL, @tid, NULL, @rules::jsonb);
+            """, conn);
+        insert2.Parameters.AddWithValue("tid", tenantId);
+        insert2.Parameters.AddWithValue("rules", SampleRules);
+
+        // Two (NULL user, tenant, NULL key) base rows must collide despite the NULLs.
+        var ex = await FluentActions.Awaiting(() => insert2.ExecuteNonQueryAsync()).Should().ThrowAsync<PostgresException>();
+        ex.Which.SqlState.Should().Be("23505");
+    }
+
+    [Test]
+    public async Task RulesJson_roundtrips_through_the_real_jsonb_column()
+    {
+        var tenantId = Guid.NewGuid();
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync();
+
+        await using (var insert = new NpgsqlCommand(
+            """
+            INSERT INTO acceptance_rules_overrides ("UserId", "TenantId", "DocumentTypeKey", "RulesJson")
+            VALUES (NULL, @tid, 'design', @rules::jsonb);
+            """, conn))
+        {
+            insert.Parameters.AddWithValue("tid", tenantId);
+            insert.Parameters.AddWithValue("rules", SampleRules);
+            await insert.ExecuteNonQueryAsync();
+        }
+
+        await using var read = new NpgsqlCommand(
+            "SELECT \"RulesJson\"->>'autonomyLevel' FROM acceptance_rules_overrides WHERE \"TenantId\" = @tid;", conn);
+        read.Parameters.AddWithValue("tid", tenantId);
+        var value = (string?)await read.ExecuteScalarAsync();
+        value.Should().Be("70");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.AcceptanceRules;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.AcceptanceRules;
+
+/// <summary>
+/// Unit tests for <see cref="AcceptanceRulesService"/> with a Moq'd repository
+/// (Story 39-5 AC4, AC6): three-tier resolution ordering per mode, source +
+/// version provenance, mode isolation (tenant path never consults user rows),
+/// fail-loud unknown-key rejection before any write, defensive read validation,
+/// and best-effort event emission.
+/// </summary>
+[TestFixture]
+public class AcceptanceRulesServiceTests
+{
+    private Mock<IAcceptanceRulesRepository> _repo = null!;
+    private AcceptanceRulesService _service = null!;
+
+    private static readonly Guid UserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid TenantId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [SetUp]
+    public void SetUp()
+    {
+        _repo = new Mock<IAcceptanceRulesRepository>(MockBehavior.Strict);
+        _service = new AcceptanceRulesService(_repo.Object);
+    }
+
+    private static AcceptanceRulesOverride Row(string? key, Tamma.Core.Documents.Policy.AcceptanceRules rules, int version = 3) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = UserId,
+        DocumentTypeKey = key,
+        RulesJson = AcceptanceRulesJson.Serialize(rules),
+        Version = version,
+    };
+
+    // ── Resolution ordering (single-user) ──
+
+    [Test]
+    public async Task ResolveAsync_type_override_wins()
+    {
+        var custom = AcceptanceDefaults.Rules with { AutonomyLevel = 95 };
+        _repo.Setup(r => r.GetAsync(UserId, "plan")).ReturnsAsync(Row("plan", custom, 7));
+
+        var resolved = await _service.ResolveAsync(UserId, DocumentTypeKey.Plan);
+
+        resolved.Source.Should().Be(AcceptanceRulesSource.TypeOverride);
+        resolved.Version.Should().Be(7);
+        resolved.Rules.AutonomyLevel.Should().Be(95);
+        resolved.DocumentTypeKey.Should().Be("plan");
+    }
+
+    [Test]
+    public async Task ResolveAsync_falls_back_to_base_override()
+    {
+        var baseRules = AcceptanceDefaults.Rules with { AutonomyLevel = 88 };
+        _repo.Setup(r => r.GetAsync(UserId, "design")).ReturnsAsync((AcceptanceRulesOverride?)null);
+        _repo.Setup(r => r.GetAsync(UserId, null)).ReturnsAsync(Row(null, baseRules, 4));
+
+        var resolved = await _service.ResolveAsync(UserId, DocumentTypeKey.Design);
+
+        resolved.Source.Should().Be(AcceptanceRulesSource.PrincipalDefault);
+        resolved.Version.Should().Be(4);
+        resolved.Rules.AutonomyLevel.Should().Be(88);
+    }
+
+    [Test]
+    public async Task ResolveAsync_falls_back_to_static_default()
+    {
+        _repo.Setup(r => r.GetAsync(UserId, "design")).ReturnsAsync((AcceptanceRulesOverride?)null);
+        _repo.Setup(r => r.GetAsync(UserId, null)).ReturnsAsync((AcceptanceRulesOverride?)null);
+
+        var resolved = await _service.ResolveAsync(UserId, DocumentTypeKey.Design);
+
+        resolved.Source.Should().Be(AcceptanceRulesSource.SystemDefault);
+        resolved.Version.Should().Be(1);
+        resolved.Rules.Should().Be(AcceptanceDefaults.For(DocumentTypeKey.Design));
+    }
+
+    // ── Mode isolation ──
+
+    [Test]
+    public async Task ResolveForTenantAsync_never_consults_user_rows()
+    {
+        _repo.Setup(r => r.GetByTenantAsync(TenantId, "plan")).ReturnsAsync((AcceptanceRulesOverride?)null);
+        _repo.Setup(r => r.GetByTenantAsync(TenantId, null)).ReturnsAsync((AcceptanceRulesOverride?)null);
+
+        var resolved = await _service.ResolveForTenantAsync(TenantId, DocumentTypeKey.Plan);
+
+        resolved.Source.Should().Be(AcceptanceRulesSource.SystemDefault);
+        _repo.Verify(r => r.GetAsync(It.IsAny<Guid?>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    // ── Corrupt row defensive validation ──
+
+    [Test]
+    public void ResolveAsync_throws_on_corrupt_rules_json()
+    {
+        var bad = new AcceptanceRulesOverride
+        {
+            DocumentTypeKey = "plan",
+            RulesJson = AcceptanceRulesJson.Serialize(AcceptanceDefaults.Rules with { AutonomyLevel = 5 }),
+            Version = 1,
+        };
+        _repo.Setup(r => r.GetAsync(UserId, "plan")).ReturnsAsync(bad);
+
+        _service.Invoking(s => s.ResolveAsync(UserId, DocumentTypeKey.Plan))
+            .Should().ThrowAsync<TammaError>();
+    }
+
+    // ── Upsert rejects unknown key before touching the repo ──
+
+    [Test]
+    public async Task UpsertAsync_unknown_type_key_throws_before_repository_touch()
+    {
+        await _service.Invoking(s => s.UpsertAsync(UserId, "not-a-type", AcceptanceDefaults.Rules))
+            .Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "DOCUMENT.TYPE.UNKNOWN");
+
+        _repo.Verify(r => r.UpsertAsync(It.IsAny<AcceptanceRulesOverride>(), It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task UpsertAsync_invalid_rules_throws_before_repository_touch()
+    {
+        var invalid = AcceptanceDefaults.Rules with { AutonomyLevel = 200 };
+        await _service.Invoking(s => s.UpsertAsync(UserId, "plan", invalid))
+            .Should().ThrowAsync<TammaError>()
+            .Where(e => e.Code == "ACCEPTANCE_RULES.INVALID");
+
+        _repo.Verify(r => r.UpsertAsync(It.IsAny<AcceptanceRulesOverride>(), It.IsAny<Guid?>()), Times.Never);
+    }
+
+    // ── Event emission ──
+
+    [Test]
+    public async Task UpsertAsync_emits_created_event()
+    {
+        var events = new Mock<IEventRepository>();
+        events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent d) => d);
+        var eventsService = new AcceptanceRulesEventsService(events.Object);
+        var service = new AcceptanceRulesService(_repo.Object, eventsService);
+
+        var saved = Row("plan", AcceptanceDefaults.Rules, 1);
+        _repo.Setup(r => r.UpsertAsync(It.IsAny<AcceptanceRulesOverride>(), UserId))
+            .ReturnsAsync((saved, true));
+
+        await service.UpsertAsync(UserId, "plan", AcceptanceDefaults.Rules);
+
+        events.Verify(e => e.AppendAsync(It.Is<DomainEvent>(
+            d => d.Type == AcceptanceRulesEventsService.CreatedType)), Times.Once);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesToolParityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/AcceptanceRules/AcceptanceRulesToolParityTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Services.AcceptanceRules;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Api.Tests.AcceptanceRules;
+
+/// <summary>
+/// AC3 parity pin: the <c>get_acceptance_rules</c> tool output and the payload
+/// embedded in an <see cref="AcceptanceRequest"/> both come from
+/// <see cref="IAcceptanceRulesResolver"/> and serialize identically through the
+/// one canonical <see cref="AcceptanceRulesJson.Options"/>. Also: the tool binds
+/// its principal at construction (a principal smuggled into <c>argumentsJson</c>
+/// is ignored), and never throws.
+/// </summary>
+[TestFixture]
+public class AcceptanceRulesToolParityTests
+{
+    private static readonly Guid UserId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    private static ResolvedAcceptanceRules Resolved() => new(
+        Rules: AcceptanceDefaults.For(DocumentTypeKey.Plan) with { AutonomyLevel = 91 },
+        Source: AcceptanceRulesSource.TypeOverride,
+        Version: 5,
+        DocumentTypeKey: DocumentTypeKey.Plan.ToWire(),
+        ResolvedAt: DateTimeOffset.UnixEpoch);
+
+    private static GetAcceptanceRulesTool ToolBoundTo(Guid userId, ResolvedAcceptanceRules resolved,
+        out Mock<IAcceptanceRulesResolver> resolver)
+    {
+        resolver = new Mock<IAcceptanceRulesResolver>();
+        resolver.Setup(r => r.ResolveAsync(userId, DocumentTypeKey.Plan, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolved);
+        var factory = new GetAcceptanceRulesToolFactory(resolver.Object);
+        return factory.Create(userId: userId);
+    }
+
+    [Test]
+    public async Task Tool_output_equals_request_embedded_payload_byte_for_byte()
+    {
+        var resolved = Resolved();
+        var tool = ToolBoundTo(UserId, resolved, out _);
+
+        var result = await tool.ExecuteAsync("call-1", "{\"documentTypeKey\":\"plan\"}");
+        result.Success.Should().BeTrue();
+
+        // The same resolved rules embedded in a request.
+        var document = MakeEnvelope(DocumentTypeKey.Plan);
+        var review = MakeEnvelope(DocumentTypeKey.Review);
+        var request = AcceptanceRequestFactory.Create(document, review, new[] { document }, 0, resolved);
+
+        var embedded = JsonSerializer.Serialize(request.Rules, AcceptanceRulesJson.Options);
+        result.Output.Should().Be(embedded);
+    }
+
+    [Test]
+    public async Task Tool_ignores_a_principal_smuggled_into_arguments()
+    {
+        var resolved = Resolved();
+        var tool = ToolBoundTo(UserId, resolved, out var resolver);
+
+        var smuggled = "{\"userId\":\"99999999-9999-9999-9999-999999999999\"," +
+                       "\"tenantId\":\"88888888-8888-8888-8888-888888888888\"," +
+                       "\"documentTypeKey\":\"plan\"}";
+        var result = await tool.ExecuteAsync("call-2", smuggled);
+
+        result.Success.Should().BeTrue();
+        // Resolver was called ONLY with the construction-bound principal.
+        resolver.Verify(r => r.ResolveAsync(UserId, DocumentTypeKey.Plan, It.IsAny<CancellationToken>()), Times.Once);
+        resolver.Verify(r => r.ResolveForTenantAsync(It.IsAny<Guid>(), It.IsAny<DocumentTypeKey>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Tool_returns_failure_not_throws_on_unknown_type()
+    {
+        var tool = ToolBoundTo(UserId, Resolved(), out _);
+        var result = await tool.ExecuteAsync("call-3", "{\"documentTypeKey\":\"not-a-type\"}");
+        result.Success.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task Tool_returns_failure_not_throws_on_malformed_arguments()
+    {
+        var tool = ToolBoundTo(UserId, Resolved(), out _);
+        var result = await tool.ExecuteAsync("call-4", "{ this is not json ");
+        result.Success.Should().BeFalse();
+    }
+
+    [Test]
+    public void Factory_requires_exactly_one_principal()
+    {
+        var resolver = new Mock<IAcceptanceRulesResolver>().Object;
+        var factory = new GetAcceptanceRulesToolFactory(resolver);
+        factory.Invoking(f => f.Create()).Should().Throw<ArgumentException>();
+        factory.Invoking(f => f.Create(userId: UserId, tenantId: Guid.NewGuid()))
+            .Should().Throw<ArgumentException>();
+    }
+
+    private static DocumentEnvelope MakeEnvelope(DocumentTypeKey type)
+    {
+        using var payload = JsonDocument.Parse("{}");
+        return DocumentEnvelope.CreateDraft(
+            type, 1, "ISSUE-1", "corr-1",
+            DocumentProducer.Create("architect", "plan-review", "plan-review"),
+            payload.RootElement);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceContractTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceContractTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Tests.Documents.Policy;
+
+/// <summary>
+/// Contract-half tests for the acceptor (Story 39-5 AC2): polymorphic JSON with
+/// pinned <c>kind</c> discriminators, the closed derived-type sets (no
+/// <c>AutoAccept</c>), the human-only <c>Reject</c> pin, and the D7 no-branch
+/// factory pin (every autonomy level yields an orchestrator-bound request of
+/// identical shape modulo the rules payload).
+/// </summary>
+[TestFixture]
+public class AcceptanceContractTests
+{
+    [Test]
+    public void AcceptanceDecision_has_exactly_four_derived_types()
+    {
+        var derived = typeof(AcceptanceDecision).GetNestedTypes()
+            .Where(t => t.IsSubclassOf(typeof(AcceptanceDecision)))
+            .Select(t => t.Name)
+            .ToArray();
+        derived.Should().BeEquivalentTo("Accept", "RequestRevision", "Reject", "Escalate");
+        derived.Should().NotContain("AutoAccept");
+    }
+
+    [Test]
+    public void AcceptanceRouting_has_exactly_two_derived_types()
+    {
+        var derived = typeof(AcceptanceRouting).GetNestedTypes()
+            .Where(t => t.IsSubclassOf(typeof(AcceptanceRouting)))
+            .Select(t => t.Name)
+            .ToArray();
+        derived.Should().BeEquivalentTo("DecideSelf", "AssignToRole");
+    }
+
+    [TestCase("accept")]
+    [TestCase("request-revision")]
+    [TestCase("reject")]
+    [TestCase("escalate")]
+    public void AcceptanceDecision_serializes_with_kind_discriminator(string kind)
+    {
+        AcceptanceDecision decision = kind switch
+        {
+            "accept" => new AcceptanceDecision.Accept(),
+            "request-revision" => new AcceptanceDecision.RequestRevision("please fix"),
+            "reject" => new AcceptanceDecision.Reject("no"),
+            _ => new AcceptanceDecision.Escalate(AcceptanceEscalationReason.AcceptorJudgment, "unsure"),
+        };
+
+        var json = JsonSerializer.Serialize(decision, AcceptanceRulesJson.Options);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("kind").GetString().Should().Be(kind);
+
+        var back = JsonSerializer.Deserialize<AcceptanceDecision>(json, AcceptanceRulesJson.Options);
+        back.Should().BeOfType(decision.GetType());
+    }
+
+    [TestCase("decide-self")]
+    [TestCase("assign-to-role")]
+    public void AcceptanceRouting_serializes_with_kind_discriminator(string kind)
+    {
+        AcceptanceRouting routing = kind == "decide-self"
+            ? new AcceptanceRouting.DecideSelf()
+            : new AcceptanceRouting.AssignToRole("architect", AssignmentBasis.Initiator);
+
+        var json = JsonSerializer.Serialize(routing, AcceptanceRulesJson.Options);
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("kind").GetString().Should().Be(kind);
+
+        var back = JsonSerializer.Deserialize<AcceptanceRouting>(json, AcceptanceRulesJson.Options);
+        back.Should().BeOfType(routing.GetType());
+    }
+
+    [Test]
+    public void Escalate_reason_serializes_as_wire_string()
+    {
+        var json = JsonSerializer.Serialize(
+            (AcceptanceDecision)new AcceptanceDecision.Escalate(AcceptanceEscalationReason.RoundsExhausted, "done"),
+            AcceptanceRulesJson.Options);
+        json.Should().Contain("\"reason\":\"rounds-exhausted\"");
+    }
+
+    // ── Factory: D7 no-branch pin ──
+
+    [Test]
+    public void Factory_yields_orchestrator_bound_request_for_every_autonomy_level()
+    {
+        var document = AcceptanceTestData.Envelope(DocumentTypeKey.Plan);
+        var review = AcceptanceTestData.Envelope(DocumentTypeKey.Review);
+        var lineage = new[] { document };
+
+        AcceptanceRequest? first = null;
+        for (var level = 70; level <= 100; level++)
+        {
+            var rules = new ResolvedAcceptanceRules(
+                AcceptanceDefaults.Rules with { AutonomyLevel = level },
+                AcceptanceRulesSource.SystemDefault, 1, DocumentTypeKey.Plan.ToWire(), DateTimeOffset.UnixEpoch);
+
+            var req = AcceptanceRequestFactory.Create(document, review, lineage, roundsUsed: 1, rules);
+
+            req.DecisionSessionId.Should().NotBe(Guid.Empty);
+            req.Document.Should().Be(document);
+            req.Review.Should().Be(review);
+            req.RoundsUsed.Should().Be(1);
+            req.IssueId.Should().Be(document.IssueId);
+            req.Rules.Rules.AutonomyLevel.Should().Be(level);
+
+            // Shape identical modulo the rules payload + the minted session id.
+            if (first is null) first = req;
+            else
+            {
+                req.Document.Should().Be(first.Document);
+                req.Review.Should().Be(first.Review);
+                req.RoundsUsed.Should().Be(first.RoundsUsed);
+                req.IssueId.Should().Be(first.IssueId);
+            }
+        }
+    }
+
+    [Test]
+    public void Factory_rejects_a_non_review_review_envelope()
+    {
+        var document = AcceptanceTestData.Envelope(DocumentTypeKey.Plan);
+        var notAReview = AcceptanceTestData.Envelope(DocumentTypeKey.Design);
+        var rules = AcceptanceTestData.Resolved(DocumentTypeKey.Plan);
+
+        FluentActions.Invoking(() =>
+                AcceptanceRequestFactory.Create(document, notAReview, new[] { document }, 0, rules))
+            .Should().Throw<TammaError>()
+            .Which.Code.Should().Be("ACCEPTANCE_REQUEST.INVALID");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceDefaultsDriftTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceDefaultsDriftTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Tests.Documents.Policy;
+
+/// <summary>
+/// Drift tests pinning the shipped acceptance defaults (Story 39-5 AC5). Same
+/// posture as <c>RolePhaseMapTests</c> — changing a default is a conscious,
+/// reviewed edit here. Pins the shared knobs AND the per-type reviewer defaults
+/// (panel-for-plan/review vs single-architect-otherwise) so 39-14's PlanReview
+/// migration cannot silently regress.
+/// </summary>
+[TestFixture]
+public class AcceptanceDefaultsDriftTests
+{
+    [Test]
+    public void Shared_knobs_are_pinned()
+    {
+        var r = AcceptanceDefaults.Rules;
+        r.AutonomyLevel.Should().Be(70);
+        r.MaxRevisionRounds.Should().Be(2);
+        r.MaxValidationRepairAttempts.Should().Be(2);
+        r.AmbiguityEscalationThreshold.Should().Be(0.7);
+        r.AlwaysEscalate.Should().BeEmpty();
+        r.DecisionGuidance.Should().NotBeNullOrWhiteSpace();
+        r.RoutingGuidance.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Test]
+    public void Base_row_is_single_architect_unanimous()
+    {
+        var sel = AcceptanceDefaults.Rules.ReviewerSelection;
+        sel.Mode.Should().Be(ReviewerMode.SingleReviewer);
+        sel.ReviewerRole.Should().Be(AgentRole.Architect.ToWire());
+        sel.PanelRoles.Should().BeEmpty();
+        sel.DecisionRule.Should().Be(ReviewDecisionRule.Unanimous);
+    }
+
+    [Test]
+    public void Panel_roster_is_the_exact_seven_roles()
+    {
+        AcceptanceDefaults.PanelRoster.Should().Equal(
+            AgentRole.Architect.ToWire(),
+            AgentRole.Developer.ToWire(),
+            AgentRole.Tester.ToWire(),
+            AgentRole.Security.ToWire(),
+            AgentRole.Devops.ToWire(),
+            AgentRole.ProductOwner.ToWire(),
+            AgentRole.SeniorDeveloper.ToWire());
+        AcceptanceDefaults.PanelRoster.Should().HaveCount(7);
+        AcceptanceDefaults.PanelRoster.Should().NotContain(AgentRole.TechWriter.ToWire());
+    }
+
+    [TestCase(DocumentTypeKey.Plan)]
+    [TestCase(DocumentTypeKey.Review)]
+    public void Plan_and_review_default_to_a_majority_panel(DocumentTypeKey type)
+    {
+        var sel = AcceptanceDefaults.For(type).ReviewerSelection;
+        sel.Mode.Should().Be(ReviewerMode.Panel);
+        sel.DecisionRule.Should().Be(ReviewDecisionRule.Majority);
+        sel.ReviewerRole.Should().BeNull();
+        sel.PanelRoles.Should().Equal(AcceptanceDefaults.PanelRoster);
+    }
+
+    [TestCase(DocumentTypeKey.Findings)]
+    [TestCase(DocumentTypeKey.AmbiguityAssessment)]
+    [TestCase(DocumentTypeKey.Clarification)]
+    [TestCase(DocumentTypeKey.Decomposition)]
+    [TestCase(DocumentTypeKey.Design)]
+    [TestCase(DocumentTypeKey.TriageDecision)]
+    [TestCase(DocumentTypeKey.Diagnosis)]
+    [TestCase(DocumentTypeKey.TestSpec)]
+    public void Every_other_type_defaults_to_single_architect_unanimous(DocumentTypeKey type)
+    {
+        var sel = AcceptanceDefaults.For(type).ReviewerSelection;
+        sel.Mode.Should().Be(ReviewerMode.SingleReviewer);
+        sel.ReviewerRole.Should().Be(AgentRole.Architect.ToWire());
+        sel.DecisionRule.Should().Be(ReviewDecisionRule.Unanimous);
+    }
+
+    [Test]
+    public void Every_per_type_default_is_valid()
+    {
+        foreach (var type in Enum.GetValues<DocumentTypeKey>())
+            AcceptanceDefaults.For(type).Invoking(r => r.Validate()).Should().NotThrow();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceGuardrailsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceGuardrailsTests.cs
@@ -1,0 +1,244 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.Core.Tests.Documents.Policy;
+
+/// <summary>
+/// Guardrail tests (Story 39-5 AC8). Pre-gate short-circuits, the forged-approval
+/// clamp, the human-only reject clamp, the round-budget clamp, and a hand-rolled
+/// seeded-random property test (Design Decision D11 — NO FsCheck) proving bounded
+/// termination.
+/// </summary>
+[TestFixture]
+public class AcceptanceGuardrailsTests
+{
+    private static AcceptanceGateContext Ctx(
+        AcceptanceRules rules,
+        ReviewDecision decision = ReviewDecision.Approve,
+        bool blocking = false,
+        int roundsUsed = 0,
+        ApprovalChannel channel = ApprovalChannel.Orchestrator,
+        string? actionWire = null,
+        DocumentTypeKey type = DocumentTypeKey.Plan) =>
+        new(type, actionWire, new ReviewFacts(decision, blocking), roundsUsed, rules, channel);
+
+    // ── Pre-gate ──
+
+    [Test]
+    public void PreGate_escalates_on_always_escalate_document_type_class()
+    {
+        var rules = AcceptanceDefaults.Rules with
+        {
+            AlwaysEscalate = new[] { new EscalationClass(EscalationClassKind.DocumentType, DocumentTypeKey.Plan.ToWire()) },
+        };
+        AcceptanceGuardrails.TryPreGate(Ctx(rules), out var esc).Should().BeTrue();
+        esc.Reason.Should().Be(AcceptanceEscalationReason.AlwaysEscalateClass);
+    }
+
+    [Test]
+    public void PreGate_escalates_on_always_escalate_agent_action_class()
+    {
+        var action = AgentAction.WriteAdr.ToWire();
+        var rules = AcceptanceDefaults.Rules with
+        {
+            AlwaysEscalate = new[] { new EscalationClass(EscalationClassKind.AgentAction, action) },
+        };
+        AcceptanceGuardrails.TryPreGate(Ctx(rules, actionWire: action), out var esc).Should().BeTrue();
+        esc.Reason.Should().Be(AcceptanceEscalationReason.AlwaysEscalateClass);
+    }
+
+    [Test]
+    public void PreGate_escalates_when_rounds_exhausted()
+    {
+        var rules = AcceptanceDefaults.Rules with { MaxRevisionRounds = 2 };
+        AcceptanceGuardrails.TryPreGate(Ctx(rules, roundsUsed: 2), out var esc).Should().BeTrue();
+        esc.Reason.Should().Be(AcceptanceEscalationReason.RoundsExhausted);
+    }
+
+    [Test]
+    public void PreGate_passes_when_no_class_matches_and_rounds_remain()
+    {
+        var rules = AcceptanceDefaults.Rules with { MaxRevisionRounds = 3 };
+        AcceptanceGuardrails.TryPreGate(Ctx(rules, roundsUsed: 1), out _).Should().BeFalse();
+    }
+
+    // ── Clamp: forged approval ──
+
+    [Test]
+    public void Clamp_Accept_with_blocking_issue_escalates()
+    {
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.Accept(),
+            Ctx(AcceptanceDefaults.Rules, ReviewDecision.Approve, blocking: true));
+        result.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.BlockingReviewViolation);
+    }
+
+    [Test]
+    public void Clamp_Accept_over_request_changes_escalates()
+    {
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.Accept(),
+            Ctx(AcceptanceDefaults.Rules, ReviewDecision.RequestChanges, blocking: false));
+        result.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.BlockingReviewViolation);
+    }
+
+    [Test]
+    public void Clamp_Accept_over_clean_approval_passes_through()
+    {
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.Accept(),
+            Ctx(AcceptanceDefaults.Rules, ReviewDecision.Approve, blocking: false));
+        result.Should().BeOfType<AcceptanceDecision.Accept>();
+    }
+
+    // ── Clamp: reject is human-only ──
+
+    [Test]
+    public void Clamp_Reject_on_orchestrator_channel_escalates()
+    {
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.Reject("no"),
+            Ctx(AcceptanceDefaults.Rules, channel: ApprovalChannel.Orchestrator));
+        result.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.RejectRequiresHuman);
+    }
+
+    [TestCase(ApprovalChannel.User)]
+    [TestCase(ApprovalChannel.Api)]
+    public void Clamp_Reject_on_human_channel_passes_through(ApprovalChannel channel)
+    {
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.Reject("final no"),
+            Ctx(AcceptanceDefaults.Rules, channel: channel));
+        result.Should().BeOfType<AcceptanceDecision.Reject>();
+    }
+
+    // ── Clamp: round budget ──
+
+    [Test]
+    public void Clamp_RequestRevision_past_budget_escalates()
+    {
+        var rules = AcceptanceDefaults.Rules with { MaxRevisionRounds = 2 };
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.RequestRevision("again"),
+            Ctx(rules, roundsUsed: 2));
+        result.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.RoundsExhausted);
+    }
+
+    [Test]
+    public void Clamp_RequestRevision_within_budget_passes_through()
+    {
+        var rules = AcceptanceDefaults.Rules with { MaxRevisionRounds = 3 };
+        var result = AcceptanceGuardrails.Clamp(
+            new AcceptanceDecision.RequestRevision("again"),
+            Ctx(rules, roundsUsed: 1));
+        result.Should().BeOfType<AcceptanceDecision.RequestRevision>();
+    }
+
+    [Test]
+    public void Clamp_never_manufactures_Accept_from_a_non_Accept_input()
+    {
+        var rules = AcceptanceDefaults.Rules;
+        AcceptanceDecision[] nonAccepts =
+        {
+            new AcceptanceDecision.RequestRevision("x"),
+            new AcceptanceDecision.Reject("x"),
+            new AcceptanceDecision.Escalate(AcceptanceEscalationReason.AcceptorJudgment, "x"),
+        };
+        foreach (var d in nonAccepts)
+            AcceptanceGuardrails.Clamp(d, Ctx(rules)).Should().NotBeOfType<AcceptanceDecision.Accept>();
+    }
+
+    // ── Property-style: bounded termination (D11) ──
+
+    [Test]
+    public void Property_arbitrary_decision_sequences_terminate_within_bounds()
+    {
+        const int iterations = 1000;
+        for (var i = 0; i < iterations; i++)
+        {
+            var seed = i;
+            var rng = new Random(seed);
+            try
+            {
+                RunOneTerminationTrial(rng);
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Termination trial failed for seed {seed}: {ex.Message}");
+            }
+        }
+    }
+
+    private static void RunOneTerminationTrial(Random rng)
+    {
+        // Random VALID rules (empty always-escalate so we exercise the round
+        // bound, not the pre-gate class short-circuit).
+        var rules = (AcceptanceDefaults.Rules with
+        {
+            AutonomyLevel = rng.Next(70, 101),
+            MaxRevisionRounds = rng.Next(1, 11),
+            MaxValidationRepairAttempts = rng.Next(0, 11),
+            AmbiguityEscalationThreshold = Math.Round(rng.NextDouble(), 3),
+            AlwaysEscalate = Array.Empty<EscalationClass>(),
+        }).Validate();
+
+        // Human channel so Reject is a legitimate terminal (not clamped away).
+        var channel = ApprovalChannel.User;
+        var maxGatePasses = rules.MaxRevisionRounds + 1;
+
+        var rounds = 0;
+        var gatePasses = 0;
+        var terminated = false;
+
+        while (gatePasses <= maxGatePasses)
+        {
+            gatePasses++;
+            var reviewDecision = (ReviewDecision)rng.Next(0, 3);
+            var blocking = rng.Next(0, 2) == 1;
+            var ctx = Ctx(rules, reviewDecision, blocking, rounds, channel);
+
+            if (AcceptanceGuardrails.TryPreGate(ctx, out _))
+            {
+                terminated = true;
+                break;
+            }
+
+            var proposed = RandomDecision(rng);
+            var clamped = AcceptanceGuardrails.Clamp(proposed, ctx);
+
+            if (clamped is AcceptanceDecision.RequestRevision)
+            {
+                rounds++;
+                continue;
+            }
+
+            // Accept, Reject (human channel), or Escalate → terminal.
+            clamped.Should().Match(d =>
+                d is AcceptanceDecision.Accept
+                || d is AcceptanceDecision.Reject
+                || d is AcceptanceDecision.Escalate);
+            terminated = true;
+            break;
+        }
+
+        terminated.Should().BeTrue(
+            $"the gate must terminate within {maxGatePasses} passes (rounds budget {rules.MaxRevisionRounds})");
+        gatePasses.Should().BeLessThanOrEqualTo(maxGatePasses);
+    }
+
+    private static AcceptanceDecision RandomDecision(Random rng) => rng.Next(0, 4) switch
+    {
+        0 => new AcceptanceDecision.Accept(),
+        1 => new AcceptanceDecision.RequestRevision("revise"),
+        2 => new AcceptanceDecision.Reject("no"),
+        _ => new AcceptanceDecision.Escalate(AcceptanceEscalationReason.AcceptorJudgment, "unsure"),
+    };
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceRulesModelTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceRulesModelTests.cs
@@ -1,0 +1,201 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Tests.Documents.Policy;
+
+/// <summary>
+/// Model + validation drift tests for <see cref="AcceptanceRules"/> and its closed
+/// enums (Story 39-5 AC1, AC4 validation half, AC8 bounds-rejection clause).
+/// Validation REJECTS, never clamps.
+/// </summary>
+[TestFixture]
+public class AcceptanceRulesModelTests
+{
+    [Test]
+    public void Valid_record_passes_validation() =>
+        AcceptanceTestData.ValidRules().Invoking(r => r.Validate()).Should().NotThrow();
+
+    // ── Autonomy 70–100 ──
+    [TestCase(69, false)]
+    [TestCase(70, true)]
+    [TestCase(100, true)]
+    [TestCase(101, false)]
+    public void AutonomyLevel_is_bounded_70_to_100(int level, bool ok) =>
+        Assert(AcceptanceTestData.ValidRules() with { AutonomyLevel = level }, ok);
+
+    // ── Rounds 1–10 ──
+    [TestCase(0, false)]
+    [TestCase(1, true)]
+    [TestCase(10, true)]
+    [TestCase(11, false)]
+    public void MaxRevisionRounds_is_bounded_1_to_10(int rounds, bool ok) =>
+        Assert(AcceptanceTestData.ValidRules() with { MaxRevisionRounds = rounds }, ok);
+
+    // ── Repair 0–10 ──
+    [TestCase(-1, false)]
+    [TestCase(0, true)]
+    [TestCase(10, true)]
+    [TestCase(11, false)]
+    public void MaxValidationRepairAttempts_is_bounded_0_to_10(int repair, bool ok) =>
+        Assert(AcceptanceTestData.ValidRules() with { MaxValidationRepairAttempts = repair }, ok);
+
+    // ── Threshold [0,1] ──
+    [TestCase(-0.01, false)]
+    [TestCase(0.0, true)]
+    [TestCase(1.0, true)]
+    [TestCase(1.1, false)]
+    public void AmbiguityEscalationThreshold_is_bounded_0_to_1(double t, bool ok) =>
+        Assert(AcceptanceTestData.ValidRules() with { AmbiguityEscalationThreshold = t }, ok);
+
+    [Test]
+    public void Unknown_always_escalate_document_type_key_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            AlwaysEscalate = new[] { new EscalationClass(EscalationClassKind.DocumentType, "not-a-type") },
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>()
+            .Which.Code.Should().Be("ACCEPTANCE_RULES.INVALID");
+    }
+
+    [Test]
+    public void Unknown_always_escalate_agent_action_key_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            AlwaysEscalate = new[] { new EscalationClass(EscalationClassKind.AgentAction, "not-an-action") },
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>()
+            .Which.Code.Should().Be("ACCEPTANCE_RULES.INVALID");
+    }
+
+    [Test]
+    public void Valid_always_escalate_classes_pass()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            AlwaysEscalate = new[]
+            {
+                new EscalationClass(EscalationClassKind.DocumentType, DocumentTypeKey.Design.ToWire()),
+                new EscalationClass(EscalationClassKind.AgentAction, AgentAction.WriteAdr.ToWire()),
+            },
+        };
+        rules.Invoking(r => r.Validate()).Should().NotThrow();
+    }
+
+    [Test]
+    public void Unknown_reviewer_role_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            ReviewerSelection = AcceptanceTestData.SingleArchitect() with { ReviewerRole = "not-a-role" },
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>()
+            .Which.Code.Should().Be("ACCEPTANCE_RULES.INVALID");
+    }
+
+    [Test]
+    public void SingleReviewer_without_role_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            ReviewerSelection = AcceptanceTestData.SingleArchitect() with { ReviewerRole = null },
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>();
+    }
+
+    [Test]
+    public void Panel_with_empty_roster_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            ReviewerSelection = new ReviewerSelection(
+                ReviewerMode.Panel, null, Array.Empty<string>(), null, ReviewDecisionRule.Majority),
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>();
+    }
+
+    [Test]
+    public void Panel_quorum_beyond_roster_rejects()
+    {
+        var rules = AcceptanceTestData.ValidRules() with
+        {
+            ReviewerSelection = new ReviewerSelection(
+                ReviewerMode.Panel, null, new[] { AgentRole.Architect.ToWire() }, 2, ReviewDecisionRule.Majority),
+        };
+        rules.Invoking(r => r.Validate()).Should().Throw<TammaError>();
+    }
+
+    // ── Enum wire round-trips + count pins ──
+
+    [Test]
+    public void EscalationClassKind_has_two_members_with_wire_roundtrip()
+    {
+        Enum.GetValues<EscalationClassKind>().Length.Should().Be(2);
+        EscalationClassKind.DocumentType.ToWire().Should().Be("document-type");
+        EscalationClassKind.AgentAction.ToWire().Should().Be("agent-action");
+    }
+
+    [Test]
+    public void ReviewerMode_wire_roundtrip()
+    {
+        ReviewerMode.SingleReviewer.ToWire().Should().Be("single-reviewer");
+        ReviewerMode.Panel.ToWire().Should().Be("panel");
+    }
+
+    [Test]
+    public void ReviewDecisionRule_wire_roundtrip()
+    {
+        ReviewDecisionRule.Unanimous.ToWire().Should().Be("unanimous");
+        ReviewDecisionRule.Majority.ToWire().Should().Be("majority");
+    }
+
+    [Test]
+    public void AcceptanceRulesSource_has_three_members_with_wire_roundtrip()
+    {
+        Enum.GetValues<AcceptanceRulesSource>().Length.Should().Be(3);
+        AcceptanceRulesSource.SystemDefault.ToWire().Should().Be("system-default");
+        AcceptanceRulesSource.PrincipalDefault.ToWire().Should().Be("principal-default");
+        AcceptanceRulesSource.TypeOverride.ToWire().Should().Be("type-override");
+    }
+
+    [Test]
+    public void AcceptanceEscalationReason_has_exactly_six_members() =>
+        Enum.GetValues<AcceptanceEscalationReason>().Length.Should().Be(6);
+
+    [TestCase(AcceptanceEscalationReason.RoundsExhausted, "rounds-exhausted")]
+    [TestCase(AcceptanceEscalationReason.AlwaysEscalateClass, "always-escalate-class")]
+    [TestCase(AcceptanceEscalationReason.BlockingReviewViolation, "blocking-review-violation")]
+    [TestCase(AcceptanceEscalationReason.AmbiguityAboveThreshold, "ambiguity-above-threshold")]
+    [TestCase(AcceptanceEscalationReason.AcceptorJudgment, "acceptor-judgment")]
+    [TestCase(AcceptanceEscalationReason.RejectRequiresHuman, "reject-requires-human")]
+    public void AcceptanceEscalationReason_wire_roundtrip(AcceptanceEscalationReason r, string wire) =>
+        r.ToWire().Should().Be(wire);
+
+    [Test]
+    public void ToLifecycleOutcome_maps_two_reasons_and_nulls_the_other_four()
+    {
+        AcceptanceEscalationReason.RoundsExhausted.ToLifecycleOutcome()
+            .Should().Be(DocumentLifecycleOutcome.RoundsExhausted);
+        AcceptanceEscalationReason.AmbiguityAboveThreshold.ToLifecycleOutcome()
+            .Should().Be(DocumentLifecycleOutcome.AmbiguityAboveThreshold);
+
+        AcceptanceEscalationReason.AlwaysEscalateClass.ToLifecycleOutcome().Should().BeNull();
+        AcceptanceEscalationReason.BlockingReviewViolation.ToLifecycleOutcome().Should().BeNull();
+        AcceptanceEscalationReason.AcceptorJudgment.ToLifecycleOutcome().Should().BeNull();
+        AcceptanceEscalationReason.RejectRequiresHuman.ToLifecycleOutcome().Should().BeNull();
+    }
+
+    private static void Assert(AcceptanceRules rules, bool shouldPass)
+    {
+        if (shouldPass)
+            rules.Invoking(r => r.Validate()).Should().NotThrow();
+        else
+            rules.Invoking(r => r.Validate()).Should().Throw<TammaError>()
+                .Which.Code.Should().Be("ACCEPTANCE_RULES.INVALID");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceTestData.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Policy/AcceptanceTestData.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Tests.Documents.Policy;
+
+/// <summary>Shared fixtures for the acceptance-policy test suites (Story 39-5).</summary>
+internal static class AcceptanceTestData
+{
+    /// <summary>A known-valid rules record; override individual knobs via <c>with</c>.</summary>
+    public static AcceptanceRules ValidRules() => AcceptanceDefaults.Rules;
+
+    public static ReviewerSelection SingleArchitect() => new(
+        Mode: ReviewerMode.SingleReviewer,
+        ReviewerRole: AgentRole.Architect.ToWire(),
+        PanelRoles: Array.Empty<string>(),
+        Quorum: null,
+        DecisionRule: ReviewDecisionRule.Unanimous);
+
+    public static DocumentEnvelope Envelope(DocumentTypeKey type)
+    {
+        using var payload = JsonDocument.Parse("{}");
+        return DocumentEnvelope.CreateDraft(
+            type: type,
+            schemaVersion: 1,
+            issueId: "ISSUE-1",
+            correlationId: "corr-1",
+            producedBy: DocumentProducer.Create("architect", "plan-review", "plan-review"),
+            payload: payload.RootElement);
+    }
+
+    public static ResolvedAcceptanceRules Resolved(DocumentTypeKey type) => new(
+        Rules: AcceptanceDefaults.For(type),
+        Source: AcceptanceRulesSource.SystemDefault,
+        Version: 1,
+        DocumentTypeKey: type.ToWire(),
+        ResolvedAt: DateTimeOffset.UnixEpoch);
+}

--- a/packages/dashboard/src/components/acceptance-rules/RulesEditDialog.tsx
+++ b/packages/dashboard/src/components/acceptance-rules/RulesEditDialog.tsx
@@ -1,0 +1,384 @@
+/**
+ * RulesEditDialog (Story 39-5)
+ *
+ * Edits one document type's acceptance rules (or the `base` dial row): the
+ * autonomy 70–100 slider, the numeric bounds, the ambiguity threshold, the
+ * always-escalate class list, the reviewer selection, and the decision/routing
+ * guidance text. Save → PUT; Reset → DELETE (falls back to the next tier).
+ */
+
+import { useMemo, useState, type JSX } from 'react';
+import type {
+  AcceptanceRules,
+  EscalationClass,
+  EscalationClassKind,
+  ResolvedAcceptanceRules,
+  ReviewDecisionRule,
+  ReviewerMode,
+} from '../../services/admin/acceptance-rules-api-client.js';
+
+const MIN_AUTONOMY = 70;
+const MAX_AUTONOMY = 100;
+
+export interface RulesEditDialogProps {
+  resolved: ResolvedAcceptanceRules;
+  onSave: (documentTypeKey: string, body: AcceptanceRules) => Promise<unknown>;
+  onReset: (documentTypeKey: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function RulesEditDialog({
+  resolved,
+  onSave,
+  onReset,
+  onClose,
+}: RulesEditDialogProps): JSX.Element {
+  const initial = resolved.rules;
+  const [autonomyLevel, setAutonomyLevel] = useState(initial.autonomyLevel);
+  const [maxRevisionRounds, setMaxRevisionRounds] = useState(initial.maxRevisionRounds);
+  const [maxValidationRepairAttempts, setMaxValidationRepairAttempts] = useState(
+    initial.maxValidationRepairAttempts,
+  );
+  const [ambiguityEscalationThreshold, setAmbiguityEscalationThreshold] = useState(
+    initial.ambiguityEscalationThreshold,
+  );
+  const [alwaysEscalate, setAlwaysEscalate] = useState<EscalationClass[]>(
+    initial.alwaysEscalate,
+  );
+  const [reviewerMode, setReviewerMode] = useState<ReviewerMode>(
+    initial.reviewerSelection.mode,
+  );
+  const [reviewerRole, setReviewerRole] = useState<string>(
+    initial.reviewerSelection.reviewerRole ?? '',
+  );
+  const [panelRolesText, setPanelRolesText] = useState<string>(
+    initial.reviewerSelection.panelRoles.join(', '),
+  );
+  const [quorumText, setQuorumText] = useState<string>(
+    initial.reviewerSelection.quorum != null ? String(initial.reviewerSelection.quorum) : '',
+  );
+  const [decisionRule, setDecisionRule] = useState<ReviewDecisionRule>(
+    initial.reviewerSelection.decisionRule,
+  );
+  const [decisionGuidance, setDecisionGuidance] = useState(initial.decisionGuidance);
+  const [routingGuidance, setRoutingGuidance] = useState(initial.routingGuidance);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isBase = resolved.documentTypeKey === 'base';
+
+  const body = useMemo<AcceptanceRules>(() => {
+    const panelRoles = panelRolesText
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    const quorum = quorumText.trim() === '' ? null : Number(quorumText.trim());
+    return {
+      autonomyLevel,
+      maxRevisionRounds,
+      maxValidationRepairAttempts,
+      ambiguityEscalationThreshold,
+      alwaysEscalate,
+      reviewerSelection: {
+        mode: reviewerMode,
+        reviewerRole: reviewerMode === 'single-reviewer' ? reviewerRole || null : null,
+        panelRoles: reviewerMode === 'panel' ? panelRoles : [],
+        quorum,
+        decisionRule,
+      },
+      decisionGuidance,
+      routingGuidance,
+    };
+  }, [
+    autonomyLevel,
+    maxRevisionRounds,
+    maxValidationRepairAttempts,
+    ambiguityEscalationThreshold,
+    alwaysEscalate,
+    reviewerMode,
+    reviewerRole,
+    panelRolesText,
+    quorumText,
+    decisionRule,
+    decisionGuidance,
+    routingGuidance,
+  ]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(resolved.documentTypeKey, body);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await onReset(resolved.documentTypeKey);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const addEscalation = () =>
+    setAlwaysEscalate((prev) => [...prev, { kind: 'document-type', key: '' }]);
+  const removeEscalation = (idx: number) =>
+    setAlwaysEscalate((prev) => prev.filter((_, i) => i !== idx));
+  const updateEscalation = (idx: number, patch: Partial<EscalationClass>) =>
+    setAlwaysEscalate((prev) => prev.map((c, i) => (i === idx ? { ...c, ...patch } : c)));
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="w-full max-w-2xl max-h-[90vh] overflow-y-auto bg-white rounded-lg shadow-xl p-6 dark:bg-gray-900">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Acceptance rules — <span className="font-mono">{resolved.documentTypeKey}</span>
+          </h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">source: {resolved.source}</span>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-md bg-red-50 border border-red-200 p-3 text-sm text-red-700 dark:bg-red-950 dark:text-red-300 dark:border-red-800">
+            {error}
+          </div>
+        )}
+
+        {/* Autonomy dial */}
+        <label className="block mb-4">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Autonomy level: {autonomyLevel}
+          </span>
+          <input
+            type="range"
+            aria-label="Autonomy level"
+            min={MIN_AUTONOMY}
+            max={MAX_AUTONOMY}
+            value={autonomyLevel}
+            onChange={(e) => setAutonomyLevel(Number(e.target.value))}
+            className="w-full mt-1"
+          />
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            70 = supervised baseline · 100 = full auto
+          </span>
+        </label>
+
+        {/* Bounds + threshold */}
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Max revision rounds</span>
+            <input
+              type="number"
+              aria-label="Max revision rounds"
+              min={1}
+              max={10}
+              value={maxRevisionRounds}
+              onChange={(e) => setMaxRevisionRounds(Number(e.target.value))}
+              className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Max repair attempts</span>
+            <input
+              type="number"
+              aria-label="Max repair attempts"
+              min={0}
+              max={10}
+              value={maxValidationRepairAttempts}
+              onChange={(e) => setMaxValidationRepairAttempts(Number(e.target.value))}
+              className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            />
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Ambiguity threshold</span>
+            <input
+              type="number"
+              aria-label="Ambiguity threshold"
+              min={0}
+              max={1}
+              step={0.05}
+              value={ambiguityEscalationThreshold}
+              onChange={(e) => setAmbiguityEscalationThreshold(Number(e.target.value))}
+              className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            />
+          </label>
+        </div>
+
+        {/* Always-escalate classes */}
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Always-escalate classes</span>
+            <button
+              type="button"
+              onClick={addEscalation}
+              className="text-xs px-2 py-1 rounded border border-gray-300 hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-800 dark:text-gray-200"
+            >
+              + Add
+            </button>
+          </div>
+          {alwaysEscalate.length === 0 && (
+            <p className="text-xs text-gray-500 dark:text-gray-400">None — nothing always escalates.</p>
+          )}
+          {alwaysEscalate.map((cls, idx) => (
+            <div key={idx} className="flex items-center gap-2 mb-1">
+              <select
+                aria-label={`Escalation kind ${idx}`}
+                value={cls.kind}
+                onChange={(e) => updateEscalation(idx, { kind: e.target.value as EscalationClassKind })}
+                className="rounded border border-gray-300 px-2 py-1 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+              >
+                <option value="document-type">document-type</option>
+                <option value="agent-action">agent-action</option>
+              </select>
+              <input
+                type="text"
+                aria-label={`Escalation key ${idx}`}
+                value={cls.key}
+                placeholder="wire key (e.g. design)"
+                onChange={(e) => updateEscalation(idx, { key: e.target.value })}
+                className="flex-1 rounded border border-gray-300 px-2 py-1 text-sm font-mono dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+              />
+              <button
+                type="button"
+                onClick={() => removeEscalation(idx)}
+                className="text-xs text-red-600 hover:underline dark:text-red-400"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+
+        {/* Reviewer selection */}
+        <div className="grid grid-cols-2 gap-4 mb-4">
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Reviewer mode</span>
+            <select
+              aria-label="Reviewer mode"
+              value={reviewerMode}
+              onChange={(e) => setReviewerMode(e.target.value as ReviewerMode)}
+              className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            >
+              <option value="single-reviewer">single-reviewer</option>
+              <option value="panel">panel</option>
+            </select>
+          </label>
+          <label className="block">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Decision rule</span>
+            <select
+              aria-label="Decision rule"
+              value={decisionRule}
+              onChange={(e) => setDecisionRule(e.target.value as ReviewDecisionRule)}
+              className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+            >
+              <option value="unanimous">unanimous</option>
+              <option value="majority">majority</option>
+            </select>
+          </label>
+          {reviewerMode === 'single-reviewer' ? (
+            <label className="block col-span-2">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Reviewer role</span>
+              <input
+                type="text"
+                aria-label="Reviewer role"
+                value={reviewerRole}
+                placeholder="architect"
+                onChange={(e) => setReviewerRole(e.target.value)}
+                className="w-full mt-1 rounded border border-gray-300 px-2 py-1 font-mono dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+              />
+            </label>
+          ) : (
+            <>
+              <label className="block col-span-2">
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Panel roles (comma-separated)</span>
+                <input
+                  type="text"
+                  aria-label="Panel roles"
+                  value={panelRolesText}
+                  placeholder="architect, developer, tester"
+                  onChange={(e) => setPanelRolesText(e.target.value)}
+                  className="w-full mt-1 rounded border border-gray-300 px-2 py-1 font-mono dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                />
+              </label>
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Quorum (optional)</span>
+                <input
+                  type="number"
+                  aria-label="Quorum"
+                  min={1}
+                  value={quorumText}
+                  onChange={(e) => setQuorumText(e.target.value)}
+                  className="w-full mt-1 rounded border border-gray-300 px-2 py-1 dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+                />
+              </label>
+            </>
+          )}
+        </div>
+
+        {/* Guidance */}
+        <label className="block mb-4">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Decision guidance</span>
+          <textarea
+            aria-label="Decision guidance"
+            rows={3}
+            value={decisionGuidance}
+            onChange={(e) => setDecisionGuidance(e.target.value)}
+            className="w-full mt-1 rounded border border-gray-300 px-2 py-1 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+          />
+        </label>
+        <label className="block mb-6">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Routing guidance</span>
+          <textarea
+            aria-label="Routing guidance"
+            rows={3}
+            value={routingGuidance}
+            onChange={(e) => setRoutingGuidance(e.target.value)}
+            className="w-full mt-1 rounded border border-gray-300 px-2 py-1 text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100"
+          />
+        </label>
+
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={handleReset}
+            disabled={saving || resolved.source === 'system-default'}
+            className="px-3 py-1.5 text-sm font-medium text-red-700 border border-red-300 rounded-md hover:bg-red-50 disabled:opacity-40 dark:text-red-300 dark:border-red-700 dark:hover:bg-red-950"
+          >
+            Reset to default
+          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-40"
+            >
+              {saving ? 'Saving…' : isBase ? 'Save base override' : 'Save override'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/dashboard/src/components/acceptance-rules/RulesTable.tsx
+++ b/packages/dashboard/src/components/acceptance-rules/RulesTable.tsx
@@ -1,0 +1,78 @@
+/**
+ * RulesTable (Story 39-5)
+ *
+ * Lists the resolved acceptance rules for every document type with a
+ * default-vs-override provenance badge and the effective autonomy level. Row
+ * click opens the edit dialog.
+ */
+
+import type { JSX } from 'react';
+import type {
+  AcceptanceRulesSource,
+  ResolvedAcceptanceRules,
+} from '../../services/admin/acceptance-rules-api-client.js';
+
+const SOURCE_LABEL: Record<AcceptanceRulesSource, string> = {
+  'system-default': 'Default',
+  'principal-default': 'Base override',
+  'type-override': 'Type override',
+};
+
+const SOURCE_CLASS: Record<AcceptanceRulesSource, string> = {
+  'system-default':
+    'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+  'principal-default':
+    'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300',
+  'type-override':
+    'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300',
+};
+
+export interface RulesTableProps {
+  rows: ResolvedAcceptanceRules[];
+  onRowClick: (documentTypeKey: string) => void;
+}
+
+export function RulesTable({ rows, onRowClick }: RulesTableProps): JSX.Element {
+  return (
+    <div className="overflow-x-auto border border-gray-200 rounded-md dark:border-gray-700">
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Document type</th>
+            <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Autonomy</th>
+            <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Rounds</th>
+            <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Reviewer</th>
+            <th className="px-4 py-2 text-left font-medium text-gray-600 dark:text-gray-300">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr
+              key={row.documentTypeKey}
+              data-testid={`rules-row-${row.documentTypeKey}`}
+              onClick={() => onRowClick(row.documentTypeKey)}
+              className="border-t border-gray-100 cursor-pointer hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-gray-800"
+            >
+              <td className="px-4 py-2 font-mono text-gray-900 dark:text-gray-100">{row.documentTypeKey}</td>
+              <td className="px-4 py-2 text-gray-700 dark:text-gray-300">{row.rules.autonomyLevel}</td>
+              <td className="px-4 py-2 text-gray-700 dark:text-gray-300">{row.rules.maxRevisionRounds}</td>
+              <td className="px-4 py-2 text-gray-700 dark:text-gray-300">
+                {row.rules.reviewerSelection.mode === 'panel'
+                  ? `panel (${row.rules.reviewerSelection.panelRoles.length})`
+                  : (row.rules.reviewerSelection.reviewerRole ?? '—')}
+              </td>
+              <td className="px-4 py-2">
+                <span
+                  data-testid={`rules-source-${row.documentTypeKey}`}
+                  className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${SOURCE_CLASS[row.source]}`}
+                >
+                  {SOURCE_LABEL[row.source]}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/dashboard/src/hooks/admin/useAcceptanceRules.ts
+++ b/packages/dashboard/src/hooks/admin/useAcceptanceRules.ts
@@ -1,0 +1,82 @@
+/**
+ * useAcceptanceRules (Story 39-5)
+ *
+ * Loads the resolved-per-type acceptance-rules snapshot once on mount and
+ * exposes the mutation surface (upsert override, reset override, refresh) used
+ * by the admin acceptance-rules page. Mirrors `useSystemPrompts` — read-mostly,
+ * page-scoped, no Zustand store; mutation handlers re-fetch so the table
+ * reflects the new provenance on the next render.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  acceptanceRulesApi,
+  type AcceptanceRules,
+  type AcceptanceRulesUpsertRequest,
+  type ResolvedAcceptanceRules,
+} from '../../services/admin/acceptance-rules-api-client.js';
+
+export interface UseAcceptanceRulesResult {
+  /** Resolved rules for every document type — empty while the first load is in flight. */
+  rows: ResolvedAcceptanceRules[];
+  /** The shipped principal-base defaults — `null` until loaded. */
+  defaults: AcceptanceRules | null;
+  loading: boolean;
+  error: string | null;
+  /** Refetch the resolved snapshot (used after a mutation to refresh provenance). */
+  reload: () => Promise<void>;
+  /** Save an override for a document type (or the literal `base` dial row). */
+  upsert: (
+    documentTypeKey: string,
+    body: AcceptanceRulesUpsertRequest,
+  ) => Promise<ResolvedAcceptanceRules>;
+  /** Delete an override → resolves back to the next tier. */
+  reset: (documentTypeKey: string) => Promise<void>;
+}
+
+export function useAcceptanceRules(): UseAcceptanceRulesResult {
+  const [rows, setRows] = useState<ResolvedAcceptanceRules[]>([]);
+  const [defaults, setDefaults] = useState<AcceptanceRules | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [resolved, def] = await Promise.all([
+        acceptanceRulesApi.listEffective(),
+        acceptanceRulesApi.getDefaults(),
+      ]);
+      setRows(resolved);
+      setDefaults(def);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load acceptance rules');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const upsert = useCallback(
+    async (documentTypeKey: string, body: AcceptanceRulesUpsertRequest) => {
+      const saved = await acceptanceRulesApi.upsert(documentTypeKey, body);
+      void reload();
+      return saved;
+    },
+    [reload],
+  );
+
+  const reset = useCallback(
+    async (documentTypeKey: string) => {
+      await acceptanceRulesApi.reset(documentTypeKey);
+      void reload();
+    },
+    [reload],
+  );
+
+  return { rows, defaults, loading, error, reload, upsert, reset };
+}

--- a/packages/dashboard/src/pages/admin/acceptance-rules/AcceptanceRulesAdminPage.tsx
+++ b/packages/dashboard/src/pages/admin/acceptance-rules/AcceptanceRulesAdminPage.tsx
@@ -1,0 +1,69 @@
+/**
+ * AcceptanceRulesAdminPage (Story 39-5)
+ *
+ * Admin page for the configurable acceptance policy. Lists the effective rules
+ * per document type with default-vs-override provenance, and edits the autonomy
+ * dial (70–100), bounds, escalation criteria, always-escalate classes, reviewer
+ * selection, and decision/routing guidance. Mirrors ConventionsAdminPage.
+ *
+ * RBAC: wrapped in AdminGuard so only admin/owner reach it; the API additionally
+ * enforces acceptance-rules:manage on writes (members 403).
+ */
+
+import { useState, type JSX } from 'react';
+import { LoadingSpinner } from '../../../components/common/LoadingSpinner.js';
+import { RulesTable } from '../../../components/acceptance-rules/RulesTable.js';
+import { RulesEditDialog } from '../../../components/acceptance-rules/RulesEditDialog.js';
+import { useAcceptanceRules } from '../../../hooks/admin/useAcceptanceRules.js';
+import type { ResolvedAcceptanceRules } from '../../../services/admin/acceptance-rules-api-client.js';
+
+export function AcceptanceRulesAdminPage(): JSX.Element {
+  const { rows, loading, error, reload, upsert, reset } = useAcceptanceRules();
+  const [selected, setSelected] = useState<ResolvedAcceptanceRules | null>(null);
+
+  const openEditor = (documentTypeKey: string) => {
+    const row = rows.find((r) => r.documentTypeKey === documentTypeKey) ?? null;
+    setSelected(row);
+  };
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-1 dark:text-gray-100">Acceptance Rules</h1>
+      <p className="text-sm text-gray-500 mb-6 dark:text-gray-400">
+        Configure how autonomous Tamma is per document type — the autonomy dial (70–100),
+        revision/repair bounds, escalation criteria, always-escalate classes, reviewer
+        selection, and the decision/routing guidance the orchestrator reads. A deployment
+        with no overrides runs on the shipped defaults.
+      </p>
+
+      {loading && rows.length === 0 ? (
+        <div className="flex justify-center py-16">
+          <LoadingSpinner size="lg" />
+        </div>
+      ) : error ? (
+        <div className="bg-red-50 border border-red-200 rounded-md p-4 text-sm text-red-700 dark:bg-red-950 dark:text-red-300 dark:border-red-800">
+          <div className="font-medium mb-1">Failed to load acceptance rules</div>
+          <div className="mb-3">{error}</div>
+          <button
+            type="button"
+            onClick={() => void reload()}
+            className="px-3 py-1.5 text-xs font-medium text-red-700 border border-red-300 bg-white rounded-md hover:bg-red-100 dark:bg-gray-800 dark:text-red-300 dark:border-red-700"
+          >
+            Retry
+          </button>
+        </div>
+      ) : (
+        <RulesTable rows={rows} onRowClick={openEditor} />
+      )}
+
+      {selected && (
+        <RulesEditDialog
+          resolved={selected}
+          onSave={upsert}
+          onReset={reset}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard/src/pages/admin/acceptance-rules/__tests__/AcceptanceRulesAdminPage.test.tsx
+++ b/packages/dashboard/src/pages/admin/acceptance-rules/__tests__/AcceptanceRulesAdminPage.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AcceptanceRulesAdminPage } from '../AcceptanceRulesAdminPage.js';
+import type {
+  AcceptanceRules,
+  AcceptanceRulesSource,
+  ResolvedAcceptanceRules,
+} from '../../../../services/admin/acceptance-rules-api-client.js';
+
+const mockUseAcceptanceRules = vi.fn();
+
+vi.mock('../../../../hooks/admin/useAcceptanceRules.js', () => ({
+  useAcceptanceRules: () => mockUseAcceptanceRules(),
+}));
+
+const DOCUMENT_TYPES = [
+  'findings',
+  'ambiguity-assessment',
+  'clarification',
+  'decomposition',
+  'plan',
+  'design',
+  'review',
+  'triage-decision',
+  'diagnosis',
+  'test-spec',
+];
+
+function makeRules(overrides?: Partial<AcceptanceRules>): AcceptanceRules {
+  return {
+    autonomyLevel: 70,
+    maxRevisionRounds: 2,
+    maxValidationRepairAttempts: 2,
+    ambiguityEscalationThreshold: 0.7,
+    alwaysEscalate: [],
+    reviewerSelection: {
+      mode: 'single-reviewer',
+      reviewerRole: 'architect',
+      panelRoles: [],
+      quorum: null,
+      decisionRule: 'unanimous',
+    },
+    decisionGuidance: 'decide guidance',
+    routingGuidance: 'route guidance',
+    ...overrides,
+  };
+}
+
+function makeRow(
+  documentTypeKey: string,
+  source: AcceptanceRulesSource = 'system-default',
+  rules?: Partial<AcceptanceRules>,
+): ResolvedAcceptanceRules {
+  return {
+    rules: makeRules(rules),
+    source,
+    version: 1,
+    documentTypeKey,
+    resolvedAt: '2026-07-22T00:00:00.000Z',
+  };
+}
+
+function makeRows(): ResolvedAcceptanceRules[] {
+  return DOCUMENT_TYPES.map((t) =>
+    t === 'plan' || t === 'review'
+      ? makeRow(t, 'type-override', {
+          reviewerSelection: {
+            mode: 'panel',
+            reviewerRole: null,
+            panelRoles: ['architect', 'developer', 'tester'],
+            quorum: null,
+            decisionRule: 'majority',
+          },
+        })
+      : makeRow(t),
+  );
+}
+
+function setup(overrides?: Partial<ReturnType<typeof mockUseAcceptanceRules>>) {
+  const upsert = vi.fn().mockResolvedValue(makeRow('design'));
+  const reset = vi.fn().mockResolvedValue(undefined);
+  const reload = vi.fn().mockResolvedValue(undefined);
+  const value = {
+    rows: makeRows(),
+    defaults: makeRules(),
+    loading: false,
+    error: null,
+    reload,
+    upsert,
+    reset,
+    ...overrides,
+  };
+  mockUseAcceptanceRules.mockReturnValue(value);
+  return { upsert, reset, reload };
+}
+
+describe('AcceptanceRulesAdminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a row for every document type with a provenance badge', () => {
+    setup();
+    render(<AcceptanceRulesAdminPage />);
+    for (const t of DOCUMENT_TYPES) {
+      expect(screen.getByTestId(`rules-row-${t}`)).toBeTruthy();
+      expect(screen.getByTestId(`rules-source-${t}`)).toBeTruthy();
+    }
+    // plan/review resolve from a type override; others from the default.
+    expect(screen.getByTestId('rules-source-plan').textContent).toContain('Type override');
+    expect(screen.getByTestId('rules-source-findings').textContent).toContain('Default');
+  });
+
+  it('constrains the autonomy dial to 70–100', async () => {
+    setup();
+    render(<AcceptanceRulesAdminPage />);
+    await userEvent.click(screen.getByTestId('rules-row-design'));
+    const slider = (await screen.findByLabelText('Autonomy level')) as HTMLInputElement;
+    expect(slider.min).toBe('70');
+    expect(slider.max).toBe('100');
+  });
+
+  it('saves the edited payload via upsert (PUT)', async () => {
+    const { upsert } = setup();
+    render(<AcceptanceRulesAdminPage />);
+    await userEvent.click(screen.getByTestId('rules-row-design'));
+
+    const rounds = (await screen.findByLabelText('Max revision rounds')) as HTMLInputElement;
+    await userEvent.clear(rounds);
+    await userEvent.type(rounds, '4');
+
+    await userEvent.click(screen.getByText('Save override'));
+
+    await waitFor(() => expect(upsert).toHaveBeenCalledTimes(1));
+    const [key, body] = upsert.mock.calls[0]!;
+    expect(key).toBe('design');
+    expect(body.maxRevisionRounds).toBe(4);
+    expect(body.autonomyLevel).toBe(70);
+  });
+
+  it('resets an override via reset (DELETE)', async () => {
+    const { reset } = setup();
+    render(<AcceptanceRulesAdminPage />);
+    // plan is a type-override, so the Reset button is enabled.
+    await userEvent.click(screen.getByTestId('rules-row-plan'));
+    await userEvent.click(await screen.findByText('Reset to default'));
+    await waitFor(() => expect(reset).toHaveBeenCalledWith('plan'));
+  });
+
+  it('shows an error banner when the hook reports an error', () => {
+    setup({ rows: [], error: 'boom', loading: false });
+    render(<AcceptanceRulesAdminPage />);
+    expect(screen.getByText('Failed to load acceptance rules')).toBeTruthy();
+  });
+});

--- a/packages/dashboard/src/router.tsx
+++ b/packages/dashboard/src/router.tsx
@@ -12,6 +12,7 @@ import { PromptsPage } from './pages/settings/PromptsPage.js';
 import { PromptsAdminPage } from './pages/admin/prompts/PromptsAdminPage.js';
 // Story 27-11 — platform-admin convention management UI.
 import { ConventionsAdminPage } from './pages/admin/conventions/ConventionsAdminPage.js';
+import { AcceptanceRulesAdminPage } from './pages/admin/acceptance-rules/AcceptanceRulesAdminPage.js';
 // Story 27-12 — tenant convention management UI.
 import { ConventionsPage } from './pages/settings/ConventionsPage.js';
 // Story 28-11 — platform-admin tenant-status UX.
@@ -195,6 +196,15 @@ export const router = createBrowserRouter([
         element: (
           <AdminGuard>
             <ConventionsAdminPage />
+          </AdminGuard>
+        ),
+      },
+      // Story 39-5: acceptance-rules (autonomy dial + policy) management UI.
+      {
+        path: '/admin/acceptance-rules',
+        element: (
+          <AdminGuard>
+            <AcceptanceRulesAdminPage />
           </AdminGuard>
         ),
       },

--- a/packages/dashboard/src/services/admin/acceptance-rules-api-client.ts
+++ b/packages/dashboard/src/services/admin/acceptance-rules-api-client.ts
@@ -1,0 +1,136 @@
+/**
+ * Acceptance Rules API Client (Story 39-5)
+ *
+ * Typed wrapper for `/api/acceptance-rules/*` exposed by
+ * `apps/tamma-elsa/src/Tamma.Api/Endpoints/AcceptanceRulesEndpoints.cs`.
+ *
+ * Resolution + provenance:
+ *   Each resolved row carries `source` — one of:
+ *     "system-default"    — the shipped static default (no override)
+ *     "principal-default" — the principal base override (the dial)
+ *     "type-override"     — a per-document-type override
+ *
+ * RBAC: reads are any authenticated tenant member (AuthenticatedAny); writes
+ * require `acceptance-rules:manage` (tenant_owner / tenant_admin) — members get
+ * 403 on PUT/DELETE.
+ *
+ * Error codes surfaced by the API:
+ *   ACCEPTANCE_RULES.INVALID  (400) — out-of-range knob (autonomy, bounds, threshold)
+ *   DOCUMENT.TYPE.UNKNOWN     (400) — a typo'd document type key
+ */
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '/api';
+
+export interface ApiError extends Error {
+  status?: number;
+  code?: string;
+}
+
+async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${url}`, {
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    credentials: 'include',
+    ...options,
+  });
+
+  if (!response.ok) {
+    const body = (await response
+      .json()
+      .catch(() => ({ error: response.statusText }))) as Record<string, string>;
+    const err = new Error(body['error'] ?? `HTTP ${response.status}`) as ApiError;
+    err.status = response.status;
+    if (body['code'] !== undefined) err.code = body['code'];
+    throw err;
+  }
+
+  if (response.status === 204) return undefined as T;
+  return response.json() as Promise<T>;
+}
+
+// === Types ===================================================================
+
+export type AcceptanceRulesSource =
+  | 'system-default'
+  | 'principal-default'
+  | 'type-override';
+
+export type EscalationClassKind = 'document-type' | 'agent-action';
+export type ReviewerMode = 'single-reviewer' | 'panel';
+export type ReviewDecisionRule = 'unanimous' | 'majority';
+
+export interface EscalationClass {
+  kind: EscalationClassKind;
+  key: string;
+}
+
+export interface ReviewerSelection {
+  mode: ReviewerMode;
+  reviewerRole: string | null;
+  panelRoles: string[];
+  quorum: number | null;
+  decisionRule: ReviewDecisionRule;
+}
+
+export interface AcceptanceRules {
+  autonomyLevel: number;
+  maxRevisionRounds: number;
+  maxValidationRepairAttempts: number;
+  ambiguityEscalationThreshold: number;
+  alwaysEscalate: EscalationClass[];
+  reviewerSelection: ReviewerSelection;
+  decisionGuidance: string;
+  routingGuidance: string;
+}
+
+export interface ResolvedAcceptanceRules {
+  rules: AcceptanceRules;
+  source: AcceptanceRulesSource;
+  version: number;
+  documentTypeKey: string;
+  resolvedAt: string;
+}
+
+export type AcceptanceRulesUpsertRequest = AcceptanceRules;
+
+// === Client ==================================================================
+
+export const acceptanceRulesApi = {
+  /** GET /api/acceptance-rules — resolved rules for every document type + provenance. */
+  listEffective(): Promise<ResolvedAcceptanceRules[]> {
+    return fetchJSON<ResolvedAcceptanceRules[]>('/acceptance-rules');
+  },
+
+  /** GET /api/acceptance-rules/defaults — the shipped principal-base rules row. */
+  getDefaults(): Promise<AcceptanceRules> {
+    return fetchJSON<AcceptanceRules>('/acceptance-rules/defaults');
+  },
+
+  /**
+   * GET /api/acceptance-rules/{documentTypeKey} — resolved rules for one type,
+   * or the literal `base` dial row.
+   */
+  getResolved(documentTypeKey: string): Promise<ResolvedAcceptanceRules> {
+    return fetchJSON<ResolvedAcceptanceRules>(
+      `/acceptance-rules/${encodeURIComponent(documentTypeKey)}`,
+    );
+  },
+
+  /** PUT /api/acceptance-rules/{documentTypeKey} — create/update an override. */
+  upsert(
+    documentTypeKey: string,
+    body: AcceptanceRulesUpsertRequest,
+  ): Promise<ResolvedAcceptanceRules> {
+    return fetchJSON<ResolvedAcceptanceRules>(
+      `/acceptance-rules/${encodeURIComponent(documentTypeKey)}`,
+      { method: 'PUT', body: JSON.stringify(body) },
+    );
+  },
+
+  /** DELETE /api/acceptance-rules/{documentTypeKey} — reset to the next tier. */
+  reset(documentTypeKey: string): Promise<void> {
+    return fetchJSON<void>(
+      `/acceptance-rules/${encodeURIComponent(documentTypeKey)}`,
+      { method: 'DELETE' },
+    );
+  },
+};


### PR DESCRIPTION
## What

Epic 39 **PR-D** — **Story 39-5, the critical-path gate**, and the **first Tenant EF migration** in the serialization chain. Spans `Tamma.Core` + `Tamma.Data` + `Tamma.Api` + the dashboard.

## Core (`Tamma.Core/Documents/Policy/`)

- **`AcceptanceRules`** — the `AutonomyLevel` (70–100) dial, bounds, escalation criteria, per-type reviewer selection (with `DecisionRule` unanimous/majority), guidance prose; `Validate()` **rejects, never clamps**, and fail-loud-parses always-escalate keys + reviewer roles against the registries.
- **`AcceptanceDefaults`** — per-type reviewer defaults: `plan` and code/`review` types default to the **7-role Majority panel** (so 39-14's PlanReview migration is behavior-preserving with zero config); everything else single-architect/Unanimous.
- **Acceptor contract** — `AcceptanceRequest` (+ factory with **no auto-accept branch**), `AcceptanceDecision` (`Accept | RequestRevision | Reject | Escalate`), `AcceptanceRouting` (`DecideSelf | AssignToRole` — role-addressed). **`ApprovalChannel`** enum owned here. `AcceptanceEscalationReason` (6 members; `ToLifecycleOutcome()` maps 2 → outcome, 4 → null).
- **`AcceptanceGuardrails`** (pure) — the forged-approval clamp (Accept + blocking issue → Escalate) and the **human-only `Reject`** clamp (orchestrator-channel Reject → `Escalate(RejectRequiresHuman)`); references 39-4's `ReviewDecision` directly (no shadow copy). `Clamp` structurally can only pass through or escalate.

## Data — first Tenant migration

`acceptance_rules_overrides` table: `user_id` XOR `tenant_id` CHECK, `jsonb` `RulesJson`, unique `(principal, DocumentTypeKey)` **NULLS NOT DISTINCT** (so base-dial rows dedupe). Migration `20260722011909_AddAcceptanceRulesOverrides`; **`has-pending-model-changes` clean**.

## API

- **`AcceptanceRulesService`** — 3-tier wholesale resolution (type override → base override → per-type default), per-mode (`ResolveAsync`/`ResolveForTenantAsync`), with mutation events.
- **`/api/acceptance-rules`** admin REST — `AuthenticatedAny` reads; `acceptance-rules:manage` (admin/owner) writes; `{documentTypeKey}` accepts `base` for the deployment dial.
- **`get_acceptance_rules`** `IToolExecutor` — principal-bound via factory, **not** globally DI-registered (so it never leaks into coding-agent tool loops); parity-pinned byte-identical to the request-embedded payload.

## Dashboard

`/admin/acceptance-rules` screen — autonomy slider, bounds, escalation-class picker, reviewer selection, guidance textareas, with default/base/override provenance badges.

## Verification

- Builds clean: `Tamma.Core`, `Tamma.Data`, `Tamma.Api`.
- **381 `Tamma.Core.Tests` green** incl. 75 new Policy tests (model, defaults-drift pinning the per-type panel, contract, guardrails + a 1000-iteration hand-rolled seeded-`Random` termination property — no FsCheck).
- **Migration `has-pending-model-changes` clean.**
- Dashboard `pnpm build` + 5 vitest pass.
- The `Tamma.Api.Tests/AcceptanceRules` suites (service/tool/endpoints Moq+InMemory, plus the Testcontainers migration test) **compile**; the Api.Tests assembly is Docker-gated (assembly-wide Postgres testcontainer fixture), so they run under **CI's Postgres**, not locally.

## Notes

- Per-mode ownership written down (single-user: `user_id`; SaaS: `tenant_id`, admin/owner write, members read; no per-user layer on tenant rules).
- Reads use `AuthenticatedAny` per AC7 (the documented convention-store deviation from the prompt store's `SettingsView` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_