### PR TITLE
feat(39-9): Deterministic Repair Ring — validator-feedback repair in the managed layer

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
@@ -100,6 +100,19 @@ public class CallLlmInlineActivity : CodeActivity
     [Input(Description = "Registry-resolved max tokens (registry path only; 0 = unset → InputJson/legacy default)")]
     public Input<int> RegistryMaxTokensProp { get; set; } = new(0);
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Story 39-9 (D10) — additive/optional repair-ring inputs. Default empty ⇒
+    // zero behaviour change for the 30+ existing dispatchers. `documentType` is the
+    // wire KEY whose validator gates the repair ring server-side; `issueId` rides
+    // through purely for the LLM.* event tags (AC6).
+    // ─────────────────────────────────────────────────────────────────────
+
+    [Input(Description = "Story 39-9 — document-type key gating the repair ring (empty = no validation)")]
+    public Input<string?> DocumentTypeProp { get; set; } = new((string?)null);
+
+    [Input(Description = "Story 39-9 — issue id for LLM.* event tags (empty = none)")]
+    public Input<string?> IssueIdProp { get; set; } = new((string?)null);
+
     private readonly ILogger<CallLlmInlineActivity>? _logger;
     private readonly TammaApiClient? _apiClient;
 
@@ -163,6 +176,8 @@ public class CallLlmInlineActivity : CodeActivity
         var renderedPrompt = RenderedPromptProp.Get(context);
         var variablesJson = VariablesJsonProp.Get(context);
         var registryMaxTokens = RegistryMaxTokensProp.Get(context);
+        var documentType = DocumentTypeProp.Get(context);
+        var issueId = IssueIdProp.Get(context);
 
         var input = ParseInput(inputJson);
         var toolLoopConfig = ParseToolLoopConfig(toolLoopConfigJson);
@@ -179,7 +194,8 @@ public class CallLlmInlineActivity : CodeActivity
         var request = BuildLlmCallRequest(
             input, providerName, systemPrompt, toolsJson, model,
             enableToolLoop, toolLoopConfig, tenantIdRaw, correlationId,
-            agentRole, action, renderedPrompt, variablesJson, registryMaxTokens);
+            agentRole, action, renderedPrompt, variablesJson, registryMaxTokens,
+            documentType, issueId);
 
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var tenantHeader = string.IsNullOrWhiteSpace(tenantIdRaw) ? null : tenantIdRaw!.Trim();
@@ -255,7 +271,9 @@ public class CallLlmInlineActivity : CodeActivity
         string? action = null,
         string? renderedPrompt = null,
         string? variablesJson = null,
-        int registryMaxTokens = 0)
+        int registryMaxTokens = 0,
+        string? documentType = null,
+        string? issueId = null)
     {
         // Finding I-1 — the API renders the prompt AUTHORITATIVELY (Epic 27,
         // (principal, role, action) resolution). The engine forwards NO system
@@ -305,6 +323,9 @@ public class CallLlmInlineActivity : CodeActivity
                 BudgetCapUsd = input.BudgetCapUsd,
             },
             CorrelationId = correlationId,
+            // Story 39-9 (D10) — additive/optional; null/empty ⇒ omitted on the wire.
+            DocumentType = string.IsNullOrWhiteSpace(documentType) ? null : documentType,
+            IssueId = string.IsNullOrWhiteSpace(issueId) ? null : issueId,
         };
     }
 
@@ -345,6 +366,9 @@ public class CallLlmInlineActivity : CodeActivity
             PromptTokens = response.Usage.PromptTokens,
             CompletionTokens = response.Usage.CompletionTokens,
             CredentialSource = response.CredentialSource,
+            // Story 39-9 (AC4, D6) — classify the failure for the diagnostic (and, for
+            // content_validation, the breaker exclusion). Only classify what is certain.
+            FailureCode = response.Success ? null : ClassifyFailureCode(response.FailureCode, httpStatus),
         };
 
         var normalized = new NormalizedLlmResponse
@@ -365,12 +389,38 @@ public class CallLlmInlineActivity : CodeActivity
                     .ToList(),
         };
 
+        // Story 39-9 (D10) — surface the content-validation block as a workflow
+        // variable (empty when absent, i.e. no validator ran).
+        var contentValidationJson = response.ContentValidation is null
+            ? string.Empty
+            : JsonSerializer.Serialize(response.ContentValidation);
+
         return new MappedLlmVariables(
             diagnostic,
             normalized,
             response.Usage.ToolLoopTokens,
             response.Usage.ToolLoopTurns,
-            response.Usage.ToolLoopExhausted);
+            response.Usage.ToolLoopExhausted,
+            contentValidationJson);
+    }
+
+    /// <summary>
+    /// Story 39-9 (AC4, D6) — map a wire failure code / HTTP status to the closed
+    /// diagnostic vocabulary. CONTENT_VALIDATION_FAILED → content_validation (the
+    /// breaker-exclusion signal); BUDGET_EXCEEDED → budget; 429 → rate_limit;
+    /// 0 / 5xx → transport; anything else stays null (classify only what is certain).
+    /// </summary>
+    internal static string? ClassifyFailureCode(string? wireFailureCode, int httpStatus)
+    {
+        if (string.Equals(wireFailureCode, "CONTENT_VALIDATION_FAILED", StringComparison.Ordinal))
+            return DiagnosticFailureCodes.ContentValidation;
+        if (string.Equals(wireFailureCode, "BUDGET_EXCEEDED", StringComparison.Ordinal))
+            return DiagnosticFailureCodes.Budget;
+        if (httpStatus == 429)
+            return DiagnosticFailureCodes.RateLimit;
+        if (httpStatus == 0 || (httpStatus >= 500 && httpStatus <= 599))
+            return DiagnosticFailureCodes.Transport;
+        return null;
     }
 
     /// <summary>
@@ -396,6 +446,8 @@ public class CallLlmInlineActivity : CodeActivity
             ErrorMessage = message,
             DurationMs = durationMs,
             StartedAtUtc = startedAtUtc,
+            // Story 39-9 (AC4) — a null-body / raw-5xx result is a TRANSPORT failure.
+            FailureCode = DiagnosticFailureCodes.Transport,
         };
         var normalized = new NormalizedLlmResponse
         {
@@ -403,7 +455,7 @@ public class CallLlmInlineActivity : CodeActivity
             HttpStatusCode = 0,
             ErrorMessage = message,
         };
-        return new MappedLlmVariables(diagnostic, normalized, 0, 0, false);
+        return new MappedLlmVariables(diagnostic, normalized, 0, 0, false, string.Empty);
     }
 
     /// <summary>
@@ -419,6 +471,8 @@ public class CallLlmInlineActivity : CodeActivity
         context.SetVariable("ToolLoopTokens", v.ToolLoopTokens);
         context.SetVariable("ToolLoopTurns", v.ToolLoopTurns);
         context.SetVariable("ToolLoopExhausted", v.ToolLoopExhausted);
+        // Story 39-9 (D10) — the content-validation block (empty when no validator ran).
+        context.SetVariable("ContentValidationJson", v.ContentValidationJson);
     }
 
     private static string ComposeFailureMessage(string? failureCode, string? failureReason)
@@ -497,4 +551,5 @@ public sealed record MappedLlmVariables(
     NormalizedLlmResponse Response,
     int ToolLoopTokens,
     int ToolLoopTurns,
-    bool ToolLoopExhausted);
+    bool ToolLoopExhausted,
+    string ContentValidationJson);

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
@@ -162,6 +162,52 @@ public class ProviderAttemptDiagnostic
     /// (Epics 34/35, 32-9/32-10) branch on this tag.
     /// </summary>
     public string? CredentialSource { get; set; }
+
+    /// <summary>
+    /// Story 39-9 (AC4) — a small closed-vocabulary classifier for WHY this attempt
+    /// failed (see <see cref="DiagnosticFailureCodes"/>). ADDITIVE and nullable:
+    /// older serialized diagnostics (JSON without this field) deserialize to
+    /// <c>null</c>, and default STJ ignores it for unaware readers — existing
+    /// consumers are unaffected. The load-bearing value is
+    /// <see cref="DiagnosticFailureCodes.ContentValidation"/>: a diagnostic so tagged
+    /// is EXCLUDED from circuit-breaker failure recording (a content failure is the
+    /// provider working fine on a wrong document — it must never open the breaker).
+    /// <c>null</c> ⇒ unclassified (classify only what is certain).
+    /// </summary>
+    public string? FailureCode { get; set; }
+}
+
+/// <summary>
+/// Story 39-9 (AC4, Design Decision D6) — the small, closed vocabulary for
+/// <see cref="ProviderAttemptDiagnostic.FailureCode"/>. The ONLY value with
+/// behaviour attached is <see cref="ContentValidation"/> (breaker exclusion); the
+/// rest classify transport/rate-limit/budget for diagnostics.
+/// </summary>
+public static class DiagnosticFailureCodes
+{
+    /// <summary>A deterministic document-validation failure — the provider worked;
+    /// the output is wrong. EXCLUDED from circuit-breaker failure recording.</summary>
+    public const string ContentValidation = "content_validation";
+
+    /// <summary>A transport / connectivity / 5xx / timeout failure (breaker's business).</summary>
+    public const string Transport = "transport";
+
+    /// <summary>A provider rate-limit (HTTP 429) failure.</summary>
+    public const string RateLimit = "rate_limit";
+
+    /// <summary>A budget-exhaustion failure.</summary>
+    public const string Budget = "budget";
+
+    /// <summary>
+    /// Story 39-9 (AC5, D6) — the SHARED pure predicate both diagnostic recorders use
+    /// to decide whether a diagnostic counts as a PROVIDER failure for the circuit
+    /// breaker. A content-validation failure counts as NEITHER a failure NOR a success
+    /// (it records nothing): it must never increment the breaker's failure count, and
+    /// it must never reset a healthy provider's counters either. Everything else that
+    /// did not succeed is a real provider failure.
+    /// </summary>
+    public static bool CountsAsProviderFailure(ProviderAttemptDiagnostic d) =>
+        !d.Succeeded && d.FailureCode != ContentValidation;
 }
 
 // ============================================================

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -163,6 +163,15 @@ public sealed record LlmCallApiRequest
     [JsonPropertyName("toolLoopConfig")] public ToolLoopConfig? ToolLoopConfig { get; init; }
     [JsonPropertyName("params")] public LlmCallApiParams Params { get; init; } = new();
     [JsonPropertyName("correlationId")] public string CorrelationId { get; init; } = string.Empty;
+
+    /// <summary>Story 39-9 (D2/D10) — the document-type wire KEY gating the repair
+    /// ring. Additive/optional: null/omitted ⇒ no validation (the default for the
+    /// 30+ existing dispatchers).</summary>
+    [JsonPropertyName("documentType")] public string? DocumentType { get; init; }
+
+    /// <summary>Story 39-9 (D10) — the issue id, additive/optional, for the
+    /// <c>LLM.*</c> event tags (AC6).</summary>
+    [JsonPropertyName("issueId")] public string? IssueId { get; init; }
 }
 
 /// <summary>
@@ -200,6 +209,39 @@ public sealed record LlmCallApiResponse
     [JsonPropertyName("failureCode")] public string? FailureCode { get; init; }
     [JsonPropertyName("failureReason")] public string? FailureReason { get; init; }
     [JsonPropertyName("httpStatusCode")] public int? HttpStatusCode { get; init; }
+
+    /// <summary>Story 39-9 (AC3) — the KEY-FREE content-validation block. Mirrors
+    /// <c>Tamma.Api.Services.Agents.ContentValidationDto</c>. Null when no validator
+    /// ran (additive — old readers ignore it).</summary>
+    [JsonPropertyName("contentValidation")] public LlmCallContentValidationDto? ContentValidation { get; init; }
+}
+
+/// <summary>Story 39-9 — the content-validation projection. Mirrors
+/// <c>Tamma.Api.Services.Agents.ContentValidationDto</c>.</summary>
+public sealed record LlmCallContentValidationDto
+{
+    [JsonPropertyName("valid")] public bool Valid { get; init; }
+    [JsonPropertyName("repairTurns")] public int RepairTurns { get; init; }
+    [JsonPropertyName("violations")] public IReadOnlyList<LlmCallContentViolationDto> Violations { get; init; }
+        = Array.Empty<LlmCallContentViolationDto>();
+    [JsonPropertyName("history")] public IReadOnlyList<LlmCallRepairTurnDto> History { get; init; }
+        = Array.Empty<LlmCallRepairTurnDto>();
+}
+
+/// <summary>Story 39-9 — a single violation. Mirrors <c>ContentViolationDto</c>.</summary>
+public sealed record LlmCallContentViolationDto
+{
+    [JsonPropertyName("code")] public string Code { get; init; } = string.Empty;
+    [JsonPropertyName("message")] public string Message { get; init; } = string.Empty;
+}
+
+/// <summary>Story 39-9 — one repair-turn verdict. Mirrors <c>RepairTurnDto</c>.</summary>
+public sealed record LlmCallRepairTurnDto
+{
+    [JsonPropertyName("turn")] public int Turn { get; init; }
+    [JsonPropertyName("valid")] public bool Valid { get; init; }
+    [JsonPropertyName("violations")] public IReadOnlyList<LlmCallContentViolationDto> Violations { get; init; }
+        = Array.Empty<LlmCallContentViolationDto>();
 }
 
 /// <summary>Token usage projection. Mirrors <c>Tamma.Api.Services.Agents.UsageDto</c>.</summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/RecordDiagnosticsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/RecordDiagnosticsActivity.cs
@@ -103,7 +103,7 @@ public class RecordDiagnosticsActivity : CodeActivity<string>
         {
             cbStates = CheckCircuitBreakerActivity.RecordSuccess(cbStates, providerName);
         }
-        else
+        else if (DiagnosticFailureCodes.CountsAsProviderFailure(diagnostic))
         {
             var config = LoadProviderConfig(providerName);
             cbStates = CheckCircuitBreakerActivity.RecordFailure(
@@ -111,6 +111,8 @@ public class RecordDiagnosticsActivity : CodeActivity<string>
                 config.CircuitBreakerFailureThreshold,
                 config.CircuitBreakerCooldownSeconds);
         }
+        // Story 39-9 (AC5, D6) — else: a content_validation failure records NEITHER
+        // failure NOR success; the breaker state is left untouched.
 
         // 3. Update budget
         if (diagnostic.Succeeded || diagnostic.PromptTokens > 0)
@@ -191,12 +193,16 @@ public class RecordDiagnosticsActivity : CodeActivity<string>
                     await apiClient.RecordProviderSuccessAsync(
                         providerName, accountId, context.CancellationToken).ConfigureAwait(false);
                 }
-                else
+                else if (DiagnosticFailureCodes.CountsAsProviderFailure(diagnostic))
                 {
                     await apiClient.RecordProviderFailureAsync(
                         providerName, diagnostic.ErrorMessage, accountId, context.CancellationToken)
                         .ConfigureAwait(false);
                 }
+                // Story 39-9 (AC5, D6) — else: a content_validation failure is NEVER
+                // reported into the shared breaker via RecordProviderFailureAsync
+                // (nor as a success). The RecordDiagnosticsAsync ingest above still
+                // captures it as a general diagnostic — only the breaker path is excluded.
             }
             catch (Exception apiEx)
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/RecordDiagnosticsInlineActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/RecordDiagnosticsInlineActivity.cs
@@ -82,10 +82,14 @@ public class RecordDiagnosticsInlineActivity : CodeActivity
         {
             cbStates = CheckCircuitBreakerActivity.RecordSuccess(cbStates, providerName);
         }
-        else
+        else if (DiagnosticFailureCodes.CountsAsProviderFailure(diagnostic))
         {
             cbStates = CheckCircuitBreakerActivity.RecordFailure(cbStates, providerName);
         }
+        // Story 39-9 (AC5, D6) — else: a content_validation failure is the provider
+        // working fine on a wrong document. It records NEITHER a failure (must never
+        // open the breaker on a healthy provider) NOR a success (it did not succeed) —
+        // the breaker state is left untouched.
 
         // 3. Update budget (simple cost estimate)
         BudgetState? budget;

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmCallEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/LlmCallEndpoints.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Tamma.Api.Services.Agents;
+using Tamma.Core;
 using Tamma.Core.Logging;
 using Tamma.Data;
 
@@ -70,7 +71,40 @@ public static class LlmCallEndpoints
         // a different tenant for the gate / budget / credential path. null ⇒
         // single-user / platform scope.
         var authoritativeTenantId = tenantContext.TenantId;
-        var managedRequest = ManagedAgentRequest.From(request, authoritativeTenantId);
+
+        // Story 39-9 (D2) — compose the document-content validation delegate from the
+        // wire document-type KEY (a delegate cannot ride HTTP). Fail-loud: an unknown /
+        // unregistered key throws a TammaError, which we map to the same non-retryable
+        // AGENT_UNRESOLVED 422-in-200 envelope config failures use (fail-closed — never
+        // "skip validation"). A null/empty key ⇒ null ⇒ no validation (the default for
+        // the 30+ existing dispatchers; zero behaviour change).
+        DocumentContentValidation? documentValidation;
+        try
+        {
+            documentValidation = DocumentValidationBinder.Bind(request.DocumentType);
+        }
+        catch (TammaError ex)
+        {
+            logger.LogWarning(
+                "call-LLM rejected an unknown/unregistered documentType; failing the run as "
+                + "AGENT_UNRESOLVED (422). documentType={DocumentType}, correlationId={CorrelationId}, code={Code}",
+                LogSanitizer.Clean(request.DocumentType),
+                LogSanitizer.Clean(request.CorrelationId),
+                LogSanitizer.Clean(ex.Code));
+
+            var unresolved = new AgentRunResult
+            {
+                Success = false,
+                Role = request.Role,
+                CorrelationId = request.CorrelationId,
+                FailureCode = AgentRunFailureCodes.AgentUnresolved,
+                FailureReason = "unknown or unregistered documentType",
+                HttpStatusCode = 422,
+            };
+            return mapper.ToHttpResult(unresolved);
+        }
+
+        var managedRequest = ManagedAgentRequest.From(request, authoritativeTenantId, documentValidation);
 
         logger.LogInformation(
             "call-LLM received: correlationId={CorrelationId}, role={Role}, persona={Persona}, "

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -767,6 +767,16 @@ builder.Services.AddScoped<Tamma.Api.Services.Agents.IInlineToolLoopRunner,
 builder.Services.AddScoped<Tamma.Api.Services.Agents.IManagedAgent,
     Tamma.Api.Services.Agents.ManagedAgent>();
 
+// Story 39-9 — the GLOBAL deterministic repair-ring config (bounds + per-type gate).
+// Default OFF for every document type (EnabledDocumentTypes empty), default 1 turn,
+// hard cap 2 by clamp. Bound from the "RepairRing" section (TenantBackupOptions block
+// pattern). ManagedAgent reads it to build the per-call RepairRingPlan.
+builder.Services.AddOptions<Tamma.Api.Services.Agents.RepairRingOptions>()
+    .Configure(opts =>
+        builder.Configuration
+            .GetSection(Tamma.Api.Services.Agents.RepairRingOptions.SectionName)
+            .Bind(opts));
+
 // Story 32-6 — the per-agent ACTION TRAIL emitter. The single seam ManagedAgent
 // (and later 32-7 panels / 32-8 review gate) calls to record AGENT.TASK.* /
 // AGENT.TOOL_CALL.* / AGENT.ITERATION.* / AGENT.PANEL.* / REVIEW.BUG.* events into

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunResult.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRunResult.cs
@@ -1,3 +1,5 @@
+using Tamma.Core.Documents;
+
 namespace Tamma.Api.Services.Agents;
 
 /// <summary>
@@ -89,4 +91,24 @@ public sealed record AgentRunResult
     /// circuit breaker keep working. <c>null</c> on success or when no HTTP call
     /// was made.</summary>
     public int? HttpStatusCode { get; init; }
+
+    // --- Story 39-9 — deterministic repair-ring outcome (additive) -----------
+
+    /// <summary>Story 39-9 — the content-validation verdict: <c>true</c> when the
+    /// produced (or repaired) document passed, <c>false</c> on an exhausted content
+    /// failure, <c>null</c> when no validator applied.</summary>
+    public bool? ContentValid { get; init; }
+
+    /// <summary>Story 39-9 — the number of repair turns run (0 when the initial
+    /// produce validated, repair was gated off, or no validator applied).</summary>
+    public int RepairTurns { get; init; }
+
+    /// <summary>Story 39-9 (AC3) — the ordered per-turn validation history, carried
+    /// on the result for the 39-6 <c>ValidationExhausted</c> escalation lineage.
+    /// <c>null</c> when no validator applied.</summary>
+    public IReadOnlyList<RepairTurnRecord>? RepairHistory { get; init; }
+
+    /// <summary>Story 39-9 (AC3) — the FINAL validator violations on a content
+    /// failure (empty/<c>null</c> on success or when no validator applied).</summary>
+    public IReadOnlyList<DocumentViolation>? ContentViolations { get; init; }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/DocumentValidationBinder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/DocumentValidationBinder.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (Design Decision D2) — composes the <see cref="DocumentContentValidation"/>
+/// delegate API-side from a document-type wire KEY. A validator delegate cannot ride
+/// HTTP from the engine, so the wire carries only the key; this binder resolves it to
+/// an <see cref="IDocumentType"/> via <see cref="DocumentTypeRegistry"/> and wraps
+/// <see cref="IDocumentType.Validate"/> behind a fence-strip + <see cref="JsonDocument"/>
+/// parse front.
+///
+/// <para><b>Fail-loud (D2).</b> An unknown / unregistered key throws the registry's
+/// <c>TammaError</c> — the endpoint maps that to the <c>AGENT_UNRESOLVED</c> 422-in-200
+/// envelope (fail-closed; never "skip validation"). A null / empty key means "no
+/// validation" and returns <c>null</c> (the default for the 30+ existing dispatchers).</para>
+///
+/// <para><b>Unparseable payload.</b> When the produced document is not JSON (after
+/// stripping a markdown code fence), the delegate does NOT throw — it returns an
+/// invalid result carrying a synthetic <c>PAYLOAD_NOT_JSON</c> violation, so the
+/// repair ring can feed it back to the model like any other violation.</para>
+/// </summary>
+public static class DocumentValidationBinder
+{
+    /// <summary>The synthetic violation code emitted when the produced document is
+    /// not parseable JSON.</summary>
+    public const string PayloadNotJsonCode = "PAYLOAD_NOT_JSON";
+
+    /// <summary>
+    /// Compose the document-content validation seam for <paramref name="documentTypeKey"/>.
+    /// Null / empty ⇒ <c>null</c> (no validation). Otherwise resolves the type
+    /// (fail-loud on an unknown key) and returns a delegate over its validator.
+    /// </summary>
+    public static DocumentContentValidation? Bind(string? documentTypeKey)
+    {
+        if (string.IsNullOrWhiteSpace(documentTypeKey))
+        {
+            return null;
+        }
+
+        var key = documentTypeKey.Trim();
+
+        // Fail-loud (D2): an unknown wire string or an unregistered key throws a
+        // TammaError here (DOCUMENT.TYPE.UNKNOWN / DOCUMENT.TYPE.NOT_REGISTERED),
+        // which the endpoint catches and maps to a 422 envelope.
+        var documentType = DocumentTypeRegistry.Resolve(key);
+
+        return new DocumentContentValidation(
+            key,
+            payload => Validate(documentType, payload));
+    }
+
+    private static DocumentValidationResult Validate(IDocumentType documentType, string producedText)
+    {
+        var json = ExtractJson(producedText);
+
+        JsonElement element;
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            element = doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return DocumentValidationResult.Invalid(
+                new DocumentViolation(
+                    PayloadNotJsonCode,
+                    "The produced document is not valid JSON. Re-emit the document as a single JSON object."));
+        }
+
+        return documentType.Validate(element);
+    }
+
+    /// <summary>
+    /// Strip a leading/trailing markdown code fence (<c>```json … ```</c> or
+    /// <c>``` … ```</c>) so a fenced model response still parses. Precedent:
+    /// <c>ApplyReviewFixesActivity.ExtractJson</c>.
+    /// </summary>
+    private static string ExtractJson(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return "{}";
+        }
+
+        var trimmed = text.Trim();
+        if (trimmed.StartsWith("```", StringComparison.Ordinal))
+        {
+            var firstNewline = trimmed.IndexOf('\n');
+            if (firstNewline > 0)
+            {
+                trimmed = trimmed[(firstNewline + 1)..];
+            }
+            if (trimmed.EndsWith("```", StringComparison.Ordinal))
+            {
+                trimmed = trimmed[..^3].TrimEnd();
+            }
+        }
+
+        return trimmed;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IInlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/IInlineToolLoopRunner.cs
@@ -1,6 +1,45 @@
 using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Documents;
 
 namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (D1/D2) — the deterministic repair-ring plan handed to
+/// <see cref="IInlineToolLoopRunner.RunAsync"/>. The runner is registry-free: it
+/// sees only the composed <see cref="Validate"/> delegate (built API-side over
+/// <c>DocumentTypeRegistry.Resolve(key).Validate</c> with a fence-strip / parse
+/// front — a delegate cannot ride HTTP), the gate flag, and the already-clamped
+/// turn cap. This keeps the ring unit-testable with fake validators.
+/// </summary>
+/// <param name="DocumentTypeKey">The document-type wire key (event tag only).</param>
+/// <param name="Validate">Pure validator: produced-document text → verdict. Never
+/// throws for a malformed payload — it returns an invalid result carrying a
+/// synthetic <c>PAYLOAD_NOT_JSON</c> violation.</param>
+/// <param name="RepairEnabled">Whether repair turns run for this type
+/// (<c>EnabledDocumentTypes</c> membership). When <c>false</c>, the runner
+/// validates ONCE and never appends a repair turn (AC9).</param>
+/// <param name="MaxRepairTurns">The already-clamped
+/// <c>RepairRingOptions.EffectiveMaxRepairTurns</c> (0..2) — the runner does no
+/// clamping of its own.</param>
+public sealed record RepairRingPlan(
+    string DocumentTypeKey,
+    Func<string, DocumentValidationResult> Validate,
+    bool RepairEnabled,
+    int MaxRepairTurns);
+
+/// <summary>
+/// Story 39-9 (D4) — the validation verdict for a single turn in the repair ring.
+/// Turn 0 is the initial produce validation; turns 1..N are repair re-validations.
+/// The runner returns the ordered history; <c>ManagedAgent</c> replays it into the
+/// <c>LLM.*</c> DCB events (the runner stays event-store-free).
+/// </summary>
+/// <param name="Turn">0 = initial produce validation; 1..N = repair turns.</param>
+/// <param name="Valid">Whether the document validated on this turn.</param>
+/// <param name="Violations">The domain-phrased violations (empty when valid).</param>
+public sealed record RepairTurnRecord(
+    int Turn,
+    bool Valid,
+    IReadOnlyList<DocumentViolation> Violations);
 
 /// <summary>
 /// Story 32-5 (AC4) — the extracted, reusable agentic tool-loop seam.
@@ -25,6 +64,12 @@ public interface IInlineToolLoopRunner
     /// request-scoped <c>ApiKey</c>). Returns the final response plus cumulative
     /// token totals, completed turns, and whether the loop exhausted maxSteps.
     /// </summary>
+    /// <param name="repair">Story 39-9 (D1) — the deterministic repair-ring plan,
+    /// or <c>null</c> when no document validation applies (behaviour then byte-identical
+    /// to before the ring existed). This parameter has NO DEFAULT VALUE by design:
+    /// C# expression trees reject omitted optional arguments (CS0854), so a defaulted
+    /// parameter would silently break strict Moq setups — an explicit parameter makes
+    /// every call site a conscious edit.</param>
     Task<InlineToolLoopResult> RunAsync(
         string provider,
         LlmProviderConfig providerConfig,
@@ -37,6 +82,7 @@ public interface IInlineToolLoopRunner
         bool enableToolLoop,
         ToolLoopConfig loopConfig,
         string correlationId,
+        RepairRingPlan? repair,
         CancellationToken ct);
 
     /// <summary>
@@ -87,6 +133,26 @@ public sealed record InlineToolLoopResult
     /// <summary>Key-free per-tool-call summaries. Empty in the verbatim extraction
     /// (the loop tracks a count only); populated by a follow-on.</summary>
     public IReadOnlyList<ToolCallSummary> ToolCalls { get; init; } = Array.Empty<ToolCallSummary>();
+
+    // --- Story 39-9 (D1) — deterministic repair-ring outcome (additive) --------
+
+    /// <summary>Story 39-9 — the final content-validation verdict: <c>true</c> when
+    /// the produced (or repaired) document passed its validator, <c>false</c> when it
+    /// still failed after exhausting the ring, and <c>null</c> when NO validator was
+    /// supplied (<c>repair == null</c>) — behaviour then byte-identical to before the
+    /// ring existed.</summary>
+    public bool? ContentValid { get; init; }
+
+    /// <summary>Story 39-9 — the number of repair turns actually run (0 when the
+    /// initial produce validated, when repair was gated off, or when no validator
+    /// was supplied). Counted SEPARATELY from <see cref="Turns"/> (tool-loop turns).</summary>
+    public int RepairTurns { get; init; }
+
+    /// <summary>Story 39-9 — the ordered per-turn validation history (turn 0 = the
+    /// initial produce validation; 1..N = repair re-validations). Empty when no
+    /// validator was supplied. <c>ManagedAgent</c> replays this into the <c>LLM.*</c>
+    /// DCB events.</summary>
+    public IReadOnlyList<RepairTurnRecord> RepairHistory { get; init; } = Array.Empty<RepairTurnRecord>();
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ILlmCallResponseMapper.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ILlmCallResponseMapper.cs
@@ -70,6 +70,15 @@ public static class AgentRunFailureCodes
     /// <summary>The tool loop exhausted maxSteps with no usable response.</summary>
     public const string LoopExhausted = "LOOP_EXHAUSTED";
 
+    /// <summary>Story 39-9 (D5) — the produced document still failed its deterministic
+    /// validator after the repair ring was exhausted. A CONTENT failure (the provider
+    /// worked; the output is wrong — think 422 vs 503), NOT a transport/provider
+    /// problem: the mapper stamps body <c>httpStatusCode</c> 422 (NOT in RetryCheck's
+    /// transient set), and the diagnostic path excludes it from the circuit breaker.
+    /// The final violations + per-turn history ride on the result for the 39-6
+    /// <c>ValidationExhausted</c> lineage.</summary>
+    public const string ContentValidationFailed = "CONTENT_VALIDATION_FAILED";
+
     /// <summary>A SaaS gate denial of a CLI-token / unknown provider ⇒ 400.</summary>
     public const string SaasProviderNotAllowed = "SAAS_PROVIDER_NOT_ALLOWED";
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
@@ -79,14 +79,18 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
         bool enableToolLoop,
         ToolLoopConfig loopConfig,
         string correlationId,
+        RepairRingPlan? repair,
         CancellationToken ct)
     {
         // The loop already folds the cumulative totals onto the response's
         // PromptTokens/CompletionTokens (their sum == the old TotalTokens), so
         // we discard the redundant scalar and surface the split counts below.
-        var (response, _, turns, exhausted) = await AgenticToolLoop(
-            provider, providerConfig, model, systemPrompt, userPrompt,
-            maxTokens, temperature, tools, loopConfig, correlationId, ct);
+        // Story 39-9 — the loop also runs the deterministic repair ring (when
+        // `repair` is supplied) inside the SAME conversation before returning.
+        var (response, _, turns, exhausted, contentValid, repairTurns, repairHistory) =
+            await AgenticToolLoop(
+                provider, providerConfig, model, systemPrompt, userPrompt,
+                maxTokens, temperature, tools, loopConfig, correlationId, repair, ct);
 
         return new InlineToolLoopResult
         {
@@ -96,7 +100,12 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
             InputTokens = response.PromptTokens,
             OutputTokens = response.CompletionTokens,
             Turns = turns,
-            Exhausted = exhausted
+            Exhausted = exhausted,
+            // Story 39-9 (D1) — repair-ring outcome. All default (ContentValid == null)
+            // when no validator was supplied ⇒ behaviour byte-identical to before.
+            ContentValid = contentValid,
+            RepairTurns = repairTurns,
+            RepairHistory = repairHistory,
         };
     }
 
@@ -107,7 +116,8 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
     /// <summary>
     /// Multi-turn agentic tool loop. Calls LLM, executes tools, feeds results back, repeats.
     /// </summary>
-    private async Task<(NormalizedLlmResponse Response, int TotalTokens, int Turns, bool Exhausted)>
+    private async Task<(NormalizedLlmResponse Response, int TotalTokens, int Turns, bool Exhausted,
+            bool? ContentValid, int RepairTurns, IReadOnlyList<RepairTurnRecord> RepairHistory)>
         AgenticToolLoop(
             string providerName,
             LlmProviderConfig providerConfig,
@@ -119,6 +129,7 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
             IReadOnlyList<ResolvedTool>? tools,
             ToolLoopConfig loopConfig,
             string workflowInstanceId,
+            RepairRingPlan? repair,
             CancellationToken cancellationToken)
     {
         var messages = new List<ConversationMessage>
@@ -537,14 +548,95 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
             }
         }
 
+        // ═══ Story 39-9 — deterministic repair ring (AC1, AC2, D3, D9) ═══
+        // Runs HERE — the only place the `messages` conversation, the resolved
+        // provider config, the model, and the `tools` declarations are all in
+        // scope — so validate-then-repair happens inside the SAME conversation
+        // before the loop returns. When `repair` is null (no document validation)
+        // this whole block is skipped and behaviour is byte-identical to before.
+        bool? contentValid = null;
+        var repairTurns = 0;
+        var repairHistory = new List<RepairTurnRecord>();
+
+        if (repair is not null && lastResponse.Success && !string.IsNullOrEmpty(lastResponse.ResponseText))
+        {
+            // Preserve the PRODUCED document in the conversation (AC1). The main loop
+            // breaks on end_turn WITHOUT appending the final assistant text, so append
+            // it here — otherwise the repair turn would ask the model to "fix the
+            // document you produced" with that document absent from the history.
+            messages.Add(new ConversationMessage { Role = "assistant", Content = lastResponse.ResponseText });
+
+            // Turn 0 — validate the produced document. The validator never throws
+            // (a malformed payload yields a synthetic PAYLOAD_NOT_JSON violation).
+            var verdict = repair.Validate(lastResponse.ResponseText!);
+            contentValid = verdict.IsValid;
+            repairHistory.Add(new RepairTurnRecord(0, verdict.IsValid, verdict.Violations));
+
+            while (!verdict.IsValid
+                   && repair.RepairEnabled
+                   && repairTurns < repair.MaxRepairTurns)
+            {
+                // Append the harness-generated, redacted repair message to the SAME
+                // conversation (D9 — redaction at the append site, since violation
+                // messages may quote model output). No system prompt / prior turns
+                // are dropped — the conversation is not restarted (AC1).
+                var repairMessage = ToolOutputHelper.RedactSecrets(
+                    RepairMessageComposer.Compose(verdict.Violations));
+                messages.Add(new ConversationMessage { Role = "user", Content = repairMessage });
+
+                // Re-invoke ONCE (D3 — a repair turn is one model call; NO tool
+                // execution). Same client/config/tools declarations (Anthropic
+                // requires the tools when history carries tool blocks). Repair turns
+                // NEVER touch loopConfig.MaxSteps / completedTurns.
+                var repairResponse = providerName.Equals("anthropic", StringComparison.OrdinalIgnoreCase)
+                    ? await CallAnthropicMultiTurn(
+                        httpClient, providerConfig, model, messages, maxTokens, temperature, tools)
+                    : await CallOpenAiMultiTurn(
+                        httpClient, providerConfig, model, messages, maxTokens, temperature, tools);
+
+                repairTurns++;
+
+                // A transport failure DURING a repair turn is orthogonal: it is a
+                // provider failure, surfaced exactly as today (breaker/retry
+                // semantics apply upstream), and it ends the ring. The content
+                // verdict axis is not conflated with the transport axis.
+                if (!repairResponse.Success)
+                {
+                    lastResponse = repairResponse;
+                    break;
+                }
+
+                // Accumulate the repair-turn token spend so budget accounting stays
+                // truthful (these land on the cumulative totals written below).
+                totalPromptTokens += repairResponse.PromptTokens;
+                totalCompletionTokens += repairResponse.CompletionTokens;
+                lastResponse = repairResponse;
+
+                // Preserve the repaired document in the conversation for any further
+                // turn (again the produce loop's end_turn break would drop it).
+                messages.Add(new ConversationMessage
+                {
+                    Role = "assistant",
+                    Content = repairResponse.ResponseText,
+                });
+
+                // Re-validate. A ToolUse stop with no usable text simply re-validates
+                // as invalid and consumes the turn (D3) — bounded by MaxRepairTurns.
+                verdict = repair.Validate(repairResponse.ResponseText ?? string.Empty);
+                contentValid = verdict.IsValid;
+                repairHistory.Add(new RepairTurnRecord(repairTurns, verdict.IsValid, verdict.Violations));
+            }
+        }
+
         // Update token counts on last response to reflect cumulative totals
+        // (INCLUDING any repair-turn spend accumulated above).
         lastResponse.PromptTokens = totalPromptTokens;
         lastResponse.CompletionTokens = totalCompletionTokens;
 
         var totalTokens = totalPromptTokens + totalCompletionTokens;
         var turns = completedTurns;
 
-        return (lastResponse, totalTokens, turns, exhausted);
+        return (lastResponse, totalTokens, turns, exhausted, contentValid, repairTurns, repairHistory);
     }
 
     // =======================================================================

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallRequest.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallRequest.cs
@@ -102,6 +102,18 @@ public sealed record LlmCallRequest
     /// <summary>Workflow instance id — links the run back to the parent workflow
     /// and tags every DCB event. Required.</summary>
     public required string CorrelationId { get; init; }
+
+    /// <summary>Story 39-9 (D2/D10) — the document-type wire KEY (e.g.
+    /// <c>decomposition</c>) whose deterministic validator gates the repair ring.
+    /// <c>null</c>/empty ⇒ no validation (the ring is invisible — the default for the
+    /// 30+ existing dispatchers). Additive/optional: old JSON deserializes clean.
+    /// The endpoint composes the validator delegate from this key server-side (a
+    /// delegate cannot ride HTTP); an unknown key fails loud.</summary>
+    public string? DocumentType { get; init; }
+
+    /// <summary>Story 39-9 (D10) — the issue id, additive/optional, threaded through
+    /// purely for the <c>LLM.*</c> event tags (AC6). <c>null</c> ⇒ no change.</summary>
+    public string? IssueId { get; init; }
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponse.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponse.cs
@@ -76,7 +76,35 @@ public sealed record LlmCallResponse
     /// engine's <c>RetryCheck</c> + circuit breaker keep working. <c>null</c> on
     /// success or when no HTTP call was made.</summary>
     public int? HttpStatusCode { get; init; }
+
+    /// <summary>Story 39-9 (AC3) — the KEY-FREE content-validation block. Present when
+    /// a document validator ran (the produce dispatch supplied a <c>documentType</c>);
+    /// <c>null</c> otherwise (the default for the 30+ existing dispatchers). Story 39-6
+    /// consumes it (violations + per-turn history) to build its
+    /// <c>ValidationExhausted</c> lineage.</summary>
+    public ContentValidationDto? ContentValidation { get; init; }
 }
+
+/// <summary>
+/// Story 39-9 (AC3, design §wire) — the KEY-FREE content-validation projection carried
+/// on <see cref="LlmCallResponse.ContentValidation"/>. Deterministic-validator output
+/// only: a valid flag, the repair-turn count, the FINAL violations, and the ordered
+/// per-turn history. Never carries a key, a prompt body, or a provider error.
+/// </summary>
+public sealed record ContentValidationDto(
+    bool Valid,
+    int RepairTurns,
+    IReadOnlyList<ContentViolationDto> Violations,
+    IReadOnlyList<RepairTurnDto> History);
+
+/// <summary>Story 39-9 — a single domain-phrased violation (stable code + message).</summary>
+public sealed record ContentViolationDto(string Code, string Message);
+
+/// <summary>Story 39-9 — one turn's validation verdict (turn 0 = initial produce).</summary>
+public sealed record RepairTurnDto(
+    int Turn,
+    bool Valid,
+    IReadOnlyList<ContentViolationDto> Violations);
 
 /// <summary>
 /// Story 32-5 (design §2.3) — token usage projection. Token COUNT fields only —

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponseMapper.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/LlmCallResponseMapper.cs
@@ -46,7 +46,32 @@ public sealed class LlmCallResponseMapper : ILlmCallResponseMapper
             FailureCode = run.FailureCode,
             FailureReason = run.FailureReason,
             HttpStatusCode = run.HttpStatusCode,
+            ContentValidation = ToContentValidationDto(run),
         };
+    }
+
+    /// <summary>Story 39-9 — project the repair-ring outcome onto the wire block.
+    /// <c>null</c> when no validator applied (<see cref="AgentRunResult.ContentValid"/>
+    /// is <c>null</c>) ⇒ additive, zero change for existing dispatchers.</summary>
+    private static ContentValidationDto? ToContentValidationDto(AgentRunResult run)
+    {
+        if (run.ContentValid is null)
+        {
+            return null;
+        }
+
+        var finalViolations = (run.ContentViolations ?? Array.Empty<Tamma.Core.Documents.DocumentViolation>())
+            .Select(v => new ContentViolationDto(v.Code, v.Message))
+            .ToList();
+
+        var history = (run.RepairHistory ?? Array.Empty<RepairTurnRecord>())
+            .Select(t => new RepairTurnDto(
+                t.Turn,
+                t.Valid,
+                t.Violations.Select(v => new ContentViolationDto(v.Code, v.Message)).ToList()))
+            .ToList();
+
+        return new ContentValidationDto(run.ContentValid.Value, run.RepairTurns, finalViolations, history);
     }
 
     /// <inheritdoc />
@@ -87,6 +112,14 @@ public sealed class LlmCallResponseMapper : ILlmCallResponseMapper
             // is NOT in RetryCheck's transient set {0, 429, 502, 503, 504}, so the
             // engine will NOT retry a config failure against the same provider.
             AgentRunFailureCodes.AgentUnresolved => Results.Ok(WithBodyStatus(body, 422)),
+            // Story 39-9 (D5) — CONTENT_VALIDATION_FAILED is a CONTENT failure (the
+            // provider worked; the document is wrong). It rides a 200 success:false
+            // envelope with a body httpStatusCode of 422 (Unprocessable Entity), which
+            // is NOT in RetryCheck's transient set {0, 429, 502, 503, 504}, so the
+            // provider chain does NOT retry it — the lifecycle maps it to
+            // ValidationExhausted. (The breaker exclusion is enforced engine-side.)
+            AgentRunFailureCodes.ContentValidationFailed =>
+                Results.Ok(WithBodyStatus(body, body.HttpStatusCode ?? 422)),
             // PROVIDER_ERROR / PROVIDER_CREDENTIAL_UNAVAILABLE / BUDGET_EXCEEDED /
             // LOOP_EXHAUSTED / anything else ⇒ 200 success:false (+ preserved
             // httpStatusCode inside the body).

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
@@ -1,11 +1,14 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Tamma.Activities.LlmCall.Credentials;
 using Tamma.Activities.LlmCall.Models;
+using Tamma.Activities.LlmCall.Tools;
 using Tamma.Api.Services.Providers;
 using Tamma.Api.Services.Security;
 using Tamma.Core;
+using Tamma.Core.Documents;
 using Tamma.Data.Entities;
 using Tamma.Data.Repositories;
 
@@ -73,6 +76,10 @@ public sealed class ManagedAgent : IManagedAgent
     // byte-for-byte identical whether 0 or N tap subscribers are attached (AC6),
     // and a publish failure NEVER faults the run (AC5, log-and-swallow).
     private readonly Tamma.Api.Services.Streaming.ILlmRunStreamBus? _runStreamBus;
+    // Story 39-9 — GLOBAL repair-ring config (bounds + per-type gate). Optional
+    // trailing ctor arg (null ⇒ new RepairRingOptions() = default OFF, cap 1) so the
+    // existing unit-test ctors are unchanged; DI-registered in the API host.
+    private readonly RepairRingOptions _repairOptions;
     private readonly ILogger<ManagedAgent> _logger;
 
     // NOTE: the process mode (single-user vs SaaS) is NOT a dependency here — the
@@ -92,7 +99,8 @@ public sealed class ManagedAgent : IManagedAgent
         ILogger<ManagedAgent> logger,
         Tamma.Activities.Security.IContentSanitizer? sanitizer = null,
         IAgentTrailEmitter? trail = null,
-        Tamma.Api.Services.Streaming.ILlmRunStreamBus? runStreamBus = null)
+        Tamma.Api.Services.Streaming.ILlmRunStreamBus? runStreamBus = null,
+        IOptions<RepairRingOptions>? repairOptions = null)
     {
         _gate = gate ?? throw new ArgumentNullException(nameof(gate));
         _budget = budget ?? throw new ArgumentNullException(nameof(budget));
@@ -115,6 +123,10 @@ public sealed class ManagedAgent : IManagedAgent
         // the terminal `final` frame is published as a side-effect after the run
         // completes. Absent ⇒ no publish (older unit-test ctors).
         _runStreamBus = runStreamBus;
+        // Optional (Story 39-9): the global repair-ring config. When absent, the
+        // default is repair OFF for every document type (EnabledDocumentTypes empty)
+        // with a hard cap of 2 and a default of 1 — the mechanism ships dark.
+        _repairOptions = repairOptions?.Value ?? new RepairRingOptions();
     }
 
     /// <inheritdoc />
@@ -290,6 +302,18 @@ public sealed class ManagedAgent : IManagedAgent
                 ApiKey = credential.ApiKey, // request-scoped; dropped after the call
             };
 
+            // ── Story 39-9 — build the deterministic repair-ring plan (AC1/AC9). ──
+            // null DocumentValidation ⇒ null plan ⇒ the runner's ring is inert and
+            // behaviour is byte-identical to before. The gate + already-clamped cap
+            // come from the GLOBAL RepairRingOptions (no per-call knob — D8).
+            var repairPlan = request.DocumentValidation is null
+                ? null
+                : new RepairRingPlan(
+                    request.DocumentValidation.DocumentTypeKey,
+                    request.DocumentValidation.Validate,
+                    _repairOptions.IsEnabledFor(request.DocumentValidation.DocumentTypeKey),
+                    _repairOptions.EffectiveMaxRepairTurns);
+
             InlineToolLoopResult loop;
             try
             {
@@ -305,6 +329,7 @@ public sealed class ManagedAgent : IManagedAgent
                     enableToolLoop: request.EnableToolLoop,
                     loopConfig: request.ToolLoopConfig ?? new ToolLoopConfig(),
                     correlationId: request.CorrelationId,
+                    repair: repairPlan,
                     ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { throw; }
@@ -351,6 +376,35 @@ public sealed class ManagedAgent : IManagedAgent
                     .ConfigureAwait(false);
             }
 
+            // ── Story 39-9 — repair-ring events + typed content-failure (D4/D5). ──
+            // We reach here ONLY on a transport-successful loop (provider-error and
+            // loop-exhausted paths already returned). Replay the per-turn validation
+            // history into the LLM.* DCB events (best-effort — D4), then map an
+            // exhausted content failure to the typed, non-transient
+            // CONTENT_VALIDATION_FAILED (422): never a provider error, never a bare
+            // exception, and it NEVER trips the circuit breaker (D6).
+            if (repairPlan is not null && loop.RepairHistory.Count > 0)
+            {
+                await EmitRepairEventsAsync(ctx, request, repairPlan, loop, ct).ConfigureAwait(false);
+            }
+
+            if (loop.ContentValid == false)
+            {
+                var finalViolations = loop.RepairHistory.Count > 0
+                    ? loop.RepairHistory[^1].Violations
+                    : (IReadOnlyList<DocumentViolation>)Array.Empty<DocumentViolation>();
+
+                // Token counts (INCLUDING repair-turn spend) ride the result via
+                // FailTerminalAsync's inTok/outTok so budget accounting stays truthful.
+                return await FailTerminalAsync(ctx, sw, AgentRunFailureCodes.ContentValidationFailed,
+                    "produced document failed deterministic validation after the repair ring was exhausted",
+                    httpStatus: 422,
+                    inTok, outTok, toolLoopTokens, loop.Turns, loop.Exhausted, ct,
+                    contentValid: false, repairTurns: loop.RepairTurns,
+                    repairHistory: loop.RepairHistory, contentViolations: finalViolations)
+                    .ConfigureAwait(false);
+            }
+
             // ── 7. meter (cost basis + markup + usage) ──
             var costBasis = _pricing.Compute(ctx.Provider, ctx.Model, inTok, outTok);
             var price = _markup.Apply(costBasis, ctx.CredentialSource, ctx.Provider, ctx.Model, request.TenantId);
@@ -380,6 +434,12 @@ public sealed class ManagedAgent : IManagedAgent
                 CorrelationId = request.CorrelationId,
                 CredentialSource = ctx.CredentialSource,
                 ResponseText = loop.Response.ResponseText,
+                // Story 39-9 — the repair-ring outcome rides the success result too
+                // (additive; all null/empty when no validator applied).
+                ContentValid = loop.ContentValid,
+                RepairTurns = loop.RepairTurns,
+                RepairHistory = repairPlan is null ? null : loop.RepairHistory,
+                ContentViolations = null,
             };
 
             await EmitUsageAsync(result, request.TenantId, ct).ConfigureAwait(false);
@@ -424,7 +484,10 @@ public sealed class ManagedAgent : IManagedAgent
     /// run is the terminal <c>AGENT.RUN.FAILED</c> DCB event, not a usage row.</para></summary>
     private async Task<AgentRunResult> FailTerminalAsync(
         RunContext ctx, Stopwatch sw, string failureCode, string reason, int? httpStatus,
-        int inTok, int outTok, int toolLoopTokens, int turns, bool exhausted, CancellationToken ct)
+        int inTok, int outTok, int toolLoopTokens, int turns, bool exhausted, CancellationToken ct,
+        bool? contentValid = null, int repairTurns = 0,
+        IReadOnlyList<RepairTurnRecord>? repairHistory = null,
+        IReadOnlyList<DocumentViolation>? contentViolations = null)
     {
         _logger.LogWarning(
             "Managed run failed: failureCode={FailureCode}, httpStatus={HttpStatus}, "
@@ -452,6 +515,11 @@ public sealed class ManagedAgent : IManagedAgent
             FailureCode = failureCode,
             FailureReason = reason,
             HttpStatusCode = httpStatus,
+            // Story 39-9 — additive; set only on the CONTENT_VALIDATION_FAILED path.
+            ContentValid = contentValid,
+            RepairTurns = repairTurns,
+            RepairHistory = repairHistory,
+            ContentViolations = contentViolations,
         };
 
         await EmitAsync(AgentRunEventTypes.Failed, ctx, failureCode, ct).ConfigureAwait(false);
@@ -603,6 +671,113 @@ public sealed class ManagedAgent : IManagedAgent
             // NOT swallowed silently into losing the run — the run still returns.
             _logger.LogError(ex,
                 "AGENT.RUN.* event append failed (type={Type}); the run result still returns. "
+                + "correlationId={CorrelationId}, tenantId={TenantId}",
+                type, ctx.CorrelationId, ctx.TenantId);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Story 39-9 — repair-ring DCB events (best-effort; D4). The runner returns
+    // the per-turn history free of any event-store dependency; ManagedAgent — which
+    // already owns IEventRepository and the best-effort EmitAsync posture — replays
+    // it into LLM.VALIDATION.FAILED / LLM.REPAIR.SUCCEEDED / LLM.REPAIR.EXHAUSTED.
+    // Tags carry issueId/documentType/role/action/repairTurn/correlationId/tenantId
+    // so per-(role, action) × documentType rates are computable from events alone (AC7).
+    // -----------------------------------------------------------------------
+
+    private async Task EmitRepairEventsAsync(
+        RunContext ctx, ManagedAgentRequest request, RepairRingPlan plan,
+        InlineToolLoopResult loop, CancellationToken ct)
+    {
+        // One LLM.VALIDATION.FAILED per failed validation (including turn 0). Data
+        // carries the redacted violation summaries (code + domain-phrased message).
+        foreach (var record in loop.RepairHistory)
+        {
+            if (record.Valid)
+            {
+                continue;
+            }
+
+            var summaries = record.Violations
+                .Select(v => new
+                {
+                    code = v.Code,
+                    message = ToolOutputHelper.RedactSecrets(v.Message ?? string.Empty),
+                })
+                .ToArray();
+
+            await EmitRepairEventAsync(
+                RepairRingEventTypes.ValidationFailed, ctx, request, plan.DocumentTypeKey,
+                repairTurn: record.Turn,
+                data: new { violations = summaries },
+                ct).ConfigureAwait(false);
+        }
+
+        // LLM.REPAIR.SUCCEEDED — the first repair turn (turn > 0) that validated.
+        var succeeded = loop.RepairHistory.FirstOrDefault(r => r.Turn > 0 && r.Valid);
+        if (succeeded is not null)
+        {
+            await EmitRepairEventAsync(
+                RepairRingEventTypes.RepairSucceeded, ctx, request, plan.DocumentTypeKey,
+                repairTurn: succeeded.Turn,
+                data: new { turn = succeeded.Turn },
+                ct).ConfigureAwait(false);
+        }
+
+        // LLM.REPAIR.EXHAUSTED — cap hit, still invalid, and repair was ENABLED (a
+        // gate-off run never exhausts: it emits only LLM.VALIDATION.FAILED — AC9).
+        if (loop.ContentValid == false && plan.RepairEnabled && loop.RepairTurns >= plan.MaxRepairTurns)
+        {
+            var finalViolationCount = loop.RepairHistory.Count > 0
+                ? loop.RepairHistory[^1].Violations.Count
+                : 0;
+
+            await EmitRepairEventAsync(
+                RepairRingEventTypes.RepairExhausted, ctx, request, plan.DocumentTypeKey,
+                repairTurn: loop.RepairTurns,
+                data: new { turnCount = loop.RepairTurns, finalViolationCount },
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    private async Task EmitRepairEventAsync(
+        string type, RunContext ctx, ManagedAgentRequest request, string documentType,
+        int repairTurn, object data, CancellationToken ct)
+    {
+        try
+        {
+            var tagsObj = new
+            {
+                issueId = request.IssueId,
+                documentType,
+                role = ctx.Role,
+                action = request.Action,
+                repairTurn,
+                correlationId = ctx.CorrelationId,
+                tenantId = ctx.TenantId?.ToString(),
+            };
+
+            await _events.AppendAsync(new DomainEvent
+            {
+                Id = Guid.NewGuid(),
+                Type = type,
+                TenantId = ctx.TenantId,
+                Tags = JsonSerializer.Serialize(tagsObj),
+                Metadata = JsonSerializer.Serialize(new
+                {
+                    workflowVersion = "1.0.0",
+                    eventSource = "system",
+                }),
+                Data = JsonSerializer.Serialize(data),
+                CreatedAt = DateTime.UtcNow,
+            }).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort (D4): an append failure is logged at ERROR, never swallowed
+            // into losing the run — the run result still returns.
+            _logger.LogError(ex,
+                "LLM.* repair event append failed (type={Type}); the run result still returns. "
                 + "correlationId={CorrelationId}, tenantId={TenantId}",
                 type, ctx.CorrelationId, ctx.TenantId);
         }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgentRequest.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgentRequest.cs
@@ -1,6 +1,24 @@
 using Tamma.Activities.LlmCall.Models;
+using Tamma.Core.Documents;
 
 namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (D2) — the composed document-content validation seam handed to
+/// <c>ManagedAgent</c> / the runner. It carries the document-type wire KEY (for
+/// event tags) plus a pure <see cref="Validate"/> delegate built API-side over
+/// <c>DocumentTypeRegistry.Resolve(key).Validate</c> (a delegate cannot cross
+/// HTTP). Composition is done by <see cref="DocumentValidationBinder.Bind"/>;
+/// <c>ManagedAgent</c> and the runner never touch the registry — keeping them
+/// unit-testable with fake validators.
+/// </summary>
+/// <param name="DocumentTypeKey">The document-type wire key (event tag only).</param>
+/// <param name="Validate">Produced-document text → validation verdict. Never throws
+/// for malformed input — returns an invalid result with a synthetic
+/// <c>PAYLOAD_NOT_JSON</c> violation.</param>
+public sealed record DocumentContentValidation(
+    string DocumentTypeKey,
+    Func<string, DocumentValidationResult> Validate);
 
 /// <summary>
 /// Story 32-5 — the INTERNAL input to <see cref="IManagedAgent.RunAsync"/>,
@@ -75,6 +93,18 @@ public sealed record ManagedAgentRequest
     /// <summary>Workflow instance id. Always set.</summary>
     public required string CorrelationId { get; init; }
 
+    /// <summary>Story 39-9 (D2/D10) — the composed document-content validation seam.
+    /// <c>null</c> ⇒ no validation runs (the repair ring is invisible; behaviour
+    /// byte-identical to before). Composed API-side by
+    /// <see cref="DocumentValidationBinder.Bind"/> from the wire
+    /// <see cref="LlmCallRequest.DocumentType"/> key.</summary>
+    public DocumentContentValidation? DocumentValidation { get; init; }
+
+    /// <summary>Story 39-9 (D10) — the issue id, threaded through as an additive
+    /// optional input purely for the <c>LLM.*</c> event tags (AC6). <c>null</c>/empty
+    /// for the 30+ existing dispatchers ⇒ zero behaviour change.</summary>
+    public string? IssueId { get; init; }
+
     /// <summary>
     /// Pure mapping from the wire request to the internal request. The tenant
     /// scope is the <paramref name="authoritativeTenantId"/> derived from the
@@ -90,7 +120,17 @@ public sealed record ManagedAgentRequest
     /// thin client may still send it, but it carries no server-side authority.
     /// Every other field is carried forward verbatim.</para>
     /// </summary>
-    public static ManagedAgentRequest From(LlmCallRequest request, Guid? authoritativeTenantId) =>
+    /// <param name="documentValidation">Story 39-9 (D2) — the composed
+    /// document-content validation seam, built by the endpoint from
+    /// <see cref="LlmCallRequest.DocumentType"/> via
+    /// <see cref="DocumentValidationBinder.Bind"/> BEFORE this mapping (so a bad
+    /// document-type key can fail loud at the endpoint, never here). <c>null</c> ⇒
+    /// no validation. The delegate is composed outside this pure map because a
+    /// registry lookup + fail-loud is not a pure mapping concern.</param>
+    public static ManagedAgentRequest From(
+        LlmCallRequest request,
+        Guid? authoritativeTenantId,
+        DocumentContentValidation? documentValidation = null) =>
         new()
         {
             TenantId = authoritativeTenantId,
@@ -108,5 +148,8 @@ public sealed record ManagedAgentRequest
             ToolLoopConfig = request.ToolLoopConfig,
             Params = request.Params,
             CorrelationId = request.CorrelationId,
+            // Story 39-9 (D10) — additive pass-throughs (default empty ⇒ no change).
+            DocumentValidation = documentValidation,
+            IssueId = request.IssueId,
         };
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairMessageComposer.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairMessageComposer.cs
@@ -1,0 +1,51 @@
+using System.Text;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (AC8, Design Decision D9) — the PURE, deterministic composer of the
+/// harness-generated repair message appended to the conversation when a produced
+/// document fails its deterministic validator.
+///
+/// <para>Contract (golden-pinned by <c>RepairMessageComposerTests</c>): a fixed
+/// instruction preamble + one line per violation (<c>- [{Code}] {Message}</c>,
+/// verbatim, in input order) + a fixed re-emit instruction. Same violations in ⇒
+/// byte-identical message out. It contains ONLY validator output plus fixed text —
+/// NEVER a provider error body (those live on a different axis,
+/// <c>NormalizedLlmResponse.ErrorMessage</c>) and NEVER credentials. Because a
+/// violation message can quote model output, the CALLER runs the composed message
+/// through <c>ToolOutputHelper.RedactSecrets</c> before appending it (the runner
+/// append site — D9), keeping this function free of I/O and side effects.</para>
+/// </summary>
+public static class RepairMessageComposer
+{
+    // Fixed template text. Any change here is a CONSCIOUS edit — the golden test
+    // pins the exact output so prompt drift cannot slip through silently.
+    private const string Preamble =
+        "The document you produced did not pass validation. The following problems were found:";
+
+    private const string ReEmitInstruction =
+        "Fix every problem listed above and re-emit the COMPLETE corrected document. " +
+        "Output only the corrected document — do not include explanations, apologies, or commentary.";
+
+    /// <summary>
+    /// Compose the deterministic repair message for <paramref name="violations"/>.
+    /// Pure and order-preserving; the caller redacts the result before appending.
+    /// </summary>
+    public static string Compose(IReadOnlyList<DocumentViolation> violations)
+    {
+        ArgumentNullException.ThrowIfNull(violations);
+
+        var sb = new StringBuilder();
+        sb.Append(Preamble);
+        foreach (var v in violations)
+        {
+            sb.Append('\n');
+            sb.Append("- [").Append(v.Code).Append("] ").Append(v.Message);
+        }
+        sb.Append('\n').Append('\n');
+        sb.Append(ReEmitInstruction);
+        return sb.ToString();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairRingEventTypes.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairRingEventTypes.cs
@@ -1,0 +1,29 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (AC6) — DCB event-type constants for the deterministic repair ring,
+/// emitted from <c>ManagedAgent</c> via the tenant <c>IEventRepository</c> (D4 — the
+/// runner stays event-store-free and returns the history; <c>ManagedAgent</c> replays
+/// it). Pattern <c>AGGREGATE.ACTION.STATUS</c> (per CLAUDE.md "Event Types"), matching
+/// the neighbouring <see cref="AgentRunEventTypes"/> convention. Kept here as the single
+/// source so composition code never hand-types a literal that could drift from the
+/// Story 4-7 query / audit expectations.
+///
+/// <para>All three are tagged <c>{ issueId, documentType, role, action, repairTurn,
+/// correlationId, tenantId }</c> so per-<c>(role, action) × documentType</c> cell
+/// validation-failure / first-repair-success / exhaustion rates are computable from the
+/// events alone (AC7).</para>
+/// </summary>
+public static class RepairRingEventTypes
+{
+    /// <summary>A produced document failed validation (emitted per failed validation,
+    /// including the initial turn 0). Data carries the redacted violation summaries.</summary>
+    public const string ValidationFailed = "LLM.VALIDATION.FAILED";
+
+    /// <summary>A repair turn produced a valid document (data: the turn number).</summary>
+    public const string RepairSucceeded = "LLM.REPAIR.SUCCEEDED";
+
+    /// <summary>The repair cap was hit and the document is still invalid (data: turn
+    /// count + final violation count).</summary>
+    public const string RepairExhausted = "LLM.REPAIR.EXHAUSTED";
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairRingOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/RepairRingOptions.cs
@@ -1,0 +1,53 @@
+namespace Tamma.Api.Services.Agents;
+
+/// <summary>
+/// Story 39-9 (AC2, AC9, Design Decision D8) — GLOBAL configuration for the
+/// deterministic repair ring. There is deliberately NO per-call, per-workflow, or
+/// per-prompt knob: the only lever is this options class, bound once from the
+/// <c>RepairRing</c> config section in <c>Program.cs</c>.
+///
+/// <para><b>Hard cap by clamp, not validation (AC2).</b>
+/// <see cref="EffectiveMaxRepairTurns"/> clamps <see cref="MaxRepairTurns"/> into
+/// <c>[0, <see cref="HardCap"/>]</c>, so it is structurally impossible for any
+/// configuration value — however large — to drive more than two in-conversation
+/// repair turns. The tool-loop precedent showed the second identical correction
+/// rarely converges; beyond the cap the correct escalation is the lifecycle's
+/// review/revise ring, not more repair.</para>
+///
+/// <para><b>Dark by default (AC9).</b> <see cref="EnabledDocumentTypes"/> defaults
+/// EMPTY: the mechanism ships OFF for every document type. Flipping a type ON
+/// requires observed real-provider failure-rate evidence — recorded in a
+/// <c>.dev/findings/</c> entry — before the extra turn is justified.</para>
+/// </summary>
+public sealed class RepairRingOptions
+{
+    /// <summary>The config section this options class binds from.</summary>
+    public const string SectionName = "RepairRing";
+
+    /// <summary>The absolute ceiling on in-conversation repair turns (AC2). No
+    /// config value can exceed it — <see cref="EffectiveMaxRepairTurns"/> clamps.</summary>
+    public const int HardCap = 2;
+
+    /// <summary>Configured maximum repair turns (default 1). The EFFECTIVE value
+    /// callers must use is <see cref="EffectiveMaxRepairTurns"/>, which enforces the
+    /// hard cap; this raw setter can hold any value but never takes effect above
+    /// <see cref="HardCap"/>.</summary>
+    public int MaxRepairTurns { get; set; } = 1;
+
+    /// <summary>
+    /// The document-type KEYS (wire strings, e.g. <c>decomposition</c>) for which
+    /// repair is enabled. Defaults EMPTY (AC9 — dark launch). Enabling a type
+    /// requires a <c>.dev/findings/</c> entry with real-provider failure-rate
+    /// evidence justifying the extra turn's token spend.
+    /// </summary>
+    public string[] EnabledDocumentTypes { get; set; } = Array.Empty<string>();
+
+    /// <summary>The clamped, HARD-CAPPED maximum repair turns (AC2). This — never
+    /// <see cref="MaxRepairTurns"/> — is what the ring is bounded by.</summary>
+    public int EffectiveMaxRepairTurns => Math.Clamp(MaxRepairTurns, 0, HardCap);
+
+    /// <summary>Whether repair is enabled for <paramref name="documentTypeKey"/>
+    /// (case-insensitive membership of <see cref="EnabledDocumentTypes"/>).</summary>
+    public bool IsEnabledFor(string documentTypeKey) =>
+        EnabledDocumentTypes.Contains(documentTypeKey, StringComparer.OrdinalIgnoreCase);
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
@@ -69,6 +69,14 @@ public class LlmCallWorkflow : WorkflowBase
         var sessionIdVar = builder.WithVariable<string>("SessionId", "");
         var tenantIdVar = builder.WithVariable<string>("TenantId", "");
 
+        // Story 39-9 (D10) — additive/optional repair-ring inputs. Default empty ⇒
+        // zero behaviour change for the 30+ existing dispatchers. documentType is the
+        // wire KEY gating the server-side repair ring; issueId rides through for the
+        // LLM.* event tags; contentValidation surfaces the wire block back to callers.
+        var documentTypeVar = builder.WithVariable<string>("DocumentType", "");
+        var issueIdVar = builder.WithVariable<string>("IssueId", "");
+        var contentValidationVar = builder.WithVariable<string>("ContentValidationJson", "");
+
         // Legacy input support
         var inputVar = builder.WithVariable<string>("InputJson", "");
 
@@ -157,6 +165,12 @@ public class LlmCallWorkflow : WorkflowBase
 
                 // Tenant ID for tenant-scoped prompt resolution (Story 27-6)
                 tenantIdVar.Set(context, context.GetInput<string>("tenantId") ?? "");
+
+                // Story 39-9 (D10) — additive/optional repair-ring inputs. Read
+                // unconditionally so both the typed-role and legacy-InputJson paths
+                // carry them; empty ⇒ no validation (the default).
+                documentTypeVar.Set(context, context.GetInput<string>("documentType") ?? "");
+                issueIdVar.Set(context, context.GetInput<string>("issueId") ?? "");
 
                 var role = context.GetInput<string>("agentRole") ?? context.GetInput<string>("role");
                 if (!string.IsNullOrWhiteSpace(role))
@@ -544,7 +558,9 @@ public class LlmCallWorkflow : WorkflowBase
                                                             workflowOutputVar,
                                                             enableToolLoopVar,
                                                             toolLoopConfigJsonVar,
-                                                            tenantIdVar)
+                                                            tenantIdVar,
+                                                            documentTypeVar,
+                                                            issueIdVar)
                                                     }
                                                 }, "Budget OK")
                                             }, "Budget Exhausted?")
@@ -691,7 +707,16 @@ public class LlmCallWorkflow : WorkflowBase
                         var output = SafeDeserialize<LlmCallWorkflowOutput>(outputJson);
                         return (object)(output?.ToolLoopExhausted ?? false);
                     })
-                }, "Output: toolLoopExhausted")
+                }, "Output: toolLoopExhausted"),
+                // Story 39-9 (D10) — surface the content-validation wire block back to
+                // the caller (empty when no validator ran). Additive output.
+                WithLabel(new SetOutput
+                {
+                    Id = "OutputContentValidation",
+                    Name = "Output: contentValidation",
+                    OutputName = new("contentValidation"),
+                    OutputValue = new(context => (object)(contentValidationVar.Get(context) ?? ""))
+                }, "Output: contentValidation")
             }
         };
         setOutputs.SetDisplayText("Set Outputs");
@@ -772,7 +797,9 @@ public class LlmCallWorkflow : WorkflowBase
         Variable<string> workflowOutputVar,
         Variable<bool> enableToolLoopVar,
         Variable<string> toolLoopConfigJsonVar,
-        Variable<string> tenantIdVar)
+        Variable<string> tenantIdVar,
+        Variable<string> documentTypeVar,
+        Variable<string> issueIdVar)
     {
         var whileLoop = new While((string?)null);
         whileLoop.Id = "RetryLoop";
@@ -923,7 +950,10 @@ public class LlmCallWorkflow : WorkflowBase
                     ActionProp = new(context => actionVar.Get(context)),
                     RenderedPromptProp = new(context => taskPromptVar.Get(context)),
                     VariablesJsonProp = new(context => variablesJsonVar.Get(context)),
-                    RegistryMaxTokensProp = new(context => registryMaxTokensVar.Get(context))
+                    RegistryMaxTokensProp = new(context => registryMaxTokensVar.Get(context)),
+                    // Story 39-9 (D10) — thread the additive/optional repair-ring inputs.
+                    DocumentTypeProp = new(context => documentTypeVar.Get(context)),
+                    IssueIdProp = new(context => issueIdVar.Get(context))
                 }, "Call LLM"),
                 WithLabel(new RecordDiagnosticsInlineActivity
                 {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/DiagnosticFailureCodeTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/DiagnosticFailureCodeTests.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Tests.LlmCall;
+
+/// <summary>
+/// Story 39-9 (AC4) — the additive <see cref="ProviderAttemptDiagnostic.FailureCode"/>
+/// and its population by the thin client. Pure JSON + static-method coverage (no
+/// Docker, no live provider). Proves: old serialized diagnostics (no
+/// <c>failureCode</c>) deserialize cleanly to <c>null</c>; a round-trip preserves the
+/// value; the <see cref="CallLlmInlineActivity.MapResponseToVariables"/> mapping table;
+/// and <see cref="CallLlmInlineActivity.BuildTransportFailure"/> → <c>transport</c>.
+/// </summary>
+[TestFixture]
+public class DiagnosticFailureCodeTests
+{
+    // -------------------------------------------------------------------
+    // Additive tolerance: old JSON deserializes clean; round-trip preserves.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public void OldJson_WithoutFailureCode_DeserializesToNull()
+    {
+        // A diagnostic serialized before this field existed.
+        const string oldJson = """
+        {"ProviderName":"anthropic","Succeeded":false,"HttpStatusCode":503,"PromptTokens":10}
+        """;
+
+        var diag = JsonSerializer.Deserialize<ProviderAttemptDiagnostic>(oldJson);
+
+        diag.Should().NotBeNull();
+        diag!.FailureCode.Should().BeNull("older JSON has no failureCode ⇒ additive/null");
+        diag.ProviderName.Should().Be("anthropic");
+        diag.HttpStatusCode.Should().Be(503);
+    }
+
+    [Test]
+    public void FailureCode_RoundTrips()
+    {
+        var original = new ProviderAttemptDiagnostic
+        {
+            ProviderName = "anthropic",
+            Succeeded = false,
+            FailureCode = DiagnosticFailureCodes.ContentValidation,
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<ProviderAttemptDiagnostic>(json);
+
+        restored!.FailureCode.Should().Be(DiagnosticFailureCodes.ContentValidation);
+    }
+
+    // -------------------------------------------------------------------
+    // MapResponseToVariables mapping table (D6).
+    // -------------------------------------------------------------------
+
+    [TestCase("CONTENT_VALIDATION_FAILED", 422, "content_validation")]
+    [TestCase("BUDGET_EXCEEDED", 200, "budget")]
+    [TestCase("PROVIDER_ERROR", 429, "rate_limit")]
+    [TestCase("PROVIDER_ERROR", 503, "transport")]
+    [TestCase("PROVIDER_ERROR", 0, "transport")]
+    [TestCase("AGENT_UNRESOLVED", 422, null)]
+    public void MapResponseToVariables_ClassifiesFailureCode(
+        string wireFailureCode, int httpStatus, string? expected)
+    {
+        var response = new LlmCallApiResponse
+        {
+            Success = false,
+            FailureCode = wireFailureCode,
+            FailureReason = "boom",
+            HttpStatusCode = httpStatus,
+        };
+
+        var mapped = CallLlmInlineActivity.MapResponseToVariables(
+            response, "anthropic", model: "claude", attemptNumber: 1,
+            durationMs: 5, startedAtUtc: DateTime.UtcNow);
+
+        mapped.Diagnostic.FailureCode.Should().Be(expected);
+    }
+
+    [Test]
+    public void MapResponseToVariables_Success_LeavesFailureCodeNull()
+    {
+        var response = new LlmCallApiResponse
+        {
+            Success = true,
+            Text = "ok",
+            HttpStatusCode = 200,
+        };
+
+        var mapped = CallLlmInlineActivity.MapResponseToVariables(
+            response, "anthropic", model: "claude", attemptNumber: 1,
+            durationMs: 5, startedAtUtc: DateTime.UtcNow);
+
+        mapped.Diagnostic.FailureCode.Should().BeNull();
+    }
+
+    // -------------------------------------------------------------------
+    // ClassifyFailureCode — the pure classifier used above (direct unit).
+    // -------------------------------------------------------------------
+
+    [TestCase("CONTENT_VALIDATION_FAILED", 422, "content_validation")]
+    [TestCase("BUDGET_EXCEEDED", 0, "budget")]
+    [TestCase(null, 429, "rate_limit")]
+    [TestCase(null, 500, "transport")]
+    [TestCase(null, 0, "transport")]
+    [TestCase("SOMETHING_ELSE", 200, null)]
+    public void ClassifyFailureCode_MapsPerVocabulary(string? wire, int http, string? expected)
+    {
+        CallLlmInlineActivity.ClassifyFailureCode(wire, http).Should().Be(expected);
+    }
+
+    // -------------------------------------------------------------------
+    // BuildTransportFailure — a null-body/raw-5xx result is a TRANSPORT failure.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public void BuildTransportFailure_SetsTransportFailureCode()
+    {
+        var mapped = CallLlmInlineActivity.BuildTransportFailure(
+            "anthropic", model: "claude", attemptNumber: 2, durationMs: 3, startedAtUtc: DateTime.UtcNow);
+
+        mapped.Diagnostic.Succeeded.Should().BeFalse();
+        mapped.Diagnostic.FailureCode.Should().Be(DiagnosticFailureCodes.Transport);
+        mapped.Diagnostic.HttpStatusCode.Should().Be(0);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/RecordDiagnosticsBreakerExclusionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/RecordDiagnosticsBreakerExclusionTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Tests.LlmCall;
+
+/// <summary>
+/// Story 39-9 (AC5) — the load-bearing N-vs-N proof that content failures never trip
+/// the provider circuit breaker. Drives the SAME decision the two diagnostic recorders
+/// make — <see cref="DiagnosticFailureCodes.CountsAsProviderFailure"/> gating
+/// <see cref="CheckCircuitBreakerActivity.RecordFailure"/> / <c>RecordSuccess</c> —
+/// over the workflow-variable breaker dict. Pure (no Docker, no Elsa context): the
+/// shared helper is the single source of the exclusion, so exercising it here is the
+/// faithful proof both recorder call sites uphold.
+/// </summary>
+[TestFixture]
+public class RecordDiagnosticsBreakerExclusionTests
+{
+    private const string Provider = "anthropic";
+
+    /// <summary>The recorder's branch, verbatim: success resets; a real provider
+    /// failure records; a content failure records NEITHER.</summary>
+    private static Dictionary<string, CircuitBreakerState> Apply(
+        Dictionary<string, CircuitBreakerState> states, ProviderAttemptDiagnostic diag)
+    {
+        if (diag.Succeeded)
+            return CheckCircuitBreakerActivity.RecordSuccess(states, Provider);
+        if (DiagnosticFailureCodes.CountsAsProviderFailure(diag))
+            return CheckCircuitBreakerActivity.RecordFailure(states, Provider, failureThreshold: 5);
+        return states; // content_validation ⇒ neither failure nor success
+    }
+
+    private static ProviderAttemptDiagnostic Fail(string? failureCode) => new()
+    {
+        ProviderName = Provider,
+        Succeeded = false,
+        HttpStatusCode = failureCode == DiagnosticFailureCodes.ContentValidation ? 422 : 503,
+        FailureCode = failureCode,
+    };
+
+    [Test]
+    public void FiveContentValidationFailures_LeaveBreakerClosed_ZeroConsecutive()
+    {
+        var states = new Dictionary<string, CircuitBreakerState>();
+
+        for (var i = 0; i < 5; i++)
+            states = Apply(states, Fail(DiagnosticFailureCodes.ContentValidation));
+
+        // The breaker was never touched: no state row was even created.
+        states.TryGetValue(Provider, out var state);
+        (state?.Status ?? CircuitBreakerStatus.Closed).Should().Be(CircuitBreakerStatus.Closed);
+        (state?.ConsecutiveFailures ?? 0).Should().Be(0,
+            "a content_validation failure never increments the breaker's failure count");
+    }
+
+    [Test]
+    public void FiveTransportFailures_OpenTheBreaker()
+    {
+        var states = new Dictionary<string, CircuitBreakerState>();
+
+        for (var i = 0; i < 5; i++)
+            states = Apply(states, Fail(DiagnosticFailureCodes.Transport));
+
+        states[Provider].Status.Should().Be(CircuitBreakerStatus.Open,
+            "5 transport failures at threshold 5 trip the breaker");
+        states[Provider].ConsecutiveFailures.Should().Be(5);
+    }
+
+    [Test]
+    public void ContentValidationFailure_DoesNotResetCounters_NotASuccess()
+    {
+        var states = new Dictionary<string, CircuitBreakerState>();
+
+        // Two real transport failures accumulate.
+        states = Apply(states, Fail(DiagnosticFailureCodes.Transport));
+        states = Apply(states, Fail(DiagnosticFailureCodes.Transport));
+        states[Provider].ConsecutiveFailures.Should().Be(2);
+
+        // A content failure must NOT reset the count (it is not a success).
+        states = Apply(states, Fail(DiagnosticFailureCodes.ContentValidation));
+        states[Provider].ConsecutiveFailures.Should().Be(2,
+            "a content_validation failure records nothing — it is neither a failure nor a success");
+    }
+
+    [Test]
+    public void CountsAsProviderFailure_ExcludesOnlyContentValidation()
+    {
+        DiagnosticFailureCodes.CountsAsProviderFailure(Fail(DiagnosticFailureCodes.ContentValidation))
+            .Should().BeFalse();
+        DiagnosticFailureCodes.CountsAsProviderFailure(Fail(DiagnosticFailureCodes.Transport))
+            .Should().BeTrue();
+        DiagnosticFailureCodes.CountsAsProviderFailure(Fail(DiagnosticFailureCodes.RateLimit))
+            .Should().BeTrue();
+        DiagnosticFailureCodes.CountsAsProviderFailure(Fail(null))
+            .Should().BeTrue("an unclassified failure is still a provider failure");
+        DiagnosticFailureCodes.CountsAsProviderFailure(
+            new ProviderAttemptDiagnostic { Succeeded = true })
+            .Should().BeFalse("a success is never a provider failure");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerRepairTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerRepairTests.cs
@@ -1,0 +1,253 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 39-9 (AC1, AC2, AC9) — the deterministic repair ring driven end-to-end
+/// through the real <see cref="InlineToolLoopRunner"/> with a scripted fake HTTP
+/// handler and a FAKE validator delegate (registry-free — D2). Proves in-conversation
+/// repair, re-validate-and-exit-on-pass, the cap, the gate, transport orthogonality,
+/// MaxSteps isolation, and the null-plan no-op.
+/// </summary>
+[TestFixture]
+public class InlineToolLoopRunnerRepairTests
+{
+    private const string Model = "claude-sonnet-4-20250514";
+
+    // (a) invalid → valid: the repair turn fixes the document.
+    [Test]
+    public async Task Repair_InvalidThenValid_PreservesConversation_ContentValidTrue()
+    {
+        var produce = EndTurn("PRODUCED-DOC", 100, 40);
+        var repaired = EndTurn("REPAIRED-DOC", 60, 20);
+        var handler = new SequencedCapturingHandler(produce, repaired);
+        var runner = NewRunner(handler);
+
+        // Verdicts consumed in order: produce invalid, repair valid.
+        var validate = Validator(Invalid("MISSING_FIELD", "Field 'x' is required."), Valid());
+        var plan = new RepairRingPlan("decomposition", validate, RepairEnabled: true, MaxRepairTurns: 1);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "SYS-PROMPT", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-a", plan, CancellationToken.None);
+
+        result.ContentValid.Should().BeTrue();
+        result.RepairTurns.Should().Be(1);
+        result.RepairHistory.Select(h => (h.Turn, h.Valid))
+            .Should().Equal((0, false), (1, true));
+        result.Response.ResponseText.Should().Be("REPAIRED-DOC");
+        // Token totals include BOTH the produce and the repair turn.
+        result.InputTokens.Should().Be(160);
+        result.OutputTokens.Should().Be(60);
+
+        // The SECOND HTTP request preserves the conversation: original system prompt,
+        // the produced document, AND the composed repair message.
+        handler.CapturedBodies.Should().HaveCount(2);
+        var repairBody = handler.CapturedBodies[1];
+        repairBody.Should().Contain("SYS-PROMPT", "the system prompt is preserved (not restarted)");
+        repairBody.Should().Contain("PRODUCED-DOC", "the produced document rides in the conversation");
+        repairBody.Should().Contain("did not pass validation", "the harness repair message is appended");
+        repairBody.Should().Contain("MISSING_FIELD", "the domain-phrased violation is fed back verbatim");
+    }
+
+    // (b) always-invalid: stops at the cap, ContentValid false, history 1 + cap.
+    [Test]
+    public async Task Repair_AlwaysInvalid_StopsAtCap_ContentValidFalse()
+    {
+        var handler = new SequencedCapturingHandler(
+            EndTurn("D0", 10, 5), EndTurn("D1", 10, 5), EndTurn("D2", 10, 5));
+        var runner = NewRunner(handler);
+
+        var validate = Validator(
+            Invalid("E", "always bad"), Invalid("E", "always bad"), Invalid("E", "always bad"));
+        var plan = new RepairRingPlan("decomposition", validate, RepairEnabled: true, MaxRepairTurns: 2);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "sys", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-b", plan, CancellationToken.None);
+
+        result.ContentValid.Should().BeFalse();
+        result.RepairTurns.Should().Be(2, "bounded by the cap of 2");
+        result.RepairHistory.Should().HaveCount(3, "turn 0 + cap repair turns");
+        result.RepairHistory.Should().OnlyContain(h => !h.Valid);
+    }
+
+    // (c) gate off: exactly ONE HTTP call, ContentValid false, RepairTurns 0.
+    [Test]
+    public async Task Repair_GateOff_NoRepairTurn_OneHttpCall()
+    {
+        var handler = new SequencedCapturingHandler(EndTurn("D0", 10, 5));
+        var runner = NewRunner(handler);
+
+        var validate = Validator(Invalid("E", "bad"));
+        var plan = new RepairRingPlan("decomposition", validate, RepairEnabled: false, MaxRepairTurns: 1);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "sys", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-c", plan, CancellationToken.None);
+
+        result.ContentValid.Should().BeFalse();
+        result.RepairTurns.Should().Be(0, "the gate is off ⇒ zero extra turns (AC9)");
+        result.RepairHistory.Should().HaveCount(1, "only the turn-0 validation");
+        handler.CapturedBodies.Should().HaveCount(1, "no repair re-invocation");
+    }
+
+    // (d) transport 503 during the repair turn → provider failure, preserved status.
+    [Test]
+    public async Task Repair_Transport503DuringRepair_SurfacesAsProviderFailure()
+    {
+        var handler = new FirstOkThen503(EndTurn("D0", 10, 5), "rate limited");
+        var runner = NewRunner(handler);
+
+        var validate = Validator(Invalid("E", "bad")); // only turn 0 validates
+        var plan = new RepairRingPlan("decomposition", validate, RepairEnabled: true, MaxRepairTurns: 1);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "sys", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-d", plan, CancellationToken.None);
+
+        result.Response.Success.Should().BeFalse("a transport failure during repair is a provider failure");
+        result.Response.HttpStatusCode.Should().Be(503, "the upstream status is preserved (orthogonality)");
+    }
+
+    // (e) repair turns leave the tool-loop MaxSteps accounting untouched.
+    [Test]
+    public async Task Repair_DoesNotConsumeToolLoopTurnsOrExhaustion()
+    {
+        var handler = new SequencedCapturingHandler(EndTurn("D0", 10, 5), EndTurn("D1", 10, 5));
+        var runner = NewRunner(handler);
+
+        var validate = Validator(Invalid("E", "bad"), Valid());
+        var plan = new RepairRingPlan("decomposition", validate, RepairEnabled: true, MaxRepairTurns: 1);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "sys", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig { MaxSteps = 20 }, "corr-e", plan,
+            CancellationToken.None);
+
+        result.Turns.Should().Be(1, "only the single produce turn counts as a tool-loop turn");
+        result.Exhausted.Should().BeFalse("repair turns never drive MaxSteps exhaustion");
+        result.RepairTurns.Should().Be(1);
+    }
+
+    // (f) null plan → repair fields default; behaviour byte-identical to today.
+    [Test]
+    public async Task NullPlan_LeavesRepairFieldsDefault_ByteIdenticalBehaviour()
+    {
+        var handler = new SequencedCapturingHandler(EndTurn("only", 10, 5));
+        var runner = NewRunner(handler);
+
+        var result = await runner.RunAsync(
+            "anthropic", Config(), Model, "sys", "user", 4096, 0.7,
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-f", repair: null,
+            CancellationToken.None);
+
+        result.ContentValid.Should().BeNull();
+        result.RepairTurns.Should().Be(0);
+        result.RepairHistory.Should().BeEmpty();
+        result.Response.ResponseText.Should().Be("only");
+        handler.CapturedBodies.Should().HaveCount(1);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static DocumentValidationResult Valid() => DocumentValidationResult.Valid();
+
+    private static DocumentValidationResult Invalid(string code, string message) =>
+        DocumentValidationResult.Invalid(new DocumentViolation(code, message));
+
+    /// <summary>A stateful validator delegate consuming the supplied verdicts in order
+    /// (the last verdict repeats if more calls arrive).</summary>
+    private static Func<string, DocumentValidationResult> Validator(params DocumentValidationResult[] verdicts)
+    {
+        var i = 0;
+        return _ =>
+        {
+            var v = verdicts[Math.Min(i, verdicts.Length - 1)];
+            i++;
+            return v;
+        };
+    }
+
+    private static InlineToolLoopRunner NewRunner(HttpMessageHandler handler)
+    {
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(() => new HttpClient(handler, disposeHandler: false));
+        return new InlineToolLoopRunner(
+            NullLogger<InlineToolLoopRunner>.Instance, factory.Object, configuration: null,
+            sanitizer: null, toolRegistry: null, toolCallValidator: null, contextCompactor: null,
+            eventEmitter: null, parallelExecutor: null, credentialResolver: null);
+    }
+
+    private static LlmProviderConfig Config() => new()
+    {
+        Name = "anthropic",
+        BaseUrl = "https://api.anthropic.com",
+        ApiKey = "test-key",
+        TimeoutSeconds = 120,
+    };
+
+    private static string EndTurn(string text, int inputTokens, int outputTokens) =>
+        JsonSerializer.Serialize(new
+        {
+            content = new[] { new { type = "text", text } },
+            stop_reason = "end_turn",
+            usage = new { input_tokens = inputTokens, output_tokens = outputTokens },
+            model = Model,
+        });
+
+    private sealed class SequencedCapturingHandler(params string[] bodies) : HttpMessageHandler
+    {
+        public List<string> CapturedBodies { get; } = new();
+        private int _index;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedBodies.Add(request.Content is null
+                ? string.Empty
+                : await request.Content.ReadAsStringAsync(cancellationToken));
+
+            var body = _index < bodies.Length ? bodies[_index] : bodies[^1];
+            _index++;
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    /// <summary>First call returns 200 with the produce body; the second (repair
+    /// re-invocation) returns 503.</summary>
+    private sealed class FirstOkThen503(string firstBody, string errorBody) : HttpMessageHandler
+    {
+        private int _index;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var isFirst = _index++ == 0;
+            var msg = isFirst
+                ? new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(firstBody, System.Text.Encoding.UTF8, "application/json"),
+                }
+                : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                {
+                    Content = new StringContent(errorBody, System.Text.Encoding.UTF8, "application/json"),
+                };
+            return Task.FromResult(msg);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/InlineToolLoopRunnerTests.cs
@@ -53,7 +53,7 @@ public class InlineToolLoopRunnerTests
 
         var result = await runner.RunAsync(
             "anthropic", Config(), Model, "system", "user", 4096, 0.7,
-            tools, enableToolLoop: true, new ToolLoopConfig(), "corr-1", CancellationToken.None);
+            tools, enableToolLoop: true, new ToolLoopConfig(), "corr-1", repair: null, CancellationToken.None);
 
         result.Response.Success.Should().BeTrue();
         result.Response.ResponseText.Should().Be("All done.");
@@ -78,7 +78,7 @@ public class InlineToolLoopRunnerTests
 
         var result = await runner.RunAsync(
             "anthropic", Config(), Model, "system", "user", 4096, 0.7,
-            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-2", CancellationToken.None);
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-2", repair: null, CancellationToken.None);
 
         result.Response.Success.Should().BeTrue();
         result.Turns.Should().Be(1);
@@ -107,7 +107,7 @@ public class InlineToolLoopRunnerTests
 
         var result = await runner.RunAsync(
             "anthropic", Config(), Model, "system", "user", 4096, 0.7,
-            tools, enableToolLoop: true, new ToolLoopConfig { MaxSteps = 2 }, "corr-3", CancellationToken.None);
+            tools, enableToolLoop: true, new ToolLoopConfig { MaxSteps = 2 }, "corr-3", repair: null, CancellationToken.None);
 
         result.Exhausted.Should().BeTrue();
         result.Turns.Should().Be(2);
@@ -139,7 +139,7 @@ public class InlineToolLoopRunnerTests
 
         await runner.RunAsync(
             "anthropic", Config(), Model, "system", "user", 4096, 0.7,
-            tools, enableToolLoop: true, new ToolLoopConfig(), "corr-4", CancellationToken.None);
+            tools, enableToolLoop: true, new ToolLoopConfig(), "corr-4", repair: null, CancellationToken.None);
 
         handler.CapturedBodies.Should().HaveCount(2);
         handler.CapturedBodies[1].Should().NotContain("<script>", "tool output is sanitized before feedback");
@@ -158,7 +158,7 @@ public class InlineToolLoopRunnerTests
 
         var result = await runner.RunAsync(
             "anthropic", Config(), Model, "system", "user", 4096, 0.7,
-            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-5", CancellationToken.None);
+            tools: null, enableToolLoop: true, new ToolLoopConfig(), "corr-5", repair: null, CancellationToken.None);
 
         result.Response.Success.Should().BeFalse();
         result.Response.HttpStatusCode.Should().Be(429, "the upstream status is preserved for RetryCheck");

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/LlmCallContractTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/LlmCallContractTests.cs
@@ -648,4 +648,113 @@ public class LlmCallContractTests
         apiResp.CorrelationId.Should().Be("corr-e");
         apiResp.DurationMs.Should().Be(99);
     }
+
+    // ---------------------------------------------------------------
+    // Story 39-9 — additive wire fields (documentType/issueId, contentValidation)
+    // are optional and key-free; old JSON (without them) deserializes clean.
+    // ---------------------------------------------------------------
+
+    [Test]
+    public void WireContract_RepairFields_SurviveBothDirections()
+    {
+        var engineReq = new LlmCallApiRequest
+        {
+            Role = "developer",
+            Prompt = "decompose",
+            CorrelationId = "corr-39-9",
+            DocumentType = "decomposition",
+            IssueId = "ISSUE-42",
+        };
+
+        var json = JsonSerializer.Serialize(engineReq, EngineOpts);
+        var apiReq = JsonSerializer.Deserialize<LlmCallRequest>(json, ApiOpts);
+
+        apiReq!.DocumentType.Should().Be("decomposition");
+        apiReq.IssueId.Should().Be("ISSUE-42");
+
+        // And back: API → engine.
+        var apiReq2 = new LlmCallRequest
+        {
+            Role = "developer",
+            Prompt = "decompose",
+            CorrelationId = "corr-39-9",
+            DocumentType = "plan",
+            IssueId = "ISSUE-7",
+        };
+        var json2 = JsonSerializer.Serialize(apiReq2, ApiOpts);
+        var engineReq2 = JsonSerializer.Deserialize<LlmCallApiRequest>(json2, EngineOpts);
+        engineReq2!.DocumentType.Should().Be("plan");
+        engineReq2.IssueId.Should().Be("ISSUE-7");
+    }
+
+    [Test]
+    public void WireContract_ContentValidation_ResponseBlock_SurvivesEngineToApi()
+    {
+        var apiResp = new LlmCallResponse
+        {
+            Success = false,
+            CorrelationId = "c",
+            FailureCode = "CONTENT_VALIDATION_FAILED",
+            HttpStatusCode = 422,
+            ContentValidation = new ContentValidationDto(
+                Valid: false,
+                RepairTurns: 1,
+                Violations: new[] { new ContentViolationDto("MISSING_FIELD", "Field 'x' required.") },
+                History: new[]
+                {
+                    new RepairTurnDto(0, false, new[] { new ContentViolationDto("MISSING_FIELD", "Field 'x' required.") }),
+                    new RepairTurnDto(1, false, new[] { new ContentViolationDto("MISSING_FIELD", "Field 'x' required.") }),
+                }),
+        };
+
+        // API serializes (CamelCase) → engine deserializes ([JsonPropertyName]).
+        var json = JsonSerializer.Serialize(apiResp, ApiOpts);
+        var engineResp = JsonSerializer.Deserialize<LlmCallApiResponse>(json, EngineOpts);
+
+        engineResp!.ContentValidation.Should().NotBeNull();
+        engineResp.ContentValidation!.Valid.Should().BeFalse();
+        engineResp.ContentValidation.RepairTurns.Should().Be(1);
+        engineResp.ContentValidation.Violations.Should().ContainSingle()
+            .Which.Code.Should().Be("MISSING_FIELD");
+        engineResp.ContentValidation.History.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void WireContract_OldJson_WithoutRepairFields_DeserializesClean()
+    {
+        // A request/response serialized before Story 39-9 (no documentType/issueId/
+        // contentValidation). STJ ignores unknown members; missing members default.
+        const string oldReq = """{"role":"developer","prompt":"p","correlationId":"c"}""";
+        var req = JsonSerializer.Deserialize<LlmCallApiRequest>(oldReq, EngineOpts);
+        req!.DocumentType.Should().BeNull();
+        req.IssueId.Should().BeNull();
+
+        const string oldResp = """{"success":true,"correlationId":"c"}""";
+        var resp = JsonSerializer.Deserialize<LlmCallApiResponse>(oldResp, EngineOpts);
+        resp!.ContentValidation.Should().BeNull();
+    }
+
+    [Test]
+    public void ContentValidationDtos_ExposeNoKeyBearingProperty()
+    {
+        var types = new[]
+        {
+            typeof(ContentValidationDto),
+            typeof(ContentViolationDto),
+            typeof(RepairTurnDto),
+        };
+        var banned = new[] { "Key", "ApiKey", "Secret", "Credential", "Token" };
+
+        foreach (var type in types)
+        {
+            foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var bad in banned)
+                {
+                    prop.Name.Contains(bad, StringComparison.OrdinalIgnoreCase)
+                        .Should().BeFalse($"{type.Name}.{prop.Name} matched banned fragment '{bad}'");
+                }
+            }
+        }
+    }
 }

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentContentValidationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentContentValidationTests.cs
@@ -1,0 +1,360 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.Providers;
+using Tamma.Api.Services.Security;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 39-9 (AC1, AC3, AC6, AC9) — the managed-layer orchestration of the repair
+/// ring: the typed CONTENT_VALIDATION_FAILED (422-in-200, not transient), the payload
+/// completeness (violations + history + tokens, no usage row), the LLM.* event trail
+/// with its tags, the repaired-success path, and the gate-off behaviour. The runner is
+/// a strict Moq returning a crafted <see cref="InlineToolLoopResult"/> so this exercises
+/// ManagedAgent (not the runner internals — those are InlineToolLoopRunnerRepairTests).
+/// </summary>
+[TestFixture]
+public class ManagedAgentContentValidationTests
+{
+    private const string DocType = "decomposition";
+
+    private Mock<ISaaSProviderGate> _gate = null!;
+    private Mock<IBudgetGuard> _budget = null!;
+    private Mock<IAgentResolverService> _resolver = null!;
+    private Mock<IProviderCredentialResolver> _credentials = null!;
+    private Mock<IInlineToolLoopRunner> _runner = null!;
+    private Mock<IProviderPricingService> _pricing = null!;
+    private IProviderMarkupEngine _markup = null!;
+    private RecordingUsageEmitter _usage = null!;
+    private RecordingEventRepository _events = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _gate = new Mock<ISaaSProviderGate>(MockBehavior.Strict);
+        _budget = new Mock<IBudgetGuard>(MockBehavior.Strict);
+        _resolver = new Mock<IAgentResolverService>(MockBehavior.Strict);
+        _credentials = new Mock<IProviderCredentialResolver>(MockBehavior.Strict);
+        _runner = new Mock<IInlineToolLoopRunner>(MockBehavior.Strict);
+        _pricing = new Mock<IProviderPricingService>(MockBehavior.Loose);
+        _markup = new PassthroughProviderMarkupEngine();
+        _usage = new RecordingUsageEmitter();
+        _events = new RecordingEventRepository();
+
+        SetupResolve();
+        SetupGateAllow();
+        SetupBudgetWithin();
+        SetupCredential();
+    }
+
+    private ManagedAgent Build(RepairRingOptions opts) => new(
+        _gate.Object, _budget.Object, _resolver.Object, _credentials.Object,
+        _runner.Object, _pricing.Object, _markup, _usage, _events,
+        NullLogger<ManagedAgent>.Instance,
+        repairOptions: Options.Create(opts));
+
+    // -------------------------------------------------------------------
+    // Exhausted-invalid → typed CONTENT_VALIDATION_FAILED + event trail.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task ExhaustedInvalid_TypedContentFailure_422_WithPayloadAndEvents()
+    {
+        var loop = LoopResult(
+            contentValid: false, repairTurns: 1, text: "still-bad", inTok: 120, outTok: 40,
+            history: new[]
+            {
+                new RepairTurnRecord(0, false, Vio("MISSING_FIELD", "Field 'x' required.")),
+                new RepairTurnRecord(1, false, Vio("MISSING_FIELD", "Field 'x' required.")),
+            });
+        SetupRunner(loop);
+
+        var sut = Build(EnabledFor(DocType)); // repair ON, cap 1
+        var run = await sut.RunAsync(ReqWithDoc(issueId: "ISSUE-7"));
+
+        run.Success.Should().BeFalse();
+        run.FailureCode.Should().Be(AgentRunFailureCodes.ContentValidationFailed);
+        run.HttpStatusCode.Should().Be(422, "a content failure is 422-style, not a transient provider error");
+        run.RepairTurns.Should().Be(1);
+        run.ContentValid.Should().BeFalse();
+        run.ContentViolations.Should().ContainSingle().Which.Code.Should().Be("MISSING_FIELD");
+        run.RepairHistory.Should().HaveCount(2);
+        run.InputTokens.Should().Be(120, "token counts (incl. repair spend) ride the result");
+        run.OutputTokens.Should().Be(40);
+
+        _usage.Records.Should().BeEmpty("a failed run emits NO usage row (32-9 decision)");
+
+        _events.TypeCount(AgentRunEventTypes.Failed).Should().Be(1, "exactly one terminal AGENT.RUN.FAILED");
+        _events.TypeCount(AgentRunEventTypes.Success).Should().Be(0);
+        _events.TypeCount(RepairRingEventTypes.ValidationFailed).Should().Be(2, "turn 0 and turn 1");
+        _events.TypeCount(RepairRingEventTypes.RepairExhausted).Should().Be(1);
+        _events.TypeCount(RepairRingEventTypes.RepairSucceeded).Should().Be(0);
+
+        // Tags carry issueId / documentType / role / action / repairTurn.
+        var vf = _events.OfType(RepairRingEventTypes.ValidationFailed).First();
+        vf.Tags.Should().Contain("ISSUE-7").And.Contain(DocType).And.Contain("developer");
+        vf.Tags.Should().Contain("\"repairTurn\"");
+    }
+
+    // -------------------------------------------------------------------
+    // Repaired → success with RepairTurns == 1 + LLM.REPAIR.SUCCEEDED.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task Repaired_Success_WithRepairSucceededEvent()
+    {
+        var loop = LoopResult(
+            contentValid: true, repairTurns: 1, text: "fixed", inTok: 80, outTok: 20,
+            history: new[]
+            {
+                new RepairTurnRecord(0, false, Vio("E", "bad")),
+                new RepairTurnRecord(1, true, Array.Empty<DocumentViolation>()),
+            });
+        SetupRunner(loop);
+
+        var sut = Build(EnabledFor(DocType));
+        var run = await sut.RunAsync(ReqWithDoc(issueId: "ISSUE-9"));
+
+        run.Success.Should().BeTrue();
+        run.RepairTurns.Should().Be(1);
+        run.ContentValid.Should().BeTrue();
+        run.ResponseText.Should().Be("fixed");
+
+        _events.TypeCount(AgentRunEventTypes.Success).Should().Be(1);
+        _events.TypeCount(RepairRingEventTypes.ValidationFailed).Should().Be(1, "only turn 0 failed");
+        _events.TypeCount(RepairRingEventTypes.RepairSucceeded).Should().Be(1);
+        _events.TypeCount(RepairRingEventTypes.RepairExhausted).Should().Be(0);
+    }
+
+    // -------------------------------------------------------------------
+    // Gate OFF → only VALIDATION.FAILED; plan handed to the runner is disabled.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task GateOff_OnlyValidationFailed_PlanDisabled()
+    {
+        var loop = LoopResult(
+            contentValid: false, repairTurns: 0, text: "bad", inTok: 10, outTok: 5,
+            history: new[] { new RepairTurnRecord(0, false, Vio("E", "bad")) });
+        var capturedPlan = SetupRunner(loop);
+
+        var sut = Build(new RepairRingOptions()); // default: nothing enabled
+        var run = await sut.RunAsync(ReqWithDoc(issueId: "ISSUE-1"));
+
+        run.FailureCode.Should().Be(AgentRunFailureCodes.ContentValidationFailed);
+        run.RepairTurns.Should().Be(0, "gate off ⇒ zero extra turns");
+
+        capturedPlan().Should().NotBeNull();
+        capturedPlan()!.RepairEnabled.Should().BeFalse("the plan handed to the runner is gated off (AC9)");
+
+        _events.TypeCount(RepairRingEventTypes.ValidationFailed).Should().Be(1);
+        _events.TypeCount(RepairRingEventTypes.RepairExhausted).Should().Be(0, "no exhaustion when gated off");
+        _events.TypeCount(RepairRingEventTypes.RepairSucceeded).Should().Be(0);
+    }
+
+    // -------------------------------------------------------------------
+    // No DocumentValidation → no LLM.* events, no new fields set.
+    // -------------------------------------------------------------------
+
+    [Test]
+    public async Task NoDocumentValidation_NoRepairEvents_FieldsDefault()
+    {
+        var loop = LoopResult(contentValid: null, repairTurns: 0, text: "ok", inTok: 10, outTok: 5,
+            history: Array.Empty<RepairTurnRecord>());
+        SetupRunner(loop);
+
+        var sut = Build(EnabledFor(DocType));
+        var run = await sut.RunAsync(ReqNoDoc());
+
+        run.Success.Should().BeTrue();
+        run.ContentValid.Should().BeNull();
+        run.RepairHistory.Should().BeNull();
+        _events.TypeCount(RepairRingEventTypes.ValidationFailed).Should().Be(0);
+        _events.TypeCount(RepairRingEventTypes.RepairSucceeded).Should().Be(0);
+        _events.TypeCount(RepairRingEventTypes.RepairExhausted).Should().Be(0);
+    }
+
+    // -------------------------------------------------------------------
+    // Mapper: content failure rides a 200 envelope; body status 422 (not transient).
+    // -------------------------------------------------------------------
+
+    [Test]
+    public void Mapper_ContentFailure_RidesInside200_BodyStatus422()
+    {
+        var run = new AgentRunResult
+        {
+            Success = false,
+            Role = "developer",
+            CorrelationId = "c",
+            FailureCode = AgentRunFailureCodes.ContentValidationFailed,
+            FailureReason = "document failed validation",
+            HttpStatusCode = 422,
+            ContentValid = false,
+            RepairTurns = 1,
+            ContentViolations = new[] { new DocumentViolation("E", "bad") },
+            RepairHistory = new[] { new RepairTurnRecord(0, false, Vio("E", "bad")) },
+        };
+
+        var http = new LlmCallResponseMapper().ToHttpResult(run);
+        http.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<LlmCallResponse>>();
+        var body = ((Microsoft.AspNetCore.Http.HttpResults.Ok<LlmCallResponse>)http).Value!;
+
+        body.Success.Should().BeFalse();
+        body.HttpStatusCode.Should().Be(422, "422 is NOT in RetryCheck's transient set {0,429,502,503,504}");
+        body.ContentValidation.Should().NotBeNull();
+        body.ContentValidation!.Valid.Should().BeFalse();
+        body.ContentValidation.RepairTurns.Should().Be(1);
+        body.ContentValidation.Violations.Should().ContainSingle().Which.Code.Should().Be("E");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static IReadOnlyList<DocumentViolation> Vio(string code, string message) =>
+        new[] { new DocumentViolation(code, message) };
+
+    private static RepairRingOptions EnabledFor(string key) =>
+        new() { EnabledDocumentTypes = new[] { key } };
+
+    private static InlineToolLoopResult LoopResult(
+        bool? contentValid, int repairTurns, string text, int inTok, int outTok,
+        IReadOnlyList<RepairTurnRecord> history) => new()
+    {
+        Response = new NormalizedLlmResponse
+        {
+            Success = true,
+            ResponseText = text,
+            HttpStatusCode = 200,
+            PromptTokens = inTok,
+            CompletionTokens = outTok,
+        },
+        InputTokens = inTok,
+        OutputTokens = outTok,
+        Turns = 1,
+        Exhausted = false,
+        ContentValid = contentValid,
+        RepairTurns = repairTurns,
+        RepairHistory = history,
+    };
+
+    /// <summary>Set up the strict runner mock to return <paramref name="loop"/>, and
+    /// return an accessor for the RepairRingPlan the SUT handed the runner.</summary>
+    private Func<RepairRingPlan?> SetupRunner(InlineToolLoopResult loop)
+    {
+        RepairRingPlan? captured = null;
+        _runner
+            .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, LlmProviderConfig, string, string, string, int, double,
+                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, RepairRingPlan?, CancellationToken>(
+                (_, _, _, _, _, _, _, _, _, _, _, plan, _) =>
+                {
+                    captured = plan;
+                    return Task.FromResult(loop);
+                });
+        return () => captured;
+    }
+
+    private static ManagedAgentRequest ReqWithDoc(string issueId) => new()
+    {
+        TenantId = Guid.NewGuid(),
+        Role = "developer",
+        Action = "issue-decomposition",
+        Prompt = "decompose the issue",
+        CorrelationId = "corr-cv",
+        Params = new LlmCallParams { MaxTokens = 4096, Temperature = 0.7 },
+        DocumentValidation = new DocumentContentValidation(DocType, _ => DocumentValidationResult.Valid()),
+        IssueId = issueId,
+    };
+
+    private static ManagedAgentRequest ReqNoDoc() => new()
+    {
+        TenantId = Guid.NewGuid(),
+        Role = "developer",
+        Prompt = "do the thing",
+        CorrelationId = "corr-nodoc",
+        Params = new LlmCallParams { MaxTokens = 4096, Temperature = 0.7 },
+    };
+
+    private void SetupResolve() =>
+        _resolver
+            .Setup(r => r.ResolveForRoleAsync("developer", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ResolvedAgentConfig
+            {
+                Role = "developer",
+                Handle = "tamma-developer",
+                Provider = "anthropic",
+                Model = "claude-sonnet-4",
+                Temperature = 0.7,
+                MaxTokens = 4096,
+                TokenBudget = 100_000,
+                SystemPrompt = "You are a developer.",
+                AgentId = Guid.NewGuid(),
+                AgentVersion = 7,
+                Source = "system-public",
+            });
+
+    private void SetupGateAllow() =>
+        _gate.Setup(g => g.InspectAsync(It.IsAny<ProviderGateContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ProviderGateDecision.Allow(ProviderAuthModel.ApiKey));
+
+    private void SetupBudgetWithin() =>
+        _budget.Setup(b => b.IsWithinBudgetAsync(It.IsAny<Guid?>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+    private void SetupCredential() =>
+        _credentials.Setup(c => c.ResolveAsync(It.IsAny<Guid?>(), "anthropic", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ProviderCredential("sk-test-key", CredentialSource.Platform,
+                "platform:anthropic/api-key", null));
+
+    // fakes
+    private sealed class RecordingUsageEmitter : IUsageEmitter
+    {
+        public List<UsageRecord> Records { get; } = new();
+        public Task EmitAsync(UsageRecord record, CancellationToken ct = default)
+        {
+            Records.Add(record);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingEventRepository : IEventRepository
+    {
+        public ConcurrentBag<DomainEvent> Appended { get; } = new();
+        public int TypeCount(string type) => Appended.Count(e => e.Type == type);
+        public IEnumerable<DomainEvent> OfType(string type) => Appended.Where(e => e.Type == type);
+
+        public Task<DomainEvent> AppendAsync(DomainEvent evt)
+        {
+            Appended.Add(evt);
+            return Task.FromResult(evt);
+        }
+
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit)
+            => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type)
+            => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ManagedAgentTests.cs
@@ -115,10 +115,11 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .Returns<string, LlmProviderConfig, string, string, string, int, double,
-                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, CancellationToken>(
-                (_, _, _, _, _, _, _, _, _, _, _, _) =>
+                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, RepairRingPlan?, CancellationToken>(
+                (_, _, _, _, _, _, _, _, _, _, _, _, _) =>
                 {
                     startedBeforeRun = _events.TypeCount(AgentRunEventTypes.Started) == 1;
                     return Task.FromResult(SuccessLoop(1, 1, "x"));
@@ -165,10 +166,11 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .Returns<string, LlmProviderConfig, string, string, string, int, double,
-                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, CancellationToken>(
-                (provider, cfg, model, _, _, _, _, _, _, _, _, _) =>
+                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, RepairRingPlan?, CancellationToken>(
+                (provider, cfg, model, _, _, _, _, _, _, _, _, _, _) =>
                 {
                     runnerProvider = provider;
                     runnerModel = model;
@@ -356,7 +358,8 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new InlineToolLoopResult
             {
                 Response = new NormalizedLlmResponse
@@ -391,7 +394,8 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new InlineToolLoopResult
             {
                 // success but exhausted with no usable text
@@ -532,10 +536,11 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .Returns<string, LlmProviderConfig, string, string, string, int, double,
-                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, CancellationToken>(
-                (_, _, _, systemPrompt, userPrompt, _, _, _, _, _, _, _) =>
+                IReadOnlyList<ResolvedTool>?, bool, ToolLoopConfig, string, RepairRingPlan?, CancellationToken>(
+                (_, _, _, systemPrompt, userPrompt, _, _, _, _, _, _, _, _) =>
                 {
                     sentSystemPrompt = systemPrompt;
                     sentUserPrompt = userPrompt;
@@ -582,7 +587,8 @@ public class ManagedAgentTests
             .Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException($"upstream rejected key {TestApiKey} (401)"));
 
         var run = await _sut.RunAsync(Req(Guid.NewGuid(), "developer"));
@@ -692,7 +698,8 @@ public class ManagedAgentTests
         _runner.Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(SuccessLoop(inTok, outTok, text));
 
     private static InlineToolLoopResult SuccessLoop(int inTok, int outTok, string text) => new()

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairMessageComposerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairMessageComposerTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Tools;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 39-9 (AC8) — the deterministic, safe, golden-pinned repair message. Same
+/// violations ⇒ byte-identical message; violations appear verbatim; only validator
+/// output + fixed instruction text (never a provider error body — the composer takes
+/// only <see cref="DocumentViolation"/>s, enforced at compile time); a secret-shaped
+/// token in a violation message is redacted through the runner's redaction seam.
+/// </summary>
+[TestFixture]
+public class RepairMessageComposerTests
+{
+    private static IReadOnlyList<DocumentViolation> TwoViolations() => new[]
+    {
+        new DocumentViolation("DANGLING_DEPENDS_ON", "Task 'T3' depends on undeclared 'T9'."),
+        new DocumentViolation("MISSING_FIELD", "Field 'acceptanceCriteria' is required but was not present."),
+    };
+
+    [Test]
+    public void Compose_IsDeterministic_ByteIdenticalAcrossCalls()
+    {
+        var first = RepairMessageComposer.Compose(TwoViolations());
+        var second = RepairMessageComposer.Compose(TwoViolations());
+
+        second.Should().Be(first, "same violations in ⇒ byte-identical message out");
+    }
+
+    [Test]
+    public void Compose_GoldenTemplate_ForTwoViolations()
+    {
+        var message = RepairMessageComposer.Compose(TwoViolations());
+
+        const string expected =
+            "The document you produced did not pass validation. The following problems were found:\n" +
+            "- [DANGLING_DEPENDS_ON] Task 'T3' depends on undeclared 'T9'.\n" +
+            "- [MISSING_FIELD] Field 'acceptanceCriteria' is required but was not present.\n" +
+            "\n" +
+            "Fix every problem listed above and re-emit the COMPLETE corrected document. " +
+            "Output only the corrected document — do not include explanations, apologies, or commentary.";
+
+        message.Should().Be(expected, "the template is golden-pinned — any drift is a conscious edit");
+    }
+
+    [Test]
+    public void Compose_EmitsEveryViolationVerbatim_InInputOrder()
+    {
+        var message = RepairMessageComposer.Compose(TwoViolations());
+
+        message.Should().Contain("- [DANGLING_DEPENDS_ON] Task 'T3' depends on undeclared 'T9'.");
+        message.Should().Contain("- [MISSING_FIELD] Field 'acceptanceCriteria' is required but was not present.");
+        message.IndexOf("DANGLING_DEPENDS_ON", StringComparison.Ordinal)
+            .Should().BeLessThan(message.IndexOf("MISSING_FIELD", StringComparison.Ordinal),
+                "input order is preserved");
+    }
+
+    [Test]
+    public void ComposeThenRedact_ScrubsSecretShapedTokenFromViolationMessage()
+    {
+        // A violation message can quote model output that embeds a secret-shaped token.
+        // The runner appends the composed message through ToolOutputHelper.RedactSecrets (D9).
+        var violations = new[]
+        {
+            new DocumentViolation(
+                "BAD_VALUE",
+                "The field 'apiKey' contained sk-abcdefghijklmnopqrstuvwxyz012345 which is invalid."),
+        };
+
+        var redacted = ToolOutputHelper.RedactSecrets(RepairMessageComposer.Compose(violations));
+
+        redacted.Should().NotContain("sk-abcdefghijklmnopqrstuvwxyz012345");
+        redacted.Should().Contain("[REDACTED]");
+        redacted.Should().Contain("[BAD_VALUE]", "the violation code survives redaction");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairRingEventRateTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairRingEventRateTests.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Tests.Infrastructure;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 39-9 (AC7) — proves that per-<c>(role, action) × documentType</c> repair
+/// rates are computable FROM THE EVENTS ALONE via the Story 4-7 query path
+/// (<see cref="IEventRepository.QueryEventsAsync"/> with the <c>"LLM."</c> type
+/// prefix), with no extra store. Seeds a mixed <c>LLM.*</c> stream across two cells
+/// through the real <see cref="EventRepository"/> and recomputes validation-failure,
+/// first-repair-success, and exhaustion counts purely by tag grouping.
+///
+/// <para><b>Docker-gated:</b> runs against a Postgres testcontainer (the JSONB tag
+/// predicates + BIGSERIAL cursor are not translatable on EF-InMemory). Compiles
+/// everywhere; its runtime is CI's Postgres.</para>
+/// </summary>
+[TestFixture]
+public class RepairRingEventRateTests
+{
+    private static readonly Guid Tenant = Guid.Parse("eeeeeeee-9999-9999-9999-eeeeeeeeeeee");
+
+    private PostgreSqlContainer _postgres = null!;
+    private DbContextOptions<TenantDbContext> _options = null!;
+    private ITenantDbContextFactory _factory = null!;
+    private EventRepository _repo = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("repair_rate_test")
+            .WithUsername("tamma")
+            .WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+
+        _options = new DbContextOptionsBuilder<TenantDbContext>()
+            .UseNpgsql(_postgres.GetConnectionString())
+            .Options;
+
+        await using (var db = new TestTenantDbContext(_options, Tenant))
+        {
+            await db.Database.EnsureCreatedAsync();
+        }
+
+        _factory = new TestTenantDbContextFactory(_options);
+        _repo = new EventRepository(_factory, new TenantContext(), platformEvents: null);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_postgres is not null)
+        {
+            await _postgres.DisposeAsync();
+        }
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await using var conn = new NpgsqlConnection(_postgres.GetConnectionString());
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "TRUNCATE TABLE domain_events;";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [Test]
+    public async Task PerCellRates_ComputableFromEventsAlone()
+    {
+        // Cell 1 — developer / issue-decomposition / decomposition:
+        //   3 first-attempt validation failures; 2 repaired; 1 exhausted.
+        await SeedValidationFailedAsync("developer", "issue-decomposition", "decomposition", repairTurn: 0);
+        await SeedValidationFailedAsync("developer", "issue-decomposition", "decomposition", repairTurn: 0);
+        await SeedValidationFailedAsync("developer", "issue-decomposition", "decomposition", repairTurn: 0);
+        await SeedRepairSucceededAsync("developer", "issue-decomposition", "decomposition");
+        await SeedRepairSucceededAsync("developer", "issue-decomposition", "decomposition");
+        await SeedRepairExhaustedAsync("developer", "issue-decomposition", "decomposition");
+
+        // Cell 2 — architect / design-proposal / design:
+        //   2 first-attempt validation failures; 0 repaired; 2 exhausted.
+        await SeedValidationFailedAsync("architect", "design-proposal", "design", repairTurn: 0);
+        await SeedValidationFailedAsync("architect", "design-proposal", "design", repairTurn: 0);
+        await SeedRepairExhaustedAsync("architect", "design-proposal", "design");
+        await SeedRepairExhaustedAsync("architect", "design-proposal", "design");
+
+        // Read the whole LLM.* stream via the Story 4-7 query path.
+        var (events, _) = await _repo.QueryEventsAsync(
+            Tenant, type: "LLM.", typeIsPrefix: true,
+            correlationId: null, actor: null, from: null, to: null,
+            cursor: null, limit: 500);
+
+        // Group by the (role, action, documentType) cell — tags alone.
+        var byCell = events
+            .GroupBy(e => (
+                Role: TagOf(e, "role"),
+                Action: TagOf(e, "action"),
+                DocumentType: TagOf(e, "documentType")))
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        // ── Cell 1 ──
+        var cell1 = byCell[("developer", "issue-decomposition", "decomposition")];
+        FirstAttemptFailures(cell1).Should().Be(3);
+        Count(cell1, RepairRingEventTypes.RepairSucceeded).Should().Be(2);
+        Count(cell1, RepairRingEventTypes.RepairExhausted).Should().Be(1);
+        FirstRepairSuccessRate(cell1).Should().BeApproximately(2d / 3d, 1e-9);
+        ExhaustionRate(cell1).Should().BeApproximately(1d / 3d, 1e-9);
+
+        // ── Cell 2 ──
+        var cell2 = byCell[("architect", "design-proposal", "design")];
+        FirstAttemptFailures(cell2).Should().Be(2);
+        Count(cell2, RepairRingEventTypes.RepairSucceeded).Should().Be(0);
+        Count(cell2, RepairRingEventTypes.RepairExhausted).Should().Be(2);
+        FirstRepairSuccessRate(cell2).Should().Be(0d);
+        ExhaustionRate(cell2).Should().Be(1d);
+    }
+
+    // ── rate helpers (events → rates, tags only) ─────────────────────────
+
+    private static int FirstAttemptFailures(IEnumerable<DomainEvent> cell) =>
+        cell.Count(e => e.Type == RepairRingEventTypes.ValidationFailed && TagOf(e, "repairTurn") == "0");
+
+    private static int Count(IEnumerable<DomainEvent> cell, string type) =>
+        cell.Count(e => e.Type == type);
+
+    private static double FirstRepairSuccessRate(IReadOnlyList<DomainEvent> cell)
+    {
+        var failures = FirstAttemptFailures(cell);
+        return failures == 0 ? 0d : (double)Count(cell, RepairRingEventTypes.RepairSucceeded) / failures;
+    }
+
+    private static double ExhaustionRate(IReadOnlyList<DomainEvent> cell)
+    {
+        var failures = FirstAttemptFailures(cell);
+        return failures == 0 ? 0d : (double)Count(cell, RepairRingEventTypes.RepairExhausted) / failures;
+    }
+
+    // ── seed helpers ─────────────────────────────────────────────────────
+
+    private Task SeedValidationFailedAsync(string role, string action, string documentType, int repairTurn) =>
+        SeedAsync(RepairRingEventTypes.ValidationFailed, role, action, documentType, repairTurn);
+
+    private Task SeedRepairSucceededAsync(string role, string action, string documentType) =>
+        SeedAsync(RepairRingEventTypes.RepairSucceeded, role, action, documentType, repairTurn: 1);
+
+    private Task SeedRepairExhaustedAsync(string role, string action, string documentType) =>
+        SeedAsync(RepairRingEventTypes.RepairExhausted, role, action, documentType, repairTurn: 1);
+
+    private async Task SeedAsync(string type, string role, string action, string documentType, int repairTurn)
+    {
+        var tags = JsonSerializer.Serialize(new
+        {
+            issueId = "ISSUE-1",
+            documentType,
+            role,
+            action,
+            repairTurn,
+            correlationId = "corr-1",
+            tenantId = Tenant.ToString(),
+        });
+
+        await using var db = await _factory.CreateAsync(Tenant);
+        db.DomainEvents.Add(new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = Tenant,
+            Tags = tags,
+            Metadata = "{}",
+            Data = "{}",
+            CreatedAt = DateTime.UtcNow,
+        });
+        await db.SaveChangesAsync();
+    }
+
+    private static string? TagOf(DomainEvent e, string key)
+    {
+        if (string.IsNullOrEmpty(e.Tags))
+        {
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(e.Tags);
+        if (!doc.RootElement.TryGetProperty(key, out var prop))
+        {
+            return null;
+        }
+
+        return prop.ValueKind switch
+        {
+            JsonValueKind.String => prop.GetString(),
+            JsonValueKind.Number => prop.GetRawText(),
+            _ => prop.GetRawText(),
+        };
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairRingOptionsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/RepairRingOptionsTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// Story 39-9 (AC2, AC9) — the GLOBAL repair-ring options: default bounds, the
+/// hard-cap clamp (no config value can exceed 2), and the default-OFF per-type gate.
+/// </summary>
+[TestFixture]
+public class RepairRingOptionsTests
+{
+    [Test]
+    public void Defaults_MaxRepairTurnsOne_EnabledTypesEmpty()
+    {
+        var opts = new RepairRingOptions();
+
+        opts.MaxRepairTurns.Should().Be(1, "the default is a single repair turn (AC2)");
+        opts.EffectiveMaxRepairTurns.Should().Be(1);
+        opts.EnabledDocumentTypes.Should().BeEmpty("the mechanism ships DARK (AC9)");
+        RepairRingOptions.HardCap.Should().Be(2);
+    }
+
+    [TestCase(5, 2)]   // any large value clamps to the hard cap
+    [TestCase(3, 2)]
+    [TestCase(2, 2)]
+    [TestCase(1, 1)]
+    [TestCase(0, 0)]
+    [TestCase(-1, 0)]  // negative clamps to zero
+    public void EffectiveMaxRepairTurns_ClampsIntoZeroToHardCap(int configured, int effective)
+    {
+        var opts = new RepairRingOptions { MaxRepairTurns = configured };
+        opts.EffectiveMaxRepairTurns.Should().Be(effective,
+            "no config value can drive more than the hard cap of 2, nor fewer than 0");
+    }
+
+    [Test]
+    public void IsEnabledFor_IsCaseInsensitive()
+    {
+        var opts = new RepairRingOptions { EnabledDocumentTypes = new[] { "decomposition" } };
+
+        opts.IsEnabledFor("decomposition").Should().BeTrue();
+        opts.IsEnabledFor("Decomposition").Should().BeTrue("membership is case-insensitive");
+        opts.IsEnabledFor("DECOMPOSITION").Should().BeTrue();
+        opts.IsEnabledFor("plan").Should().BeFalse("an unlisted type is gated off");
+    }
+
+    [Test]
+    public void IsEnabledFor_DefaultOptions_AlwaysFalse()
+    {
+        var opts = new RepairRingOptions();
+        opts.IsEnabledFor("decomposition").Should().BeFalse("default OFF for every type (AC9)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Streaming/BufferedNonRegressionTests.cs
@@ -132,7 +132,8 @@ public class BufferedNonRegressionTests
         runner.Setup(r => r.RunAsync(It.IsAny<string>(), It.IsAny<LlmProviderConfig>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<ResolvedTool>?>(), It.IsAny<bool>(),
-                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                It.IsAny<ToolLoopConfig>(), It.IsAny<string>(), It.IsAny<RepairRingPlan?>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new InlineToolLoopResult
             {
                 Response = new NormalizedLlmResponse


### PR DESCRIPTION
## What

Epic 39 **PR-E** — Story 39-9, the last Wave-2 story. A bounded, harness-generated **repair turn** in the managed LLM layer: when a produced document fails its deterministic validator, the domain-phrased violations are appended as a user message in the **same conversation** and the model is re-invoked, at most `EffectiveMaxRepairTurns` times, then re-validated.

**Ships dark by default** (`EnabledDocumentTypes` empty) — fully additive, **zero behavior change** for the 30+ existing `llm-call` dispatchers. 39-6/39-12 opt a document type in later.

## Mechanism

- **`InlineToolLoopRunner`** — the ring: validate turn 0 → append the redacted composed message to the same `messages` list → re-invoke (no tool execution, D3) → re-validate, bounded. `RunAsync` gains `RepairRingPlan?` with **no default** (D1) so every call site + Moq setup is a conscious edit (a missed one is a compile error, not a silent hole).
- **Hard cap** — `EffectiveMaxRepairTurns => Math.Clamp(MaxRepairTurns, 0, 2)`; there is no per-call knob, so no config/workflow/prompt can exceed 2.
- **Typed exhaustion** — `CONTENT_VALIDATION_FAILED`, body 422, **not** in the transient retry set `{0,429,502,503,504}` → the provider chain never retries a content failure; carries the final violations + per-turn history for 39-6's `ValidationExhausted` lineage. No usage row; token counts (incl. repair spend) stay truthful.
- **Validator composed API-side** (a delegate can't cross HTTP) — the wire carries the `documentType` key; `LlmCallEndpoints` builds the `Func` over `DocumentTypeRegistry.Resolve(key).Validate` with a fence-strip/parse front (`PAYLOAD_NOT_JSON` on unparseable, fail-loud on unknown key). The runner/agent see only the delegate.
- **Circuit-breaker isolation** — `ProviderAttemptDiagnostic.FailureCode` (additive) + `DiagnosticFailureCodes`; a shared pure `CountsAsProviderFailure` at **both** recorders excludes `content_validation` (a content failure trips *neither* failure nor success), so a bad model output can never open the breaker on a healthy provider.
- **Measurability** — `LLM.VALIDATION.FAILED` / `LLM.REPAIR.SUCCEEDED` / `LLM.REPAIR.EXHAUSTED` (emitted by `ManagedAgent`, best-effort), tagged so repair rates are computable per `(role, action) × documentType` via the existing Story 4-7 query path.
- `documentType`/`issueId` thread through additively (default empty). `RepairMessageComposer` is pure + golden-pinned; output redacted via `ToolOutputHelper.RedactSecrets`.

## Verification

- **No schema change** — `has-pending-model-changes` clean.
- Builds clean across `Tamma.Core` + `Tamma.Activities` + `Tamma.Api` + **both test projects** — the test-project build proves the invasive `RunAsync` arity change landed correctly at every call site and Moq setup (`ManagedAgentTests` ×6 setups, `InlineToolLoopRunnerTests` ×5 calls, `BufferedNonRegressionTests` ×1, `LlmCallContractTests` +4 wire tests).
- **20 pure `Tamma.Activities.Tests` green** (`DiagnosticFailureCode` mapping + `RecordDiagnosticsBreakerExclusion` — the N-vs-N breaker proof).
- The Repair-ring suites (`RepairRingOptions`, `RepairMessageComposer`, `InlineToolLoopRunnerRepair`, `ManagedAgentContentValidation`, `RepairRingEventRate`) live in the Docker-gated `Tamma.Api.Tests` assembly — they compile and run under **CI's Postgres**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_