### PR TITLE
feat(39-8): Escalation &amp; Approval Surface — generic decision gate, resume endpoints, ESCALATION/APPROVAL events

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ApprovalEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ApprovalEvents.cs
@@ -1,0 +1,81 @@
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-8 (Escalation &amp; Approval Surface) — central catalogue of the
+/// <c>APPROVAL.*</c> / <c>ESCALATION.*</c> DCB event family: the uniform
+/// approval-and-escalation surface that absorbs the old Story 4-6 goal, extended
+/// with document lineage, transport <c>channel</c>, and time-to-resolve data.
+/// Type pattern follows the platform's <c>AGGREGATE.ACTION.STATUS</c> convention
+/// (<c>CLAUDE.md</c>) and mirrors the sibling event catalogues (e.g.
+/// <see cref="Tamma.Activities.Decomposition.DecompositionEvents"/>, and 39-6's
+/// <c>DocumentEvents</c> — the "sibling <c>ApprovalEvents.cs</c>" the story names).
+///
+/// <para><b>Emit sites (each an atomic request+suspend or a single append):</b>
+/// <list type="bullet">
+///   <item><c>APPROVAL.REQUESTED</c> — the ACCEPT stage published an
+///     <c>AcceptanceRequest</c> and the generic gate suspended (one path — to the
+///     orchestrator). Emitted by <see cref="WaitForDocumentDecisionActivity"/>'s
+///     <c>Execute</c>; <c>channel</c> is structurally <c>orchestrator</c>.</item>
+///   <item><c>APPROVAL.PROVIDED</c> — the injected decision arrived on resume.
+///     Emitted by the gate's callback; carries the server-derived decider +
+///     <c>channel</c> + <c>durationMs</c>.</item>
+///   <item><c>ESCALATION.TRIGGERED</c> — an unhandleable lifecycle outcome or an
+///     always-escalate hit routed through the escalated exit region. Emitted by
+///     <see cref="EmitEscalationEventActivity"/>; carries the full document
+///     lineage (never a bare failure string).</item>
+///   <item><c>ESCALATION.RESOLVED</c> — an escalation was dispositioned
+///     (resolved/overridden/abandoned). Appended by the Tamma.Api
+///     <c>EscalationDispositionService</c> (the lifecycle has already exited, so
+///     disposition is an event append, not a workflow resume).</item>
+/// </list></para>
+///
+/// <para><b>D9 — <c>DOCUMENT.ESCALATED</c> vs <c>ESCALATION.TRIGGERED</c>.</b>
+/// Both are emitted at the same escalated exit and this is DELIBERATE, not
+/// accidental double-emission: <c>DOCUMENT.ESCALATED</c> (39-6) is the
+/// document-family STATE transition; <c>ESCALATION.TRIGGERED</c> (39-8) is the
+/// EXCEPTION-SURFACE record that additionally carries lineage / <c>channel</c> /
+/// timing. 39-11's dashboards treat <c>ESCALATION.*</c> as the exception surface
+/// and <c>DOCUMENT.*</c> as state history so the two never double-count.</para>
+///
+/// <para><b>Pinned field names</b> (AC3 / the epic README promise — kept stable so
+/// the 39-11 lineage API and dashboards can query them without a join):
+/// tags <c>issueId</c> / <c>documentId</c> / <c>documentType</c> /
+/// <c>correlationId</c> (+ <c>sessionId</c> on <c>APPROVAL.*</c>,
+/// <c>escalationId</c> on <c>ESCALATION.*</c>, <c>tenantId</c> when set); data
+/// <c>channel</c> (closed set <c>orchestrator | user | api</c>),
+/// <c>requestedAtUtc</c>, and the denormalized <c>durationMs</c> on the resolving
+/// (<c>PROVIDED</c> / <c>RESOLVED</c>) event.</para>
+/// </summary>
+public static class ApprovalEvents
+{
+    public const string Requested = "APPROVAL.REQUESTED";
+    public const string Provided = "APPROVAL.PROVIDED";
+
+    // The exception surface. TRIGGERED is a LOUD (error-status) row.
+    public const string EscalationTriggered = "ESCALATION.TRIGGERED";
+    public const string EscalationResolved = "ESCALATION.RESOLVED";
+
+    /// <summary>
+    /// Parse a tenant id from the loose string form threaded through the workflow
+    /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
+    /// (approval/escalation events in single-user mode are platform-scope,
+    /// TenantId null). Mirrors <see cref="Tamma.Activities.Decomposition.DecompositionEvents.ParseTenantId"/>.
+    /// </summary>
+    public static Guid? ParseTenantId(string? tenantId)
+        => Guid.TryParse(tenantId, out var g) ? g : null;
+
+    /// <summary>
+    /// Status convention: an <c>ESCALATION.TRIGGERED</c> is a LOUD (error-status)
+    /// audit row (the exception surface); the <c>APPROVAL.REQUESTED</c> request+suspend
+    /// is an informational (started) row; every other transition
+    /// (<c>APPROVAL.PROVIDED</c>, <c>ESCALATION.RESOLVED</c>) is a normal
+    /// (success-status) row. A human REJECT is a legitimate decision, so
+    /// <c>APPROVAL.PROVIDED</c> is a success row regardless of the decision kind.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        EscalationTriggered => "error",
+        Requested => "started",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitEscalationEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitEscalationEventActivity.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using System.Text.Json.Serialization;
+using Tamma.Activities.Core;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-8 (AC1/AC6) — emits an <c>ESCALATION.*</c> DCB event for the document
+/// lifecycle's escalated exit region by appending a <see cref="TammaEvent"/> to the
+/// workflow's <c>tamma:events</c> transient list via
+/// <see cref="TammaEventEmitter.Emit"/>; the merged engine event drain
+/// (<c>EventPersistenceMiddleware</c> + <c>EventDrain</c>) flushes it DURABLY to the
+/// tenant <c>domain_events</c> store — the same pattern
+/// <see cref="Tamma.Activities.Decomposition.EmitDecompositionEventActivity"/> uses.
+/// No activity holds a DB / repository dependency of its own.
+///
+/// <para><b>D9 — one emit site.</b> All four unhandleable outcomes AND every
+/// always-escalate hit route through 39-6's escalated terminal, so one node here
+/// covers AC1's both clauses. The event embeds the FULL serialized 39-6 document
+/// lineage (AC6) as a nested JSON object — never a bare failure string — plus the
+/// typed outcome name, the effective policy reference, and a freshly minted
+/// <c>escalationId</c> the disposition surface pairs on.</para>
+/// </summary>
+[Activity(
+    "Tamma.Documents",
+    "Emit Escalation Event",
+    "Emit an ESCALATION.* DCB event (with full document lineage) for the escalation exception surface",
+    Kind = ActivityKind.Task
+)]
+public class EmitEscalationEventActivity : Activity
+{
+    private readonly ILogger<EmitEscalationEventActivity>? _logger;
+
+    [Input(Description = "Event type — ESCALATION.TRIGGERED / .RESOLVED")]
+    public Input<string> EventType { get; set; } = default!;
+
+    [Input(Description = "Escalation id (unguessable Guid string — the pairing key)")]
+    public Input<string?> EscalationId { get; set; } = new((string?)null);
+
+    [Input(Description = "Typed outcome / escalate-reason wire name")]
+    public Input<string?> Outcome { get; set; } = new((string?)null);
+
+    [Input(Description = "Serialized 39-6 DocumentLineage (embedded verbatim as a JSON object)")]
+    public Input<string?> LineageJson { get; set; } = new((string?)null);
+
+    [Input(Description = "Resolved acceptance-rules reference")]
+    public Input<string?> RulesReference { get; set; } = new((string?)null);
+
+    [Input(Description = "Transport channel (orchestrator|user|api)")]
+    public Input<string?> Channel { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Document id under escalation")]
+    public Input<string?> DocumentId { get; set; } = new((string?)null);
+
+    [Input(Description = "Document type key")]
+    public Input<string?> DocumentType { get; set; } = new((string?)null);
+
+    [Input(Description = "Correlation id")]
+    public Input<string?> CorrelationId { get; set; } = new((string?)null);
+
+    [Input(Description = "Decision-session id")]
+    public Input<string?> SessionId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → platform-scope event)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Free-text detail for the audit payload")]
+    public Input<string?> Detail { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public EmitEscalationEventActivity() { }
+
+    public EmitEscalationEventActivity(ILogger<EmitEscalationEventActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var type = EventType.Get(context) ?? ApprovalEvents.EscalationTriggered;
+
+        var evt = BuildTammaEvent(
+            type,
+            EscalationId.Get(context),
+            Outcome.Get(context),
+            LineageJson.Get(context),
+            RulesReference.Get(context),
+            Channel.Get(context),
+            IssueId.Get(context),
+            DocumentId.Get(context),
+            DocumentType.Get(context),
+            CorrelationId.Get(context),
+            SessionId.Get(context),
+            ApprovalEvents.ParseTenantId(TenantId.Get(context)),
+            Detail.Get(context));
+
+        TammaEventEmitter.Emit(context, this, _logger, evt);
+
+        _logger?.LogInformation(
+            "Emitted {Type} for escalation {EscalationId} (outcome={Outcome}, document={DocumentId})",
+            type, EscalationId.Get(context), Outcome.Get(context), DocumentId.Get(context));
+
+        // Complete on the default outcome so a mid-flow emit node continues to the next activity
+        // (the escalated exit region wires this before its terminal). A plain Activity does not
+        // auto-complete, so this explicit completion is required.
+        await context.CompleteActivityAsync();
+    }
+
+    /// <summary>
+    /// Map the escalation inputs onto a <see cref="TammaEvent"/>. Tags carry the queryable DCB
+    /// index keys (<c>issueId</c>/<c>documentId</c>/<c>documentType</c>/<c>correlationId</c>/
+    /// <c>escalationId</c>/<c>sessionId</c>/<c>tenantId</c>); <c>Data</c> carries the exception
+    /// payload — the typed <c>outcome</c>, the full <c>lineage</c> embedded as a nested JSON
+    /// object (AC6 — NEVER a bare string), the <c>rulesReference</c>, the <c>channel</c>, and any
+    /// <c>detail</c>. Status is driven off the type (<see cref="ApprovalEvents.StatusForEvent"/>)
+    /// so a TRIGGERED is a LOUD error row. Pure (no Elsa context); exposed for unit testing.
+    /// </summary>
+    public static TammaEvent BuildTammaEvent(
+        string type,
+        string? escalationId,
+        string? outcome,
+        string? lineageJson,
+        string? rulesReference,
+        string? channel,
+        string? issueId,
+        string? documentId,
+        string? documentType,
+        string? correlationId,
+        string? sessionId,
+        Guid? tenantId,
+        string? detail)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (!string.IsNullOrWhiteSpace(documentId)) tags["documentId"] = documentId;
+        if (!string.IsNullOrWhiteSpace(documentType)) tags["documentType"] = documentType;
+        if (!string.IsNullOrWhiteSpace(correlationId)) tags["correlationId"] = correlationId;
+        if (!string.IsNullOrWhiteSpace(escalationId)) tags["escalationId"] = escalationId;
+        if (!string.IsNullOrWhiteSpace(sessionId)) tags["sessionId"] = sessionId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            // AC6 — the lineage is embedded as a nested JSON OBJECT, never a bare string, so a
+            // handler can reconstruct the whole story from the one event.
+            ["lineage"] = EmbedLineage(lineageJson),
+        };
+        if (!string.IsNullOrWhiteSpace(outcome)) data["outcome"] = outcome;
+        if (!string.IsNullOrWhiteSpace(rulesReference)) data["rulesReference"] = rulesReference;
+        if (!string.IsNullOrWhiteSpace(channel)) data["channel"] = channel;
+        if (!string.IsNullOrWhiteSpace(detail)) data["detail"] = detail;
+
+        return new TammaEvent
+        {
+            EventType = type,
+            Status = ApprovalEvents.StatusForEvent(type),
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    /// <summary>Parse the serialized lineage into a <see cref="JsonNode"/> so it serializes as a
+    /// nested object; an unparseable/empty payload is wrapped in an object (never surfaced as a
+    /// bare string) so AC6's "never a bare failure string" holds even on malformed input.</summary>
+    private static JsonNode EmbedLineage(string? lineageJson)
+    {
+        if (!string.IsNullOrWhiteSpace(lineageJson))
+        {
+            try
+            {
+                if (JsonNode.Parse(lineageJson) is JsonNode node)
+                    return node;
+            }
+            catch (JsonException)
+            {
+                // fall through to the wrapped-object form
+            }
+        }
+
+        return new JsonObject { ["_unparsed"] = lineageJson };
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
@@ -1,0 +1,390 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Attributes;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.ADL;
+using Tamma.Activities.Core;
+using Tamma.Core;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-8 (AC4) — the ONE generic document-decision gate. Suspends any
+/// lifecycle on a tenant-folded, unguessable bookmark until the orchestrator (or
+/// the human the orchestrator assigned) supplies a decision, then surfaces that
+/// decision — mapped onto 39-5's <see cref="AcceptanceDecision"/> — as a typed
+/// outcome the flowchart branches on. It generalizes the five proven per-workflow
+/// resume gates (<c>WaitForDesignApprovalActivity</c> et al.) into a single reuse:
+/// the 39-6 ACCEPT stage registers THIS gate regardless of who the orchestrator
+/// routes the decision to (self-decision and assigned-human decision resume it
+/// identically — the decider varies, the gate does not).
+///
+/// <para><b>SECURITY (IDOR)</b> — the bookmark name folds in the tenant id (the
+/// design/merge-gate posture, <see cref="DecisionBookmarkName"/> →
+/// <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/>). A resume caller
+/// scoped to tenant A computes a name keyed by tenant A, so it can NEVER resolve
+/// tenant B's gate; a cross-tenant attempt simply 404s. The session id is itself an
+/// unguessable 128-bit decision-session Guid (39-6 mints it at Init), so within a
+/// tenant the name is unguessable too.</para>
+///
+/// <para><b>D8 — no SLA timer.</b> Unlike the design/escalation gates, NO
+/// <c>DelayFor</c> timeout is armed: suspended-on-bookmark is a legal resumability
+/// posture (39-10), the orchestrator/Task-View liveness policy belongs to
+/// 39-17/39-19, and a silent timeout would be a decision nobody took. The
+/// <c>DelayFor</c> pattern (see <c>WaitForDesignApprovalActivity</c>) is the
+/// retrofit seam if that policy ever arrives.</para>
+///
+/// <para><b>Events (D3).</b> The gate emits both <c>APPROVAL.*</c> events itself,
+/// via <see cref="TammaEventEmitter"/> → the durable <c>EventDrain</c>:
+/// <c>APPROVAL.REQUESTED</c> at <see cref="Execute"/> (request+suspend is one
+/// atomic site), <c>APPROVAL.PROVIDED</c> at the resume callback. Emitting inside
+/// the engine (not the endpoint) keeps the events on the durable drain with full
+/// workflow tag context and keeps the endpoint a thin resume seam.</para>
+/// </summary>
+[Activity(
+    "Tamma.Documents",
+    "Wait For Document Decision",
+    "Suspend any lifecycle until a document decision (accept/request-revision/reject/escalate) is injected on the tenant-folded bookmark",
+    Kind = ActivityKind.Task
+)]
+[FlowNode("Accept", "RequestRevision", "Reject", "Escalate")]
+public class WaitForDocumentDecisionActivity : Activity
+{
+    private readonly ILogger<WaitForDocumentDecisionActivity>? _logger;
+
+    /// <summary>Decision-session id (39-6 mints it at Init) — the unguessable bookmark scope.</summary>
+    [Input(Description = "Decision-session id (bookmark scoping)")]
+    public Input<Guid> SessionId { get; set; } = default!;
+
+    /// <summary>Tenant id (GUID string or empty for single-user). Folded into the bookmark
+    /// name so a cross-tenant resume can never resolve this gate.</summary>
+    [Input(Description = "Tenant id (bookmark scoping — prevents cross-tenant resume/IDOR)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    /// <summary>D4 — ISO-8601 timestamp the accept stage stamped when it built the request;
+    /// REQUIRED. The callback runs on a rehydrated activity (Execute-time locals are gone),
+    /// so <c>durationMs</c> is computed off this re-read input, not activity-instance state.</summary>
+    [Input(Description = "ISO-8601 UTC time the acceptance request was published (durationMs basis)")]
+    public Input<string> RequestedAtUtc { get; set; } = default!;
+
+    /// <summary>D7 — the resolved-rules summary (source+version+autonomy) the decision is made
+    /// under; stamped by the server into both REQUESTED and PROVIDED so orchestrator decisions
+    /// are auditable without trusting the orchestrator's self-report.</summary>
+    [Input(Description = "Resolved acceptance-rules reference (source+version+autonomy summary)")]
+    public Input<string?> RulesReference { get; set; } = new((string?)null);
+
+    [Input(Description = "Issue / requirement id (tag threading)")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Document id under decision (tag threading)")]
+    public Input<string?> DocumentId { get; set; } = new((string?)null);
+
+    [Input(Description = "Document type key (tag threading)")]
+    public Input<string?> DocumentType { get; set; } = new((string?)null);
+
+    [Input(Description = "Correlation id (tag threading)")]
+    public Input<string?> CorrelationId { get; set; } = new((string?)null);
+
+    /// <summary>The serialized 39-5 <see cref="AcceptanceDecision"/> (canonical form).</summary>
+    [Output(Description = "Serialized AcceptanceDecision (39-5)")]
+    public Output<string> DecisionJson { get; set; } = default!;
+
+    [Output(Description = "Decider feedback / notes")]
+    public Output<string?> Feedback { get; set; } = default!;
+
+    [Output(Description = "Server-derived decider identity")]
+    public Output<string?> DeciderId { get; set; } = default!;
+
+    [Output(Description = "Transport channel the decision arrived on (orchestrator|user|api)")]
+    public Output<string> Channel { get; set; } = default!;
+
+    [Output(Description = "Time-to-decision in milliseconds (denormalized)")]
+    public Output<long> DurationMs { get; set; } = default!;
+
+    [JsonConstructor]
+    public WaitForDocumentDecisionActivity() { }
+
+    public WaitForDocumentDecisionActivity(ILogger<WaitForDocumentDecisionActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// D2 — the SINGLE canonical decision-bookmark name
+    /// (<c>document-decision-{tenant}-{session}</c>). Shared by the suspend side
+    /// (<see cref="Execute"/>) and the resume side
+    /// (<c>DocumentDecisionResumeEndpoint</c>) so the two match byte-for-byte. The
+    /// tenant segment is normalised via the SAME
+    /// <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/> transform on both
+    /// sides so the names always agree.
+    /// </summary>
+    public static string DecisionBookmarkName(string? tenantId, Guid sessionId)
+    {
+        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
+        return $"document-decision-{tenant}-{sessionId}";
+    }
+
+    protected override void Execute(ActivityExecutionContext context)
+    {
+        var sessionId = SessionId.Get(context);
+        var tenantId = TenantId.Get(context);
+        var requestedAtUtc = RequestedAtUtc.Get(context);
+
+        // D4 — fail LOUD if the durationMs basis is missing/unparseable, rather than
+        // silently emitting a meaningless duration on resume.
+        if (string.IsNullOrWhiteSpace(requestedAtUtc) || !TryParseIso(requestedAtUtc, out _))
+        {
+            throw new TammaError(
+                "DOCUMENT.DECISION.MISSING_REQUESTED_AT",
+                $"WaitForDocumentDecisionActivity requires a valid ISO-8601 RequestedAtUtc; got '{requestedAtUtc}'.",
+                new Dictionary<string, object?> { ["requestedAtUtc"] = requestedAtUtc, ["sessionId"] = sessionId },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+        }
+
+        var bookmarkName = DecisionBookmarkName(tenantId, sessionId);
+
+        // APPROVAL.REQUESTED — request+suspend is one atomic site (D3). channel is always
+        // orchestrator (D6 — every request routes to the orchestrator).
+        TammaEventEmitter.Emit(context, this, _logger, BuildRequestedEvent(
+            sessionId, tenantId,
+            IssueId.Get(context), DocumentId.Get(context), DocumentType.Get(context),
+            CorrelationId.Get(context), RulesReference.Get(context), requestedAtUtc));
+
+        _logger?.LogInformation(
+            "Waiting for document decision: bookmark={BookmarkName} for session {SessionId}",
+            bookmarkName, sessionId);
+
+        context.CreateBookmark(new CreateBookmarkArgs
+        {
+            BookmarkName = bookmarkName,
+            Callback = OnDecisionReceivedAsync,
+            AutoBurn = true,
+            IncludeActivityInstanceId = false,
+        });
+    }
+
+    /// <summary>External resume path: the decision was injected. Reads it (fail-closed on
+    /// garbage, D5), computes <c>durationMs</c> off the re-read <see cref="RequestedAtUtc"/>,
+    /// emits <c>APPROVAL.PROVIDED</c>, sets the outputs, and completes on the decision-kind
+    /// outcome.</summary>
+    private async ValueTask OnDecisionReceivedAsync(ActivityExecutionContext context)
+    {
+        var read = ReadDecision(context.WorkflowInput);
+
+        var requestedAtUtc = RequestedAtUtc.Get(context);
+        var durationMs = ComputeDurationMs(requestedAtUtc);
+
+        // D7 — the authoritative rules reference is the server-stamped activity input, not the
+        // resume echo, so orchestrator decisions stay auditable.
+        var rulesReference = RulesReference.Get(context);
+
+        _logger?.LogInformation(
+            "Document decision resumed: kind={Kind} channel={Channel} decider={Decider} durationMs={Duration}",
+            read.DecisionKind, read.Channel, read.DeciderId ?? "<none>", durationMs);
+
+        TammaEventEmitter.Emit(context, this, _logger, BuildProvidedEvent(
+            SessionId.Get(context), TenantId.Get(context),
+            IssueId.Get(context), DocumentId.Get(context), DocumentType.Get(context),
+            CorrelationId.Get(context), rulesReference, read, durationMs));
+
+        context.Set(DecisionJson, read.DecisionJson);
+        context.Set(Feedback, read.Feedback);
+        context.Set(DeciderId, read.DeciderId);
+        context.Set(Channel, read.Channel);
+        context.Set(DurationMs, durationMs);
+
+        await context.CompleteActivityWithOutcomesAsync(read.Outcome);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pure read-back + mapping (exposed for unit testing)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Pure read-back of the injected decision from the bookmark resume input (D5). The
+    /// serialized 39-5 <see cref="AcceptanceDecision"/> is deserialized polymorphically;
+    /// an unparseable / missing <c>DecisionJson</c> FAIL-CLOSES to
+    /// <c>Escalate(AcceptorJudgment, "unreadable decision payload")</c> — the
+    /// serializing-dispatcher lesson (#15/#437): never mis-branch on garbage while returning
+    /// 200. Scalar fields are read via <c>.ToString()</c> (serialization-tolerant).
+    /// </summary>
+    public static DecisionReadResult ReadDecision(IDictionary<string, object> input)
+    {
+        var decisionJson = input.TryGetValue("DecisionJson", out var dj) ? dj?.ToString() : null;
+        var feedback = input.TryGetValue("Feedback", out var f) ? f?.ToString() : null;
+        var deciderId = input.TryGetValue("DeciderId", out var di) ? di?.ToString() : null;
+        var deciderDisplay = input.TryGetValue("DeciderDisplay", out var dd) ? dd?.ToString() : null;
+        var channel = input.TryGetValue("Channel", out var ch) ? ch?.ToString() : null;
+        var rulesReference = input.TryGetValue("RulesReference", out var rr) ? rr?.ToString() : null;
+
+        var decision = ParseDecisionFailClosed(decisionJson);
+        var outcome = OutcomeFor(decision);
+        var kind = KindWireFor(decision);
+
+        // Re-serialize the (possibly fail-closed) decision to the canonical form so the
+        // downstream 39-6 guardrail always reads a valid AcceptanceDecision, never the raw
+        // client string.
+        var canonicalJson = JsonSerializer.Serialize<AcceptanceDecision>(decision, SerializerOptions);
+
+        return new DecisionReadResult(
+            Decision: decision,
+            DecisionJson: canonicalJson,
+            Outcome: outcome,
+            DecisionKind: kind,
+            Feedback: feedback,
+            DeciderId: deciderId,
+            DeciderDisplay: deciderDisplay,
+            Channel: string.IsNullOrWhiteSpace(channel) ? "orchestrator" : channel,
+            RulesReference: rulesReference);
+    }
+
+    /// <summary>Deserialize the injected decision; ANY failure (null/empty/garbage/unknown
+    /// kind) fail-closes to <c>Escalate(AcceptorJudgment)</c> (D5).</summary>
+    private static AcceptanceDecision ParseDecisionFailClosed(string? decisionJson)
+    {
+        if (!string.IsNullOrWhiteSpace(decisionJson))
+        {
+            try
+            {
+                var parsed = JsonSerializer.Deserialize<AcceptanceDecision>(decisionJson, SerializerOptions);
+                if (parsed is not null) return parsed;
+            }
+            catch (JsonException)
+            {
+                // fall through to fail-closed escalation
+            }
+        }
+
+        return new AcceptanceDecision.Escalate(
+            AcceptanceEscalationReason.AcceptorJudgment,
+            "unreadable decision payload");
+    }
+
+    /// <summary>Map an <see cref="AcceptanceDecision"/> onto its flowchart outcome edge.</summary>
+    public static string OutcomeFor(AcceptanceDecision decision) => decision switch
+    {
+        AcceptanceDecision.Accept => "Accept",
+        AcceptanceDecision.RequestRevision => "RequestRevision",
+        AcceptanceDecision.Reject => "Reject",
+        AcceptanceDecision.Escalate => "Escalate",
+        _ => "Escalate",
+    };
+
+    /// <summary>The wire <c>kind</c> discriminator for an <see cref="AcceptanceDecision"/>.</summary>
+    public static string KindWireFor(AcceptanceDecision decision) => decision switch
+    {
+        AcceptanceDecision.Accept => "accept",
+        AcceptanceDecision.RequestRevision => "request-revision",
+        AcceptanceDecision.Reject => "reject",
+        AcceptanceDecision.Escalate => "escalate",
+        _ => "escalate",
+    };
+
+    private long ComputeDurationMs(string? requestedAtUtc)
+    {
+        if (TryParseIso(requestedAtUtc, out var requestedAt))
+        {
+            var ms = (long)(DateTimeOffset.UtcNow - requestedAt).TotalMilliseconds;
+            return ms < 0 ? 0 : ms;
+        }
+        return 0;
+    }
+
+    private static bool TryParseIso(string? value, out DateTimeOffset parsed)
+        => DateTimeOffset.TryParse(
+            value, CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out parsed);
+
+    // -----------------------------------------------------------------------
+    // Pure event builders (exposed for unit testing the tag/data mapping)
+    // -----------------------------------------------------------------------
+
+    public static TammaEvent BuildRequestedEvent(
+        Guid sessionId, string? tenantId,
+        string? issueId, string? documentId, string? documentType,
+        string? correlationId, string? rulesReference, string requestedAtUtc)
+    {
+        var tags = BuildApprovalTags(sessionId, tenantId, issueId, documentId, documentType, correlationId);
+
+        var data = new Dictionary<string, object?>
+        {
+            ["channel"] = "orchestrator",
+            ["requestedAtUtc"] = requestedAtUtc,
+        };
+        if (!string.IsNullOrWhiteSpace(rulesReference)) data["rulesReference"] = rulesReference;
+
+        return new TammaEvent
+        {
+            EventType = ApprovalEvents.Requested,
+            Status = ApprovalEvents.StatusForEvent(ApprovalEvents.Requested),
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    public static TammaEvent BuildProvidedEvent(
+        Guid sessionId, string? tenantId,
+        string? issueId, string? documentId, string? documentType,
+        string? correlationId, string? rulesReference,
+        DecisionReadResult read, long durationMs)
+    {
+        var tags = BuildApprovalTags(sessionId, tenantId, issueId, documentId, documentType, correlationId);
+
+        var data = new Dictionary<string, object?>
+        {
+            ["channel"] = read.Channel,
+            ["decisionKind"] = read.DecisionKind,
+            ["durationMs"] = durationMs,
+        };
+        if (!string.IsNullOrWhiteSpace(read.DeciderId)) data["deciderId"] = read.DeciderId;
+        if (!string.IsNullOrWhiteSpace(read.DeciderDisplay)) data["deciderDisplay"] = read.DeciderDisplay;
+        if (!string.IsNullOrWhiteSpace(read.Feedback)) data["feedback"] = read.Feedback;
+        if (!string.IsNullOrWhiteSpace(rulesReference)) data["rulesReference"] = rulesReference;
+
+        return new TammaEvent
+        {
+            EventType = ApprovalEvents.Provided,
+            Status = ApprovalEvents.StatusForEvent(ApprovalEvents.Provided),
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    private static Dictionary<string, object?> BuildApprovalTags(
+        Guid sessionId, string? tenantId,
+        string? issueId, string? documentId, string? documentType, string? correlationId)
+    {
+        var tags = new Dictionary<string, object?> { ["sessionId"] = sessionId.ToString() };
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (!string.IsNullOrWhiteSpace(documentId)) tags["documentId"] = documentId;
+        if (!string.IsNullOrWhiteSpace(documentType)) tags["documentType"] = documentType;
+        if (!string.IsNullOrWhiteSpace(correlationId)) tags["correlationId"] = correlationId;
+        if (ApprovalEvents.ParseTenantId(tenantId) is Guid t) tags["tenantId"] = t.ToString("D");
+        return tags;
+    }
+
+    internal static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Pure result of <see cref="ReadDecision"/> — the parsed decision plus the
+    /// server-derived passthrough fields the callback stamps into the audit trail.</summary>
+    public sealed record DecisionReadResult(
+        AcceptanceDecision Decision,
+        string DecisionJson,
+        string Outcome,
+        string DecisionKind,
+        string? Feedback,
+        string? DeciderId,
+        string? DeciderDisplay,
+        string Channel,
+        string? RulesReference);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentDecisionEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentDecisionEndpoints.cs
@@ -1,0 +1,278 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Api.Services;
+using Tamma.Api.Services.Documents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Logging;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 39-8 (AC5) — the RBAC-gated PUBLIC surface for the ONE generic document-decision
+/// gate and the escalation disposition surface. Mirrors <see cref="AdlEndpoints"/>'s
+/// server-derives-everything posture: the tenant, decider, and channel are derived from the
+/// authenticated principal SERVER-SIDE (D6/D7) — never trusted from the client body — and the
+/// decision <c>kind</c> is validated against the closed 39-5 set before anything forwards.
+///
+/// <para>The public endpoint builds the 39-5 <see cref="AcceptanceDecision"/> JSON server-side
+/// from a small typed request, then forwards to the engine's in-process resume seam
+/// (<c>POST /elsa/api/documents/decision/resume</c>) which folds the caller's ambient tenant
+/// id into the bookmark name (cross-tenant → 404).</para>
+/// </summary>
+public static class DocumentDecisionEndpoints
+{
+    /// <summary>The decision kinds the gate accepts (the closed 39-5 discriminator set). Anything
+    /// else is 400'd up front so the caller never forwards a kind that would silently route the
+    /// gate — the <c>AllowedDesignDecisions</c> posture.</summary>
+    private static readonly HashSet<string> AllowedDecisionKinds =
+        new(StringComparer.OrdinalIgnoreCase) { "accept", "request-revision", "reject", "escalate" };
+
+    private static readonly JsonSerializerOptions DecisionJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// Public decision request. The decider + channel are intentionally ABSENT — they are
+    /// derived from the authenticated principal (D6/D7), never trusted from the client.
+    /// </summary>
+    public sealed record DecisionRequest(
+        string Kind,        // accept | request-revision | reject | escalate
+        string? Notes,      // request-revision notes
+        string? Reason,     // reject reason / escalate reason wire
+        string? Detail,     // escalate detail
+        string? Feedback);  // free-text feedback captured on the trail
+
+    /// <summary>Public disposition request for an escalation.</summary>
+    public sealed record DispositionRequest(
+        string Disposition, // resolved | overridden | abandoned
+        string? Note);
+
+    // ================================================================
+    // POST /api/documents/decisions/{sessionId}/resume
+    // ================================================================
+
+    public static async Task<IResult> ResumeDecision(
+        Guid sessionId,
+        [FromBody] DecisionRequest req,
+        [FromServices] IElsaWorkflowService elsa,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.DocumentDecisionEndpoints");
+
+        if (sessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+        if (string.IsNullOrWhiteSpace(req.Kind) || !AllowedDecisionKinds.Contains(req.Kind.Trim()))
+            return Results.BadRequest(new { error = "kind must be one of: accept, request-revision, reject, escalate" });
+
+        // Build the 39-5 AcceptanceDecision server-side from the validated kind.
+        var decision = BuildDecision(req);
+        var decisionJson = JsonSerializer.Serialize(decision, DecisionJsonOptions);
+
+        // SECURITY (IDOR) — scope the resume to the caller's ambient tenant; the engine folds it
+        // into the bookmark name so a caller can only resolve a gate in its OWN tenant.
+        var tenantId = tenantContext.TenantId?.ToString();
+
+        // D7 — decider derived server-side (non-repudiation). D6 — channel derived from the
+        // authenticated principal, NEVER read from the body.
+        var deciderId = ResolveApprover(principal);
+        var channel = ApprovalChannels.Derive(principal);
+
+        try
+        {
+            var result = await elsa.ResumeDocumentDecisionAsync(
+                sessionId, tenantId, decisionJson, req.Feedback,
+                deciderId, deciderId, channel.ToWire(), rulesReference: null);
+
+            if (result.GateNotFound)
+            {
+                return Results.NotFound(new
+                {
+                    error = "gate_not_waiting",
+                    detail = "No document decision is currently suspended for this session.",
+                });
+            }
+
+            logger.LogInformation(
+                "Drove document-decision gate for session {SessionId} kind {Kind} channel {Channel} (decider {Decider})",
+                sessionId, LogSanitizer.Clean(req.Kind), channel.ToWire(), LogSanitizer.Clean(deciderId));
+
+            return Results.Ok(new
+            {
+                resumed = result.Resumed,
+                workflowInstanceId = result.WorkflowInstanceId,
+                kind = req.Kind.Trim().ToLowerInvariant(),
+                channel = channel.ToWire(),
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to resume document-decision gate for session {SessionId}", sessionId);
+            return Results.Problem(
+                detail: "Failed to resume the document-decision gate.",
+                statusCode: StatusCodes.Status502BadGateway);
+        }
+    }
+
+    // ================================================================
+    // POST /api/documents/escalations/{escalationId}/resolve
+    // ================================================================
+
+    public static async Task<IResult> ResolveEscalation(
+        string escalationId,
+        [FromBody] DispositionRequest req,
+        [FromServices] EscalationDispositionService disposition,
+        [FromServices] ITenantContext tenantContext,
+        ClaimsPrincipal principal,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.DocumentDecisionEndpoints");
+
+        if (string.IsNullOrWhiteSpace(escalationId))
+            return Results.BadRequest(new { error = "escalationId is required" });
+
+        EscalationDisposition parsed;
+        try
+        {
+            parsed = EscalationDispositionExtensions.Parse(req.Disposition);
+        }
+        catch (Tamma.Core.TammaError)
+        {
+            return Results.BadRequest(new { error = "disposition must be one of: resolved, overridden, abandoned" });
+        }
+
+        var tenantId = tenantContext.TenantId;
+        var deciderId = ResolveApprover(principal);
+        var channel = ApprovalChannels.Derive(principal);
+
+        var result = await disposition.DispositionAsync(
+            tenantId, escalationId, parsed, req.Note, deciderId, channel);
+
+        switch (result.Outcome)
+        {
+            case EscalationDispositionOutcome.NotFound:
+                return Results.NotFound(new
+                {
+                    error = "escalation_not_found",
+                    detail = "No triggered escalation exists for this escalationId.",
+                });
+            case EscalationDispositionOutcome.AlreadyResolved:
+                return Results.Conflict(new
+                {
+                    error = "escalation_already_resolved",
+                    detail = "This escalation has already been dispositioned.",
+                });
+            default:
+                logger.LogInformation(
+                    "Dispositioned escalation {EscalationId} as {Disposition} (channel {Channel}, durationMs {Duration})",
+                    LogSanitizer.Clean(escalationId), parsed.ToWire(), channel.ToWire(), result.DurationMs);
+                return Results.Ok(new
+                {
+                    resolved = true,
+                    disposition = parsed.ToWire(),
+                    channel = channel.ToWire(),
+                    durationMs = result.DurationMs,
+                });
+        }
+    }
+
+    // ================================================================
+    // Server-side derivations (copied from AdlEndpoints — I2)
+    // ================================================================
+
+    /// <summary>
+    /// Build the 39-5 <see cref="AcceptanceDecision"/> from the validated public request. A
+    /// human REJECT passes through (it clamps to Escalate only on the orchestrator channel, which
+    /// 39-6's guardrail applies); an escalate reason wire is parsed, defaulting to
+    /// <c>AcceptorJudgment</c> when a human simply chose to escalate.
+    /// </summary>
+    internal static AcceptanceDecision BuildDecision(DecisionRequest req) =>
+        req.Kind.Trim().ToLowerInvariant() switch
+        {
+            "accept" => new AcceptanceDecision.Accept(),
+            "request-revision" => new AcceptanceDecision.RequestRevision(req.Notes ?? req.Feedback ?? string.Empty),
+            "reject" => new AcceptanceDecision.Reject(req.Reason ?? req.Feedback ?? string.Empty),
+            _ => new AcceptanceDecision.Escalate(
+                ParseEscalationReason(req.Reason),
+                req.Detail ?? req.Feedback ?? req.Reason ?? string.Empty),
+        };
+
+    private static AcceptanceEscalationReason ParseEscalationReason(string? wire)
+    {
+        if (!string.IsNullOrWhiteSpace(wire))
+        {
+            foreach (var reason in Enum.GetValues<AcceptanceEscalationReason>())
+                if (string.Equals(reason.ToWire(), wire, StringComparison.OrdinalIgnoreCase))
+                    return reason;
+        }
+        return AcceptanceEscalationReason.AcceptorJudgment;
+    }
+
+    /// <summary>
+    /// Derive the decider identity from the authenticated principal (I2):
+    /// email → display name → subject id. Falls back to <c>"unknown"</c> only if the principal
+    /// carries none of these (it should never, behind auth). Copied from
+    /// <see cref="AdlEndpoints.ResolveApprover"/> per the extraction convention.
+    /// </summary>
+    internal static string ResolveApprover(ClaimsPrincipal principal)
+        => principal.FindFirst(JwtRegisteredClaimNames.Email)?.Value
+           ?? principal.FindFirst(ClaimTypes.Email)?.Value
+           ?? principal.FindFirst("name")?.Value
+           ?? principal.FindFirst(JwtRegisteredClaimNames.Sub)?.Value
+           ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value
+           ?? "unknown";
+}
+
+/// <summary>
+/// Story 39-8 (D6) — the pure derivation of the transport <see cref="ApprovalChannel"/> from
+/// the authenticated principal. There is exactly one rule, expressed as data (never a mode
+/// branch): a principal carrying the orchestrator service claim →
+/// <see cref="ApprovalChannel.Orchestrator"/>; a non-interactive service credential (API-key
+/// auth scheme, or an explicit <c>api</c>/<c>service</c> principal type) →
+/// <see cref="ApprovalChannel.Api"/>; any other authenticated human session →
+/// <see cref="ApprovalChannel.User"/>. NEVER read the channel from the request body.
+///
+/// <para>The orchestrator claim (<c>tamma:principal-type = orchestrator</c>) is minted by the
+/// 39-17 host when it lands; the constant is DEFINED HERE and 39-17/39-18 adopt it. Until then
+/// tests mint the claim directly.</para>
+/// </summary>
+public static class ApprovalChannels
+{
+    /// <summary>The claim key carrying a caller's Tamma principal type.</summary>
+    public const string PrincipalTypeClaim = "tamma:principal-type";
+
+    /// <summary>The principal-type value marking the orchestrator agent (39-17).</summary>
+    public const string OrchestratorPrincipalType = "orchestrator";
+
+    public static ApprovalChannel Derive(ClaimsPrincipal principal)
+    {
+        var principalType = principal.FindFirst(PrincipalTypeClaim)?.Value;
+
+        if (string.Equals(principalType, OrchestratorPrincipalType, StringComparison.OrdinalIgnoreCase))
+            return ApprovalChannel.Orchestrator;
+
+        if (IsServiceCredential(principal, principalType))
+            return ApprovalChannel.Api;
+
+        return ApprovalChannel.User;
+    }
+
+    private static bool IsServiceCredential(ClaimsPrincipal principal, string? principalType)
+    {
+        if (string.Equals(principalType, "api", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(principalType, "service", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // The ApiKey auth scheme stamps AuthenticationType = "ApiKey" on the identity — a
+        // non-interactive programmatic caller.
+        return principal.Identities.Any(i =>
+            string.Equals(i.AuthenticationType, "ApiKey", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -409,6 +409,8 @@ builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.AcceptanceRulesSer
 builder.Services.AddScoped<Tamma.Core.Documents.Policy.IAcceptanceRulesResolver>(
     sp => sp.GetRequiredService<Tamma.Api.Services.AcceptanceRules.AcceptanceRulesService>());
 builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.GetAcceptanceRulesToolFactory>();
+// Story 39-8 — the escalation disposition surface (appends ESCALATION.RESOLVED, FAIL-LOUD).
+builder.Services.AddScoped<Tamma.Api.Services.Documents.EscalationDispositionService>();
 builder.Services.AddProviderHealthServices();
 builder.Services.AddDiagnosticsServices();
 builder.Services.AddSanitizationServices();
@@ -2838,6 +2840,20 @@ adl.MapPost("/clarify/resume", AdlEndpoints.ResumeClarify);
 // derived server-side (I2). IDOR guard: the engine folds the caller's ambient tenant
 // id into the bookmark name, so a cross-tenant/unknown session → 404.
 adl.MapPost("/design/resume", AdlEndpoints.ResumeDesign);
+
+// ── Story 39-8: generic document-decision gate + escalation disposition ──
+// The ONE generic decision gate's public surface (resume) + the escalation disposition
+// surface. D10 — AuthenticatedAny, DEVIATING from the adl group's WorkflowsManage: AC5 says
+// SaaS deciders are tenant MEMBERS per RBAC, and the whole point of orchestrator-assigned
+// decisions (Task View, 39-20) is that member users decide — WorkflowsManage (owner/admin)
+// would 403 exactly the assigned decider. Security still holds: tenant folding + a 128-bit
+// session id (cross-tenant → 404, unguessable within tenant). Per-assignee authorization
+// ("only the user the orchestrator assigned") is 39-20's ITaskAudienceResolver — recorded
+// here as explicit MIGRATION DEBT (the convention-store-deviation style), not an oversight.
+// Single-user mode folds the sole user's scope (ambient tenant null → "none" segment).
+var documents = app.MapGroup("/api/documents").RequireAuthorization("AuthenticatedAny");
+documents.MapPost("/decisions/{sessionId}/resume", DocumentDecisionEndpoints.ResumeDecision);
+documents.MapPost("/escalations/{escalationId}/resolve", DocumentDecisionEndpoints.ResolveEscalation);
 
 // ── GitHub App (no auth, webhook signature verification) ──
 // Audit finding 017 — webhook gets the GitHubWebhook policy (300/min). The

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Documents/EscalationDispositionService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Documents/EscalationDispositionService.cs
@@ -1,0 +1,163 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Documents;
+
+/// <summary>
+/// Story 39-8 (AC1/AC3, D9) — the escalation DISPOSITION surface. Because the
+/// lifecycle has already EXITED when an escalation exists, dispositioning is not a
+/// workflow resume: this service appends the <c>ESCALATION.RESOLVED</c> DCB event
+/// directly, pairing on the <c>escalationId</c> tag of the originating
+/// <c>ESCALATION.TRIGGERED</c> to compute the denormalized <c>durationMs</c> and
+/// refusing a duplicate disposition.
+///
+/// <para><b>FAIL-LOUD, deliberately UNLIKE <see cref="Tamma.Api.Services.PromptStore.PromptEventsService"/>.</b>
+/// There the event is a best-effort audit side-car of a prompt mutation, so a store
+/// failure is swallowed. HERE the event IS the operation — an append that silently
+/// dropped would leave the escalation un-dispositioned with the caller believing it
+/// was resolved — so append failures propagate.</para>
+///
+/// <para><b>Disposition race (accepted).</b> <c>AppendAsync</c> has no unique
+/// constraint on <c>escalationId</c>; the 409 check is read-then-write, so two
+/// concurrent resolvers could both append. A rare double-RESOLVED is visible and
+/// reconcilable on the stream (last-write-wins for dashboards) — noted here rather
+/// than adding a table this story does not need.</para>
+/// </summary>
+public sealed class EscalationDispositionService
+{
+    // Bound on the pairing scan — an escalation is dispositioned close to when it triggers, so
+    // the most-recent window comfortably covers a live escalation without an unbounded read.
+    private const int PairingScanLimit = 500;
+
+    private readonly IEventRepository _events;
+    private readonly ILogger<EscalationDispositionService>? _logger;
+
+    public EscalationDispositionService(IEventRepository events, ILogger<EscalationDispositionService>? logger = null)
+    {
+        _events = events;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Disposition the escalation identified by <paramref name="escalationId"/>. Returns
+    /// <see cref="EscalationDispositionOutcome.NotFound"/> when no paired
+    /// <c>ESCALATION.TRIGGERED</c> exists (→ 404), <see cref="EscalationDispositionOutcome.AlreadyResolved"/>
+    /// when the escalation was already dispositioned (→ 409), or
+    /// <see cref="EscalationDispositionOutcome.Resolved"/> after appending the
+    /// <c>ESCALATION.RESOLVED</c> event (→ 200).
+    /// </summary>
+    public async Task<EscalationDispositionResult> DispositionAsync(
+        Guid? tenantId,
+        string escalationId,
+        EscalationDisposition disposition,
+        string? note,
+        string deciderId,
+        ApprovalChannel channel)
+    {
+        if (string.IsNullOrWhiteSpace(escalationId))
+            return new EscalationDispositionResult(EscalationDispositionOutcome.NotFound, 0);
+
+        // Pair on the ESCALATION.TRIGGERED carrying this escalationId (D9).
+        var triggered = await _events.QueryAsync(tenantId, ApprovalEvents.EscalationTriggered, null, PairingScanLimit);
+        var trigger = triggered.FirstOrDefault(e => TagValue(e, "escalationId") == escalationId);
+        if (trigger is null)
+        {
+            _logger?.LogWarning("No ESCALATION.TRIGGERED found for escalationId {EscalationId}", escalationId);
+            return new EscalationDispositionResult(EscalationDispositionOutcome.NotFound, 0);
+        }
+
+        // Refuse a duplicate disposition (409).
+        var resolved = await _events.QueryAsync(tenantId, ApprovalEvents.EscalationResolved, null, PairingScanLimit);
+        if (resolved.Any(e => TagValue(e, "escalationId") == escalationId))
+        {
+            _logger?.LogWarning("Escalation {EscalationId} already dispositioned", escalationId);
+            return new EscalationDispositionResult(EscalationDispositionOutcome.AlreadyResolved, 0);
+        }
+
+        var durationMs = (long)(DateTime.UtcNow - DateTime.SpecifyKind(trigger.CreatedAt, DateTimeKind.Utc)).TotalMilliseconds;
+        if (durationMs < 0) durationMs = 0;
+
+        // Copy the trigger's queryable tags so the RESOLVED row pairs on the stream, and add the
+        // escalationId (always) even if the trigger had it only structurally.
+        var tags = CopyTags(trigger, "issueId", "documentId", "documentType", "correlationId");
+        tags["escalationId"] = escalationId;
+        if (tenantId is not null) tags["tenantId"] = tenantId.Value.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["disposition"] = disposition.ToWire(),
+            ["resolvedBy"] = deciderId,
+            ["channel"] = channel.ToWire(),
+            ["durationMs"] = durationMs,
+        };
+        if (!string.IsNullOrWhiteSpace(note)) data["note"] = note;
+
+        var metadata = new Dictionary<string, object?>
+        {
+            ["workflowVersion"] = "1.0.0",
+            ["eventSource"] = "system",
+        };
+
+        var evt = new DomainEvent
+        {
+            Type = ApprovalEvents.EscalationResolved,
+            TenantId = tenantId,
+            IssueNumber = trigger.IssueNumber,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = JsonSerializer.Serialize(metadata),
+            Data = JsonSerializer.Serialize(data),
+        };
+
+        // FAIL-LOUD — the event IS the operation; an append failure must propagate.
+        await _events.AppendAsync(evt);
+
+        _logger?.LogInformation(
+            "Dispositioned escalation {EscalationId} as {Disposition} (durationMs={Duration})",
+            escalationId, disposition.ToWire(), durationMs);
+
+        return new EscalationDispositionResult(EscalationDispositionOutcome.Resolved, durationMs);
+    }
+
+    private static string? TagValue(DomainEvent evt, string key)
+    {
+        if (string.IsNullOrWhiteSpace(evt.Tags)) return null;
+        try
+        {
+            using var doc = JsonDocument.Parse(evt.Tags);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                   && doc.RootElement.TryGetProperty(key, out var v)
+                ? v.ValueKind == JsonValueKind.String ? v.GetString() : v.ToString()
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static Dictionary<string, object?> CopyTags(DomainEvent evt, params string[] keys)
+    {
+        var tags = new Dictionary<string, object?>();
+        foreach (var key in keys)
+        {
+            var value = TagValue(evt, key);
+            if (!string.IsNullOrWhiteSpace(value)) tags[key] = value;
+        }
+        return tags;
+    }
+}
+
+/// <summary>Terminal outcome of a disposition attempt (maps to 200/404/409).</summary>
+public enum EscalationDispositionOutcome
+{
+    Resolved,
+    NotFound,
+    AlreadyResolved,
+}
+
+/// <summary>Result of <see cref="EscalationDispositionService.DispositionAsync"/>.</summary>
+public sealed record EscalationDispositionResult(EscalationDispositionOutcome Outcome, long DurationMs);

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -556,6 +556,55 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
             WorkflowInstanceId: result?.WorkflowInstanceId);
     }
 
+    /// <summary>
+    /// Story 39-8 — forward a document-decision gate resume to the engine's in-process resume
+    /// endpoint, which looks up the tenant+session-scoped
+    /// <c>document-decision-{tenant}-{session}</c> bookmark and runs the owning instance with
+    /// the decision payload injected. A 404 (no gate waiting) is surfaced as
+    /// <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    /// </summary>
+    public async Task<MergeApprovalResumeResult> ResumeDocumentDecisionAsync(
+        Guid sessionId, string? tenantId, string decisionJson, string? feedback,
+        string? deciderId, string? deciderDisplay, string channel, string? rulesReference)
+    {
+        _logger.LogInformation(
+            "Resuming document-decision gate for session {SessionId} (channel={Channel})", sessionId, channel);
+
+        await EnsureHealthyAsync();
+
+        var payload = new
+        {
+            sessionId,
+            // Tenant scopes the engine's bookmark lookup (folded into the name).
+            tenantId,
+            decisionJson,
+            feedback,
+            // Server-derived identity + channel (D6/D7), forwarded for the engine's audit log.
+            deciderId,
+            deciderDisplay,
+            channel,
+            rulesReference,
+        };
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "/elsa/api/documents/decision/resume", payload, JsonOptions);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            _logger.LogWarning(
+                "No document-decision gate waiting for session {SessionId}", sessionId);
+            return new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null);
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<EngineResumeResponse>(JsonOptions);
+        return new MergeApprovalResumeResult(
+            Resumed: result?.Resumed ?? true,
+            GateNotFound: false,
+            WorkflowInstanceId: result?.WorkflowInstanceId);
+    }
+
     private sealed class EngineResumeResponse
     {
         public bool Resumed { get; set; }

--- a/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/IElsaWorkflowService.cs
@@ -117,6 +117,25 @@ public interface IElsaWorkflowService
     /// </summary>
     Task<MergeApprovalResumeResult> ResumeDesignApprovalAsync(
         Guid sessionId, string? tenantId, bool approved, string? feedback, string? reviewer);
+
+    /// <summary>
+    /// Story 39-8 — resume the ONE generic document-decision gate. Forwards to the engine's
+    /// in-process resume endpoint (which owns <c>IBookmarkStore</c>/<c>IWorkflowRuntime</c>),
+    /// which looks up the tenant+session-scoped <c>document-decision-{tenant}-{session}</c>
+    /// bookmark and runs the owning instance with the
+    /// <c>{DecisionJson, Feedback, DeciderId, DeciderDisplay, Channel, RulesReference}</c>
+    /// payload injected (the gate maps <c>DecisionJson</c> onto the 39-5 <c>AcceptanceDecision</c>
+    /// and branches Accept/RequestRevision/Reject/Escalate off it). A 404 (no wait suspended) is
+    /// surfaced as <see cref="MergeApprovalResumeResult.GateNotFound"/> rather than thrown.
+    ///
+    /// <para>SECURITY — the bookmark name folds in <paramref name="tenantId"/> (the caller's
+    /// ambient tenant, derived server-side), so a caller can only ever resolve a gate in its OWN
+    /// tenant (cross-tenant → 404). <paramref name="deciderId"/>/<paramref name="channel"/> are
+    /// server-derived (D6/D7), never trusted from the client body.</para>
+    /// </summary>
+    Task<MergeApprovalResumeResult> ResumeDocumentDecisionAsync(
+        Guid sessionId, string? tenantId, string decisionJson, string? feedback,
+        string? deciderId, string? deciderDisplay, string channel, string? rulesReference);
 }
 
 /// <summary>Outcome of a merge-approval (or deploy-approval) gate resume.</summary>

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/EscalationDisposition.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/EscalationDisposition.cs
@@ -1,0 +1,67 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// How an escalation was ultimately dispositioned (Story 39-8 AC1 — the
+/// <c>ESCALATION.RESOLVED</c> clause). A NEW <c>[Wire]</c> enum OWNED HERE by
+/// 39-8 (a drift-tested closed set; 39-18's typed messages reuse it):
+///
+/// <list type="bullet">
+/// <item><c>resolved</c> — the escalation was handled and the underlying decision
+///   stands (the exception is closed on its merits).</item>
+/// <item><c>overridden</c> — a human overrode the escalated outcome (e.g. forced
+///   an accept/reject the autonomous path could not take).</item>
+/// <item><c>abandoned</c> — the escalation was closed without a substantive
+///   decision (the work was dropped / superseded).</item>
+/// </list>
+///
+/// <para><see cref="ApprovalChannel"/> (<c>orchestrator | user | api</c>) is a
+/// SEPARATE enum DEFINED BY 39-5 (<c>Tamma.Core/Documents/ApprovalChannel.cs</c>)
+/// — it is referenced by 39-8, never redeclared here.</para>
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<EscalationDisposition>))]
+public enum EscalationDisposition
+{
+    [Wire("resolved")]   Resolved,
+    [Wire("overridden")] Overridden,
+    [Wire("abandoned")]  Abandoned,
+}
+
+/// <summary><see cref="EscalationDisposition"/> wire helper.</summary>
+public static class EscalationDispositionExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="disposition"/>.</summary>
+    public static string ToWire(this EscalationDisposition disposition) =>
+        EnumWire<EscalationDisposition>.ToWire(disposition);
+
+    /// <summary>
+    /// Resolves a wire string to an <see cref="EscalationDisposition"/>.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>ESCALATION.DISPOSITION.UNKNOWN</c> for null, empty, or unknown input.
+    /// </exception>
+    public static EscalationDisposition Parse(string input)
+    {
+        if (!string.IsNullOrWhiteSpace(input) && EnumWire<EscalationDisposition>.TryParse(input, out var disposition))
+            return disposition;
+
+        throw new TammaError(
+            "ESCALATION.DISPOSITION.UNKNOWN",
+            $"Unknown escalation disposition: '{input}'. Valid dispositions: {string.Join(", ", Enum.GetValues<EscalationDisposition>().Select(d => d.ToWire()))}.",
+            new Dictionary<string, object?> { ["input"] = input },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>Non-throwing wire lookup for an <see cref="EscalationDisposition"/>.</summary>
+    public static bool TryParse(string? input, out EscalationDisposition disposition)
+    {
+        if (!string.IsNullOrWhiteSpace(input))
+            return EnumWire<EscalationDisposition>.TryParse(input, out disposition);
+        disposition = default;
+        return false;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DocumentDecisionResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DocumentDecisionResumeEndpoint.cs
@@ -1,0 +1,158 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Activities.Documents;
+
+namespace Tamma.ElsaServer.Endpoints;
+
+/// <summary>
+/// Story 39-8 (AC5) — the generic engine-side resume seam for the ONE document-decision
+/// gate (<see cref="WaitForDocumentDecisionActivity"/>). Mirrors
+/// <see cref="DesignResumeEndpoint"/> byte-for-byte in security posture; it generalizes the
+/// convention the five existing <c>*ResumeEndpoint.cs</c> prove (which stay as-is — this is
+/// EXTRACTION, not migration).
+///
+/// <para>The gate suspends on the tenant-folded bookmark
+/// <c>document-decision-{tenant}-{session}</c> and, on resume, reads
+/// <c>{DecisionJson, Feedback, DeciderId, DeciderDisplay, Channel, RulesReference}</c> from
+/// the workflow input. This endpoint looks the bookmark up by name, then runs the owning
+/// instance from that bookmark with the decision payload INJECTED as workflow input
+/// (<c>IWorkflowClient.RunInstanceAsync</c> with <c>RunWorkflowInstanceRequest.Input</c>,
+/// which lands in <c>ActivityExecutionContext.WorkflowInput</c> the gate reads). The gate
+/// branches to its <c>Accept</c>/<c>RequestRevision</c>/<c>Reject</c>/<c>Escalate</c> outcome
+/// off the mapped 39-5 <c>AcceptanceDecision</c>.</para>
+///
+/// <para>Self-decision (orchestrator) and assigned-human decision resume this SAME bookmark —
+/// only the server-derived <c>DeciderId</c>/<c>Channel</c> vary; the gate is identical
+/// (AC4).</para>
+///
+/// <para><b>SECURITY (mirrors the design/merge/deploy/clarify gate posture):</b>
+/// <list type="bullet">
+///   <item><description><b>No IDOR</b> — the bookmark name carries the tenant id the
+///   (tenant-scoped) <c>Tamma.Api</c> caller supplies (derived server-side, never trusted
+///   from the client). A caller scoped to tenant A computes a name with tenant A, so it can
+///   NEVER resolve tenant B's gate: a cross-tenant attempt simply 404s. The session id is an
+///   unguessable 128-bit Guid, so within a tenant the name is unguessable too.</description></item>
+///   <item><description><b>Collision refusal</b> — the name is globally unique (tenant +
+///   session); &gt;1 match is an integrity violation, so we REFUSE with 409 rather than
+///   resume an arbitrary <c>bookmarks[0]</c>.</description></item>
+///   <item><description><b>Engine-service-only</b> — the route is mapped with
+///   <c>.RequireAuthorization()</c> in <c>Program.cs</c> so only the Tamma.Api→engine hop
+///   reaches it; anonymous public callers get 401. It is also excluded from the public nginx
+///   <c>/elsa/api/</c> block (internal hop only).</description></item>
+/// </list></para>
+/// </summary>
+public static class DocumentDecisionResumeEndpoint
+{
+    public sealed record ResumeRequest(
+        Guid SessionId,
+        // Tenant scope — folded into the bookmark name so the lookup can only match a gate in
+        // the caller's own tenant. Supplied by the tenant-scoped Tamma.Api caller.
+        string? TenantId,
+        // The serialized 39-5 AcceptanceDecision (validated + built server-side by Tamma.Api).
+        string DecisionJson,
+        // Decider feedback / notes (optional; captured on the audit trail either way).
+        string? Feedback,
+        // Non-repudiation — the acting identity, derived server-side by Tamma.Api from the
+        // authenticated principal. Never trusted from a client.
+        string? DeciderId,
+        string? DeciderDisplay,
+        // The server-derived transport channel (orchestrator|user|api) — D6, never body-trusted.
+        string Channel,
+        // The resolved-rules reference the decision was made under (server-stamped).
+        string? RulesReference);
+
+    /// <summary>Bookmark name the gate registers — delegates to the SINGLE canonical builder
+    /// shared with <see cref="WaitForDocumentDecisionActivity"/> so suspend-side and resume-side
+    /// names match byte-for-byte.</summary>
+    public static string BookmarkName(ResumeRequest request)
+        => WaitForDocumentDecisionActivity.DecisionBookmarkName(request.TenantId, request.SessionId);
+
+    public static async Task<IResult> Resume(
+        [FromBody] ResumeRequest request,
+        [FromServices] IBookmarkStore bookmarkStore,
+        [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] ILoggerFactory loggerFactory,
+        CancellationToken ct)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.ElsaServer.DocumentDecisionResume");
+
+        if (request.SessionId == Guid.Empty)
+            return Results.BadRequest(new { error = "sessionId is required" });
+
+        // The name carries the caller's tenant + session. A caller in tenant A produces a name
+        // keyed by tenant A and therefore can only ever resolve tenant A's gate.
+        var name = BookmarkName(request);
+
+        var bookmarks = (await bookmarkStore
+            .FindManyAsync(new BookmarkFilter { Name = name }, ct)
+            .ConfigureAwait(false)).ToList();
+
+        if (bookmarks.Count == 0)
+        {
+            logger.LogWarning(
+                "No suspended document-decision bookmark {Bookmark} — gate not waiting (already decided/advanced, wrong session, or wrong tenant)",
+                name);
+            return Results.NotFound(new
+            {
+                error = "bookmark_not_found",
+                bookmark = name,
+                detail = "No document decision is currently suspended for this session.",
+            });
+        }
+
+        // The name is unique per tenant+session; >1 match is an integrity violation, not a
+        // "pick the first" situation. REFUSE rather than resume an arbitrary instance.
+        if (bookmarks.Count > 1)
+        {
+            logger.LogError(
+                "Ambiguous document-decision bookmark {Bookmark}: {Count} live instances — refusing to resume an arbitrary one",
+                name, bookmarks.Count);
+            return Results.Conflict(new
+            {
+                error = "ambiguous_bookmark",
+                bookmark = name,
+                count = bookmarks.Count,
+                detail = "Multiple workflow instances are waiting on this decision bookmark; refusing to resume an arbitrary one.",
+            });
+        }
+
+        var bookmark = bookmarks[0];
+
+        // Inject the payload using the EXACT keys the suspend-side callback reads
+        // (WaitForDocumentDecisionActivity.ReadDecision).
+        var input = new Dictionary<string, object>
+        {
+            ["DecisionJson"] = request.DecisionJson ?? string.Empty,
+            ["Feedback"] = request.Feedback ?? string.Empty,
+            ["DeciderId"] = request.DeciderId ?? string.Empty,
+            ["DeciderDisplay"] = request.DeciderDisplay ?? string.Empty,
+            ["Channel"] = request.Channel ?? string.Empty,
+            ["RulesReference"] = request.RulesReference ?? string.Empty,
+        };
+
+        var client = await workflowRuntime
+            .CreateClientAsync(bookmark.WorkflowInstanceId, ct)
+            .ConfigureAwait(false);
+
+        await client.RunInstanceAsync(
+            new RunWorkflowInstanceRequest
+            {
+                BookmarkId = bookmark.Id,
+                Input = input,
+            },
+            ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Resumed document-decision gate {Bookmark} (instance {InstanceId}) channel={Channel} decider={Decider}",
+            name, bookmark.WorkflowInstanceId, request.Channel, request.DeciderId ?? "unknown");
+
+        return Results.Ok(new
+        {
+            resumed = true,
+            bookmark = name,
+            workflowInstanceId = bookmark.WorkflowInstanceId,
+        });
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -437,6 +437,18 @@ app.MapPost("/elsa/api/adl/design/resume",
     Tamma.ElsaServer.Endpoints.DesignResumeEndpoint.Resume)
     .RequireAuthorization();
 
+// Story 39-8 — in-process resume seam for the ONE generic document-decision gate.
+// Tamma.Api's RBAC-gated, tenant-scoped POST /api/documents/decisions/{sessionId}/resume
+// forwards here; this endpoint looks up the tenant+session-scoped
+// document-decision-{tenant}-{session} bookmark and runs the owning instance with the
+// {DecisionJson, Feedback, DeciderId, DeciderDisplay, Channel, RulesReference} payload
+// injected (the gate maps DecisionJson onto the 39-5 AcceptanceDecision and branches
+// Accept/RequestRevision/Reject/Escalate off it). Same engine-control-surface /
+// RequireAuthorization rationale as the merge/deploy/blocker/clarify/design gates.
+app.MapPost("/elsa/api/documents/decision/resume",
+    Tamma.ElsaServer.Endpoints.DocumentDecisionResumeEndpoint.Resume)
+    .RequireAuthorization();
+
 app.UseSerilogRequestLogging();
 
 Log.Information("Tamma ELSA Server starting up...");

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/ApprovalEventsTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/ApprovalEventsTests.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC1 constants, AC6 mapping half). Pins the exact four event-type constant
+/// strings + the <see cref="ApprovalEvents.StatusForEvent"/> mapping, and the
+/// <see cref="EmitEscalationEventActivity.BuildTammaEvent"/> tag/data mapping — crucially that
+/// the document lineage is embedded as a nested JSON OBJECT (never a bare string).
+/// </summary>
+[TestFixture]
+public class ApprovalEventsTests
+{
+    [Test]
+    public void Constant_strings_are_pinned()
+    {
+        ApprovalEvents.Requested.Should().Be("APPROVAL.REQUESTED");
+        ApprovalEvents.Provided.Should().Be("APPROVAL.PROVIDED");
+        ApprovalEvents.EscalationTriggered.Should().Be("ESCALATION.TRIGGERED");
+        ApprovalEvents.EscalationResolved.Should().Be("ESCALATION.RESOLVED");
+    }
+
+    [Test]
+    public void StatusForEvent_TriggeredIsErrorRow_RequestedIsStarted_RestSuccess()
+    {
+        ApprovalEvents.StatusForEvent(ApprovalEvents.EscalationTriggered).Should().Be("error",
+            "the exception surface is a LOUD error row");
+        ApprovalEvents.StatusForEvent(ApprovalEvents.Requested).Should().Be("started");
+        ApprovalEvents.StatusForEvent(ApprovalEvents.Provided).Should().Be("success",
+            "a decision (incl. a human reject) is a legitimate transition, not an error");
+        ApprovalEvents.StatusForEvent(ApprovalEvents.EscalationResolved).Should().Be("success");
+    }
+
+    [Test]
+    public void ParseTenantId_returns_null_for_empty_or_unparseable()
+    {
+        ApprovalEvents.ParseTenantId(null).Should().BeNull();
+        ApprovalEvents.ParseTenantId("").Should().BeNull();
+        ApprovalEvents.ParseTenantId("not-a-guid").Should().BeNull();
+        var g = Guid.NewGuid();
+        ApprovalEvents.ParseTenantId(g.ToString()).Should().Be(g);
+    }
+
+    [Test]
+    public void BuildTammaEvent_Triggered_MapsTagsAndData_AndEmbedsLineageAsObject()
+    {
+        var tenant = Guid.NewGuid();
+        var lineageJson = "{\"drafts\":[{\"id\":\"d1\",\"state\":\"draft\"}],\"roundsUsed\":2}";
+
+        var evt = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationTriggered,
+            escalationId: "esc-1",
+            outcome: "rounds-exhausted",
+            lineageJson: lineageJson,
+            rulesReference: "system-default@3",
+            channel: "orchestrator",
+            issueId: "issue-9",
+            documentId: "doc-7",
+            documentType: "design",
+            correlationId: "corr-5",
+            sessionId: "sess-3",
+            tenantId: tenant,
+            detail: "rounds ran out");
+
+        evt.EventType.Should().Be(ApprovalEvents.EscalationTriggered);
+        evt.Status.Should().Be("error");
+
+        evt.Tags!["issueId"].Should().Be("issue-9");
+        evt.Tags!["documentId"].Should().Be("doc-7");
+        evt.Tags!["documentType"].Should().Be("design");
+        evt.Tags!["correlationId"].Should().Be("corr-5");
+        evt.Tags!["escalationId"].Should().Be("esc-1");
+        evt.Tags!["sessionId"].Should().Be("sess-3");
+        evt.Tags!["tenantId"].Should().Be(tenant.ToString("D"));
+
+        evt.Data["outcome"].Should().Be("rounds-exhausted");
+        evt.Data["rulesReference"].Should().Be("system-default@3");
+        evt.Data["channel"].Should().Be("orchestrator");
+        evt.Data["detail"].Should().Be("rounds ran out");
+
+        // AC6 — lineage is a nested JSON object, NOT a bare string.
+        evt.Data["lineage"].Should().BeAssignableTo<JsonNode>();
+        var node = (JsonNode)evt.Data["lineage"]!;
+        node.GetValueKind().Should().Be(JsonValueKind.Object,
+            "the lineage payload must be a JSON object so a handler can read every field");
+        node["roundsUsed"]!.GetValue<int>().Should().Be(2);
+    }
+
+    [Test]
+    public void BuildTammaEvent_MalformedLineage_IsWrappedNeverBareString()
+    {
+        var evt = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationTriggered, "esc-2", "acceptor-judgment",
+            lineageJson: "not json", rulesReference: null, channel: null,
+            issueId: null, documentId: null, documentType: null, correlationId: null,
+            sessionId: null, tenantId: null, detail: null);
+
+        evt.Data["lineage"].Should().BeAssignableTo<JsonNode>();
+        ((JsonNode)evt.Data["lineage"]!).GetValueKind().Should().Be(JsonValueKind.Object,
+            "even a malformed lineage must be wrapped in an object, never surfaced as a bare string");
+    }
+
+    [Test]
+    public void BuildTammaEvent_Resolved_IsSuccessRow()
+    {
+        var evt = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationResolved, "esc-3", null,
+            lineageJson: "{}", rulesReference: null, channel: "user",
+            issueId: "i", documentId: "d", documentType: "t", correlationId: "c",
+            sessionId: "s", tenantId: null, detail: null);
+
+        evt.Status.Should().Be("success");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/ApprovalPairingReconstructionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/ApprovalPairingReconstructionTests.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Core;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC3 — the pairing test). From a captured event list ALONE, a consumer must be
+/// able to pair <c>REQUESTED↔PROVIDED</c> (via <c>correlationId</c>+<c>sessionId</c>) and
+/// <c>TRIGGERED↔RESOLVED</c> (via <c>escalationId</c>) and recompute time-to-resolve, and that
+/// recomputed duration must match the DENORMALIZED <c>durationMs</c> the resolving event
+/// carries — so dashboards never need a stream join.
+/// </summary>
+[TestFixture]
+public class ApprovalPairingReconstructionTests
+{
+    [Test]
+    public void RequestedProvided_PairByCorrelationAndSession_ReconstructsDuration()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid();
+        var requestedAt = new DateTimeOffset(2026, 7, 22, 10, 0, 0, TimeSpan.Zero);
+        const long durationMs = 5_000;
+
+        var requested = WaitForDocumentDecisionActivity.BuildRequestedEvent(
+            session, tenant.ToString(), issueId: "issue-9", documentId: "doc-7",
+            documentType: "design", correlationId: "corr-5", rulesReference: "system-default@1",
+            requestedAtUtc: requestedAt.ToString("O", CultureInfo.InvariantCulture));
+
+        var read = new WaitForDocumentDecisionActivity.DecisionReadResult(
+            new AcceptanceDecision.Accept(), "{\"kind\":\"accept\"}", "Accept", "accept",
+            Feedback: "ok", DeciderId: "alice@x.test", DeciderDisplay: "Alice", Channel: "user",
+            RulesReference: "system-default@1");
+
+        var provided = WaitForDocumentDecisionActivity.BuildProvidedEvent(
+            session, tenant.ToString(), "issue-9", "doc-7", "design", "corr-5", "system-default@1",
+            read, durationMs);
+        // The PROVIDED event fires at requestedAt + durationMs.
+        provided.Timestamp = requestedAt.UtcDateTime.AddMilliseconds(durationMs);
+
+        var stream = new List<TammaEvent> { requested, provided };
+
+        // Pair from the stream alone.
+        var req = stream.Single(e => e.EventType == ApprovalEvents.Requested);
+        var prov = stream.Single(e =>
+            e.EventType == ApprovalEvents.Provided
+            && (string?)e.Tags!["correlationId"] == (string?)req.Tags!["correlationId"]
+            && (string?)e.Tags!["sessionId"] == (string?)req.Tags!["sessionId"]);
+
+        var reqAt = DateTimeOffset.Parse((string)req.Data["requestedAtUtc"]!, CultureInfo.InvariantCulture);
+        var reconstructed = (long)(new DateTimeOffset(prov.Timestamp, TimeSpan.Zero) - reqAt).TotalMilliseconds;
+
+        reconstructed.Should().Be((long)prov.Data["durationMs"]!,
+            "the denormalized durationMs must equal the duration recomputed from the paired REQUESTED event");
+        reconstructed.Should().Be(durationMs);
+    }
+
+    [Test]
+    public void TriggeredResolved_PairByEscalationId_ReconstructsDuration()
+    {
+        var triggeredAt = new DateTimeOffset(2026, 7, 22, 11, 0, 0, TimeSpan.Zero);
+        const long durationMs = 12_000;
+        const string escalationId = "esc-42";
+
+        var triggered = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationTriggered, escalationId, outcome: "rounds-exhausted",
+            lineageJson: "{\"roundsUsed\":3}", rulesReference: "system-default@1", channel: "orchestrator",
+            issueId: "issue-9", documentId: "doc-7", documentType: "design", correlationId: "corr-5",
+            sessionId: "sess-3", tenantId: null, detail: "rounds ran out");
+        triggered.Timestamp = triggeredAt.UtcDateTime;
+
+        // The RESOLVED event (appended by the Api disposition service) mirrors the escalationId tag
+        // and carries the denormalized durationMs.
+        var resolved = new TammaEvent
+        {
+            EventType = ApprovalEvents.EscalationResolved,
+            Status = "success",
+            Timestamp = triggeredAt.UtcDateTime.AddMilliseconds(durationMs),
+            Tags = new Dictionary<string, object?> { ["escalationId"] = escalationId, ["correlationId"] = "corr-5" },
+            Data = new Dictionary<string, object?> { ["disposition"] = "resolved", ["durationMs"] = durationMs },
+        };
+
+        var stream = new List<TammaEvent> { triggered, resolved };
+
+        var trig = stream.Single(e => e.EventType == ApprovalEvents.EscalationTriggered);
+        var res = stream.Single(e =>
+            e.EventType == ApprovalEvents.EscalationResolved
+            && (string?)e.Tags!["escalationId"] == (string?)trig.Tags!["escalationId"]);
+
+        var reconstructed = (long)(res.Timestamp - trig.Timestamp).TotalMilliseconds;
+
+        reconstructed.Should().Be((long)res.Data["durationMs"]!,
+            "the RESOLVED durationMs must equal the duration recomputed from the paired TRIGGERED event");
+        reconstructed.Should().Be(durationMs);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/DocumentDecisionReadBackTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/DocumentDecisionReadBackTests.cs
@@ -1,0 +1,172 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC4). The generic gate's resume callback must read the injected decision
+/// tolerant of a SERIALIZING workflow runtime (the #15/#437 lesson), map each 39-5
+/// <c>kind</c> onto the right flowchart outcome, and FAIL-CLOSE an unparseable
+/// <c>DecisionJson</c> to <c>Escalate(AcceptorJudgment)</c> — never a mis-branch that returns
+/// 200 while advancing the wrong edge. Also covers the canonical bookmark-name builder
+/// (suspend/resume parity + tenant folding + hostile-segment normalization).
+/// </summary>
+[TestFixture]
+public class DocumentDecisionReadBackTests
+{
+    private static IDictionary<string, object> Input(params (string Key, object Value)[] entries)
+    {
+        var dict = new Dictionary<string, object>();
+        foreach (var (key, value) in entries)
+            dict[key] = value;
+        return dict;
+    }
+
+    private static JsonElement JsonStr(string s) => JsonDocument.Parse(JsonSerializer.Serialize(s)).RootElement;
+
+    // ── kind → outcome mapping ─────────────────────────────────────────────
+
+    [Test]
+    public void ReadDecision_Accept_MapsToAcceptOutcome()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "{\"kind\":\"accept\"}")));
+        read.Outcome.Should().Be("Accept");
+        read.DecisionKind.Should().Be("accept");
+        read.Decision.Should().BeOfType<AcceptanceDecision.Accept>();
+    }
+
+    [Test]
+    public void ReadDecision_RequestRevision_MapsToRequestRevisionOutcome()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "{\"kind\":\"request-revision\",\"notes\":\"tighten the data model\"}")));
+        read.Outcome.Should().Be("RequestRevision");
+        read.DecisionKind.Should().Be("request-revision");
+        read.Decision.Should().BeOfType<AcceptanceDecision.RequestRevision>()
+            .Which.Notes.Should().Be("tighten the data model");
+    }
+
+    [Test]
+    public void ReadDecision_Reject_MapsToRejectOutcome()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "{\"kind\":\"reject\",\"reason\":\"wrong approach\"}")));
+        read.Outcome.Should().Be("Reject");
+        read.DecisionKind.Should().Be("reject");
+        read.Decision.Should().BeOfType<AcceptanceDecision.Reject>()
+            .Which.Reason.Should().Be("wrong approach");
+    }
+
+    [Test]
+    public void ReadDecision_Escalate_MapsToEscalateOutcome()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "{\"kind\":\"escalate\",\"reason\":\"acceptor-judgment\",\"detail\":\"unsure\"}")));
+        read.Outcome.Should().Be("Escalate");
+        read.DecisionKind.Should().Be("escalate");
+        read.Decision.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.AcceptorJudgment);
+    }
+
+    // ── fail-closed on garbage (D5) ────────────────────────────────────────
+
+    [Test]
+    public void ReadDecision_UnparseableJson_FailClosesToEscalate()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "not json at all")));
+        read.Outcome.Should().Be("Escalate",
+            "an unreadable decision payload must fail closed to Escalate, never mis-branch while returning 200");
+        read.Decision.Should().BeOfType<AcceptanceDecision.Escalate>()
+            .Which.Reason.Should().Be(AcceptanceEscalationReason.AcceptorJudgment);
+    }
+
+    [Test]
+    public void ReadDecision_MissingDecisionJson_FailClosesToEscalate()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("Feedback", "n/a")));
+        read.Outcome.Should().Be("Escalate",
+            "a missing decision must fail closed to Escalate, never a false accept");
+    }
+
+    // ── serialization tolerance of the scalar fields ───────────────────────
+
+    [Test]
+    public void ReadDecision_ReadsScalarFields_TolerantOfStringAndJsonElement()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(Input(
+            ("DecisionJson", "{\"kind\":\"accept\"}"),
+            ("Feedback", "looks good"),
+            ("DeciderId", "alice@x.test"),
+            ("DeciderDisplay", JsonStr("Alice")),
+            ("Channel", "user"),
+            ("RulesReference", "type-override@2")));
+
+        read.Feedback.Should().Be("looks good");
+        read.DeciderId.Should().Be("alice@x.test");
+        read.DeciderDisplay.Should().Be("Alice");
+        read.Channel.Should().Be("user");
+        read.RulesReference.Should().Be("type-override@2");
+    }
+
+    [Test]
+    public void ReadDecision_MissingChannel_DefaultsToOrchestrator()
+    {
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "{\"kind\":\"accept\"}")));
+        read.Channel.Should().Be("orchestrator",
+            "a decision with no explicit channel is treated as the orchestrator self-decision");
+    }
+
+    [Test]
+    public void ReadDecision_CanonicalizesDecisionJson()
+    {
+        // The output DecisionJson must be a valid re-serialized AcceptanceDecision the 39-6
+        // guardrail can deserialize, even when the input had extra whitespace / ordering.
+        var read = WaitForDocumentDecisionActivity.ReadDecision(
+            Input(("DecisionJson", "  {  \"kind\" : \"accept\"  }  ")));
+        var reparsed = JsonSerializer.Deserialize<AcceptanceDecision>(read.DecisionJson);
+        reparsed.Should().BeOfType<AcceptanceDecision.Accept>();
+    }
+
+    // ── canonical bookmark name — parity + tenant folding + normalization ──
+
+    [Test]
+    public void DecisionBookmarkName_IsDeterministic_AndFoldsTenant()
+    {
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+
+        var a1 = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenantA, session);
+        var a2 = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenantA, session);
+        var b1 = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenantB, session);
+
+        a1.Should().Be(a2, "the builder must be deterministic so suspend + resume names match byte-for-byte");
+        a1.Should().StartWith("document-decision-");
+        a1.Should().Contain(session.ToString());
+        a1.Should().NotBe(b1, "folding the tenant into the name is the IDOR guard");
+    }
+
+    [Test]
+    public void DecisionBookmarkName_NullTenant_UsesStablePlaceholder()
+    {
+        var session = Guid.NewGuid();
+        WaitForDocumentDecisionActivity.DecisionBookmarkName(null, session)
+            .Should().Be($"document-decision-none-{session}");
+    }
+
+    [Test]
+    public void DecisionBookmarkName_HostileSegment_IsNormalized()
+    {
+        var session = Guid.NewGuid();
+        // A hostile tenant segment can't smuggle delimiters into the name.
+        WaitForDocumentDecisionActivity.DecisionBookmarkName("Ten ANT/../x-9", session)
+            .Should().Be($"document-decision-ten_ant_.._x_9-{session}");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/EscalationLineageCompletenessTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/EscalationLineageCompletenessTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC6). Every field of the 39-6 document lineage must survive into the
+/// <c>ESCALATION.TRIGGERED</c> event's <c>lineage</c> data — a handler reconstructs the whole
+/// story from the one event, never a bare failure string.
+///
+/// <para><b>Substitution note.</b> The plan specifies reflecting over 39-6's
+/// <c>DocumentLineage</c> wire properties to prove no field is dropped. 39-6 is NOT landed yet
+/// (the type does not exist), so this test instead uses a REPRESENTATIVE lineage JSON object
+/// string and asserts (a) it is embedded VERBATIM (every property round-trips) into the event's
+/// <c>lineage</c> field and (b) the payload is a JSON OBJECT, never a bare string. When 39-6
+/// lands, swap the representative string for reflection over <c>DocumentLineage</c>.</para>
+/// </summary>
+[TestFixture]
+public class EscalationLineageCompletenessTests
+{
+    // A representative shape of 39-6's DocumentLineage: draft envelope ids+states, review ids
+    // (member reviews for panels), rounds used, last domain-phrased violations, the typed
+    // outcome, and the effective policy reference.
+    private const string RepresentativeLineageJson = """
+    {
+      "drafts": [
+        { "id": "draft-1", "state": "superseded" },
+        { "id": "draft-2", "state": "reviewed" }
+      ],
+      "reviews": [
+        { "id": "review-1", "reviewer": "panel-member-a", "decision": "request-changes" },
+        { "id": "review-2", "reviewer": "panel-member-b", "decision": "approve" }
+      ],
+      "roundsUsed": 2,
+      "lastViolations": [ "the API contract omits pagination", "no rollback path documented" ],
+      "outcome": "rounds-exhausted",
+      "policyReference": "system-default@3"
+    }
+    """;
+
+    [Test]
+    public void TriggeredEvent_EmbedsLineageVerbatim_EveryFieldSurvives()
+    {
+        var evt = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationTriggered, "esc-1", "rounds-exhausted",
+            lineageJson: RepresentativeLineageJson, rulesReference: "system-default@3", channel: "orchestrator",
+            issueId: "issue-9", documentId: "doc-7", documentType: "design", correlationId: "corr-5",
+            sessionId: "sess-3", tenantId: null, detail: null);
+
+        evt.Data["lineage"].Should().BeAssignableTo<JsonNode>();
+        var embedded = (JsonNode)evt.Data["lineage"]!;
+        embedded.GetValueKind().Should().Be(JsonValueKind.Object,
+            "the lineage must be a JSON object, never a bare failure string");
+
+        // Reflect over the SOURCE lineage's every wire property and assert each appears in the
+        // embedded lineage (no field dropped — survives future lineage additions).
+        var source = JsonNode.Parse(RepresentativeLineageJson)!.AsObject();
+        foreach (var (key, _) in source)
+        {
+            embedded.AsObject().ContainsKey(key).Should().BeTrue(
+                $"lineage field '{key}' must survive into the escalation event");
+        }
+
+        // Deep equality — the whole story round-trips.
+        JsonNode.DeepEquals(embedded, source).Should().BeTrue(
+            "the embedded lineage must equal the source lineage byte-for-byte (verbatim embedding)");
+    }
+
+    [Test]
+    public void TriggeredEvent_LineageIsNeverABareString()
+    {
+        var evt = EmitEscalationEventActivity.BuildTammaEvent(
+            ApprovalEvents.EscalationTriggered, "esc-1", "rounds-exhausted",
+            lineageJson: RepresentativeLineageJson, rulesReference: null, channel: null,
+            issueId: null, documentId: null, documentType: null, correlationId: null,
+            sessionId: null, tenantId: null, detail: null);
+
+        (evt.Data["lineage"] is string).Should().BeFalse(
+            "the lineage payload must never be a bare string (AC6)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DocumentDecisionResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/DocumentDecisionResumeEndpointTests.cs
@@ -1,0 +1,145 @@
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Entities;
+using Elsa.Workflows.Runtime.Filters;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.ElsaServer.Endpoints;
+
+namespace Tamma.Activities.Tests.Endpoints;
+
+/// <summary>
+/// Story 39-8 (AC5 engine half) — the generic engine-side document-decision resume seam
+/// (<c>POST /elsa/api/documents/decision/resume</c>). Verifies it computes the SAME
+/// tenant+session-scoped bookmark name as the suspend-side activity
+/// (<c>document-decision-{tenant}-{session}</c>) and injects the EXACT D5 input keys; is
+/// IDOR-safe (cross-tenant → 404, never resolves the victim's gate); REFUSES a duplicate
+/// bookmark with 409 (never <c>bookmarks[0]</c>); 404s a miss; and 400s an empty session.
+/// Copied from <c>DesignResumeEndpointTests</c>.
+/// </summary>
+[TestFixture]
+public class DocumentDecisionResumeEndpointTests
+{
+    private Mock<IBookmarkStore> _bookmarks = null!;
+    private Mock<IWorkflowRuntime> _runtime = null!;
+    private Mock<IWorkflowClient> _client = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _bookmarks = new Mock<IBookmarkStore>();
+        _runtime = new Mock<IWorkflowRuntime>();
+        _client = new Mock<IWorkflowClient>();
+        _runtime
+            .Setup(r => r.CreateClientAsync(It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_client.Object);
+        _client
+            .Setup(c => c.RunInstanceAsync(It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RunWorkflowInstanceResponse());
+    }
+
+    private static DocumentDecisionResumeEndpoint.ResumeRequest Req(
+        Guid session, string? tenant, string decisionJson = "{\"kind\":\"accept\"}", string channel = "user") =>
+        new(session, tenant, decisionJson, Feedback: "ok", DeciderId: "who@x.test",
+            DeciderDisplay: "Who", Channel: channel, RulesReference: "system-default@1");
+
+    private static StoredBookmark Bookmark(string name, string instanceId)
+        => new() { Name = name, WorkflowInstanceId = instanceId, Id = Guid.NewGuid().ToString() };
+
+    private void SetupFind(string expectedName, params StoredBookmark[] matches) =>
+        _bookmarks
+            .Setup(b => b.FindManyAsync(
+                It.Is<BookmarkFilter>(f => f.Name == expectedName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(matches.AsEnumerable());
+
+    private Task<IResult> Invoke(DocumentDecisionResumeEndpoint.ResumeRequest req)
+        => DocumentDecisionResumeEndpoint.Resume(
+            req, _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    [Test]
+    public async Task Resume_Valid_UsesCanonicalName_InjectsExactD5Keys_ResumesMatch()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var expected = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenant, session);
+        SetupFind(expected, Bookmark(expected, "wf-1"));
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.Is<RunWorkflowInstanceRequest>(r =>
+                (string)r.Input!["DecisionJson"] == "{\"kind\":\"accept\"}"
+                && (string)r.Input!["Feedback"] == "ok"
+                && (string)r.Input!["DeciderId"] == "who@x.test"
+                && (string)r.Input!["DeciderDisplay"] == "Who"
+                && (string)r.Input!["Channel"] == "user"
+                && (string)r.Input!["RulesReference"] == "system-default@1"),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _runtime.Verify(r => r.CreateClientAsync("wf-1", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Resume_CrossTenant_DifferentName_Returns404_NeverResumes()
+    {
+        var session = Guid.NewGuid();
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+        var nameA = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenantA, session);
+        var nameB = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenantB, session);
+        SetupFind(nameA, Bookmark(nameA, "wf-victim")); // A's gate is live
+        SetupFind(nameB /* zero matches for B */);
+
+        var result = await Invoke(Req(session, tenantB));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound,
+            "a cross-tenant caller computes a different bookmark name and must 404, never resolving the victim's gate");
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Resume_NoMatchingBookmark_Returns404_NeverResumes()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenant, session);
+        SetupFind(name /* zero matches */);
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Resume_MoreThanOneMatch_Refuses409_DoesNotResumeArbitrary()
+    {
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var name = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenant, session);
+        SetupFind(name, Bookmark(name, "wf-a"), Bookmark(name, "wf-b"));
+
+        var result = await Invoke(Req(session, tenant));
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status409Conflict);
+        _client.Verify(c => c.RunInstanceAsync(
+            It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never,
+            "an ambiguous bookmark must refuse, not resume an arbitrary instance");
+    }
+
+    [Test]
+    public async Task Resume_EmptySession_Returns400()
+    {
+        var result = await Invoke(Req(Guid.Empty, Guid.NewGuid().ToString()));
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentDecisionRoundTripTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentDecisionRoundTripTests.cs
@@ -1,0 +1,310 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Options;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.Core;
+using Tamma.Activities.Documents;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-8 (AC7 a/b/c, AC4/AC5 runtime halves). A GENUINE suspend/resume round-trip of the
+/// ONE generic document-decision gate through the REAL Elsa runtime (the same harness intent as
+/// the plan's Testcontainers round-trip, run here against Elsa's in-process persistence — no
+/// Docker needed, and the plan's step-8 <c>GateHarnessWorkflow</c> fallback since 39-6 is not
+/// landed). Drives publish→gate→terminal:
+/// <list type="bullet">
+///   <item>(a) supervised: the lifecycle SUSPENDS on the tenant-folded bookmark and emits
+///     <c>APPROVAL.REQUESTED</c>; resuming with an Accept reaches the <c>Accepted</c> terminal
+///     and emits <c>APPROVAL.PROVIDED</c> carrying the decider + a positive <c>durationMs</c>
+///     across the genuine suspend/resume (D4 proven against real persistence).</item>
+///   <item>(b) rejection: resuming with a <c>reject</c> + feedback reaches the <c>Rejected</c>
+///     terminal with the feedback on the trail.</item>
+///   <item>(c) escalation: an <c>escalate</c> resume reaches the <c>Escalated</c> terminal and
+///     the escalated exit emits <c>ESCALATION.TRIGGERED</c> with the FULL lineage embedded (the
+///     disposition half — <c>ESCALATION.RESOLVED</c> — is covered by
+///     <c>Tamma.Api.Tests.Documents.EscalationDispositionTests</c>).</item>
+/// </list>
+///
+/// <para>Excluded from the fast local test filter by the <c>RoundTrip</c> name; runs in CI.</para>
+/// </summary>
+[TestFixture]
+public class DocumentDecisionRoundTripTests
+{
+    private const string LineageJson =
+        "{\"drafts\":[{\"id\":\"d1\",\"state\":\"reviewed\"}],\"roundsUsed\":3,\"outcome\":\"rounds-exhausted\"}";
+
+    [Test]
+    public async Task Supervised_Suspends_EmitsRequested_ThenAcceptResumesToAccepted_WithDurationMs()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+
+        var (state, workflow) = await RunToSuspendAsync(provider, session, tenant);
+
+        // Suspended on the canonical tenant-folded bookmark, and APPROVAL.REQUESTED is on the stream.
+        state.SubStatus.Should().Be(WorkflowSubStatus.Suspended, "the gate must suspend the lifecycle");
+        var expectedBookmark = WaitForDocumentDecisionActivity.DecisionBookmarkName(tenant, session);
+        var bookmark = state.Bookmarks.SingleOrDefault(b => b.Name == expectedBookmark);
+        bookmark.Should().NotBeNull("the gate must register the canonical decision bookmark");
+        CapturedTypes(capture).Should().Contain(ApprovalEvents.Requested);
+
+        // Resume with Accept.
+        var result = await ResumeAsync(provider, workflow, state, bookmark!.Id, new Dictionary<string, object>
+        {
+            ["DecisionJson"] = "{\"kind\":\"accept\"}",
+            ["Feedback"] = "ship it",
+            ["DeciderId"] = "alice@x.test",
+            ["DeciderDisplay"] = "Alice",
+            ["Channel"] = "user",
+            ["RulesReference"] = "system-default@1",
+        });
+
+        result.WorkflowState.Status.Should().Be(WorkflowStatus.Finished);
+        Terminal(result).Should().Be("Accepted");
+
+        var provided = CapturedEvents(capture).Single(e => Type(e) == ApprovalEvents.Provided);
+        Data(provided, "deciderId").Should().Be("alice@x.test");
+        Data(provided, "channel").Should().Be("user");
+        provided.GetProperty("data").GetProperty("durationMs").GetInt64().Should().BeGreaterThan(0,
+            "durationMs must be positive across a genuine suspend/resume (D4)");
+    }
+
+    [Test]
+    public async Task Rejection_ResumesToRejected_WithFeedbackOnTheTrail()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var (state, workflow) = await RunToSuspendAsync(provider, session, tenant);
+        var bookmark = state.Bookmarks.Single();
+
+        var result = await ResumeAsync(provider, workflow, state, bookmark.Id, new Dictionary<string, object>
+        {
+            ["DecisionJson"] = "{\"kind\":\"reject\",\"reason\":\"wrong approach\"}",
+            ["Feedback"] = "revise the data model",
+            ["DeciderId"] = "bob@x.test",
+            ["Channel"] = "user",
+        });
+
+        Terminal(result).Should().Be("Rejected");
+        var provided = CapturedEvents(capture).Single(e => Type(e) == ApprovalEvents.Provided);
+        Data(provided, "decisionKind").Should().Be("reject");
+        Data(provided, "feedback").Should().Be("revise the data model");
+    }
+
+    [Test]
+    public async Task Escalation_ResumesToEscalated_EmitsTriggeredWithFullLineage()
+    {
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var session = Guid.NewGuid();
+        var tenant = Guid.NewGuid().ToString();
+        var (state, workflow) = await RunToSuspendAsync(provider, session, tenant);
+        var bookmark = state.Bookmarks.Single();
+
+        var result = await ResumeAsync(provider, workflow, state, bookmark.Id, new Dictionary<string, object>
+        {
+            ["DecisionJson"] = "{\"kind\":\"escalate\",\"reason\":\"rounds-exhausted\",\"detail\":\"rounds ran out\"}",
+            ["Channel"] = "orchestrator",
+        });
+
+        Terminal(result).Should().Be("Escalated");
+
+        var triggered = CapturedEvents(capture).Single(e => Type(e) == ApprovalEvents.EscalationTriggered);
+        var lineage = triggered.GetProperty("data").GetProperty("lineage");
+        lineage.ValueKind.Should().Be(JsonValueKind.Object, "the escalation must carry lineage as an object, never a bare string");
+        lineage.GetProperty("roundsUsed").GetInt32().Should().Be(3);
+    }
+
+    // ── Harness ─────────────────────────────────────────────────────────────
+
+    private static async Task<(Elsa.Workflows.State.WorkflowState State, Workflow Workflow)> RunToSuspendAsync(
+        IServiceProvider rootProvider, Guid session, string tenant)
+    {
+        using var scope = rootProvider.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<IWorkflowRunner>();
+        var workflow = GateHarnessWorkflow.Build(session, tenant, DateTimeOffset.UtcNow.AddSeconds(-2));
+        var result = await runner.RunAsync(workflow, new RunWorkflowOptions(), CancellationToken.None);
+        return (result.WorkflowState, workflow);
+    }
+
+    private static async Task<Elsa.Workflows.Models.RunWorkflowResult> ResumeAsync(
+        IServiceProvider rootProvider, Workflow workflow,
+        Elsa.Workflows.State.WorkflowState state, string bookmarkId, IDictionary<string, object> input)
+    {
+        using var scope = rootProvider.CreateScope();
+        var runner = scope.ServiceProvider.GetRequiredService<IWorkflowRunner>();
+        return await runner.RunAsync(workflow, state,
+            new RunWorkflowOptions { BookmarkId = bookmarkId, Input = input }, CancellationToken.None);
+    }
+
+    private static string? Terminal(Elsa.Workflows.Models.RunWorkflowResult result)
+        => result.WorkflowState.Output.TryGetValue("terminal", out var t) ? t?.ToString() : null;
+
+    private static List<JsonElement> CapturedEvents(CapturingHandler capture) =>
+        capture.Bodies
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray()
+                .Select(e => e.Clone()))
+            .ToList();
+
+    private static List<string?> CapturedTypes(CapturingHandler capture) =>
+        CapturedEvents(capture).Select(Type).ToList();
+
+    private static string? Type(JsonElement e) => e.GetProperty("eventType").GetString();
+
+    private static string? Data(JsonElement e, string key)
+        => e.GetProperty("data").TryGetProperty(key, out var v) ? v.GetString() : null;
+
+    private static ServiceProvider BuildProvider(CapturingHandler capture)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddElsa(elsa =>
+        {
+            elsa.AddActivity<WaitForDocumentDecisionActivity>();
+            elsa.AddActivity<EmitEscalationEventActivity>();
+            elsa.UseWorkflows(w => w.UseTammaEventPersistence());
+        });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = "http://tamma.test",
+                ["Engine:CallbackUrl"] = "http://engine.test",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+
+        services.AddSingleton(_ => new Tamma.Activities.LlmCall.TammaApiClient(
+            new HttpClient(capture) { BaseAddress = null },
+            NullLogger<Tamma.Activities.LlmCall.TammaApiClient>.Instance,
+            config));
+
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Step-8 fallback — a test-only workflow exercising publish→gate→terminal for the ONE
+    /// generic document-decision gate (39-6's real <c>DocumentLifecycleWorkflow</c> is not landed
+    /// yet). The gate branches to a <c>terminal</c> output per decision kind; the Escalate branch
+    /// additionally emits <c>ESCALATION.TRIGGERED</c> with the full lineage.
+    /// </summary>
+    private static class GateHarnessWorkflow
+    {
+        public static Workflow Build(Guid session, string? tenant, DateTimeOffset requestedAt)
+        {
+            var gate = new WaitForDocumentDecisionActivity
+            {
+                Id = "DecisionGate",
+                SessionId = new Input<Guid>(_ => session),
+                TenantId = new Input<string?>(_ => tenant),
+                RequestedAtUtc = new Input<string>(_ => requestedAt.ToString("O", CultureInfo.InvariantCulture)),
+                RulesReference = new Input<string?>(_ => "system-default@1"),
+                IssueId = new Input<string?>(_ => "issue-9"),
+                DocumentId = new Input<string?>(_ => "doc-7"),
+                DocumentType = new Input<string?>(_ => "design"),
+                CorrelationId = new Input<string?>(_ => "corr-5"),
+            };
+
+            var setAccepted = Terminal("SetAccepted", "Accepted");
+            var setRevision = Terminal("SetRevision", "RevisionRequested");
+            var setRejected = Terminal("SetRejected", "Rejected");
+            var setEscalated = Terminal("SetEscalated", "Escalated");
+
+            var emitEscalation = new EmitEscalationEventActivity
+            {
+                Id = "EmitEscalation",
+                EventType = new Input<string>(_ => ApprovalEvents.EscalationTriggered),
+                EscalationId = new Input<string?>(_ => Guid.NewGuid().ToString()),
+                Outcome = new Input<string?>(_ => "rounds-exhausted"),
+                LineageJson = new Input<string?>(_ => LineageJson),
+                RulesReference = new Input<string?>(_ => "system-default@1"),
+                Channel = new Input<string?>(_ => "orchestrator"),
+                IssueId = new Input<string?>(_ => "issue-9"),
+                DocumentId = new Input<string?>(_ => "doc-7"),
+                DocumentType = new Input<string?>(_ => "design"),
+                CorrelationId = new Input<string?>(_ => "corr-5"),
+                SessionId = new Input<string?>(_ => session.ToString()),
+                TenantId = new Input<string?>(_ => tenant),
+                Detail = new Input<string?>(_ => "rounds ran out"),
+            };
+
+            var finishAccepted = new Finish { Id = "FinishAccepted" };
+            var finishRevision = new Finish { Id = "FinishRevision" };
+            var finishRejected = new Finish { Id = "FinishRejected" };
+            var finishEscalated = new Finish { Id = "FinishEscalated" };
+
+            var flowchart = new Flowchart
+            {
+                Id = "GateHarness",
+                Start = gate,
+                Activities =
+                {
+                    gate,
+                    setAccepted, finishAccepted,
+                    setRevision, finishRevision,
+                    setRejected, finishRejected,
+                    emitEscalation, setEscalated, finishEscalated,
+                },
+                Connections =
+                {
+                    new FlowConnection(new FlowEndpoint(gate, "Accept"), new FlowEndpoint(setAccepted)),
+                    new FlowConnection(new FlowEndpoint(setAccepted), new FlowEndpoint(finishAccepted)),
+                    new FlowConnection(new FlowEndpoint(gate, "RequestRevision"), new FlowEndpoint(setRevision)),
+                    new FlowConnection(new FlowEndpoint(setRevision), new FlowEndpoint(finishRevision)),
+                    new FlowConnection(new FlowEndpoint(gate, "Reject"), new FlowEndpoint(setRejected)),
+                    new FlowConnection(new FlowEndpoint(setRejected), new FlowEndpoint(finishRejected)),
+                    new FlowConnection(new FlowEndpoint(gate, "Escalate"), new FlowEndpoint(emitEscalation)),
+                    new FlowConnection(new FlowEndpoint(emitEscalation), new FlowEndpoint(setEscalated)),
+                    new FlowConnection(new FlowEndpoint(setEscalated), new FlowEndpoint(finishEscalated)),
+                },
+            };
+
+            return new Workflow(flowchart);
+        }
+
+        private static SetOutput Terminal(string id, string value) => new()
+        {
+            Id = id,
+            OutputName = new("terminal"),
+            OutputValue = new(_ => (object)value),
+        };
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"ok\":true,\"persisted\":1}"),
+            };
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/EscalationDispositionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/EscalationDispositionTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Api.Services.Documents;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC1 RESOLVED clause, AC3 denormalized duration, D9). The escalation disposition
+/// service must pair on the <c>escalationId</c> tag of the originating
+/// <c>ESCALATION.TRIGGERED</c>, append an <c>ESCALATION.RESOLVED</c> carrying
+/// disposition/note/<c>durationMs</c> (computed from the trigger's <c>CreatedAt</c>) with the
+/// trigger's tags copied, 404 an unknown escalationId, and 409 a double-disposition. FAIL-LOUD:
+/// the append is the operation.
+/// </summary>
+[TestFixture]
+public class EscalationDispositionTests
+{
+    private Mock<IEventRepository> _events = null!;
+    private EscalationDispositionService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _events = new Mock<IEventRepository>();
+        _service = new EscalationDispositionService(_events.Object, NullLogger<EscalationDispositionService>.Instance);
+    }
+
+    private static DomainEvent Trigger(string escalationId, DateTime createdAt)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["escalationId"] = escalationId,
+            ["issueId"] = "issue-9",
+            ["documentId"] = "doc-7",
+            ["documentType"] = "design",
+            ["correlationId"] = "corr-5",
+        };
+        return new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = ApprovalEvents.EscalationTriggered,
+            Tags = JsonSerializer.Serialize(tags),
+            Data = "{}",
+            CreatedAt = createdAt,
+            IssueNumber = 9,
+        };
+    }
+
+    private void SetupTriggered(params DomainEvent[] events) =>
+        _events.Setup(r => r.QueryAsync(It.IsAny<Guid?>(), ApprovalEvents.EscalationTriggered, null, It.IsAny<int>()))
+            .ReturnsAsync(events.ToList());
+
+    private void SetupResolved(params DomainEvent[] events) =>
+        _events.Setup(r => r.QueryAsync(It.IsAny<Guid?>(), ApprovalEvents.EscalationResolved, null, It.IsAny<int>()))
+            .ReturnsAsync(events.ToList());
+
+    [Test]
+    public async Task Disposition_Resolved_AppendsResolvedWithDurationAndCopiedTags()
+    {
+        var tenant = Guid.NewGuid();
+        var trigger = Trigger("esc-1", DateTime.UtcNow.AddSeconds(-10));
+        SetupTriggered(trigger);
+        SetupResolved(/* none yet */);
+
+        DomainEvent? appended = null;
+        _events.Setup(r => r.AppendAsync(It.IsAny<DomainEvent>()))
+            .Callback<DomainEvent>(e => appended = e)
+            .ReturnsAsync((DomainEvent e) => e);
+
+        var result = await _service.DispositionAsync(
+            tenant, "esc-1", EscalationDisposition.Overridden, "manual override", "alice@x.test", ApprovalChannel.User);
+
+        result.Outcome.Should().Be(EscalationDispositionOutcome.Resolved);
+        result.DurationMs.Should().BeGreaterThan(9_000).And.BeLessThan(120_000);
+
+        appended.Should().NotBeNull();
+        appended!.Type.Should().Be(ApprovalEvents.EscalationResolved);
+        appended.TenantId.Should().Be(tenant);
+
+        var tags = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(appended.Tags)!;
+        tags["escalationId"].GetString().Should().Be("esc-1");
+        tags["issueId"].GetString().Should().Be("issue-9");
+        tags["documentId"].GetString().Should().Be("doc-7");
+        tags["documentType"].GetString().Should().Be("design");
+        tags["correlationId"].GetString().Should().Be("corr-5");
+
+        var data = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(appended.Data)!;
+        data["disposition"].GetString().Should().Be("overridden");
+        data["note"].GetString().Should().Be("manual override");
+        data["resolvedBy"].GetString().Should().Be("alice@x.test");
+        data["channel"].GetString().Should().Be("user");
+        data["durationMs"].GetInt64().Should().Be(result.DurationMs);
+    }
+
+    [Test]
+    public async Task Disposition_UnknownEscalationId_Returns404_NoAppend()
+    {
+        SetupTriggered(/* no matching trigger */);
+        SetupResolved();
+
+        var result = await _service.DispositionAsync(
+            Guid.NewGuid(), "missing", EscalationDisposition.Resolved, null, "dev@x.test", ApprovalChannel.User);
+
+        result.Outcome.Should().Be(EscalationDispositionOutcome.NotFound);
+        _events.Verify(r => r.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Disposition_AlreadyResolved_Returns409_NoAppend()
+    {
+        var trigger = Trigger("esc-2", DateTime.UtcNow.AddSeconds(-5));
+        SetupTriggered(trigger);
+
+        // A RESOLVED already exists for this escalationId.
+        var resolvedTags = JsonSerializer.Serialize(new Dictionary<string, object?> { ["escalationId"] = "esc-2" });
+        SetupResolved(new DomainEvent { Type = ApprovalEvents.EscalationResolved, Tags = resolvedTags, Data = "{}", CreatedAt = DateTime.UtcNow });
+
+        var result = await _service.DispositionAsync(
+            Guid.NewGuid(), "esc-2", EscalationDisposition.Resolved, null, "dev@x.test", ApprovalChannel.User);
+
+        result.Outcome.Should().Be(EscalationDispositionOutcome.AlreadyResolved);
+        _events.Verify(r => r.AppendAsync(It.IsAny<DomainEvent>()), Times.Never);
+    }
+
+    [Test]
+    public void Disposition_AppendFailure_PropagatesFailLoud()
+    {
+        var trigger = Trigger("esc-3", DateTime.UtcNow.AddSeconds(-1));
+        SetupTriggered(trigger);
+        SetupResolved();
+        _events.Setup(r => r.AppendAsync(It.IsAny<DomainEvent>()))
+            .ThrowsAsync(new InvalidOperationException("store down"));
+
+        var act = async () => await _service.DispositionAsync(
+            Guid.NewGuid(), "esc-3", EscalationDisposition.Resolved, null, "dev@x.test", ApprovalChannel.Api);
+
+        act.Should().ThrowAsync<InvalidOperationException>(
+            "the disposition service is FAIL-LOUD — the event IS the operation, unlike best-effort emitters");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/DocumentDecisionApiTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Endpoints/DocumentDecisionApiTests.cs
@@ -1,0 +1,217 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data;
+
+namespace Tamma.Api.Tests.Endpoints;
+
+/// <summary>
+/// Story 39-8 (AC5 public half, AC1 decider clause, AC3 channel derivation). The RBAC-gated
+/// document-decision surface (<c>POST /api/documents/decisions/{sessionId}/resume</c>) must:
+/// derive tenant + decider + channel SERVER-SIDE (the request carries no decider/channel);
+/// build the 39-5 <see cref="AcceptanceDecision"/> JSON server-side; reject an invalid
+/// <c>kind</c> with 400 BEFORE any forward; surface an engine 404 as 404; and pin
+/// <see cref="ApprovalChannels.Derive"/> onto its three members. A member-role caller is
+/// allowed (D10 — the group is AuthenticatedAny, the handler has no owner/admin gate).
+/// </summary>
+[TestFixture]
+public class DocumentDecisionApiTests
+{
+    private Mock<IElsaWorkflowService> _elsa = null!;
+    private readonly NullLoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    [SetUp]
+    public void SetUp() => _elsa = new Mock<IElsaWorkflowService>();
+
+    private static ITenantContext TenantContext(Guid? tenantId)
+    {
+        var ctx = new Mock<ITenantContext>();
+        ctx.SetupGet(c => c.TenantId).Returns(tenantId);
+        return ctx.Object;
+    }
+
+    private static ClaimsPrincipal Human(string email)
+        => new(new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Email, email) }, "AuthenticationTypes.Federation"));
+
+    private static ClaimsPrincipal Orchestrator()
+        => new(new ClaimsIdentity(new[]
+        {
+            new Claim(ApprovalChannels.PrincipalTypeClaim, ApprovalChannels.OrchestratorPrincipalType),
+            new Claim(JwtRegisteredClaimNames.Sub, "orchestrator-agent"),
+        }, "AuthenticationTypes.Federation"));
+
+    private static ClaimsPrincipal ServiceCredential()
+        => new(new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Sub, "svc-1") }, "ApiKey"));
+
+    private static int? StatusCodeOf(IResult result)
+        => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    // ── server-side derivation of tenant + decider + channel ───────────────
+
+    [Test]
+    public async Task ResumeDecision_ValidAccept_ForwardsAmbientTenant_ServerBuiltDecision_DerivedDeciderAndChannel()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        string? capturedDecisionJson = null;
+        string? capturedTenant = null;
+        string? capturedDecider = null;
+        string? capturedChannel = null;
+
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, string, string?, string?, string?, string, string?>(
+                (_, t, dj, _, did, _, ch, _) => { capturedTenant = t; capturedDecisionJson = dj; capturedDecider = did; capturedChannel = ch; })
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: true, GateNotFound: false, WorkflowInstanceId: "wf-1"));
+
+        var req = new DocumentDecisionEndpoints.DecisionRequest("accept", null, null, null, "ship it");
+
+        var result = await DocumentDecisionEndpoints.ResumeDecision(
+            session, req, _elsa.Object, TenantContext(tenant), Human("alice@example.com"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+        capturedTenant.Should().Be(tenant.ToString(), "the ambient tenant is folded into the bookmark name server-side");
+        capturedDecider.Should().Be("alice@example.com", "the decider is derived from the principal (non-repudiation)");
+        capturedChannel.Should().Be("user", "a human session derives the user channel");
+
+        // The decision JSON is built server-side and is a valid 39-5 AcceptanceDecision.
+        capturedDecisionJson.Should().NotBeNull();
+        JsonSerializer.Deserialize<AcceptanceDecision>(capturedDecisionJson!).Should().BeOfType<AcceptanceDecision.Accept>();
+    }
+
+    [Test]
+    public async Task ResumeDecision_RequestRevision_BuildsRequestRevisionWithNotes()
+    {
+        var session = Guid.NewGuid();
+        string? capturedDecisionJson = null;
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, string, string?, string?, string?, string, string?>(
+                (_, _, dj, _, _, _, _, _) => capturedDecisionJson = dj)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-2"));
+
+        var req = new DocumentDecisionEndpoints.DecisionRequest("request-revision", "tighten it", null, null, null);
+
+        await DocumentDecisionEndpoints.ResumeDecision(
+            session, req, _elsa.Object, TenantContext(Guid.NewGuid()), Human("bob@x.test"), _loggerFactory);
+
+        var decision = JsonSerializer.Deserialize<AcceptanceDecision>(capturedDecisionJson!);
+        decision.Should().BeOfType<AcceptanceDecision.RequestRevision>()
+            .Which.Notes.Should().Be("tighten it");
+    }
+
+    // ── validation before forward ──────────────────────────────────────────
+
+    [TestCase("")]
+    [TestCase("   ")]
+    [TestCase("maybe")]
+    [TestCase("auto-accept")]
+    public async Task ResumeDecision_InvalidKind_Returns400_NoForward(string kind)
+    {
+        var req = new DocumentDecisionEndpoints.DecisionRequest(kind, null, null, null, null);
+        var result = await DocumentDecisionEndpoints.ResumeDecision(
+            Guid.NewGuid(), req, _elsa.Object, TenantContext(Guid.NewGuid()), Human("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeDocumentDecisionAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResumeDecision_EmptySession_Returns400_NoForward()
+    {
+        var req = new DocumentDecisionEndpoints.DecisionRequest("accept", null, null, null, null);
+        var result = await DocumentDecisionEndpoints.ResumeDecision(
+            Guid.Empty, req, _elsa.Object, TenantContext(Guid.NewGuid()), Human("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status400BadRequest);
+        _elsa.Verify(s => s.ResumeDocumentDecisionAsync(
+            It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+            It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()), Times.Never);
+    }
+
+    [Test]
+    public async Task ResumeDecision_EngineGateNotWaiting_Returns404()
+    {
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(Resumed: false, GateNotFound: true, WorkflowInstanceId: null));
+
+        var req = new DocumentDecisionEndpoints.DecisionRequest("accept", null, null, null, null);
+        var result = await DocumentDecisionEndpoints.ResumeDecision(
+            session, req, _elsa.Object, TenantContext(Guid.NewGuid()), Human("dev@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Test]
+    public async Task ResumeDecision_MemberRoleCaller_IsAllowed_D10()
+    {
+        // The handler has no owner/admin gate (the group is AuthenticatedAny) — a plain member
+        // human forwards successfully. Hardening to WorkflowsManage would be a conscious change
+        // that trips THIS test.
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-9"));
+
+        var req = new DocumentDecisionEndpoints.DecisionRequest("accept", null, null, null, null);
+        var result = await DocumentDecisionEndpoints.ResumeDecision(
+            session, req, _elsa.Object, TenantContext(Guid.NewGuid()), Human("member@x.test"), _loggerFactory);
+
+        StatusCodeOf(result).Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── ApprovalChannels.Derive pins (AC3) ─────────────────────────────────
+
+    [Test]
+    public void Derive_OrchestratorClaim_MapsToOrchestrator() =>
+        ApprovalChannels.Derive(Orchestrator()).Should().Be(ApprovalChannel.Orchestrator);
+
+    [Test]
+    public void Derive_HumanSession_MapsToUser() =>
+        ApprovalChannels.Derive(Human("alice@x.test")).Should().Be(ApprovalChannel.User);
+
+    [Test]
+    public void Derive_ServiceCredential_MapsToApi() =>
+        ApprovalChannels.Derive(ServiceCredential()).Should().Be(ApprovalChannel.Api);
+
+    [Test]
+    public async Task ResumeDecision_OrchestratorPrincipal_DerivesOrchestratorChannel()
+    {
+        var session = Guid.NewGuid();
+        string? capturedChannel = null;
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, string, string?, string?, string?, string, string?>(
+                (_, _, _, _, _, _, ch, _) => capturedChannel = ch)
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-o"));
+
+        var req = new DocumentDecisionEndpoints.DecisionRequest("accept", null, null, null, null);
+        await DocumentDecisionEndpoints.ResumeDecision(
+            session, req, _elsa.Object, TenantContext(Guid.NewGuid()), Orchestrator(), _loggerFactory);
+
+        capturedChannel.Should().Be("orchestrator");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Secrets/Rotation/RotationTriggerServiceTests.cs
@@ -178,5 +178,7 @@ public sealed class RotationTriggerServiceTests
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
         public Task<MergeApprovalResumeResult> ResumeDesignApprovalAsync(Guid sid, string? t, bool approved, string? feedback, string? reviewer) =>
             Task.FromResult(new MergeApprovalResumeResult(false, false, null));
+        public Task<MergeApprovalResumeResult> ResumeDocumentDecisionAsync(Guid sid, string? t, string decisionJson, string? feedback, string? deciderId, string? deciderDisplay, string channel, string? rulesReference) =>
+            Task.FromResult(new MergeApprovalResumeResult(false, false, null));
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/EscalationDispositionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/EscalationDispositionTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Story 39-8 (AC3 — the escalation-disposition closed set is drift-tested). Pins the
+/// <see cref="EscalationDisposition"/> wire round-trips + the exactly-3 count so an accidental
+/// member add/remove trips the count pin, and that <c>Parse</c> throws a
+/// <see cref="TammaError"/> on unknowns (the <c>AgentRoleTests</c> style).
+///
+/// <para><see cref="ApprovalChannel"/>'s own round-trip + 3-member count pin lives in 39-5's
+/// suite (39-8 CONSUMES that type); 39-8 pins only that <c>ApprovalChannels.Derive</c> maps
+/// onto its three members correctly (see <c>DocumentDecisionApiTests</c>).</para>
+/// </summary>
+[TestFixture]
+public class EscalationDispositionTests
+{
+    [Test]
+    public void Has_exactly_three_dispositions() =>
+        Enum.GetValues<EscalationDisposition>().Length.Should().Be(3);
+
+    [TestCase(EscalationDisposition.Resolved, "resolved")]
+    [TestCase(EscalationDisposition.Overridden, "overridden")]
+    [TestCase(EscalationDisposition.Abandoned, "abandoned")]
+    public void ToWire_returns_canonical_string(EscalationDisposition disposition, string wire) =>
+        disposition.ToWire().Should().Be(wire);
+
+    [Test]
+    public void Roundtrip_holds_for_every_disposition()
+    {
+        foreach (var d in Enum.GetValues<EscalationDisposition>())
+            EscalationDispositionExtensions.Parse(d.ToWire()).Should().Be(d);
+    }
+
+    [Test]
+    public void Parse_throws_TammaError_on_unknown()
+    {
+        var act = () => EscalationDispositionExtensions.Parse("dismissed");
+        act.Should().Throw<TammaError>()
+            .Which.Code.Should().Be("ESCALATION.DISPOSITION.UNKNOWN");
+    }
+
+    [Test]
+    public void Parse_throws_on_null_or_empty()
+    {
+        ((Action)(() => EscalationDispositionExtensions.Parse(null!))).Should().Throw<TammaError>();
+        ((Action)(() => EscalationDispositionExtensions.Parse(""))).Should().Throw<TammaError>();
+        ((Action)(() => EscalationDispositionExtensions.Parse("   "))).Should().Throw<TammaError>();
+    }
+
+    [Test]
+    public void Parse_is_case_sensitive()
+    {
+        // Wire strings are canonical lowercase; non-canonical casing is rejected.
+        ((Action)(() => EscalationDispositionExtensions.Parse("Resolved"))).Should().Throw<TammaError>();
+    }
+
+    [Test]
+    public void TryParse_returns_false_on_unknown_and_empty()
+    {
+        EscalationDispositionExtensions.TryParse("nope", out _).Should().BeFalse();
+        EscalationDispositionExtensions.TryParse("", out _).Should().BeFalse();
+        EscalationDispositionExtensions.TryParse(null, out _).Should().BeFalse();
+        EscalationDispositionExtensions.TryParse("resolved", out var d).Should().BeTrue();
+        d.Should().Be(EscalationDisposition.Resolved);
+    }
+}

--- a/docs/stories/4-6-event-capture-approvals-escalations.md
+++ b/docs/stories/4-6-event-capture-approvals-escalations.md
@@ -1,6 +1,6 @@
 # Story 4.6: Event Capture - Approvals & Escalations
 
-Status: ready-for-dev
+Status: superseded-by-39-8
 
 ## Story
 

--- a/docs/stories/epic-39/story-39-8/39-8-escalation-and-approval-surface-events-suspend-resume-lineage.md
+++ b/docs/stories/epic-39/story-39-8/39-8-escalation-and-approval-surface-events-suspend-resume-lineage.md
@@ -84,3 +84,27 @@ P0 — This is the exception sink of the entire epic: every 39-6 unhandleable ou
 | 2026-07-19 | 1.0.0   | Initial story creation | Claude |
 | 2026-07-20 | 1.1.0   | Aligned with the 39-5 acceptor redesign: `APPROVAL.*` events cover both acceptors (orchestrator decisions emit with `channel=orchestrator` + effective-rules reference), gate maps onto `AcceptanceDecision` | Claude |
 | 2026-07-20 | 1.2.0   | Channel-transport alignment: both acceptor paths suspend on the one generic gate and resume through this surface via the 39-18 channels; no channel applies a decision directly | Claude |
+
+## Completion Notes
+
+### AC2 — Story 4-6 coverage subsumed (mapping table)
+
+Story 4-6 (`docs/stories/4-6-event-capture-approvals-escalations.md`, now `Status: superseded-by-39-8`) specified the `APPROVAL.*` / `ESCALATION.*` event family for audit-oversight capture. Every 4-6 acceptance criterion is satisfied by this surface, extended with document lineage, channel, and resolution timing:
+
+| 4-6 AC | 39-8 mechanism | Where |
+|---|---|---|
+| AC1 — approval REQUESTED captured | `APPROVAL.REQUESTED` emitted at the gate's `Execute` (request+suspend is one atomic site) with `channel=orchestrator` + `requestedAtUtc` + `rulesReference` | `Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs` (`BuildRequestedEvent`); `ApprovalEvents.Requested` |
+| AC2 — approval PROVIDED with approver + timestamp | `APPROVAL.PROVIDED` emitted at the resume callback with server-derived `deciderId`/`deciderDisplay`, `channel`, `decisionKind`, `feedback`, `durationMs` | `WaitForDocumentDecisionActivity.cs` (`BuildProvidedEvent`); decider derived in `Tamma.Api/Endpoints/DocumentDecisionEndpoints.cs` (`ResolveApprover`) |
+| AC3 — escalation TRIGGERED with reason | `ESCALATION.TRIGGERED` (LOUD error row) with typed `outcome`, full `lineage`, `rulesReference`, `channel` | `Tamma.Activities/Documents/EmitEscalationEventActivity.cs`; `ApprovalEvents.EscalationTriggered` |
+| AC4 — resolution capture (note + timing) | `ESCALATION.RESOLVED` with `disposition`, `note`, `resolvedBy`, `channel`, denormalized `durationMs` | `Tamma.Api/Services/Documents/EscalationDispositionService.cs`; `POST /api/documents/escalations/{escalationId}/resolve` |
+| AC5 — pairing reconstructable from the stream | `correlationId`(+`sessionId`/`escalationId`) tags on all four events; duration recomputable and denormalized | `ApprovalPairingReconstructionTests` |
+| AC6 — channel recorded | closed `channel` set (`orchestrator \| user \| api`), server-derived on resume, never body-trusted | `ApprovalChannels.Derive` in `DocumentDecisionEndpoints.cs`; `ApprovalChannel` (39-5) |
+
+### AC8 / D11 — legacy escalation reconciliation (documentation only, zero code change)
+
+Per Design Decision D11, the two pre-existing ad-hoc escalation call-sites are recorded as MIGRATION DEBT for Stories 39-14/39-15 rather than retro-emitting `ESCALATION.TRIGGERED` (which would double-count escalation dashboards and carries no `documentId`/lineage). Both files are left UNCHANGED by this story:
+
+- `apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs` — already emits `CODE_REVIEW.ESCALATED` at the raise point (the mentorship-scoped 4-6 partial). Migration to the unified `ESCALATION.*` surface is 39-14/39-15 work.
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs` — the merge-gate "Escalated" terminal region; `CodeReviewWorkflow` emits `CODE_REVIEW.ESCALATION_RESOLVED`. Same migration debt.
+
+No existing behavior regresses; the decision is recorded here with file pointers as D11 requires.


### PR DESCRIPTION
## Story 39-8 — Escalation &amp; Approval Surface (Epic 39, Wave 3)

Implements the platform's **one generic document-decision gate** and **one exception surface** for the universal document lifecycle. Consumes 39-5's `ApprovalChannel` / `AcceptanceDecision`; ships the test-only `GateHarnessWorkflow` fallback because 39-6 (`DocumentLifecycleWorkflow`) has not landed yet.

### What's in it

**Core / vocabulary (`Tamma.Core`)**
- `EscalationDisposition` — new `[Wire]` enum `{resolved | overridden | abandoned}` with `ToWire`/`Parse` (throws `TammaError ESCALATION.DISPOSITION.UNKNOWN`)/`TryParse`. Does not redeclare `ApprovalChannel` (39-5 owns it).

**Gate + events (`Tamma.Activities/Documents`)**
- `WaitForDocumentDecisionActivity` — the ONE reusable gate. Suspends any lifecycle on a **tenant-folded, unguessable bookmark** (`document-decision-{tenant}-{session}`, IDOR guard) and maps the injected decision onto `AcceptanceDecision`. No SLA timer (suspended-on-bookmark is a legal resumability posture — liveness policy belongs to 39-17/39-19). Fail-loud on missing `RequestedAtUtc`; pure `ReadDecision` fail-closes garbage to `Escalate(AcceptorJudgment)` (never mis-branch on a bad payload while returning 200).
- `ApprovalEvents` — `APPROVAL.REQUESTED/PROVIDED` + `ESCALATION.TRIGGERED/RESOLVED`, with denormalized `durationMs` and a drift-tested closed `channel` set. Emitted on the durable `EventDrain` with full workflow tag context.
- `EmitEscalationEventActivity` — embeds the full document **lineage** (never a bare failure string) into `ESCALATION.TRIGGERED`.

**Resume endpoints**
- `DocumentDecisionResumeEndpoint` (engine, `POST /elsa/api/documents/decision/resume`, auth-required, engine-internal) — mirrors `DesignResumeEndpoint` byte-for-byte: 404 `bookmark_not_found` on 0 matches, 409 `ambiguous_bookmark` on &gt;1 (never `bookmarks[0]`), canonical name delegation.
- `DocumentDecisionEndpoints` (public, `Tamma.Api`) — `POST /api/documents/decisions/{sessionId}/resume` and `/escalations/{escalationId}/resolve`. Tenant, decider, and channel are **derived server-side** (`ApprovalChannels.Derive` — a pure, data-driven rule, never read from the body); the decision `kind` is validated against the closed 39-5 set before anything forwards. Group is `AuthenticatedAny` so an orchestrator-assigned member user can decide (per-assignee authorization is documented 39-20 debt).
- `EscalationDispositionService` — fail-loud disposition appending `ESCALATION.RESOLVED`, pairing on `escalationId` (404 absent, 409 already-resolved), computing `durationMs` from the paired trigger.

### Key rules honored
- **Reject is human-only.** An orchestrator-channel `Reject` clamps to `Escalate(RejectRequiresHuman)` via 39-5's guardrail (applied in 39-6). The gate transports the decision; it does not judge — clamping stays in the guardrail.
- **`APPROVAL.REQUESTED.channel` is always `orchestrator`** (one routing path); `PROVIDED`/`RESOLVED` carry the server-derived resume channel.
- **`DOCUMENT.ESCALATED` (39-6) and `ESCALATION.TRIGGERED` (39-8) both emit deliberately** — the former is the document-family state transition, the latter the exception-surface record with lineage/channel/timing. Documented in both catalogues.

### Docs
- `docs/stories/4-6-event-capture-approvals-escalations.md` → `Status: superseded-by-39-8`.
- 39-8 story completion notes: the 4-6 AC→39-8 mapping table + the D11 reconciliation record (legacy `EscalateReviewActivity.cs` / `SingleIssueCycleWorkflow.cs` merge-gate left **untouched** — documented migration debt, zero code change).

### Data / migrations
None. All four events land in the existing `domain_events` table via the drain (engine) and `IEventRepository.AppendAsync` (Api). `has-pending-model-changes` is clean for both `TenantDbContext` and `ControlPlaneDbContext`.

### Verification (independently re-run)
- Builds: `Tamma.Core`, `Tamma.Activities`, `Tamma.ElsaServer`, `Tamma.Api`, and all three test projects — **green**.
- `Tamma.Core.Tests`: **390 passed** (incl. 9 new `EscalationDisposition`). `Tamma.Activities.Tests` (excl. Docker round-trip): **2531 passed**. In-memory `DocumentDecisionRoundTripTests` (approve→Accepted with `durationMs&gt;0`, reject→Rejected, escalate→Escalated + `ESCALATION.TRIGGERED` with full lineage): **3 passed**. `Tamma.Api.Tests` builds clean; its Postgres-Testcontainer suite runs in CI.
- Migration model clean; legacy escalation files confirmed untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_