### PR TITLE
feat(39-7): Review Producers — single reviewer + panel onto the unified Review type

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/DocumentEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/DocumentEvents.cs
@@ -39,6 +39,13 @@ public static class DocumentEvents
     public const string Rejected = "DOCUMENT.REJECTED";
     public const string Escalated = "DOCUMENT.ESCALATED";
 
+    // Story 39-7 — panel-producer lifecycle markers. STARTED is informational;
+    // COMPLETED is a success row; UNDECIDABLE is a LOUD error row (an undecidable
+    // panel must never be recorded as a successful review).
+    public const string ReviewPanelStarted = "DOCUMENT.REVIEW_PANEL_STARTED";
+    public const string ReviewPanelCompleted = "DOCUMENT.REVIEW_PANEL_COMPLETED";
+    public const string ReviewPanelUndecidable = "DOCUMENT.REVIEW_PANEL_UNDECIDABLE";
+
     /// <summary>
     /// Parse a tenant id from the loose string form threaded through the workflow
     /// inputs. Returns <c>null</c> for empty / single-user / unparseable values
@@ -63,8 +70,10 @@ public static class DocumentEvents
         ValidatedFailed => "error",
         Rejected => "error",
         Escalated => "error",
+        ReviewPanelUndecidable => "error",
         ReviewRequested => "started",
         RevisionStarted => "started",
+        ReviewPanelStarted => "started",
         _ => "success",
     };
 }

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentReviewWorkflow.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 39-7 (Design Decision D1) — the thin REVIEW-stage router
+/// (<c>DefinitionId = "document-review"</c>, the definition-id contract 39-6 D10
+/// pinned). Reads <c>ReviewerSelection.Mode</c> from the resolved acceptance rules
+/// (fallback <see cref="AcceptanceDefaults.Rules"/>) and dispatches ONE of the two
+/// producers — <see cref="SingleReviewerWorkflow"/> or <see cref="PanelReviewWorkflow"/>
+/// — mapping their outputs onto 39-6 D10's contract
+/// (<c>success</c>/<c>reviewJson</c>/<c>reviewDocumentId</c> + <c>failureKind</c>/
+/// <c>undecidableReason</c>/<c>memberReviewsJson</c>).
+///
+/// <para>Zero <c>llm-call</c> nodes: the router only dispatches the two producer
+/// sub-workflows by their pinned definition ids.</para>
+/// </summary>
+public class DocumentReviewWorkflow : WorkflowBase
+{
+    public const string DocumentReviewDefinitionId = "document-review";
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "Document Review";
+        builder.DefinitionId = DocumentReviewDefinitionId;
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description =
+            "Thin REVIEW-stage router: reads ReviewerSelection.Mode and dispatches the single-reviewer or " +
+            "panel producer, mapping their outputs onto the 39-6 D10 review contract";
+
+        // ── Inputs (39-6 D10) + derived ──
+        var documentType = builder.WithVariable<string>("DocumentType", "");
+        var issueId = builder.WithVariable<string>("IssueId", "");
+        var correlationId = builder.WithVariable<string>("CorrelationId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "");
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
+        var contentJson = builder.WithVariable<string>("ContentJson", "{}");
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
+        var isPanel = builder.WithVariable<bool>("IsPanel", false);
+
+        // ── Dispatch results ──
+        var producerResult = builder.WithVariable<IDictionary<string, object>?>();
+
+        // ── Outputs ──
+        var outSuccess = builder.WithVariable<bool>("OutSuccess", false);
+        var outReviewJson = builder.WithVariable<string>("OutReviewJson", "");
+        var outReviewDocId = builder.WithVariable<string>("OutReviewDocId", "");
+        var outFailureKind = builder.WithVariable<string>("OutFailureKind", "");
+        var outUndecidableReason = builder.WithVariable<string>("OutUndecidableReason", "");
+        var outMemberReviews = builder.WithVariable<string>("OutMemberReviews", "[]");
+
+        // ================================================================
+        // Init — resolve rules + mode, build subject + reviewer variables
+        // ================================================================
+        var init = new SetVariable
+        {
+            Id = "Init", Name = "Init",
+            Variable = isPanel,
+            Value = new(ctx =>
+            {
+                var docJson = ctx.GetInput<string>("documentJson") ?? "";
+                var docType = ctx.GetInput<string>("documentType") ?? "";
+                var issue = ctx.GetInput<string>("issueId") ?? "";
+                var corr = ctx.GetInput<string>("correlationId") ?? "";
+                var tenant = ctx.GetInput<string>("tenantId") ?? "";
+                var rulesInput = ctx.GetInput<string>("acceptanceRulesJson") ?? "";
+                var suppliedSubject = ctx.GetInput<string>("subjectJson");
+
+                var rules = string.IsNullOrWhiteSpace(rulesInput) ? AcceptanceDefaults.Rules : AcceptanceRulesJson.Deserialize(rulesInput);
+                var panel = rules.ReviewerSelection.Mode == ReviewerMode.Panel;
+
+                var subject = !string.IsNullOrWhiteSpace(suppliedSubject)
+                    ? suppliedSubject!
+                    : JsonSerializer.Serialize(BuildDocumentSubject(docJson, docType), DocumentJson.Options);
+
+                documentType.Set(ctx, docType);
+                issueId.Set(ctx, issue);
+                correlationId.Set(ctx, string.IsNullOrWhiteSpace(corr) ? issue : corr);
+                tenantId.Set(ctx, tenant);
+                acceptanceRulesJson.Set(ctx, rulesInput);
+                reviewerRole.Set(ctx, rules.ReviewerSelection.ReviewerRole ?? "");
+                subjectJson.Set(ctx, subject);
+                contentJson.Set(ctx, ExtractPayload(docJson));
+                variablesJson.Set(ctx, BuildReviewerVariables(docJson));
+
+                return panel;
+            })
+        };
+        init.SetDisplayText("Init");
+
+        var modeGate = new FlowDecision(ctx => isPanel.Get(ctx))
+        { Id = "ModeGate", Name = "Panel?" };
+        modeGate.SetDisplayText("Panel?");
+
+        // ── Panel branch ──
+        var dispatchPanel = new DispatchWorkflow
+        {
+            Id = "DispatchPanel", Name = "Dispatch Panel",
+            WorkflowDefinitionId = new(PanelReviewWorkflow.ReviewPanelDefinitionId),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["subjectJson"] = subjectJson.Get(ctx) ?? "",
+                ["contentJson"] = contentJson.Get(ctx) ?? "{}",
+                ["variablesJson"] = variablesJson.Get(ctx) ?? "{}",
+                ["documentTypeKey"] = documentType.Get(ctx) ?? "",
+                ["issueId"] = issueId.Get(ctx) ?? "",
+                ["correlationId"] = correlationId.Get(ctx) ?? "",
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+                ["acceptanceRulesJson"] = acceptanceRulesJson.Get(ctx) ?? "",
+            }),
+            WaitForCompletion = new(true),
+            Result = new(producerResult),
+        };
+        dispatchPanel.SetDisplayText("Dispatch Panel");
+
+        // ── Single branch ──
+        var dispatchSingle = new DispatchWorkflow
+        {
+            Id = "DispatchSingle", Name = "Dispatch Single",
+            WorkflowDefinitionId = new(SingleReviewerWorkflow.ReviewSingleReviewerDefinitionId),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                ["reviewerRole"] = reviewerRole.Get(ctx) ?? "",
+                ["subjectJson"] = subjectJson.Get(ctx) ?? "",
+                ["contentJson"] = contentJson.Get(ctx) ?? "{}",
+                ["variablesJson"] = variablesJson.Get(ctx) ?? "{}",
+                ["documentTypeKey"] = documentType.Get(ctx) ?? "",
+                ["issueId"] = issueId.Get(ctx) ?? "",
+                ["correlationId"] = correlationId.Get(ctx) ?? "",
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+                ["acceptanceRulesJson"] = acceptanceRulesJson.Get(ctx) ?? "",
+            }),
+            WaitForCompletion = new(true),
+            Result = new(producerResult),
+        };
+        dispatchSingle.SetDisplayText("Dispatch Single");
+
+        var mapOutputs = new SetVariable
+        {
+            Id = "MapOutputs", Name = "Map Outputs",
+            Variable = outSuccess,
+            Value = new(ctx =>
+            {
+                var result = producerResult.Get(ctx);
+                outReviewJson.Set(ctx, ReadString(result, "reviewJson"));
+                outReviewDocId.Set(ctx, ReadString(result, "reviewDocumentId"));
+                outFailureKind.Set(ctx, ReadString(result, "failureKind"));
+                outUndecidableReason.Set(ctx, ReadString(result, "undecidableReason"));
+                var members = ReadString(result, "memberReviewsJson");
+                outMemberReviews.Set(ctx, string.IsNullOrWhiteSpace(members) ? "[]" : members);
+                return ReadBool(result, "success");
+            })
+        };
+        mapOutputs.SetDisplayText("Map Outputs");
+
+        var setOutputs = new Sequence
+        {
+            Id = "SetOutputs", Name = "Set Outputs",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(ctx => (object)outSuccess.Get(ctx)) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutReviewJson", OutputName = new("reviewJson"), OutputValue = new(ctx => (object)(outReviewJson.Get(ctx) ?? "")) }, "Output reviewJson"),
+                WithLabel(new SetOutput { Id = "OutReviewDocId", OutputName = new("reviewDocumentId"), OutputValue = new(ctx => (object)(outReviewDocId.Get(ctx) ?? "")) }, "Output reviewDocumentId"),
+                WithLabel(new SetOutput { Id = "OutFailureKind", OutputName = new("failureKind"), OutputValue = new(ctx => (object)(outFailureKind.Get(ctx) ?? "")) }, "Output failureKind"),
+                WithLabel(new SetOutput { Id = "OutUndecidableReason", OutputName = new("undecidableReason"), OutputValue = new(ctx => (object)(outUndecidableReason.Get(ctx) ?? "")) }, "Output undecidableReason"),
+                WithLabel(new SetOutput { Id = "OutMemberReviews", OutputName = new("memberReviewsJson"), OutputValue = new(ctx => (object)(outMemberReviews.Get(ctx) ?? "[]")) }, "Output memberReviewsJson"),
+            }
+        };
+        setOutputs.SetDisplayText("Set Outputs");
+
+        var finish = new Finish { Id = "Finish", Name = "Finish" };
+        finish.SetDisplayText("Finish");
+
+        builder.Root = new Flowchart
+        {
+            Id = "DocumentReviewFlowchart",
+            Start = init,
+            Activities =
+            {
+                init, modeGate, dispatchPanel, dispatchSingle, mapOutputs, setOutputs, finish,
+            },
+            Connections =
+            {
+                Connect(init, modeGate),
+                ConnectOutcome(modeGate, "True", dispatchPanel),
+                ConnectOutcome(modeGate, "False", dispatchSingle),
+                Connect(dispatchPanel, mapOutputs),
+                Connect(dispatchSingle, mapOutputs),
+                Connect(mapOutputs, setOutputs),
+                Connect(setOutputs, finish),
+            }
+        };
+    }
+
+    // ====================================================================
+    // Pure helpers
+    // ====================================================================
+
+    private static ReviewSubject BuildDocumentSubject(string documentJson, string documentType)
+    {
+        Guid? documentId = null;
+        if (!string.IsNullOrWhiteSpace(documentJson))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(documentJson);
+                if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                    doc.RootElement.TryGetProperty("id", out var idEl) &&
+                    idEl.ValueKind == JsonValueKind.String &&
+                    Guid.TryParse(idEl.GetString(), out var g))
+                    documentId = g;
+            }
+            catch (JsonException) { /* leave null */ }
+        }
+
+        return new ReviewSubject
+        {
+            Kind = ReviewerSelectionHelper.DocumentSubjectKind,
+            DocumentId = documentId,
+            DocumentType = documentType,
+        };
+    }
+
+    private static string ExtractPayload(string documentJson)
+    {
+        if (string.IsNullOrWhiteSpace(documentJson)) return "{}";
+        try
+        {
+            using var doc = JsonDocument.Parse(documentJson);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object &&
+                doc.RootElement.TryGetProperty("payload", out var payload))
+                return payload.GetRawText();
+        }
+        catch (JsonException) { /* fall through */ }
+        return documentJson;
+    }
+
+    private static string BuildReviewerVariables(string documentJson)
+    {
+        var payload = ExtractPayload(documentJson);
+        var vars = new Dictionary<string, object?>
+        {
+            ["planJson"] = payload,
+            ["documentJson"] = documentJson ?? "",
+        };
+        return JsonSerializer.Serialize(vars);
+    }
+
+    private static string ReadString(IDictionary<string, object>? result, string key)
+        => result != null && result.TryGetValue(key, out var v) ? v?.ToString() ?? "" : "";
+
+    private static bool ReadBool(IDictionary<string, object>? result, string key)
+    {
+        if (result == null || !result.TryGetValue(key, out var v)) return false;
+        return v is true || (v is string s && bool.TryParse(s, out var b) && b);
+    }
+
+    private static FlowConnection Connect(IActivity source, IActivity target)
+        => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewPanelAggregation.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewPanelAggregation.cs
@@ -1,0 +1,187 @@
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Story 39-7 (Design Decision D6) — the PURE panel aggregation over
+/// <c>IReadOnlyList&lt;<see cref="Review"/>&gt;</c> (AC3). NO JSON parsing anywhere
+/// in this file: it operates on already-mapped unified reviews. The blocking veto
+/// (<see cref="ReviewSeverityExtensions.IsBlocking"/>) is an INVARIANT, not a knob —
+/// any member carrying a Critical issue forces the aggregate to
+/// <see cref="ReviewDecision.RequestChanges"/> regardless of the decision rule, and
+/// because the aggregate's <c>Issues</c> are the concatenation of member issues, an
+/// <c>Approve</c> aggregate with a member's Critical issue would itself fail
+/// <see cref="ReviewDocumentType.Validate"/> (<c>APPROVE_WITH_BLOCKING_ISSUES</c>).
+///
+/// <para><b>Default config = <see cref="PanelDecisionRule.Unanimous"/> +
+/// <see cref="PanelAggregationRules.MinimumUsableReviews"/> = roster size</b> ⇒
+/// behavioural parity with <see cref="ReviewAggregationHelper.AggregateVerdicts"/>
+/// (<c>All(approve)</c>). Deliberate divergences (AC8): an empty panel is
+/// <see cref="PanelUndecidableReason.EmptyPanel"/> (NOT approved — the old
+/// <c>All()</c>-on-empty bug); a garbage/failed member drops the panel below quorum
+/// to <see cref="PanelUndecidableReason.BelowQuorum"/> (NOT laundered to a
+/// pessimistic concerns verdict).</para>
+/// </summary>
+public static class ReviewPanelAggregation
+{
+    /// <summary>How the panel resolves its aggregate decision (39-5 <c>ReviewDecisionRule</c>).</summary>
+    public enum PanelDecisionRule
+    {
+        Unanimous,
+        Majority,
+    }
+
+    /// <summary>Why a panel could not decide (AC6 — surfaced typed, never silently resolved).</summary>
+    public enum PanelUndecidableReason
+    {
+        EmptyPanel,
+        BelowQuorum,
+        SplitDecision,
+    }
+
+    /// <summary>
+    /// One panel member's outcome. <see cref="Ok"/> + a non-null <see cref="Review"/>
+    /// marks a USABLE member; a failed member carries <see cref="FailureKind"/> and
+    /// is never coalesced into a phantom participant.
+    /// </summary>
+    public sealed record PanelMember(
+        string Role,
+        Guid? ReviewDocumentId,
+        Review? Review,
+        bool Ok,
+        string? FailureKind)
+    {
+        public bool IsUsable => Ok && Review is not null;
+    }
+
+    /// <summary>The two aggregation knobs (D6).</summary>
+    public sealed record PanelAggregationRules(PanelDecisionRule DecisionRule, int MinimumUsableReviews);
+
+    /// <summary>
+    /// The aggregation outcome. <see cref="Decided"/> carries an
+    /// <see cref="Aggregate"/> review; an undecidable result carries a
+    /// <see cref="Reason"/> and null aggregate, plus ALL member review ids (AC6).
+    /// </summary>
+    public sealed record PanelResult(
+        bool Decided,
+        Review? Aggregate,
+        IReadOnlyList<Guid> MemberReviewIds,
+        int SucceededCount,
+        IReadOnlyList<string> FailedRoles,
+        PanelUndecidableReason? Reason);
+
+    /// <summary>
+    /// The default aggregation config for a roster of <paramref name="rosterSize"/>:
+    /// unanimous + full-roster minimum — the <see cref="ReviewAggregationHelper.AggregateVerdicts"/>
+    /// parity configuration.
+    /// </summary>
+    public static PanelAggregationRules DefaultsFor(int rosterSize) =>
+        new(PanelDecisionRule.Unanimous, rosterSize);
+
+    /// <summary>
+    /// AC3's pure decision core over the usable members' decisions, with the
+    /// blocking veto applied first (any Critical issue ⇒ RequestChanges). A Majority
+    /// tie defaults to the safe RequestChanges here — the caller
+    /// (<see cref="Aggregate"/>) detects the tie separately to surface it as a
+    /// <see cref="PanelUndecidableReason.SplitDecision"/>.
+    /// </summary>
+    public static ReviewDecision ComputeDecision(IReadOnlyList<Review> usableReviews, PanelDecisionRule rule)
+    {
+        if (HasBlockingIssue(usableReviews))
+            return ReviewDecision.RequestChanges;
+
+        var approve = usableReviews.Count(r => r.Decision == ReviewDecision.Approve);
+        var nonApprove = usableReviews.Count - approve;
+
+        return rule switch
+        {
+            PanelDecisionRule.Unanimous => nonApprove == 0 ? ReviewDecision.Approve : ReviewDecision.RequestChanges,
+            PanelDecisionRule.Majority => approve > nonApprove ? ReviewDecision.Approve : ReviewDecision.RequestChanges,
+            _ => ReviewDecision.RequestChanges,
+        };
+    }
+
+    /// <summary>
+    /// Aggregate the panel members into a decided aggregate <see cref="Review"/> or a
+    /// typed undecidable result (D6/AC6). The aggregate's subject is the reviewed
+    /// <paramref name="subject"/>; its issues are the concatenation of member issues;
+    /// its <c>AggregatedFrom</c> lists the contributing member review ids.
+    /// </summary>
+    public static PanelResult Aggregate(
+        IReadOnlyList<PanelMember> members,
+        PanelAggregationRules rules,
+        ReviewSubject subject)
+    {
+        var usable = members.Where(m => m.IsUsable).ToList();
+        var usableReviews = usable.Select(m => m.Review!).ToList();
+        var allMemberIds = members
+            .Where(m => m.ReviewDocumentId.HasValue)
+            .Select(m => m.ReviewDocumentId!.Value)
+            .ToList();
+        var failedRoles = members.Where(m => !m.IsUsable).Select(m => m.Role).ToList();
+
+        // Divergence (a): empty panel is undecidable, NOT the old All()-on-empty approve.
+        if (usableReviews.Count == 0)
+            return Undecidable(PanelUndecidableReason.EmptyPanel, allMemberIds, 0, failedRoles);
+
+        // Divergence (b): a below-quorum panel (a failed/garbage member under the
+        // full-roster minimum) is undecidable, NOT laundered to a pessimistic verdict.
+        if (usableReviews.Count < rules.MinimumUsableReviews)
+            return Undecidable(PanelUndecidableReason.BelowQuorum, allMemberIds, usableReviews.Count, failedRoles);
+
+        // Majority split (no blocking veto in play) is undecidable.
+        if (rules.DecisionRule == PanelDecisionRule.Majority &&
+            !HasBlockingIssue(usableReviews) &&
+            IsSplit(usableReviews))
+            return Undecidable(PanelUndecidableReason.SplitDecision, allMemberIds, usableReviews.Count, failedRoles);
+
+        var decision = ComputeDecision(usableReviews, rules.DecisionRule);
+        var aggregatedFrom = usable
+            .Where(m => m.ReviewDocumentId.HasValue)
+            .Select(m => m.ReviewDocumentId!.Value)
+            .ToList();
+
+        var issues = usable.SelectMany(m => m.Review!.Issues).ToList();
+        var summary = string.Join(
+            " | ",
+            usable.Select(m => $"{m.Role}: {m.Review!.Decision.ToWire()} — {Trim(m.Review!.Summary)}"));
+
+        var aggregate = new Review
+        {
+            Subject = subject,
+            Decision = decision,
+            Summary = string.IsNullOrWhiteSpace(summary) ? "Panel aggregate review." : summary,
+            Issues = issues,
+            AggregatedFrom = aggregatedFrom.Count > 0 ? aggregatedFrom : null,
+        };
+
+        return new PanelResult(
+            Decided: true,
+            Aggregate: aggregate,
+            MemberReviewIds: allMemberIds,
+            SucceededCount: usableReviews.Count,
+            FailedRoles: failedRoles,
+            Reason: null);
+    }
+
+    private static PanelResult Undecidable(
+        PanelUndecidableReason reason, IReadOnlyList<Guid> memberIds, int succeeded, IReadOnlyList<string> failedRoles) =>
+        new(false, null, memberIds, succeeded, failedRoles, reason);
+
+    private static bool HasBlockingIssue(IReadOnlyList<Review> reviews) =>
+        reviews.Any(r => r.Issues.Any(i => i.Severity.IsBlocking()));
+
+    /// <summary>An exact approve/non-approve tie among the usable members.</summary>
+    private static bool IsSplit(IReadOnlyList<Review> reviews)
+    {
+        var approve = reviews.Count(r => r.Decision == ReviewDecision.Approve);
+        var nonApprove = reviews.Count - approve;
+        return approve == nonApprove;
+    }
+
+    private static string Trim(string? s)
+    {
+        s ??= string.Empty;
+        return s.Length <= 120 ? s : s[..120];
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewProducerHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewProducerHelper.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Story 39-7 (Design Decisions D4/D5) — the PURE reviewer-reply mapper + repair
+/// helpers for the single-reviewer producer. Maps an <c>llm-call</c> reply onto the
+/// unified 39-4 <see cref="Review"/> — canonical shape first, the CURRENT reviewer
+/// cell shape (top-level <c>issues[]</c> + a <c>verdict</c> half) second, and
+/// GARBAGE into typed <see cref="DocumentViolation"/>s, never a defaulted
+/// <c>"concerns"</c> review (the <c>PlanReviewWorkflow.ExtractReview</c> anti-pattern
+/// AC1 kills). Every mapped payload is validated by
+/// <see cref="ReviewDocumentType"/> so blocking-issues⇒not-approvable is enforced.
+///
+/// <para>No Elsa runtime dependency; same fail-closed posture as
+/// <see cref="ReviewAggregationHelper"/> — but this SUPERSEDES its parsing half.</para>
+/// </summary>
+public static class ReviewProducerHelper
+{
+    /// <summary>Violation code for a reply that could not be mapped to a review at all.</summary>
+    public const string UnparseableReply = "REVIEW.PRODUCER.UNPARSEABLE_REPLY";
+
+    /// <summary>
+    /// The outcome of <see cref="MapReviewerReply"/>: a VALID review payload, OR a
+    /// non-empty violation list (unparseable OR invalid). <see cref="Payload"/> is
+    /// non-null IFF the mapped review passed <see cref="ReviewDocumentType"/>
+    /// validation — an invalid or unparseable reply carries violations and a null
+    /// payload, never a laundered review.
+    /// </summary>
+    public sealed record MapResult(Review? Payload, IReadOnlyList<DocumentViolation> Violations)
+    {
+        public bool IsValid => Payload is not null && Violations.Count == 0;
+    }
+
+    /// <summary>
+    /// Map an <c>llm-call</c> reviewer reply onto a validated unified
+    /// <see cref="Review"/> (D4). Order: (1) canonical <see cref="Review"/> JSON;
+    /// (2) the legacy cell shape — top-level <c>issues[]</c> folded with the
+    /// <c>verdict</c> half via <see cref="Review.FromLegacyVerdictJson"/>; (3)
+    /// anything else → violations. The caller's <paramref name="subject"/> is
+    /// authoritative and overrides any subject in the reply. The mapped review is
+    /// then validated — a legacy issue with no suggested fix deserializes but FAILS
+    /// validation (routed to repair, not laundered).
+    /// </summary>
+    public static MapResult MapReviewerReply(string? llmResponse, ReviewSubject subject)
+    {
+        var json = ExtractJsonObject(llmResponse);
+        if (json is null)
+            return Fail("The reviewer reply contained no parseable JSON object.");
+
+        // (1) Canonical Review first. A legacy reply lacks the required
+        //     subject/decision/summary/issues members, so it throws here and falls
+        //     through to the legacy path — it never masquerades as canonical.
+        Review? candidate = TryDeserializeCanonical(json);
+
+        // (2) Legacy cell shape.
+        if (candidate is null)
+        {
+            try
+            {
+                candidate = MapLegacyCellShape(json, subject);
+            }
+            catch (TammaError)
+            {
+                // FromLegacyVerdictJson / severity parsing failed loud → violations,
+                // NEVER a defaulted review.
+                return Fail(
+                    "The reviewer reply is neither a canonical review nor a recognised legacy verdict shape " +
+                    "(no usable 'decision'/'verdict', or an out-of-vocabulary severity).");
+            }
+        }
+        else
+        {
+            // Canonical reply: the caller's subject is authoritative.
+            candidate = candidate with { Subject = subject };
+        }
+
+        // (3) Validate the mapped payload (blocking-issues⇒not-approvable, AC1).
+        var result = ValidateReview(candidate);
+        return result.IsValid
+            ? new MapResult(candidate, Array.Empty<DocumentViolation>())
+            : new MapResult(null, result.Violations);
+    }
+
+    private static Review? TryDeserializeCanonical(string json)
+    {
+        try
+        {
+            var review = JsonSerializer.Deserialize<Review>(json, DocumentJson.Options);
+            // A canonical review must carry the required members; a null or a legacy
+            // shape that happened to deserialize leniently is rejected.
+            return review;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Map the CURRENT reviewer cell shape (D4): the top-level <c>issues[]</c> array
+    /// (<c>task|severity|category|issue|recommendation</c>) plus the <c>verdict</c>
+    /// half delegated to <see cref="Review.FromLegacyVerdictJson"/>. The full-cell
+    /// issues mapping lives HERE (39-4 scoped its reader to verdict parity).
+    /// </summary>
+    private static Review MapLegacyCellShape(string json, ReviewSubject subject)
+    {
+        // Verdict half → decision + summary + blockingIssues-derived Critical issues.
+        var verdictReview = Review.FromLegacyVerdictJson(json, subject);
+
+        var issues = new List<ReviewIssue>();
+        using (var doc = JsonDocument.Parse(json))
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("issues", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in arr.EnumerateArray())
+                {
+                    if (item.ValueKind != JsonValueKind.Object)
+                        continue;
+
+                    var severityRaw = GetString(item, "severity");
+                    // Skip a fully-empty issue object; otherwise fail loud on a bad
+                    // severity (routed to repair, never clamped).
+                    if (severityRaw is null && GetString(item, "issue") is null && GetString(item, "category") is null)
+                        continue;
+
+                    var severity = ReviewSeverityExtensions.ParseLegacy(severityRaw);
+                    var category = GetString(item, "category") ?? string.Empty;
+                    var body = GetString(item, "issue") ?? GetString(item, "description") ?? string.Empty;
+                    var fix = GetString(item, "recommendation") ?? GetString(item, "suggestedFix") ?? string.Empty;
+                    var task = GetString(item, "task");
+                    var file = GetString(item, "file");
+                    var line = GetString(item, "line");
+
+                    var description = string.IsNullOrWhiteSpace(task) ? body : $"[{task}] {body}";
+                    issues.Add(new ReviewIssue(severity, category, description, fix, file, line));
+                }
+            }
+        }
+
+        // Concatenate the cell's issues after any blocking issues the verdict half
+        // already produced.
+        var combined = new List<ReviewIssue>(verdictReview.Issues);
+        combined.AddRange(issues);
+        return verdictReview with { Issues = combined };
+    }
+
+    private static DocumentValidationResult ValidateReview(Review review)
+    {
+        var payloadJson = JsonSerializer.Serialize(review, DocumentJson.Options);
+        using var doc = JsonDocument.Parse(payloadJson);
+        return DocumentTypeRegistry.Resolve(DocumentTypeKey.Review).Validate(doc.RootElement);
+    }
+
+    /// <summary>
+    /// Build the repair-turn variables (D5): fold the domain-phrased violations +
+    /// the review contract into the feedback variable the reviewer cell DECLARES
+    /// (default <c>workItemJson</c>), via
+    /// <see cref="ValidationFeedbackHelper.AppendFeedback"/> — a supplied-but-
+    /// undeclared variable is silently dropped at render, so we only ever write into
+    /// a declared one. Byte-identical passthrough when there are no violations.
+    /// </summary>
+    public static string BuildRepairVariables(
+        string? variablesJson,
+        IReadOnlyList<DocumentViolation> violations,
+        string feedbackVariableName,
+        string contract)
+    {
+        Dictionary<string, object?> vars;
+        try
+        {
+            vars = string.IsNullOrWhiteSpace(variablesJson)
+                ? new Dictionary<string, object?>()
+                : JsonSerializer.Deserialize<Dictionary<string, object?>>(variablesJson!) ?? new Dictionary<string, object?>();
+        }
+        catch (JsonException)
+        {
+            vars = new Dictionary<string, object?>();
+        }
+
+        // No violations → byte-identical passthrough of the feedback variable
+        // (AppendFeedback returns the base unchanged on empty errors).
+        var feedback = violations.Count == 0
+            ? string.Empty
+            : string.Join(
+                "; ",
+                violations.Select(v => v.Message)
+                    .Append("Required output contract:")
+                    .Append(contract));
+
+        var baseValue = vars.TryGetValue(feedbackVariableName, out var existing) ? existing?.ToString() : null;
+        vars[feedbackVariableName] = ValidationFeedbackHelper.AppendFeedback(baseValue, feedback);
+
+        return JsonSerializer.Serialize(vars);
+    }
+
+    /// <summary>The default feedback variable — every reviewer cell declares it.</summary>
+    public const string DefaultFeedbackVariable = "workItemJson";
+
+    /// <summary>Whether another repair attempt is allowed (D5): <c>attempts &lt; Max</c>.</summary>
+    public static bool ShouldRepair(int attempts, AcceptanceRules rules) =>
+        attempts < rules.MaxValidationRepairAttempts;
+
+    private static MapResult Fail(string message) =>
+        new(null, new[] { new DocumentViolation(UnparseableReply, message) });
+
+    private static string? GetString(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    /// <summary>Carve the first <c>{</c> … last <c>}</c> JSON object out of a reply.</summary>
+    internal static string? ExtractJsonObject(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        if (start < 0 || end <= start) return null;
+        var candidate = text[start..(end + 1)];
+        try
+        {
+            using var _ = JsonDocument.Parse(candidate);
+            return candidate;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewerSelectionHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/ReviewerSelectionHelper.cs
@@ -1,0 +1,220 @@
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// Story 39-7 (Design Decision D3) — the PURE reviewer <c>(role, action)</c>
+/// derivation the review producers dispatch through. Pulls the plan/task review
+/// action from <see cref="RolePhaseMap.GetReviewActionForRole"/> for a
+/// <c>document</c> subject, and from a LOCAL diff-review map (kept out of
+/// <see cref="RolePhaseMap"/> per AC9's frozen surface, drift-pinned by test) for a
+/// <c>diff</c> subject. An explicit <c>reviewerAction</c> override wins over
+/// derivation; either way the pair is validated fail-loud through the agent
+/// taxonomy so a bad reviewer selection is a LOUD <c>TammaError</c>, never a
+/// silent mismatch.
+///
+/// <para>Doc-comment posture mirrors <c>TriagePoDecisionHelper</c>: no Elsa runtime
+/// dependency, every branch named, reject-not-clamp.</para>
+/// </summary>
+public static class ReviewerSelectionHelper
+{
+    /// <summary>Error code for an unknown / ineligible reviewer <c>(role, action)</c> pair.</summary>
+    public const string InvalidReviewerCode = "REVIEW.PRODUCER.INVALID_REVIEWER";
+
+    /// <summary>Error code for a role that has no seat on the diff (code-review) panel.</summary>
+    public const string RoleNotOnDiffPanelCode = "REVIEW.PRODUCER.ROLE_NOT_ON_DIFF_PANEL";
+
+    /// <summary>Subject-kind wire for a document reference (39-4 <c>ReviewSubject.Kind</c>).</summary>
+    public const string DocumentSubjectKind = "document";
+
+    /// <summary>Subject-kind wire for a diff reference (39-4 <c>ReviewSubject.Kind</c>).</summary>
+    public const string DiffSubjectKind = "diff";
+
+    /// <summary>A resolved reviewer dispatch pair.</summary>
+    public sealed record ReviewerSpec(AgentRole Role, AgentAction Action);
+
+    /// <summary>
+    /// The diff (code-review) review action per role (Design Decision D3). Lives
+    /// HERE, not in <see cref="RolePhaseMap"/> (AC9 freezes that file); the drift
+    /// test pins this map against the taxonomy. <c>devops</c> / <c>product_owner</c>
+    /// / <c>tech_writer</c> have no diff-review seat.
+    /// </summary>
+    private static AgentAction DiffReviewAction(AgentRole role) => role switch
+    {
+        AgentRole.SeniorDeveloper => AgentAction.CodeReview,
+        AgentRole.Developer => AgentAction.CodeReview,
+        AgentRole.Architect => AgentAction.CodeReviewArchitecture,
+        AgentRole.Security => AgentAction.CodeReviewSecurity,
+        AgentRole.Tester => AgentAction.CodeReviewCoverage,
+        _ => throw new TammaError(
+            RoleNotOnDiffPanelCode,
+            $"Role '{role.ToWire()}' has no seat on the diff (code-review) panel — only " +
+            "senior_developer, developer, architect, security, tester review diffs.",
+            new Dictionary<string, object?> { ["role"] = role.ToWire() },
+            retryable: false,
+            severity: TammaErrorSeverity.High),
+    };
+
+    /// <summary>The 7-role document-review roster (the domain of GetReviewActionForRole).</summary>
+    private static readonly AgentRole[] s_documentRoster =
+    [
+        AgentRole.Architect,
+        AgentRole.SeniorDeveloper,
+        AgentRole.Security,
+        AgentRole.Developer,
+        AgentRole.Tester,
+        AgentRole.Devops,
+        AgentRole.ProductOwner,
+    ];
+
+    /// <summary>The 5-role diff-review roster.</summary>
+    private static readonly AgentRole[] s_diffRoster =
+    [
+        AgentRole.SeniorDeveloper,
+        AgentRole.Developer,
+        AgentRole.Architect,
+        AgentRole.Security,
+        AgentRole.Tester,
+    ];
+
+    /// <summary>
+    /// Resolve the reviewer <c>(role, action)</c> for a review dispatch (AC4 runtime
+    /// half). <paramref name="actionOverride"/> (when non-empty) wins over
+    /// derivation; otherwise the action comes from the document-review map (kind
+    /// <c>document</c>) or the diff-review map (kind <c>diff</c>). The resolved pair
+    /// is asserted taxonomy-eligible via <see cref="RolePhaseMap.IsRoleEligibleForPhase"/>.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <see cref="InvalidReviewerCode"/> for an unknown role/action, an
+    /// ineligible pair, or an unknown subject kind; code
+    /// <see cref="RoleNotOnDiffPanelCode"/> for a role with no diff seat.
+    /// </exception>
+    public static ReviewerSpec Resolve(string role, string? actionOverride, string subjectKind, string? documentTypeKey)
+    {
+        AgentRole parsedRole;
+        try
+        {
+            parsedRole = AgentRoleExtensions.Parse(role);
+        }
+        catch (ArgumentException ex)
+        {
+            throw Invalid($"Reviewer role '{role}' is not a known agent role: {ex.Message}", role, actionOverride);
+        }
+
+        AgentAction action;
+        if (!string.IsNullOrWhiteSpace(actionOverride))
+        {
+            try
+            {
+                action = AgentActionExtensions.Parse(actionOverride!);
+            }
+            catch (ArgumentException ex)
+            {
+                throw Invalid($"Reviewer action override '{actionOverride}' is not a known agent action: {ex.Message}", role, actionOverride);
+            }
+        }
+        else
+        {
+            action = subjectKind switch
+            {
+                DocumentSubjectKind => ResolveDocumentAction(parsedRole),
+                DiffSubjectKind => DiffReviewAction(parsedRole),
+                _ => throw Invalid(
+                    $"Unknown review subject kind '{subjectKind}' — expected 'document' or 'diff'.",
+                    role, actionOverride),
+            };
+        }
+
+        if (!RolePhaseMap.IsRoleEligibleForPhase(action.ToWire(), parsedRole.ToWire()))
+            throw Invalid(
+                $"Reviewer role '{parsedRole.ToWire()}' is not eligible for action '{action.ToWire()}' " +
+                "(not in that role's taxonomy action set).",
+                role, action.ToWire());
+
+        return new ReviewerSpec(parsedRole, action);
+    }
+
+    private static AgentAction ResolveDocumentAction(AgentRole role)
+    {
+        try
+        {
+            return RolePhaseMap.GetReviewActionForRole(role);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            throw Invalid(
+                $"Role '{role.ToWire()}' is not on a document review panel.",
+                role.ToWire(), null);
+        }
+    }
+
+    /// <summary>
+    /// Every <c>(role, action)</c> pair the producers can dispatch (Design Decision
+    /// D9 pin surface): the 7 document-review pairs + the 5 diff-review pairs = 12.
+    /// The <c>ContractBindingTests</c> classification guard iterates this so a
+    /// reviewer cell reachable by policy but bound nowhere fails the build.
+    /// </summary>
+    public static IReadOnlyList<(string Role, string Action)> AllDispatchablePairs { get; } = BuildAllPairs();
+
+    private static IReadOnlyList<(string Role, string Action)> BuildAllPairs()
+    {
+        var pairs = new List<(string, string)>();
+        foreach (var role in s_documentRoster)
+            pairs.Add((role.ToWire(), RolePhaseMap.GetReviewActionForRole(role).ToWire()));
+        foreach (var role in s_diffRoster)
+            pairs.Add((role.ToWire(), DiffReviewAction(role).ToWire()));
+        return pairs;
+    }
+
+    /// <summary>
+    /// The 7-role document panel roster (the superset the panel graph iterates).
+    /// </summary>
+    public static IReadOnlyList<AgentRole> DocumentPanelRoster => s_documentRoster;
+
+    /// <summary>
+    /// The effective panel roster from the acceptance rules (Design Decision D11):
+    /// a panel selection's <c>PanelRoles</c>, or a single-reviewer selection's one
+    /// role. Each role is validated fail-loud. An empty
+    /// <paramref name="acceptanceRulesJson"/> falls back to
+    /// <see cref="AcceptanceDefaults.Rules"/> (single architect).
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <see cref="InvalidReviewerCode"/> for a roster role that is not a known
+    /// agent role.
+    /// </exception>
+    public static IReadOnlyList<string> ResolvePanelRoster(string? acceptanceRulesJson)
+    {
+        var rules = string.IsNullOrWhiteSpace(acceptanceRulesJson)
+            ? AcceptanceDefaults.Rules
+            : AcceptanceRulesJson.Deserialize(acceptanceRulesJson!);
+
+        var sel = rules.ReviewerSelection;
+        var roster = sel.Mode == ReviewerMode.Panel
+            ? (sel.PanelRoles ?? Array.Empty<string>()).ToList()
+            : new List<string> { sel.ReviewerRole ?? string.Empty };
+
+        foreach (var r in roster)
+        {
+            try
+            {
+                AgentRoleExtensions.Parse(r);
+            }
+            catch (ArgumentException ex)
+            {
+                throw Invalid($"Panel roster role '{r}' is not a known agent role: {ex.Message}", r, null);
+            }
+        }
+
+        return roster;
+    }
+
+    private static TammaError Invalid(string message, string? role, string? action) =>
+        new(
+            InvalidReviewerCode,
+            message,
+            new Dictionary<string, object?> { ["role"] = role, ["action"] = action },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PanelReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PanelReviewWorkflow.cs
@@ -1,0 +1,527 @@
+using System.Text;
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities.Documents;
+using Tamma.Api.Services.Agents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 39-7 (AC2, AC6, AC7; Design Decision D2) — the panel producer
+/// (<c>DefinitionId = "review-panel"</c>). Fans out N single-reviewer runs over the
+/// policy-configured roster (a static 7-role superset with per-role membership
+/// gates), persists every member review with lineage (each member IS a full
+/// <see cref="SingleReviewerWorkflow"/> run — DOCUMENT.* events emitted inside), and
+/// aggregates via the pure <see cref="ReviewPanelAggregation"/> into an aggregate
+/// <see cref="Review"/> whose <c>AggregatedFrom</c> references its member review ids
+/// (D7). An undecidable panel surfaces TYPED (<c>DOCUMENT.REVIEW_PANEL_UNDECIDABLE</c>,
+/// <c>success=false</c>) carrying ALL member reviews — NO pessimistic aggregate is
+/// ever fabricated (AC6).
+///
+/// <para>Zero <c>llm-call</c> nodes: the panel dispatches only the
+/// <c>review-single-reviewer</c> sub-workflow (the one implementation of
+/// dispatch/validate/persist). Vocabulary static, composition dynamic.</para>
+/// </summary>
+public class PanelReviewWorkflow : WorkflowBase
+{
+    public const string ReviewPanelDefinitionId = "review-panel";
+
+    /// <summary>
+    /// The static 7-role panel roster (the domain of
+    /// <see cref="RolePhaseMap.GetReviewActionForRole"/>). Single source of truth:
+    /// the dispatch chain, the membership gates, and the capture all iterate it.
+    /// </summary>
+    private static readonly AgentRole[] PanelRoles = ReviewerSelectionHelper.DocumentPanelRoster.ToArray();
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "Panel Review";
+        builder.DefinitionId = ReviewPanelDefinitionId;
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description =
+            "Fans out N single-reviewer runs over a policy roster and aggregates their unified Reviews into " +
+            "an aggregate Review (or a typed undecidable result carrying all member reviews)";
+
+        // ── Inputs threaded to each member + the aggregation ──
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
+        var contentJson = builder.WithVariable<string>("ContentJson", "{}");
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
+        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable);
+        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "");
+        var issueId = builder.WithVariable<string>("IssueId", "");
+        var correlationId = builder.WithVariable<string>("CorrelationId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+
+        // ── Resolved panel config ──
+        var rosterJson = builder.WithVariable<string>("RosterJson", "[]");
+        var decisionRuleWire = builder.WithVariable<string>("DecisionRuleWire", "unanimous");
+        var minimumUsableReviews = builder.WithVariable<int>("MinimumUsableReviews", 0);
+        var memberCount = builder.WithVariable<int>("MemberCount", 0);
+
+        // ── Per-role member captures (JSON). Default "{}" = not dispatched. ──
+        var memberVars = PanelRoles.ToDictionary(
+            r => r,
+            r => builder.WithVariable<string>($"{r}MemberResultJson", "{}"));
+
+        // ── Shared sub-workflow dispatch result ──
+        var memberResult = builder.WithVariable<IDictionary<string, object>?>();
+
+        // ── Aggregate outputs ──
+        var decided = builder.WithVariable<bool>("Decided", false);
+        var aggregateReviewJson = builder.WithVariable<string>("AggregateReviewJson", "");
+        var aggregateEnvelopeJson = builder.WithVariable<string>("AggregateEnvelopeJson", "");
+        var aggregateDocumentId = builder.WithVariable<string>("AggregateDocumentId", "");
+        var aggregateProducerRole = builder.WithVariable<string>("AggregateProducerRole", "");
+        var aggregateProducerAction = builder.WithVariable<string>("AggregateProducerAction", "");
+        var memberReviewsJson = builder.WithVariable<string>("MemberReviewsJson", "[]");
+        var undecidableReason = builder.WithVariable<string>("UndecidableReason", "");
+        var succeededCount = builder.WithVariable<int>("SucceededCount", 0);
+
+        // ================================================================
+        // Init — resolve roster + rule + quorum (D11)
+        // ================================================================
+        var init = new SetVariable
+        {
+            Id = "Init", Name = "Init",
+            Variable = rosterJson,
+            Value = new(ctx =>
+            {
+                var subjJson = ctx.GetInput<string>("subjectJson") ?? "";
+                var rulesInput = ctx.GetInput<string>("acceptanceRulesJson") ?? "";
+                var overrideRule = ctx.GetInput<string>("panelDecisionRule");
+
+                var subject = ParseSubject(subjJson);
+                var roster = ReviewerSelectionHelper.ResolvePanelRoster(rulesInput);
+                var rules = string.IsNullOrWhiteSpace(rulesInput) ? AcceptanceDefaults.Rules : AcceptanceRulesJson.Deserialize(rulesInput);
+
+                var ruleWire = !string.IsNullOrWhiteSpace(overrideRule)
+                    ? overrideRule!
+                    : rules.ReviewerSelection.DecisionRule.ToWire();
+                var minimum = rules.ReviewerSelection.Quorum ?? roster.Count;
+
+                contentJson.Set(ctx, ctx.GetInput<string>("contentJson") ?? "{}");
+                variablesJson.Set(ctx, ctx.GetInput<string>("variablesJson") ?? "{}");
+                var feedbackVar = ctx.GetInput<string>("feedbackVariableName");
+                feedbackVariableName.Set(ctx, string.IsNullOrWhiteSpace(feedbackVar) ? ReviewProducerHelper.DefaultFeedbackVariable : feedbackVar!);
+                documentTypeKey.Set(ctx, ctx.GetInput<string>("documentTypeKey") ?? "");
+                var issue = ctx.GetInput<string>("issueId") ?? "";
+                issueId.Set(ctx, issue);
+                var corr = ctx.GetInput<string>("correlationId") ?? "";
+                correlationId.Set(ctx, string.IsNullOrWhiteSpace(corr) ? issue : corr);
+                tenantId.Set(ctx, ctx.GetInput<string>("tenantId") ?? "");
+                acceptanceRulesJson.Set(ctx, rulesInput);
+
+                subjectJson.Set(ctx, JsonSerializer.Serialize(subject, DocumentJson.Options));
+                decisionRuleWire.Set(ctx, ruleWire);
+                minimumUsableReviews.Set(ctx, minimum);
+                memberCount.Set(ctx, roster.Count);
+
+                return JsonSerializer.Serialize(roster);
+            })
+        };
+        init.SetDisplayText("Init");
+
+        var emitPanelStarted = PanelEvent(
+            "EmitPanelStarted", "Emit Panel Started", DocumentEvents.ReviewPanelStarted,
+            issueId, correlationId, tenantId,
+            ctx => $"{{\"memberCount\":{memberCount.Get(ctx)}}}", "Panel started");
+
+        // ================================================================
+        // Per-role chain: InPanel? → DispatchMember → CaptureMember → next
+        // ================================================================
+        var roleNodes = new List<(FlowDecision gate, DispatchWorkflow dispatch, SetVariable capture)>();
+        foreach (var role in PanelRoles)
+        {
+            var roleWire = role.ToWire();
+            var idBase = role.ToString();
+
+            var gate = new FlowDecision(ctx => RosterContains(rosterJson.Get(ctx), roleWire))
+            { Id = $"InPanel{idBase}", Name = $"{roleWire} In Panel?" };
+            gate.SetDisplayText($"{roleWire} In Panel?");
+
+            var dispatch = new DispatchWorkflow
+            {
+                Id = $"DispatchMember{idBase}", Name = $"Dispatch {roleWire} Review",
+                WorkflowDefinitionId = new(SingleReviewerWorkflow.ReviewSingleReviewerDefinitionId),
+                Input = new(ctx => new Dictionary<string, object>
+                {
+                    ["reviewerRole"] = roleWire,
+                    ["subjectJson"] = subjectJson.Get(ctx) ?? "",
+                    ["contentJson"] = contentJson.Get(ctx) ?? "{}",
+                    ["variablesJson"] = variablesJson.Get(ctx) ?? "{}",
+                    ["feedbackVariableName"] = feedbackVariableName.Get(ctx) ?? ReviewProducerHelper.DefaultFeedbackVariable,
+                    ["documentTypeKey"] = documentTypeKey.Get(ctx) ?? "",
+                    ["issueId"] = issueId.Get(ctx) ?? "",
+                    ["correlationId"] = correlationId.Get(ctx) ?? "",
+                    ["tenantId"] = tenantId.Get(ctx) ?? "",
+                    ["acceptanceRulesJson"] = acceptanceRulesJson.Get(ctx) ?? "",
+                }),
+                WaitForCompletion = new(true),
+                Result = new(memberResult),
+            };
+            dispatch.SetDisplayText($"Dispatch {roleWire} Review");
+
+            var capture = new SetVariable
+            {
+                Id = $"CaptureMember{idBase}", Name = $"Capture {roleWire} Review",
+                Variable = memberVars[role],
+                Value = new(ctx => (object)CaptureMember(roleWire, memberResult.Get(ctx)))
+            };
+            capture.SetDisplayText($"Capture {roleWire} Review");
+
+            roleNodes.Add((gate, dispatch, capture));
+        }
+
+        // ================================================================
+        // Aggregate — build PanelMembers from captures → ReviewPanelAggregation
+        // ================================================================
+        var aggregate = new SetVariable
+        {
+            Id = "AggregateResults", Name = "Aggregate Results",
+            Variable = decided,
+            Value = new(ctx =>
+            {
+                var subject = ParseSubject(subjectJson.Get(ctx));
+                var roster = DeserializeRoster(rosterJson.Get(ctx));
+
+                var members = new List<ReviewPanelAggregation.PanelMember>();
+                var captures = new List<string>();
+                foreach (var role in PanelRoles)
+                {
+                    var roleWire = role.ToWire();
+                    if (!roster.Contains(roleWire)) continue;
+
+                    var captureJson = memberVars[role].Get(ctx);
+                    captures.Add(captureJson);
+                    members.Add(ToPanelMember(roleWire, captureJson));
+                }
+
+                var rule = EnumWire<ReviewDecisionRule>.TryParse(decisionRuleWire.Get(ctx), out var dr)
+                    ? (dr == ReviewDecisionRule.Majority ? ReviewPanelAggregation.PanelDecisionRule.Majority : ReviewPanelAggregation.PanelDecisionRule.Unanimous)
+                    : ReviewPanelAggregation.PanelDecisionRule.Unanimous;
+
+                var rules = new ReviewPanelAggregation.PanelAggregationRules(rule, minimumUsableReviews.Get(ctx));
+                var result = ReviewPanelAggregation.Aggregate(members, rules, subject);
+
+                memberReviewsJson.Set(ctx, "[" + string.Join(",", captures) + "]");
+                succeededCount.Set(ctx, result.SucceededCount);
+
+                if (result.Decided)
+                {
+                    aggregateReviewJson.Set(ctx, JsonSerializer.Serialize(result.Aggregate, DocumentJson.Options));
+                    var firstUsable = members.First(m => m.IsUsable);
+                    var spec = ReviewerSelectionHelper.Resolve(firstUsable.Role, null, subject.Kind, documentTypeKey.Get(ctx));
+                    aggregateProducerRole.Set(ctx, spec.Role.ToWire());
+                    aggregateProducerAction.Set(ctx, spec.Action.ToWire());
+                }
+                else
+                {
+                    undecidableReason.Set(ctx, result.Reason!.Value.ToString());
+                }
+
+                return result.Decided;
+            })
+        };
+        aggregate.SetDisplayText("Aggregate Results");
+
+        var decidedGate = new FlowDecision(ctx => decided.Get(ctx))
+        { Id = "DecidedGate", Name = "Decided?" };
+        decidedGate.SetDisplayText("Decided?");
+
+        // ── Decided path ──
+        var buildAggregateEnvelope = new SetVariable
+        {
+            Id = "BuildAggregateEnvelope", Name = "Build Aggregate Envelope",
+            Variable = aggregateEnvelopeJson,
+            Value = new(ctx =>
+            {
+                JsonElement payload;
+                using (var doc = JsonDocument.Parse(aggregateReviewJson.Get(ctx)))
+                    payload = doc.RootElement.Clone();
+
+                var producer = DocumentProducer.Create(
+                    aggregateProducerRole.Get(ctx), aggregateProducerAction.Get(ctx), ReviewPanelDefinitionId);
+
+                var envelope = DocumentEnvelope.CreateDraft(
+                        DocumentTypeKey.Review, 1, issueId.Get(ctx), correlationId.Get(ctx), producer, payload,
+                        now: DateTimeOffset.UtcNow)
+                    .WithState(DocumentState.Validated, DateTimeOffset.UtcNow);
+
+                aggregateDocumentId.Set(ctx, envelope.Id.ToString());
+                return DocumentJson.Serialize(envelope);
+            })
+        };
+        buildAggregateEnvelope.SetDisplayText("Build Aggregate Envelope");
+
+        var emitAggregateProduced = ReviewDocEvent(
+            "EmitAggregateProduced", "Emit Aggregate Produced", DocumentEvents.ProducedSuccess,
+            aggregateDocumentId, issueId, correlationId, tenantId, aggregateEnvelopeJson, "Aggregate review produced");
+        var emitAggregateValidated = ReviewDocEvent(
+            "EmitAggregateValidated", "Emit Aggregate Validated", DocumentEvents.ValidatedSuccess,
+            aggregateDocumentId, issueId, correlationId, tenantId, aggregateEnvelopeJson, "Aggregate review validated");
+
+        var emitPanelCompleted = PanelEvent(
+            "EmitPanelCompleted", "Emit Panel Completed", DocumentEvents.ReviewPanelCompleted,
+            issueId, correlationId, tenantId,
+            ctx => $"{{\"memberCount\":{memberCount.Get(ctx)},\"succeededCount\":{succeededCount.Get(ctx)},\"memberReviewIds\":{memberReviewsJson.Get(ctx)}}}",
+            "Panel completed");
+
+        var setOutputsDecided = new Sequence
+        {
+            Id = "SetOutputsDecided", Name = "Set Outputs (Decided)",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutDecidedSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutDecidedReview", OutputName = new("reviewJson"), OutputValue = new(ctx => (object)(aggregateReviewJson.Get(ctx) ?? "")) }, "Output reviewJson"),
+                WithLabel(new SetOutput { Id = "OutDecidedEnvelope", OutputName = new("reviewEnvelopeJson"), OutputValue = new(ctx => (object)(aggregateEnvelopeJson.Get(ctx) ?? "")) }, "Output reviewEnvelopeJson"),
+                WithLabel(new SetOutput { Id = "OutDecidedDocId", OutputName = new("reviewDocumentId"), OutputValue = new(ctx => (object)(aggregateDocumentId.Get(ctx) ?? "")) }, "Output reviewDocumentId"),
+                WithLabel(new SetOutput { Id = "OutDecidedMembers", OutputName = new("memberReviewsJson"), OutputValue = new(ctx => (object)(memberReviewsJson.Get(ctx) ?? "[]")) }, "Output memberReviewsJson"),
+            }
+        };
+        setOutputsDecided.SetDisplayText("Set Outputs (Decided)");
+
+        // ── Undecidable path ──
+        var emitPanelUndecidable = PanelEvent(
+            "EmitPanelUndecidable", "Emit Panel Undecidable", DocumentEvents.ReviewPanelUndecidable,
+            issueId, correlationId, tenantId,
+            ctx => $"{{\"reason\":\"{undecidableReason.Get(ctx)}\",\"memberCount\":{memberCount.Get(ctx)},\"succeededCount\":{succeededCount.Get(ctx)},\"memberReviewIds\":{memberReviewsJson.Get(ctx)}}}",
+            "Panel undecidable");
+
+        var setOutputsUndecidable = new Sequence
+        {
+            Id = "SetOutputsUndecidable", Name = "Set Outputs (Undecidable)",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutUndecidableSuccess", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutUndecidableReason", OutputName = new("undecidableReason"), OutputValue = new(ctx => (object)(undecidableReason.Get(ctx) ?? "")) }, "Output undecidableReason"),
+                WithLabel(new SetOutput { Id = "OutUndecidableMembers", OutputName = new("memberReviewsJson"), OutputValue = new(ctx => (object)(memberReviewsJson.Get(ctx) ?? "[]")) }, "Output memberReviewsJson"),
+            }
+        };
+        setOutputsUndecidable.SetDisplayText("Set Outputs (Undecidable)");
+
+        var finish = new Finish { Id = "Finish", Name = "Finish" };
+        finish.SetDisplayText("Finish");
+
+        // ================================================================
+        // Flowchart
+        // ================================================================
+        var activities = new List<IActivity> { init, emitPanelStarted };
+        foreach (var (gate, dispatch, capture) in roleNodes)
+        {
+            activities.Add(gate);
+            activities.Add(dispatch);
+            activities.Add(capture);
+        }
+        activities.Add(aggregate);
+        activities.Add(decidedGate);
+        activities.Add(buildAggregateEnvelope);
+        activities.Add(emitAggregateProduced);
+        activities.Add(emitAggregateValidated);
+        activities.Add(emitPanelCompleted);
+        activities.Add(setOutputsDecided);
+        activities.Add(emitPanelUndecidable);
+        activities.Add(setOutputsUndecidable);
+        activities.Add(finish);
+
+        var connections = new List<FlowConnection>
+        {
+            Connect(init, emitPanelStarted),
+            Connect(emitPanelStarted, roleNodes[0].gate),
+        };
+
+        for (var i = 0; i < roleNodes.Count; i++)
+        {
+            var (gate, dispatch, capture) = roleNodes[i];
+            var next = i + 1 < roleNodes.Count ? (IActivity)roleNodes[i + 1].gate : aggregate;
+
+            connections.Add(ConnectOutcome(gate, "True", dispatch));
+            connections.Add(Connect(dispatch, capture));
+            connections.Add(Connect(capture, next));
+            connections.Add(ConnectOutcome(gate, "False", next));   // skipped role
+        }
+
+        connections.Add(Connect(aggregate, decidedGate));
+
+        connections.Add(ConnectOutcome(decidedGate, "True", buildAggregateEnvelope));
+        connections.Add(Connect(buildAggregateEnvelope, emitAggregateProduced));
+        connections.Add(Connect(emitAggregateProduced, emitAggregateValidated));
+        connections.Add(Connect(emitAggregateValidated, emitPanelCompleted));
+        connections.Add(Connect(emitPanelCompleted, setOutputsDecided));
+        connections.Add(Connect(setOutputsDecided, finish));
+
+        connections.Add(ConnectOutcome(decidedGate, "False", emitPanelUndecidable));
+        connections.Add(Connect(emitPanelUndecidable, setOutputsUndecidable));
+        connections.Add(Connect(setOutputsUndecidable, finish));
+
+        builder.Root = new Flowchart
+        {
+            Id = "PanelReviewFlowchart",
+            Start = init,
+            Activities = activities,
+            Connections = connections,
+        };
+    }
+
+    // ====================================================================
+    // Node factories
+    // ====================================================================
+
+    private static EmitDocumentEventActivity PanelEvent(
+        string id, string name, string eventType,
+        Variable<string> issueId, Variable<string> corr, Variable<string> tenant,
+        Func<Elsa.Expressions.Models.ExpressionExecutionContext, string> dataJson, string detail)
+    {
+        var e = new EmitDocumentEventActivity
+        {
+            Id = id, Name = name,
+            EventType = new(eventType),
+            DocumentType = new("review"),
+            Round = new(0),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            CorrelationId = new(ctx => corr.Get(ctx)),
+            TenantId = new(ctx => tenant.Get(ctx)),
+            Detail = new(detail),
+            DataJson = new(ctx => dataJson(ctx)),
+        };
+        e.SetDisplayText(name);
+        return e;
+    }
+
+    private static EmitDocumentEventActivity ReviewDocEvent(
+        string id, string name, string eventType,
+        Variable<string> docId, Variable<string> issueId, Variable<string> corr,
+        Variable<string> tenant, Variable<string> dataJson, string detail)
+    {
+        var e = new EmitDocumentEventActivity
+        {
+            Id = id, Name = name,
+            EventType = new(eventType),
+            DocumentId = new(ctx => docId.Get(ctx)),
+            DocumentType = new("review"),
+            Round = new(0),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            CorrelationId = new(ctx => corr.Get(ctx)),
+            TenantId = new(ctx => tenant.Get(ctx)),
+            Detail = new(detail),
+            DataJson = new(ctx => { var d = dataJson.Get(ctx); return string.IsNullOrWhiteSpace(d) ? null : d; }),
+        };
+        e.SetDisplayText(name);
+        return e;
+    }
+
+    // ====================================================================
+    // Pure helpers
+    // ====================================================================
+
+    private static bool RosterContains(string? rosterJson, string roleWire)
+        => DeserializeRoster(rosterJson).Contains(roleWire);
+
+    private static HashSet<string> DeserializeRoster(string? rosterJson)
+    {
+        if (string.IsNullOrWhiteSpace(rosterJson)) return new HashSet<string>(StringComparer.Ordinal);
+        try
+        {
+            return (JsonSerializer.Deserialize<List<string>>(rosterJson!) ?? new List<string>())
+                .ToHashSet(StringComparer.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return new HashSet<string>(StringComparer.Ordinal);
+        }
+    }
+
+    /// <summary>Build a member-capture JSON blob from a single-reviewer dispatch result.</summary>
+    private static string CaptureMember(string roleWire, IDictionary<string, object>? result)
+    {
+        var ok = result != null && result.TryGetValue("success", out var s)
+            && (s is true || (s is string str && bool.TryParse(str, out var b) && b));
+        var reviewJson = result != null && result.TryGetValue("reviewJson", out var rj) ? rj?.ToString() ?? "" : "";
+        var reviewDocId = result != null && result.TryGetValue("reviewDocumentId", out var rd) ? rd?.ToString() ?? "" : "";
+        var failureKind = result != null && result.TryGetValue("failureKind", out var fk) ? fk?.ToString() ?? "" : "";
+
+        var sb = new StringBuilder();
+        sb.Append('{');
+        sb.Append("\"role\":").Append(JsonSerializer.Serialize(roleWire)).Append(',');
+        sb.Append("\"ok\":").Append(ok ? "true" : "false").Append(',');
+        sb.Append("\"reviewDocumentId\":").Append(JsonSerializer.Serialize(reviewDocId)).Append(',');
+        sb.Append("\"failureKind\":").Append(JsonSerializer.Serialize(failureKind)).Append(',');
+        sb.Append("\"reviewJson\":").Append(JsonSerializer.Serialize(reviewJson));
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    /// <summary>Parse a member-capture blob into a <see cref="ReviewPanelAggregation.PanelMember"/>.</summary>
+    private static ReviewPanelAggregation.PanelMember ToPanelMember(string roleWire, string captureJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(captureJson);
+            var root = doc.RootElement;
+
+            var ok = root.TryGetProperty("ok", out var okEl) && okEl.ValueKind == JsonValueKind.True;
+            var reviewJson = root.TryGetProperty("reviewJson", out var rjEl) && rjEl.ValueKind == JsonValueKind.String
+                ? rjEl.GetString() ?? "" : "";
+            var reviewDocId = root.TryGetProperty("reviewDocumentId", out var rdEl) && rdEl.ValueKind == JsonValueKind.String
+                ? rdEl.GetString() ?? "" : "";
+            var failureKind = root.TryGetProperty("failureKind", out var fkEl) && fkEl.ValueKind == JsonValueKind.String
+                ? fkEl.GetString() : null;
+
+            Review? review = null;
+            if (ok && !string.IsNullOrWhiteSpace(reviewJson))
+            {
+                try { review = JsonSerializer.Deserialize<Review>(reviewJson, DocumentJson.Options); }
+                catch (JsonException) { review = null; }
+            }
+
+            Guid? docId = Guid.TryParse(reviewDocId, out var g) ? g : null;
+            return new ReviewPanelAggregation.PanelMember(roleWire, docId, review, ok && review is not null, string.IsNullOrWhiteSpace(failureKind) ? null : failureKind);
+        }
+        catch (JsonException)
+        {
+            return new ReviewPanelAggregation.PanelMember(roleWire, null, null, false, "capture-parse-failed");
+        }
+    }
+
+    private static ReviewSubject ParseSubject(string? subjectJson)
+    {
+        if (string.IsNullOrWhiteSpace(subjectJson))
+            throw new Tamma.Core.TammaError(
+                "REVIEW.PRODUCER.SUBJECT_MISSING",
+                "The panel producer requires a parseable ReviewSubject (subjectJson).",
+                retryable: false,
+                severity: Tamma.Core.TammaErrorSeverity.High);
+        try
+        {
+            var subject = JsonSerializer.Deserialize<ReviewSubject>(subjectJson!, DocumentJson.Options);
+            if (subject is not null) return subject;
+        }
+        catch (JsonException) { /* fall through */ }
+        throw new Tamma.Core.TammaError(
+            "REVIEW.PRODUCER.SUBJECT_MISSING",
+            "The panel producer requires a parseable ReviewSubject (subjectJson).",
+            retryable: false,
+            severity: Tamma.Core.TammaErrorSeverity.High);
+    }
+
+    private static FlowConnection Connect(IActivity source, IActivity target)
+        => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleReviewerWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleReviewerWorkflow.cs
@@ -1,0 +1,435 @@
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Memory;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime.Activities;
+using Tamma.Activities.Documents;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+using FlowEndpoint = Elsa.Workflows.Activities.Flowchart.Models.Endpoint;
+using FlowConnection = Elsa.Workflows.Activities.Flowchart.Models.Connection;
+
+using static Tamma.ElsaServer.Workflows.ActivityDisplayTextExtensions;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// Story 39-7 (AC1, AC5; Design Decisions D3–D5) — the single-reviewer producer
+/// (<c>DefinitionId = "review-single-reviewer"</c>). Given a subject (document or
+/// diff reference), a policy-selected reviewer <c>(role, action)</c>, and lineage
+/// anchors, it dispatches ONE mediated <c>llm-call</c> and yields exactly one
+/// VALIDATED unified <see cref="Review"/> envelope. Unparseable/invalid reviewer
+/// output is NOT laundered into a defaulted <c>"concerns"</c> review (the
+/// <c>PlanReviewWorkflow.ExtractReview</c> anti-pattern) — it flows through a bounded
+/// validation/repair ring back to the SAME dispatch node, and on exhaustion emits a
+/// TYPED failure (<c>success=false</c>, <c>failureKind="validation-exhausted"</c> or
+/// <c>"llm-failed"</c>) that the 39-6 caller maps to
+/// <c>ValidationExhausted</c>/<c>ReviewUndecidable</c>.
+///
+/// <para>There is NO edge from an invalid mapping to the success outputs (the
+/// no-laundering structural pin). The one <c>llm-call</c> dispatch reads its
+/// <c>(role, action)</c> from workflow variables (data-driven, D9) — validated
+/// fail-loud at <c>Init</c> via <see cref="ReviewerSelectionHelper.Resolve"/>.</para>
+/// </summary>
+public class SingleReviewerWorkflow : WorkflowBase
+{
+    public const string ReviewSingleReviewerDefinitionId = "review-single-reviewer";
+
+    protected override void Build(IWorkflowBuilder builder)
+    {
+        builder.Name = "Single Reviewer";
+        builder.DefinitionId = ReviewSingleReviewerDefinitionId;
+        builder.Version = WorkflowVersions.ComputedVersion;
+        builder.Description =
+            "Dispatches one policy-selected reviewer (role, action) llm-call and yields exactly one " +
+            "validated unified Review envelope (bounded repair; typed failure on exhaustion; never a laundered review)";
+
+        // ── Data-driven dispatch inputs (default "" so the drift scanner sees the
+        //    one llm-call dispatch as DATA-DRIVEN, D9) ──
+        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "");
+        var reviewerAction = builder.WithVariable<string>("ReviewerAction", "");
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
+        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "");
+
+        // ── Lineage + config scalars ──
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
+        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable);
+        var issueId = builder.WithVariable<string>("IssueId", "");
+        var correlationId = builder.WithVariable<string>("CorrelationId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var maxRepairAttempts = builder.WithVariable<int>("MaxRepairAttempts", AcceptanceDefaults.DefaultMaxValidationRepairAttempts);
+        var attempts = builder.WithVariable<int>("Attempts", 0);
+
+        // ── Dispatch result + routing ──
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
+        var everSucceededCall = builder.WithVariable<bool>("EverSucceededCall", false);
+        var validationOk = builder.WithVariable<bool>("ValidationOk", false);
+
+        // ── Outputs ──
+        var reviewJson = builder.WithVariable<string>("ReviewJson", "");
+        var reviewEnvelopeJson = builder.WithVariable<string>("ReviewEnvelopeJson", "");
+        var reviewDocumentId = builder.WithVariable<string>("ReviewDocumentId", "");
+        var violationsJson = builder.WithVariable<string>("ViolationsJson", "[]");
+        var failureKind = builder.WithVariable<string>("FailureKind", "");
+
+        // ================================================================
+        // Init — resolve reviewer (role, action) fail-loud (AC4), seed config
+        // ================================================================
+        var init = new SetVariable
+        {
+            Id = "Init", Name = "Init",
+            Variable = reviewerRole,
+            Value = new(ctx =>
+            {
+                var role = ctx.GetInput<string>("reviewerRole") ?? "";
+                var actionOverride = ctx.GetInput<string>("reviewerAction");
+                var subjJson = ctx.GetInput<string>("subjectJson") ?? "";
+                var varsJson = ctx.GetInput<string>("variablesJson") ?? "{}";
+                var feedbackVar = ctx.GetInput<string>("feedbackVariableName");
+                var issue = ctx.GetInput<string>("issueId") ?? "";
+                var corr = ctx.GetInput<string>("correlationId") ?? "";
+                var tenant = ctx.GetInput<string>("tenantId") ?? "";
+                var docTypeKey = ctx.GetInput<string>("documentTypeKey") ?? "";
+                var rulesInput = ctx.GetInput<string>("acceptanceRulesJson") ?? "";
+
+                var subject = ParseSubject(subjJson);
+                var spec = ReviewerSelectionHelper.Resolve(role, actionOverride, subject.Kind, docTypeKey);
+                var rules = ResolveRules(rulesInput);
+
+                reviewerAction.Set(ctx, spec.Action.ToWire());
+                subjectJson.Set(ctx, JsonSerializer.Serialize(subject, DocumentJson.Options));
+                variablesJson.Set(ctx, string.IsNullOrWhiteSpace(varsJson) ? "{}" : varsJson);
+                feedbackVariableName.Set(ctx, string.IsNullOrWhiteSpace(feedbackVar) ? ReviewProducerHelper.DefaultFeedbackVariable : feedbackVar!);
+                issueId.Set(ctx, issue);
+                correlationId.Set(ctx, string.IsNullOrWhiteSpace(corr) ? issue : corr);
+                tenantId.Set(ctx, tenant);
+                documentTypeKey.Set(ctx, docTypeKey);
+                maxRepairAttempts.Set(ctx, rules.MaxValidationRepairAttempts);
+                attempts.Set(ctx, 0);
+                everSucceededCall.Set(ctx, false);
+
+                return spec.Role.ToWire();
+            })
+        };
+        init.SetDisplayText("Init");
+
+        // ================================================================
+        // DispatchReviewerCall — the one mediated llm-call (loop target)
+        // ================================================================
+        var dispatchReviewerCall = new DispatchWorkflow
+        {
+            Id = "DispatchReviewerCall", Name = "Dispatch Reviewer Call",
+            WorkflowDefinitionId = new("llm-call"),
+            Input = new(ctx => new Dictionary<string, object>
+            {
+                // agentRole is the REAL llm-call input key (NOT role).
+                ["agentRole"] = reviewerRole.Get(ctx) ?? "",
+                ["action"] = reviewerAction.Get(ctx) ?? "",
+                ["tenantId"] = tenantId.Get(ctx) ?? "",
+                ["documentType"] = documentTypeKey.Get(ctx) ?? "",
+                ["issueId"] = issueId.Get(ctx) ?? "",
+                ["variables"] = ParseVarsDict(variablesJson.Get(ctx)),
+                ["enableTools"] = false,
+            }),
+            WaitForCompletion = new(true),
+            Result = new(llmResult),
+        };
+        dispatchReviewerCall.SetDisplayText("Dispatch Reviewer Call");
+
+        // ================================================================
+        // MapAndValidate — map reply → unified Review + validate (no laundering)
+        // ================================================================
+        var mapAndValidate = new SetVariable
+        {
+            Id = "MapAndValidate", Name = "Map And Validate",
+            Variable = validationOk,
+            Value = new(ctx =>
+            {
+                var result = llmResult.Get(ctx);
+                var success = ReadSuccessFlag(result);
+                if (success) everSucceededCall.Set(ctx, true);
+
+                if (!success)
+                {
+                    violationsJson.Set(ctx, SerializeViolations(new[]
+                    {
+                        new DocumentViolation("REVIEW.PRODUCER.LLM_FAILED",
+                            "The reviewer llm-call reported failure (no usable reply this turn)."),
+                    }));
+                    return false;
+                }
+
+                var response = ReadLlmResponse(result);
+                var subject = ParseSubject(subjectJson.Get(ctx));
+                var map = ReviewProducerHelper.MapReviewerReply(response, subject);
+
+                if (map.IsValid)
+                {
+                    reviewJson.Set(ctx, JsonSerializer.Serialize(map.Payload, DocumentJson.Options));
+                    violationsJson.Set(ctx, "[]");
+                    return true;
+                }
+
+                violationsJson.Set(ctx, SerializeViolations(map.Violations));
+                return false;
+            })
+        };
+        mapAndValidate.SetDisplayText("Map And Validate");
+
+        var validationGate = new FlowDecision(ctx => validationOk.Get(ctx))
+        { Id = "ValidationGate", Name = "Valid?" };
+        validationGate.SetDisplayText("Valid?");
+
+        // ================================================================
+        // Valid path — build envelope, emit PRODUCED/VALIDATED success, outputs
+        // ================================================================
+        var buildEnvelope = new SetVariable
+        {
+            Id = "BuildEnvelope", Name = "Build Envelope",
+            Variable = reviewEnvelopeJson,
+            Value = new(ctx =>
+            {
+                JsonElement payload;
+                using (var doc = JsonDocument.Parse(reviewJson.Get(ctx)))
+                    payload = doc.RootElement.Clone();
+
+                var producer = DocumentProducer.Create(
+                    reviewerRole.Get(ctx), reviewerAction.Get(ctx), ReviewSingleReviewerDefinitionId);
+
+                var envelope = DocumentEnvelope.CreateDraft(
+                        DocumentTypeKey.Review, 1, issueId.Get(ctx), correlationId.Get(ctx), producer, payload,
+                        now: DateTimeOffset.UtcNow)
+                    .WithState(DocumentState.Validated, DateTimeOffset.UtcNow);
+
+                reviewDocumentId.Set(ctx, envelope.Id.ToString());
+                return DocumentJson.Serialize(envelope);
+            })
+        };
+        buildEnvelope.SetDisplayText("Build Envelope");
+
+        var emitProduced = ReviewDocEvent(
+            "EmitProduced", "Emit Produced", DocumentEvents.ProducedSuccess,
+            reviewDocumentId, issueId, correlationId, tenantId, reviewEnvelopeJson, "Review produced");
+        var emitValidated = ReviewDocEvent(
+            "EmitValidated", "Emit Validated", DocumentEvents.ValidatedSuccess,
+            reviewDocumentId, issueId, correlationId, tenantId, reviewEnvelopeJson, "Review validated");
+
+        var setOutputsSuccess = new Sequence
+        {
+            Id = "SetOutputsSuccess", Name = "Set Outputs (Success)",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutSuccessTrue", OutputName = new("success"), OutputValue = new(_ => (object)true) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutReviewJson", OutputName = new("reviewJson"), OutputValue = new(ctx => (object)(reviewJson.Get(ctx) ?? "")) }, "Output reviewJson"),
+                WithLabel(new SetOutput { Id = "OutReviewEnvelope", OutputName = new("reviewEnvelopeJson"), OutputValue = new(ctx => (object)(reviewEnvelopeJson.Get(ctx) ?? "")) }, "Output reviewEnvelopeJson"),
+                WithLabel(new SetOutput { Id = "OutReviewDocId", OutputName = new("reviewDocumentId"), OutputValue = new(ctx => (object)(reviewDocumentId.Get(ctx) ?? "")) }, "Output reviewDocumentId"),
+            }
+        };
+        setOutputsSuccess.SetDisplayText("Set Outputs (Success)");
+
+        // ================================================================
+        // Invalid path — bounded repair ring back to the SAME dispatch node
+        // ================================================================
+        var repairGate = new FlowDecision(ctx =>
+            ReviewProducerHelper.ShouldRepair(attempts.Get(ctx), RepairRules(maxRepairAttempts.Get(ctx))))
+        { Id = "RepairGate", Name = "Can Repair?" };
+        repairGate.SetDisplayText("Can Repair?");
+
+        var buildRepairFeedback = new SetVariable
+        {
+            Id = "BuildRepairFeedback", Name = "Build Repair Feedback",
+            Variable = variablesJson,
+            Value = new(ctx =>
+            {
+                attempts.Set(ctx, attempts.Get(ctx) + 1);
+                var violations = DeserializeViolations(violationsJson.Get(ctx));
+                var contract = DocumentTypeRegistry.Resolve(DocumentTypeKey.Review).RenderContract();
+                return ReviewProducerHelper.BuildRepairVariables(
+                    variablesJson.Get(ctx), violations, feedbackVariableName.Get(ctx), contract);
+            })
+        };
+        buildRepairFeedback.SetDisplayText("Build Repair Feedback");
+
+        var setFailureKind = new SetVariable
+        {
+            Id = "SetFailureKind", Name = "Set Failure Kind",
+            Variable = failureKind,
+            Value = new(ctx => (object)(everSucceededCall.Get(ctx) ? "validation-exhausted" : "llm-failed"))
+        };
+        setFailureKind.SetDisplayText("Set Failure Kind");
+
+        var emitProducedFailed = ReviewDocEvent(
+            "EmitProducedFailed", "Emit Produced Failed", DocumentEvents.ProducedFailed,
+            reviewDocumentId, issueId, correlationId, tenantId, violationsJson, "Reviewer produced no valid review");
+        var emitValidatedFailed = ReviewDocEvent(
+            "EmitValidatedFailed", "Emit Validated Failed", DocumentEvents.ValidatedFailed,
+            reviewDocumentId, issueId, correlationId, tenantId, violationsJson, "Review failed validation (exhausted)");
+
+        var setOutputsFail = new Sequence
+        {
+            Id = "SetOutputsFail", Name = "Set Outputs (Fail)",
+            Activities =
+            {
+                WithLabel(new SetOutput { Id = "OutSuccessFalse", OutputName = new("success"), OutputValue = new(_ => (object)false) }, "Output success"),
+                WithLabel(new SetOutput { Id = "OutFailureKind", OutputName = new("failureKind"), OutputValue = new(ctx => (object)(failureKind.Get(ctx) ?? "")) }, "Output failureKind"),
+                WithLabel(new SetOutput { Id = "OutViolations", OutputName = new("violationsJson"), OutputValue = new(ctx => (object)(violationsJson.Get(ctx) ?? "[]")) }, "Output violationsJson"),
+            }
+        };
+        setOutputsFail.SetDisplayText("Set Outputs (Fail)");
+
+        var finish = new Finish { Id = "Finish", Name = "Finish" };
+        finish.SetDisplayText("Finish");
+
+        // ================================================================
+        // Flowchart
+        // ================================================================
+        builder.Root = new Flowchart
+        {
+            Id = "SingleReviewerFlowchart",
+            Start = init,
+            Activities =
+            {
+                init, dispatchReviewerCall, mapAndValidate, validationGate,
+                buildEnvelope, emitProduced, emitValidated, setOutputsSuccess,
+                repairGate, buildRepairFeedback,
+                setFailureKind, emitProducedFailed, emitValidatedFailed, setOutputsFail,
+                finish,
+            },
+            Connections =
+            {
+                Connect(init, dispatchReviewerCall),
+                Connect(dispatchReviewerCall, mapAndValidate),
+                Connect(mapAndValidate, validationGate),
+
+                ConnectOutcome(validationGate, "True", buildEnvelope),
+                Connect(buildEnvelope, emitProduced),
+                Connect(emitProduced, emitValidated),
+                Connect(emitValidated, setOutputsSuccess),
+                Connect(setOutputsSuccess, finish),
+
+                ConnectOutcome(validationGate, "False", repairGate),
+                ConnectOutcome(repairGate, "True", buildRepairFeedback),
+                Connect(buildRepairFeedback, dispatchReviewerCall),   // loop back to the SAME dispatch node
+                ConnectOutcome(repairGate, "False", setFailureKind),
+                Connect(setFailureKind, emitProducedFailed),
+                Connect(emitProducedFailed, emitValidatedFailed),
+                Connect(emitValidatedFailed, setOutputsFail),
+                Connect(setOutputsFail, finish),
+            }
+        };
+    }
+
+    // ====================================================================
+    // Node factories
+    // ====================================================================
+
+    private static EmitDocumentEventActivity ReviewDocEvent(
+        string id, string name, string eventType,
+        Variable<string> docId, Variable<string> issueId, Variable<string> corr,
+        Variable<string> tenant, Variable<string> dataJson, string detail)
+    {
+        var e = new EmitDocumentEventActivity
+        {
+            Id = id, Name = name,
+            EventType = new(eventType),
+            DocumentId = new(ctx => docId.Get(ctx)),
+            DocumentType = new("review"),
+            Round = new(0),
+            IssueId = new(ctx => issueId.Get(ctx)),
+            CorrelationId = new(ctx => corr.Get(ctx)),
+            TenantId = new(ctx => tenant.Get(ctx)),
+            Detail = new(detail),
+            DataJson = new(ctx => { var d = dataJson.Get(ctx); return string.IsNullOrWhiteSpace(d) ? null : d; }),
+        };
+        e.SetDisplayText(name);
+        return e;
+    }
+
+    // ====================================================================
+    // Pure helpers
+    // ====================================================================
+
+    private static AcceptanceRules ResolveRules(string? rulesInput) =>
+        string.IsNullOrWhiteSpace(rulesInput) ? AcceptanceDefaults.Rules : AcceptanceRulesJson.Deserialize(rulesInput!);
+
+    private static AcceptanceRules RepairRules(int maxRepairAttempts) =>
+        AcceptanceDefaults.Rules with { MaxValidationRepairAttempts = maxRepairAttempts };
+
+    private static ReviewSubject ParseSubject(string? subjectJson)
+    {
+        if (string.IsNullOrWhiteSpace(subjectJson))
+            throw SubjectMissing();
+        try
+        {
+            var subject = JsonSerializer.Deserialize<ReviewSubject>(subjectJson!, DocumentJson.Options);
+            return subject ?? throw SubjectMissing();
+        }
+        catch (JsonException)
+        {
+            throw SubjectMissing();
+        }
+    }
+
+    private static TammaError SubjectMissing() => new(
+        "REVIEW.PRODUCER.SUBJECT_MISSING",
+        "The single-reviewer producer requires a parseable ReviewSubject (subjectJson).",
+        retryable: false,
+        severity: TammaErrorSeverity.High);
+
+    private static string SerializeViolations(IReadOnlyList<DocumentViolation> violations) =>
+        JsonSerializer.Serialize(violations);
+
+    private static IReadOnlyList<DocumentViolation> DeserializeViolations(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return Array.Empty<DocumentViolation>();
+        try
+        {
+            return JsonSerializer.Deserialize<List<DocumentViolation>>(json!) ?? new List<DocumentViolation>();
+        }
+        catch (JsonException)
+        {
+            return Array.Empty<DocumentViolation>();
+        }
+    }
+
+    private static Dictionary<string, object> ParseVarsDict(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return new Dictionary<string, object>();
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(json!) ?? new Dictionary<string, object>();
+        }
+        catch (JsonException)
+        {
+            return new Dictionary<string, object>();
+        }
+    }
+
+    private static bool ReadSuccessFlag(IDictionary<string, object>? result)
+    {
+        if (result == null) return false;
+        if (!result.TryGetValue("success", out var s)) return false;
+        return s is true || (s is string str && bool.TryParse(str, out var b) && b);
+    }
+
+    private static string? ReadLlmResponse(IDictionary<string, object>? result)
+    {
+        if (result != null && result.TryGetValue("llmResponse", out var r) && r is not null)
+            return r.ToString();
+        return null;
+    }
+
+    private static FlowConnection Connect(IActivity source, IActivity target)
+        => new(new FlowEndpoint(source), new FlowEndpoint(target));
+
+    private static FlowConnection ConnectOutcome(IActivity source, string outcome, IActivity target)
+        => new(new FlowEndpoint(source, outcome), new FlowEndpoint(target));
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ContractBindingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ContractBindingTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NUnit.Framework;
 using Tamma.Api.Auth;
+using Tamma.ElsaServer.Workflows.Helpers;
 
 namespace Tamma.Activities.Tests.Workflows;
 
@@ -394,6 +395,13 @@ public class ContractBindingTests
                 "repair re-dispatch of the same producer spec — same cell, same binding (39-6 D2).",
             [("DocumentLifecycleWorkflow", "DispatchRevise")] =
                 "revise re-dispatch of the same producer spec — same cell, same binding (39-6 D2).",
+            // Story 39-7 — the single-reviewer producer's llm-call reads its (role, action)
+            // from workflow variables (ReviewerRole/ReviewerAction), resolved fail-loud at
+            // Init via ReviewerSelectionHelper.Resolve. Its reviewer cell contracts are
+            // classified in ReviewProducerDispatchablePairs / IntentionallyUnbound.
+            [("SingleReviewerWorkflow", "DispatchReviewerCall")] =
+                "input-driven reviewer (role, action) resolved from policy at Init (39-7 D3); the reviewer " +
+                "cell's contract is classified via AllDispatchablePairs (ReviewProducerDispatchablePairs).",
         };
 
     [Test]
@@ -422,6 +430,96 @@ public class ContractBindingTests
 
         foreach (var (_, reason) in DataDrivenDispatchJustifications)
             reason.Should().NotBeNullOrWhiteSpace("every data-driven dispatch justification must be non-empty");
+    }
+
+    // ====================================================================
+    // Review-producer dispatchable pairs (Story 39-7 D9)
+    // ====================================================================
+
+    /// <summary>
+    /// Story 39-7 (D9) — the review-producer <c>(role, action)</c> pairs that are
+    /// reachable ONLY via policy (the single-reviewer / panel producers dispatch a
+    /// data-driven llm-call), so they are emitted by NO compiled dispatch site and
+    /// cannot join <see cref="Bindings"/> / <see cref="IntentionallyUnbound"/> (whose
+    /// staleness guard requires a live emitter). The classification test asserts every
+    /// pair <see cref="ReviewerSelectionHelper.AllDispatchablePairs"/> can dispatch is
+    /// classified in one of the three tables — so a reviewer cell reachable by the
+    /// producers but bound nowhere fails the build. Pairs already emitted by a compiled
+    /// site (the 7 plan-review-family pairs from PlanReviewWorkflow, and
+    /// <c>(senior_developer, code-review)</c> from CodeReviewWorkflow) stay in
+    /// <see cref="IntentionallyUnbound"/>; the remaining code-review specialisations
+    /// live here.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<(string Role, string Action), string> ReviewProducerDispatchablePairs =
+        new Dictionary<(string, string), string>
+        {
+            [("developer", "code-review")] =
+                "diff-review producer pair (D3 diff map): developer reviews a diff via code-review; reachable " +
+                "only through the single-reviewer producer's policy-selected dispatch, no compiled emitter.",
+            [("architect", "code-review-architecture")] =
+                "diff-review producer pair (D3 diff map): architect reviews a diff via code-review-architecture; " +
+                "policy-only, no compiled emitter.",
+            [("security", "code-review-security")] =
+                "diff-review producer pair (D3 diff map): security reviews a diff via code-review-security; " +
+                "policy-only, no compiled emitter.",
+            [("tester", "code-review-coverage")] =
+                "diff-review producer pair (D3 diff map): tester reviews a diff via code-review-coverage; " +
+                "policy-only, no compiled emitter.",
+        };
+
+    [Test]
+    public void EveryReviewProducerDispatchablePair_IsClassified()
+    {
+        // AC4 (build-gate half) — every (role, action) the review producers can
+        // dispatch must be BOUND, IntentionallyUnbound, or in the review-producer
+        // table. A new reviewer cell reachable by policy but classified nowhere fails.
+        var unclassified = ReviewerSelectionHelper.AllDispatchablePairs
+            .Where(p => !Bindings.ContainsKey((p.Role, p.Action)) &&
+                        !IntentionallyUnbound.ContainsKey((p.Role, p.Action)) &&
+                        !ReviewProducerDispatchablePairs.ContainsKey((p.Role, p.Action)))
+            .Select(p => $"  ({p.Role}, {p.Action})")
+            .ToList();
+
+        unclassified.Should().BeEmpty(
+            "every reviewer (role, action) the 39-7 producers can dispatch (ReviewerSelectionHelper." +
+            "AllDispatchablePairs) must be classified — Bindings, IntentionallyUnbound, or " +
+            "ReviewProducerDispatchablePairs:" + Environment.NewLine +
+            string.Join(Environment.NewLine, unclassified));
+    }
+
+    [Test]
+    public void ReviewProducerDispatchablePairs_HasNoStaleEntries()
+    {
+        // Every entry must be a real dispatchable producer pair AND not already covered
+        // by IntentionallyUnbound (that would be dead weight / a contradiction).
+        var dispatchable = ReviewerSelectionHelper.AllDispatchablePairs
+            .Select(p => (p.Role, p.Action)).ToHashSet();
+
+        var stale = ReviewProducerDispatchablePairs.Keys
+            .Where(k => !dispatchable.Contains(k))
+            .Select(k => $"  stale (not dispatchable): ({k.Role}, {k.Action})")
+            .ToList();
+        var overlap = ReviewProducerDispatchablePairs.Keys
+            .Where(k => IntentionallyUnbound.ContainsKey(k) || Bindings.ContainsKey(k))
+            .Select(k => $"  redundant (already classified elsewhere): ({k.Role}, {k.Action})")
+            .ToList();
+
+        stale.Concat(overlap).ToList().Should().BeEmpty(
+            "ReviewProducerDispatchablePairs must list ONLY policy-only dispatchable pairs not classified " +
+            "elsewhere:" + Environment.NewLine + string.Join(Environment.NewLine, stale.Concat(overlap)));
+
+        foreach (var (_, reason) in ReviewProducerDispatchablePairs)
+            reason.Should().NotBeNullOrWhiteSpace("every review-producer pair must carry a justification");
+    }
+
+    [Test]
+    public void ReviewerSelectionHelper_AllDispatchablePairs_HasTwelveEligiblePairs()
+    {
+        // Pin the D9 surface: 7 document + 5 diff = 12, each taxonomy-eligible.
+        var pairs = ReviewerSelectionHelper.AllDispatchablePairs;
+        pairs.Should().HaveCount(12, "7 document-review pairs + 5 diff-review pairs");
+        pairs.Should().OnlyContain(p => Tamma.Api.Services.Agents.RolePhaseMap.IsRoleEligibleForPhase(p.Action, p.Role),
+            "every dispatchable review pair must be taxonomy-eligible");
     }
 
     // ====================================================================

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
@@ -194,7 +194,7 @@ public class DocumentLifecycleWorkflowStructureTests
     // ── AC5 — constant pins ────────────────────────────────────────────
 
     [Test]
-    public void DocumentEvents_HasExactlyTheTenConstants()
+    public void DocumentEvents_HasExactlyTheExpectedConstants()
     {
         var constants = typeof(DocumentEvents)
             .GetFields(BindingFlags.Public | BindingFlags.Static)
@@ -215,7 +215,11 @@ public class DocumentLifecycleWorkflowStructureTests
             "DOCUMENT.REVISION_STARTED",
             "DOCUMENT.VALIDATED.FAILED",
             "DOCUMENT.VALIDATED.SUCCESS",
-        }, "the DOCUMENT.* catalogue is pinned to exactly the ten Story 39-6 event types");
+            // Story 39-7 — panel-producer markers appended to the same catalogue.
+            "DOCUMENT.REVIEW_PANEL_STARTED",
+            "DOCUMENT.REVIEW_PANEL_COMPLETED",
+            "DOCUMENT.REVIEW_PANEL_UNDECIDABLE",
+        }, "the DOCUMENT.* catalogue is the ten Story 39-6 event types plus the three Story 39-7 panel markers");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentReviewWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentReviewWorkflowStructureTests.cs
@@ -1,0 +1,63 @@
+using Elsa.Expressions.Models;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — structural pins for the <see cref="DocumentReviewWorkflow"/> router
+/// (Design Decision D1; the 39-6 D10 definition-id contract, AC9).
+/// </summary>
+[TestFixture]
+public class DocumentReviewWorkflowStructureTests
+{
+    private static Elsa.Workflows.Activities.Flowchart.Activities.Flowchart Flowchart() =>
+        WorkflowTestHelper.GetFlowchart(WorkflowTestHelper.BuildWorkflow(new DocumentReviewWorkflow()));
+
+    [Test]
+    public void Workflow_HasStableDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new DocumentReviewWorkflow());
+        builder.Object.DefinitionId.Should().Be("document-review");
+    }
+
+    [Test]
+    public void Router_HasZeroLlmCallNodes()
+    {
+        Flowchart().Activities.OfType<DispatchWorkflow>()
+            .Where(d => ReadLiteralDefId(d) == "llm-call")
+            .Should().BeEmpty("the router only dispatches the two producer sub-workflows");
+    }
+
+    [Test]
+    public void Router_BothBranchesDispatchThePinnedProducerDefinitionIds()
+    {
+        var defIds = Flowchart().Activities.OfType<DispatchWorkflow>()
+            .Select(ReadLiteralDefId)
+            .Where(x => x is not null)
+            .ToHashSet();
+
+        defIds.Should().Contain(new[] { "review-panel", "review-single-reviewer" },
+            "the router dispatches the panel and single-reviewer producers by their pinned definition ids");
+    }
+
+    [Test]
+    public void ModeGate_RoutesPanelAndSingle()
+    {
+        var fc = Flowchart();
+        fc.Connections.Any(c => c.Source.Activity.Id == "ModeGate" && c.Source.Port == "True" && c.Target.Activity.Id == "DispatchPanel")
+            .Should().BeTrue("panel mode dispatches the panel producer");
+        fc.Connections.Any(c => c.Source.Activity.Id == "ModeGate" && c.Source.Port == "False" && c.Target.Activity.Id == "DispatchSingle")
+            .Should().BeTrue("single mode dispatches the single-reviewer producer");
+    }
+
+    private static string? ReadLiteralDefId(DispatchWorkflow dispatch)
+    {
+        var value = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId")?.GetValue(dispatch);
+        var expr = value?.GetType().GetProperty("Expression")?.GetValue(value) as Expression;
+        return expr?.Value as string;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/PanelReviewWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/PanelReviewWorkflowStructureTests.cs
@@ -1,0 +1,94 @@
+using Elsa.Expressions.Models;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — structural pins for <see cref="PanelReviewWorkflow"/> (AC2 graph
+/// half, AC7 emit sites, AC9 definition-id surface).
+/// </summary>
+[TestFixture]
+public class PanelReviewWorkflowStructureTests
+{
+    private static Elsa.Workflows.Activities.Flowchart.Activities.Flowchart Flowchart() =>
+        WorkflowTestHelper.GetFlowchart(WorkflowTestHelper.BuildWorkflow(new PanelReviewWorkflow()));
+
+    [Test]
+    public void Workflow_HasStableDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new PanelReviewWorkflow());
+        builder.Object.DefinitionId.Should().Be("review-panel");
+    }
+
+    [Test]
+    public void Panel_HasZeroLlmCallNodes()
+    {
+        var llm = Flowchart().Activities.OfType<DispatchWorkflow>()
+            .Where(d => ReadLiteralDefId(d) == "llm-call")
+            .ToList();
+        llm.Should().BeEmpty("the panel dispatches only the review-single-reviewer sub-workflow, never llm-call directly");
+    }
+
+    [Test]
+    public void Panel_HasSevenMemberDispatches_EachGuardedByAnInPanelDecision()
+    {
+        var fc = Flowchart();
+
+        var memberDispatches = fc.Activities.OfType<DispatchWorkflow>()
+            .Where(d => ReadLiteralDefId(d) == "review-single-reviewer")
+            .ToList();
+        memberDispatches.Should().HaveCount(7, "the static roster is the 7-role document panel superset");
+
+        // Every member dispatch is fed by an InPanel? FlowDecision "True" edge.
+        foreach (var dispatch in memberDispatches)
+        {
+            fc.Connections.Any(c => c.Target.Activity.Id == dispatch.Id &&
+                                    c.Source.Activity is FlowDecision && c.Source.Port == "True")
+                .Should().BeTrue($"member dispatch {dispatch.Id} must be guarded by an InPanel? decision");
+        }
+    }
+
+    [Test]
+    public void Panel_EmitsStartedCompletedUndecidableMarkers()
+    {
+        var emitTypes = Flowchart().Activities.OfType<EmitDocumentEventActivity>()
+            .Select(a => ReadLiteralString(a.EventType))
+            .ToHashSet();
+
+        emitTypes.Should().Contain(new[]
+        {
+            DocumentEvents.ReviewPanelStarted,
+            DocumentEvents.ReviewPanelCompleted,
+            DocumentEvents.ReviewPanelUndecidable,
+        });
+    }
+
+    [Test]
+    public void Undecidable_PathReachesNoEnvelopeBuild()
+    {
+        var fc = Flowchart();
+        // The "False" (undecidable) branch of DecidedGate must NOT reach BuildAggregateEnvelope.
+        fc.Connections.Any(c => c.Source.Activity.Id == "DecidedGate" && c.Source.Port == "False" && c.Target.Activity.Id == "EmitPanelUndecidable")
+            .Should().BeTrue("an undecidable panel goes straight to the undecidable marker, no aggregate fabricated");
+        fc.Connections.Any(c => c.Source.Activity.Id == "DecidedGate" && c.Source.Port == "True" && c.Target.Activity.Id == "BuildAggregateEnvelope")
+            .Should().BeTrue("only a decided panel builds an aggregate envelope");
+    }
+
+    private static string? ReadLiteralDefId(DispatchWorkflow dispatch)
+    {
+        var value = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId")?.GetValue(dispatch);
+        var expr = value?.GetType().GetProperty("Expression")?.GetValue(value) as Expression;
+        return expr?.Value as string;
+    }
+
+    private static string? ReadLiteralString(object input)
+    {
+        var expr = input.GetType().GetProperty("Expression")?.GetValue(input) as Expression;
+        return expr?.Value as string;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewPanelAggregationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewPanelAggregationTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+using Agg = Tamma.ElsaServer.Workflows.Helpers.ReviewPanelAggregation;
+using ReviewType = Tamma.Core.Documents.Types.Review;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — unit pins for <see cref="ReviewPanelAggregation"/> (Design Decision
+/// D6; covers AC3 + AC6's helper halves).
+/// </summary>
+[TestFixture]
+public class ReviewPanelAggregationTests
+{
+    private static readonly ReviewSubject Subject = new()
+    {
+        Kind = "document",
+        DocumentId = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001"),
+        DocumentType = "plan",
+    };
+
+    private static ReviewIssue Issue(ReviewSeverity sev) => new(sev, "cat", "desc", "fix");
+
+    private static ReviewType MakeReview(ReviewDecision decision, params ReviewIssue[] issues) => new()
+    {
+        Subject = Subject, Decision = decision, Summary = "s", Issues = issues,
+    };
+
+    private static Agg.PanelMember Usable(string role, ReviewType review) =>
+        new(role, Guid.NewGuid(), review, true, null);
+
+    private static Agg.PanelMember Failed(string role) =>
+        new(role, null, null, false, "validation-exhausted");
+
+    // ── default-config (Unanimous + full roster) parity table ──
+
+    [Test]
+    public void DefaultConfig_AllApprove_Approves()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.Approve)),
+            Usable("security", MakeReview(ReviewDecision.Approve)),
+        };
+
+        var result = Agg.Aggregate(members, Agg.DefaultsFor(3), Subject);
+
+        result.Decided.Should().BeTrue();
+        result.Aggregate!.Decision.Should().Be(ReviewDecision.Approve);
+    }
+
+    [Test]
+    public void DefaultConfig_AnyNonApprove_RequestsChanges()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.RequestChanges, Issue(ReviewSeverity.Major))),
+            Usable("security", MakeReview(ReviewDecision.Approve)),
+        };
+
+        var result = Agg.Aggregate(members, Agg.DefaultsFor(3), Subject);
+
+        result.Decided.Should().BeTrue();
+        result.Aggregate!.Decision.Should().Be(ReviewDecision.RequestChanges);
+    }
+
+    [Test]
+    public void BlockingVeto_MajorityApproveWithOneCritical_RequestsChanges_AndAggregateValidates()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.Approve)),
+            Usable("security", MakeReview(ReviewDecision.RequestChanges, Issue(ReviewSeverity.Critical))),
+        };
+
+        var result = Agg.Aggregate(members, new Agg.PanelAggregationRules(Agg.PanelDecisionRule.Majority, 3), Subject);
+
+        result.Decided.Should().BeTrue();
+        result.Aggregate!.Decision.Should().Be(ReviewDecision.RequestChanges,
+            "any member Critical issue vetoes the aggregate to RequestChanges regardless of majority");
+
+        // The concatenated aggregate must itself pass validation (no APPROVE_WITH_BLOCKING escape).
+        ValidateAggregate(result.Aggregate!).IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void EmptyPanel_IsUndecidable_EmptyPanel()
+    {
+        var result = Agg.Aggregate(Array.Empty<Agg.PanelMember>(), Agg.DefaultsFor(0), Subject);
+
+        result.Decided.Should().BeFalse();
+        result.Aggregate.Should().BeNull();
+        result.Reason.Should().Be(Agg.PanelUndecidableReason.EmptyPanel);
+    }
+
+    [Test]
+    public void FailedMemberUnderFullRosterMinimum_IsUndecidable_BelowQuorum_CarriesAllMembers()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.Approve)),
+            Failed("security"),
+        };
+
+        var result = Agg.Aggregate(members, Agg.DefaultsFor(3), Subject);
+
+        result.Decided.Should().BeFalse();
+        result.Aggregate.Should().BeNull();
+        result.Reason.Should().Be(Agg.PanelUndecidableReason.BelowQuorum);
+        result.SucceededCount.Should().Be(2);
+        result.FailedRoles.Should().Contain("security");
+        result.MemberReviewIds.Should().HaveCount(2, "the two usable members carry ids; the failed one has none");
+    }
+
+    [Test]
+    public void MajorityRule_ExactTie_IsUndecidable_SplitDecision()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.RequestChanges, Issue(ReviewSeverity.Major))),
+        };
+
+        var result = Agg.Aggregate(members, new Agg.PanelAggregationRules(Agg.PanelDecisionRule.Majority, 2), Subject);
+
+        result.Decided.Should().BeFalse();
+        result.Reason.Should().Be(Agg.PanelUndecidableReason.SplitDecision);
+    }
+
+    [Test]
+    public void MajorityRule_ClearMajorityApprove_Approves()
+    {
+        var members = new[]
+        {
+            Usable("architect", MakeReview(ReviewDecision.Approve)),
+            Usable("developer", MakeReview(ReviewDecision.Approve)),
+            Usable("security", MakeReview(ReviewDecision.RequestChanges, Issue(ReviewSeverity.Major))),
+        };
+
+        var result = Agg.Aggregate(members, new Agg.PanelAggregationRules(Agg.PanelDecisionRule.Majority, 1), Subject);
+
+        result.Decided.Should().BeTrue();
+        result.Aggregate!.Decision.Should().Be(ReviewDecision.Approve);
+    }
+
+    [Test]
+    public void AggregatedFrom_EqualsMemberIds_DuplicateFree()
+    {
+        var m1 = Usable("architect", MakeReview(ReviewDecision.Approve));
+        var m2 = Usable("developer", MakeReview(ReviewDecision.Approve));
+        var members = new[] { m1, m2 };
+
+        var result = Agg.Aggregate(members, Agg.DefaultsFor(2), Subject);
+
+        result.Aggregate!.AggregatedFrom.Should().BeEquivalentTo(new[] { m1.ReviewDocumentId!.Value, m2.ReviewDocumentId!.Value });
+        result.Aggregate!.AggregatedFrom!.Distinct().Should().HaveCount(result.Aggregate!.AggregatedFrom!.Count);
+    }
+
+    [Test]
+    public void ComputeDecision_AppliesBlockingVetoFirst()
+    {
+        var reviews = new[]
+        {
+            MakeReview(ReviewDecision.Approve),
+            MakeReview(ReviewDecision.Approve),
+            MakeReview(ReviewDecision.RequestChanges, Issue(ReviewSeverity.Critical)),
+        };
+
+        Agg.ComputeDecision(reviews, Agg.PanelDecisionRule.Majority).Should().Be(ReviewDecision.RequestChanges);
+    }
+
+    private static DocumentValidationResult ValidateAggregate(ReviewType aggregate)
+    {
+        var payload = JsonSerializer.Serialize(aggregate, DocumentJson.Options);
+        using var doc = JsonDocument.Parse(payload);
+        return new ReviewDocumentType().Validate(doc.RootElement);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewParityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewParityTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+using Agg = Tamma.ElsaServer.Workflows.Helpers.ReviewPanelAggregation;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 (AC8) — the behavioural PARITY harness. Replays the recorded
+/// <c>ParseRoleVerdict</c> verdict fixtures (the corpus <see cref="PlanReviewDecisionTests"/>
+/// pins) through BOTH pipelines:
+/// <list type="bullet">
+///   <item>OLD: <c>AggregateVerdicts(fixtures.Select(ParseRoleVerdict))</c> — the
+///     <see cref="ReviewAggregationHelper"/> baseline 39-14 retires.</item>
+///   <item>NEW: <see cref="ReviewProducerHelper.MapReviewerReply"/> → panel members →
+///     <see cref="ReviewPanelAggregation.Aggregate"/> at the default (Unanimous +
+///     full-roster) config.</item>
+/// </list>
+/// Parity is asserted where behaviour is PRESERVED, and the Design Decision D6
+/// divergences (empty panel; a garbage/incomplete member) are asserted AS
+/// divergences with narrative comments — never silently. The invariant across every
+/// fixture: a set containing garbage NEVER produces a NEW <c>Approve</c>.
+/// </summary>
+[TestFixture]
+public class ReviewParityTests
+{
+    // ── the recorded corpus (mirrors PlanReviewDecisionTests fixtures) ──
+    private const string ApproveStr = """{"verdict": "approve", "comments": "LGTM", "suggestedChanges": ""}""";
+    private const string ConcernsStr = """{"verdict": "concerns", "comments": "Missing error handling"}""";
+    private const string ObjApprove = """{"issues": [], "verdict": {"decision": "APPROVE", "summary": "Plan is solid", "blockingIssues": []}}""";
+    private const string ObjRequestChanges = """{"issues": [{"task": "T1", "severity": "major", "issue": "No rollback"}], "verdict": {"decision": "REQUEST_CHANGES", "summary": "Missing rollback plan", "blockingIssues": ["No rollback strategy"]}}""";
+    private const string ObjNeedsDiscussion = """{"verdict": {"decision": "NEEDS_DISCUSSION", "summary": "Scope unclear"}}""";
+    private const string Garbage = "not json at all";
+    private const string EmptyStr = "";
+
+    private static readonly ReviewSubject Subject = new()
+    {
+        Kind = "document",
+        DocumentId = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001"),
+        DocumentType = "plan",
+    };
+
+    // ── parity-preserved sets ──
+
+    [Test]
+    public void Parity_AllApprove_BothApprove()
+    {
+        var fixtures = new[] { ApproveStr, ObjApprove };
+        OldApprove(fixtures).Should().BeTrue();
+        var (decided, approve) = NewOutcome(fixtures);
+        (decided && approve).Should().BeTrue("all-approve is preserved exactly");
+    }
+
+    [Test]
+    public void Parity_OneConcerns_BothNonApprove()
+    {
+        var fixtures = new[] { ApproveStr, ConcernsStr };
+        OldApprove(fixtures).Should().BeFalse();
+        var (decided, approve) = NewOutcome(fixtures);
+        decided.Should().BeTrue();
+        approve.Should().BeFalse("a concerns verdict makes both pipelines non-approve");
+    }
+
+    [Test]
+    public void Parity_NeedsDiscussionCountsAsNonApprove()
+    {
+        var fixtures = new[] { ApproveStr, ObjNeedsDiscussion };
+        OldApprove(fixtures).Should().BeFalse();
+        var (decided, approve) = NewOutcome(fixtures);
+        decided.Should().BeTrue();
+        approve.Should().BeFalse("needs-discussion counts as non-approve, matching the old 'concerns' mapping");
+    }
+
+    // ── documented divergences (D6) ──
+
+    [Test]
+    public void Divergence_EmptyPanel_OldApproves_NewIsUndecidable()
+    {
+        // OLD BUG: AggregateVerdicts([]) == true (All() on empty). NEW: EmptyPanel
+        // undecidable — a deliberate divergence 39-14 relies on (we do NOT reproduce
+        // the empty-approves bug).
+        OldApprove(Array.Empty<string>()).Should().BeTrue("the old All()-on-empty bug approves an empty panel");
+        var (decided, approve) = NewOutcome(Array.Empty<string>());
+        decided.Should().BeFalse("DIVERGENCE: an empty panel is undecidable, never a phantom approval");
+        approve.Should().BeFalse();
+    }
+
+    [Test]
+    public void Divergence_GarbageOrIncompleteMember_OldDecidesNonApprove_NewIsUndecidable()
+    {
+        // The object REQUEST_CHANGES fixture carries issues without a category/fix and
+        // fix-less blocking issues → the strict Review type rejects it (routed to
+        // repair). OLD laundered it to a "concerns" non-approve; NEW drops the panel
+        // below quorum → undecidable. Deliberate D6 divergence — but still never approve.
+        var fixtures = new[] { ApproveStr, ObjRequestChanges };
+        OldApprove(fixtures).Should().BeFalse("old laundered the incomplete member to a non-approve concerns");
+        var (decided, approve) = NewOutcome(fixtures);
+        decided.Should().BeFalse("DIVERGENCE: an unmappable/invalid member drops the panel below quorum → undecidable");
+        approve.Should().BeFalse("the safe direction is preserved: never a false approval");
+    }
+
+    // ── the load-bearing invariant across the whole corpus ──
+
+    [Test]
+    public void Invariant_AnyGarbageSet_NeverProducesANewApprove()
+    {
+        var sets = new[]
+        {
+            new[] { Garbage, EmptyStr },
+            new[] { ApproveStr, Garbage },
+            new[] { ApproveStr, ObjRequestChanges },
+            Array.Empty<string>(),
+        };
+
+        foreach (var set in sets)
+        {
+            var (_, approve) = NewOutcome(set);
+            approve.Should().BeFalse(
+                "a set containing garbage/invalid members must NEVER yield a new Approve (never a laundered approval)");
+        }
+    }
+
+    // ── pipelines ──
+
+    private static bool OldApprove(IReadOnlyList<string> fixtures)
+    {
+        var verdicts = fixtures.Select(f => ReviewAggregationHelper.ParseRoleVerdict(f).verdict);
+        return ReviewAggregationHelper.AggregateVerdicts(verdicts);
+    }
+
+    private static (bool Decided, bool Approve) NewOutcome(IReadOnlyList<string> fixtures)
+    {
+        var members = new List<Agg.PanelMember>();
+        foreach (var (fixture, i) in fixtures.Select((f, i) => (f, i)))
+        {
+            var map = ReviewProducerHelper.MapReviewerReply(fixture, Subject);
+            members.Add(new Agg.PanelMember(
+                Role: $"role{i}",
+                ReviewDocumentId: map.IsValid ? Guid.NewGuid() : null,
+                Review: map.Payload,
+                Ok: map.IsValid,
+                FailureKind: map.IsValid ? null : "validation-exhausted"));
+        }
+
+        var result = Agg.Aggregate(members, Agg.DefaultsFor(fixtures.Count), Subject);
+        return (result.Decided, result.Decided && result.Aggregate!.Decision == ReviewDecision.Approve);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewProducerExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewProducerExecutionTests.cs
@@ -1,0 +1,372 @@
+using System.Net;
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.Core;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — full-runtime execution coverage for the review producers (Test Plan
+/// step 10, scenarios (a)–(g)). Drives the REAL producers through the Elsa runtime
+/// with a role-aware SCRIPTED <c>llm-call</c> stub and the durable event drain.
+///
+/// <para>CI-only: the class name contains <c>Execution</c> so the fast local filter
+/// (<c>FullyQualifiedName!~Execution</c>) skips it, and <c>[Explicit]</c> keeps it out
+/// of the default gate; the Postgres CI jobs run it.</para>
+/// </summary>
+[TestFixture]
+[Explicit("Full Elsa workflow-runtime integration — runs in the CI Postgres jobs, skipped in the fast local gate")]
+public class ReviewProducerExecutionTests
+{
+    [SetUp]
+    public void Reset() => ScriptedResponder.Reset();
+
+    // ── (a) single-reviewer, document subject ──
+
+    [Test]
+    public async Task SingleReviewer_DocumentSubject_LegacyReply_YieldsValidatedReviewEnvelope()
+    {
+        ScriptedResponder.SetRole("architect", LegacyApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-single-reviewer", SingleInput("architect", DocumentSubject()));
+
+        Bool(output, "success").Should().BeTrue();
+        Str(output, "reviewJson").Should().Contain("\"decision\"");
+        Str(output, "reviewDocumentId").Should().NotBeNullOrEmpty();
+
+        var types = CapturedTypes(capture);
+        types.Should().Contain(DocumentEvents.ProducedSuccess);
+        types.Should().Contain(DocumentEvents.ValidatedSuccess);
+        HasReviewDocumentTypeTag(capture).Should().BeTrue("the DOCUMENT.* events tag documentType=review");
+    }
+
+    // ── (b) single-reviewer, diff subject ──
+
+    [Test]
+    public async Task SingleReviewer_DiffSubject_CanonicalReply_YieldsDiffReview()
+    {
+        ScriptedResponder.SetRole("senior_developer", CanonicalDiffApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-single-reviewer", SingleInput("senior_developer", DiffSubject()));
+
+        Bool(output, "success").Should().BeTrue();
+        Str(output, "reviewJson").Should().Contain("\"kind\":\"diff\"");
+    }
+
+    // ── (c) invalid → repair → valid within bounds ──
+
+    [Test]
+    public async Task SingleReviewer_InvalidThenValid_RepairsWithinBounds()
+    {
+        ScriptedResponder.SetRole("architect", "garbage not a review", CanonicalApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-single-reviewer", SingleInput("architect", DocumentSubject()));
+
+        Bool(output, "success").Should().BeTrue("the second (valid) attempt succeeds within the repair bound");
+    }
+
+    // ── (d) always-garbage → validation-exhausted, NO review envelope ──
+
+    [Test]
+    public async Task SingleReviewer_AlwaysGarbage_ExhaustsValidation_NoReviewEnvelope()
+    {
+        ScriptedResponder.SetRole("architect", "garbage", "still garbage", "more garbage", "and more");
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-single-reviewer", SingleInput("architect", DocumentSubject()));
+
+        Bool(output, "success").Should().BeFalse();
+        Str(output, "failureKind").Should().Be("validation-exhausted");
+        CapturedTypes(capture).Should().Contain(DocumentEvents.ValidatedFailed);
+        CapturedTypes(capture).Should().NotContain(DocumentEvents.ValidatedSuccess,
+            "no valid review envelope may exist anywhere in the stream");
+    }
+
+    // ── (e) panel of 3 → 3 members + aggregate with AggregatedFrom ──
+
+    [Test]
+    public async Task Panel_ThreeApprovingRoles_AggregatesWithAggregatedFrom()
+    {
+        ScriptedResponder.SetRole("architect", CanonicalApprove());
+        ScriptedResponder.SetRole("developer", CanonicalApprove());
+        ScriptedResponder.SetRole("security", CanonicalApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-panel", PanelInput(new[] { "architect", "developer", "security" }, "unanimous"));
+
+        Bool(output, "success").Should().BeTrue();
+        Str(output, "reviewJson").Should().Contain("\"aggregatedFrom\"");
+        var members = JsonDocument.Parse(Str(output, "memberReviewsJson")).RootElement;
+        members.GetArrayLength().Should().Be(3);
+
+        var types = CapturedTypes(capture);
+        types.Should().Contain(DocumentEvents.ReviewPanelStarted);
+        types.Should().Contain(DocumentEvents.ReviewPanelCompleted);
+    }
+
+    // ── (f) panel undecidable → PANEL_UNDECIDABLE, no aggregate ──
+
+    [Test]
+    public async Task Panel_OneMemberExhausted_UnderFullRosterMinimum_IsUndecidable()
+    {
+        ScriptedResponder.SetRole("architect", CanonicalApprove());
+        ScriptedResponder.SetRole("developer", CanonicalApprove());
+        ScriptedResponder.SetRole("security", "garbage", "garbage", "garbage", "garbage");
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var output = await RunAsync(provider, "review-panel", PanelInput(new[] { "architect", "developer", "security" }, "unanimous"));
+
+        Bool(output, "success").Should().BeFalse();
+        Str(output, "undecidableReason").Should().Be("BelowQuorum");
+        CapturedTypes(capture).Should().Contain(DocumentEvents.ReviewPanelUndecidable);
+    }
+
+    // ── (g) router honors the 39-6 D10 contract in both modes ──
+
+    [Test]
+    public async Task Router_SingleMode_HonorsContract()
+    {
+        ScriptedResponder.SetRole("architect", CanonicalApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var rules = AcceptanceRulesJson.Serialize(AcceptanceDefaults.Rules); // single architect
+        var output = await RunAsync(provider, "document-review", RouterInput(rules));
+
+        Bool(output, "success").Should().BeTrue();
+        Str(output, "reviewJson").Should().NotBeNullOrEmpty();
+        Str(output, "reviewDocumentId").Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public async Task Router_PanelMode_HonorsContract()
+    {
+        ScriptedResponder.SetRole("architect", CanonicalApprove());
+        ScriptedResponder.SetRole("developer", CanonicalApprove());
+        ScriptedResponder.SetRole("security", CanonicalApprove());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture);
+
+        var rules = AcceptanceRulesJson.Serialize(ThreeRolePanelRules());
+        var output = await RunAsync(provider, "document-review", RouterInput(rules));
+
+        Bool(output, "success").Should().BeTrue();
+        Str(output, "memberReviewsJson").Should().Contain("reviewDocumentId");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Harness
+    // ════════════════════════════════════════════════════════════════════
+
+    private static async Task<IDictionary<string, object>> RunAsync(
+        IServiceProvider provider, string definitionId, Dictionary<string, object> input)
+    {
+        var runtime = provider.GetRequiredService<IWorkflowRuntime>();
+        var client = await runtime.CreateClientAsync();
+        await client.CreateAndRunInstanceAsync(new CreateAndRunWorkflowInstanceRequest
+        {
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId(definitionId),
+            Input = input,
+        });
+        var state = await client.ExportStateAsync();
+        return state.Output ?? new Dictionary<string, object>();
+    }
+
+    private static Dictionary<string, object> SingleInput(string role, string subjectJson) => new()
+    {
+        ["reviewerRole"] = role,
+        ["subjectJson"] = subjectJson,
+        ["variablesJson"] = "{\"planJson\":\"x\"}",
+        ["issueId"] = "issue-1",
+        ["correlationId"] = "corr-1",
+        ["tenantId"] = "",
+    };
+
+    private static Dictionary<string, object> PanelInput(string[] roles, string rule) => new()
+    {
+        ["subjectJson"] = DocumentSubject(),
+        ["variablesJson"] = "{\"planJson\":\"x\"}",
+        ["issueId"] = "issue-1",
+        ["correlationId"] = "corr-1",
+        ["tenantId"] = "",
+        ["acceptanceRulesJson"] = AcceptanceRulesJson.Serialize(PanelRules(roles, rule)),
+        ["panelDecisionRule"] = rule,
+    };
+
+    private static Dictionary<string, object> RouterInput(string rulesJson) => new()
+    {
+        ["documentJson"] = "{\"id\":\"0192a8b0-1111-7abc-8def-000000000001\",\"payload\":{\"summary\":\"x\"}}",
+        ["documentType"] = "plan",
+        ["issueId"] = "issue-1",
+        ["correlationId"] = "corr-1",
+        ["tenantId"] = "",
+        ["acceptanceRulesJson"] = rulesJson,
+    };
+
+    private static AcceptanceRules PanelRules(string[] roles, string rule) => AcceptanceDefaults.Rules with
+    {
+        ReviewerSelection = new ReviewerSelection(
+            Mode: ReviewerMode.Panel,
+            ReviewerRole: null,
+            PanelRoles: roles,
+            Quorum: null,
+            DecisionRule: rule == "majority" ? ReviewDecisionRule.Majority : ReviewDecisionRule.Unanimous),
+    };
+
+    private static AcceptanceRules ThreeRolePanelRules() => PanelRules(new[] { "architect", "developer", "security" }, "unanimous");
+
+    private static string DocumentSubject() =>
+        "{\"kind\":\"document\",\"documentId\":\"0192a8b0-1111-7abc-8def-000000000001\",\"documentType\":\"plan\"}";
+
+    private static string DiffSubject() =>
+        "{\"kind\":\"diff\",\"repository\":\"meywd/tamma\",\"prNumber\":42}";
+
+    private static string LegacyApprove() =>
+        "{\"issues\":[],\"verdict\":{\"decision\":\"APPROVE\",\"summary\":\"lgtm\",\"blockingIssues\":[]}}";
+
+    private static string CanonicalApprove() =>
+        "{\"subject\":{\"kind\":\"document\",\"documentId\":\"0192a8b0-1111-7abc-8def-000000000001\",\"documentType\":\"plan\"}," +
+        "\"decision\":\"approve\",\"summary\":\"looks good\",\"issues\":[]}";
+
+    private static string CanonicalDiffApprove() =>
+        "{\"subject\":{\"kind\":\"diff\",\"repository\":\"meywd/tamma\",\"prNumber\":42}," +
+        "\"decision\":\"approve\",\"summary\":\"clean\",\"issues\":[]}";
+
+    private static bool Bool(IDictionary<string, object> o, string key)
+        => o.TryGetValue(key, out var v) && (v is true || (v is string s && bool.TryParse(s, out var b) && b));
+
+    private static string Str(IDictionary<string, object> o, string key)
+        => o.TryGetValue(key, out var v) ? v?.ToString() ?? "" : "";
+
+    private static List<string?> CapturedTypes(CapturingHandler capture) =>
+        CapturedEvents(capture).Select(e => e.GetProperty("eventType").GetString()).ToList();
+
+    private static List<JsonElement> CapturedEvents(CapturingHandler capture) =>
+        capture.Bodies
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .ToList();
+
+    private static bool HasReviewDocumentTypeTag(CapturingHandler capture) =>
+        CapturedEvents(capture).Any(e =>
+            e.TryGetProperty("tags", out var t) &&
+            t.TryGetProperty("documentType", out var dt) &&
+            dt.GetString() == "review");
+
+    private static ServiceProvider BuildProvider(CapturingHandler capture)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        services.AddElsa(elsa =>
+        {
+            elsa.AddActivitiesFrom<EmitDocumentEventActivity>();
+            elsa.AddWorkflow<DocumentReviewWorkflow>();
+            elsa.AddWorkflow<SingleReviewerWorkflow>();
+            elsa.AddWorkflow<PanelReviewWorkflow>();
+            elsa.AddWorkflow<StubLlmCallWorkflow>();
+            elsa.UseWorkflows(w => w.UseTammaEventPersistence());
+        });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = "http://tamma.test",
+                ["Engine:CallbackUrl"] = "http://engine.test",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddSingleton(_ => new Tamma.Activities.LlmCall.TammaApiClient(
+            new HttpClient(capture) { BaseAddress = null },
+            NullLogger<Tamma.Activities.LlmCall.TammaApiClient>.Instance,
+            config));
+
+        return services.BuildServiceProvider();
+    }
+
+    // ── role-aware scripted stub llm-call ──
+
+    private static class ScriptedResponder
+    {
+        private static readonly Dictionary<string, List<string>> s_scripts = new();
+        private static readonly Dictionary<string, int> s_counters = new();
+
+        public static void Reset() { s_scripts.Clear(); s_counters.Clear(); }
+
+        public static void SetRole(string role, params string[] replies) => s_scripts[role] = replies.ToList();
+
+        public static string ForRole(string role)
+        {
+            if (!s_scripts.TryGetValue(role, out var list) || list.Count == 0) return "{}";
+            var i = s_counters.TryGetValue(role, out var c) ? c : 0;
+            s_counters[role] = i + 1;
+            return list[Math.Min(i, list.Count - 1)];
+        }
+    }
+
+    public class StubLlmCallWorkflow : WorkflowBase
+    {
+        protected override void Build(IWorkflowBuilder builder)
+        {
+            builder.DefinitionId = "llm-call";
+            builder.Root = new Sequence
+            {
+                Activities =
+                {
+                    new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) },
+                    new SetOutput
+                    {
+                        Id = "OutResponse", OutputName = new("llmResponse"),
+                        OutputValue = new(ctx => (object)ScriptedResponder.ForRole(ctx.GetInput<string>("agentRole") ?? "")),
+                    },
+                },
+            };
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = new();
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(cancellationToken));
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"ok\":true,\"persisted\":1}"),
+            };
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewProducerHelperTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewProducerHelperTests.cs
@@ -1,0 +1,134 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — unit pins for <see cref="ReviewProducerHelper"/> (Design Decisions
+/// D4/D5; covers AC1's mapping / no-laundering half).
+/// </summary>
+[TestFixture]
+public class ReviewProducerHelperTests
+{
+    private static ReviewSubject DocSubject() => new()
+    {
+        Kind = "document",
+        DocumentId = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001"),
+        DocumentType = "plan",
+    };
+
+    [Test]
+    public void MapReviewerReply_CanonicalReview_MapsAsIs()
+    {
+        var json =
+            "{\"subject\":{\"kind\":\"document\",\"documentId\":\"0192a8b0-1111-7abc-8def-000000000001\",\"documentType\":\"plan\"}," +
+            "\"decision\":\"request-changes\",\"summary\":\"needs work\",\"issues\":[" +
+            "{\"severity\":\"major\",\"category\":\"design\",\"description\":\"no rollback\",\"suggestedFix\":\"add rollback\"}]}";
+
+        var result = ReviewProducerHelper.MapReviewerReply(json, DocSubject());
+
+        result.IsValid.Should().BeTrue();
+        result.Payload!.Decision.Should().Be(ReviewDecision.RequestChanges);
+        result.Payload!.Issues.Should().ContainSingle();
+    }
+
+    [Test]
+    public void MapReviewerReply_LegacyCellShape_MapsSeverityCategoryFixIntact_AndValidates()
+    {
+        var json =
+            "{\"issues\":[{\"task\":\"T1\",\"severity\":\"major\",\"category\":\"design\",\"issue\":\"No rollback\",\"recommendation\":\"add rollback\"}]," +
+            "\"verdict\":{\"decision\":\"REQUEST_CHANGES\",\"summary\":\"needs work\",\"blockingIssues\":[]}}";
+
+        var result = ReviewProducerHelper.MapReviewerReply(json, DocSubject());
+
+        result.IsValid.Should().BeTrue();
+        result.Payload!.Decision.Should().Be(ReviewDecision.RequestChanges);
+        result.Payload!.Summary.Should().Be("needs work");
+        var issue = result.Payload!.Issues.Single();
+        issue.Severity.Should().Be(ReviewSeverity.Major);
+        issue.Category.Should().Be("design");
+        issue.SuggestedFix.Should().Be("add rollback");
+        issue.Description.Should().Contain("No rollback");
+    }
+
+    [Test]
+    public void MapReviewerReply_ObjectVerdictBlockingIssues_BecomeCriticalIssues()
+    {
+        // A blocking issue string becomes a Critical issue with no suggested fix —
+        // observable because the validator then flags it as ISSUE_MISSING_FIX (proving
+        // the blocking issue was materialised, not laundered away).
+        var json = "{\"verdict\":{\"decision\":\"REQUEST_CHANGES\",\"summary\":\"blocked\",\"blockingIssues\":[\"SQL injection\"]}}";
+
+        var result = ReviewProducerHelper.MapReviewerReply(json, DocSubject());
+
+        result.Payload.Should().BeNull("a fix-less blocking issue is routed to repair, not laundered");
+        result.Violations.Should().Contain(v => v.Code == ReviewDocumentType.IssueMissingFix);
+    }
+
+    [Test]
+    public void MapReviewerReply_ApproveWithBlockingIssue_FailsFlagshipRule()
+    {
+        var json =
+            "{\"subject\":{\"kind\":\"document\",\"documentId\":\"0192a8b0-1111-7abc-8def-000000000001\",\"documentType\":\"plan\"}," +
+            "\"decision\":\"approve\",\"summary\":\"lgtm\",\"issues\":[" +
+            "{\"severity\":\"critical\",\"category\":\"security\",\"description\":\"sqli\",\"suggestedFix\":\"parameterize\"}]}";
+
+        var result = ReviewProducerHelper.MapReviewerReply(json, DocSubject());
+
+        result.Payload.Should().BeNull();
+        result.Violations.Should().Contain(v => v.Code == ReviewDocumentType.ApproveWithBlockingIssues);
+    }
+
+    [TestCase("not json at all")]
+    [TestCase("")]
+    [TestCase("{}")]
+    [TestCase("   ")]
+    public void MapReviewerReply_Garbage_YieldsViolationsNeverADefaultedReview(string reply)
+    {
+        var result = ReviewProducerHelper.MapReviewerReply(reply, DocSubject());
+
+        result.Payload.Should().BeNull("garbage must never become a defaulted 'concerns' review");
+        result.Violations.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void BuildRepairVariables_WithoutViolations_IsBytePassthroughOfFeedbackVar()
+    {
+        var vars = "{\"workItemJson\":\"original\",\"planJson\":\"P\"}";
+        var outJson = ReviewProducerHelper.BuildRepairVariables(
+            vars, Array.Empty<DocumentViolation>(), "workItemJson", "CONTRACT");
+
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(outJson)!;
+        parsed["workItemJson"].Should().Be("original", "no violations → the feedback var is unchanged");
+        parsed["planJson"].Should().Be("P");
+    }
+
+    [Test]
+    public void BuildRepairVariables_WithViolations_AppendsOnlyIntoNamedVariable()
+    {
+        var vars = "{\"workItemJson\":\"original\",\"planJson\":\"P\"}";
+        var violations = new[] { new DocumentViolation("X", "the summary is required") };
+
+        var outJson = ReviewProducerHelper.BuildRepairVariables(vars, violations, "workItemJson", "CONTRACT");
+
+        var parsed = JsonSerializer.Deserialize<Dictionary<string, string>>(outJson)!;
+        parsed["planJson"].Should().Be("P", "only the named feedback variable is touched");
+        parsed["workItemJson"].Should().StartWith("original");
+        parsed["workItemJson"].Should().Contain(ValidationFeedbackHelper.FeedbackHeader);
+        parsed["workItemJson"].Should().Contain("the summary is required");
+    }
+
+    [Test]
+    public void ShouldRepair_RespectsMaxAttempts()
+    {
+        var rules = AcceptanceDefaults.Rules with { MaxValidationRepairAttempts = 2 };
+        ReviewProducerHelper.ShouldRepair(0, rules).Should().BeTrue();
+        ReviewProducerHelper.ShouldRepair(1, rules).Should().BeTrue();
+        ReviewProducerHelper.ShouldRepair(2, rules).Should().BeFalse();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewerSelectionHelperTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ReviewerSelectionHelperTests.cs
@@ -1,0 +1,113 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — unit pins for <see cref="ReviewerSelectionHelper"/> (Design
+/// Decision D3; covers AC4's validation half).
+/// </summary>
+[TestFixture]
+public class ReviewerSelectionHelperTests
+{
+    private static readonly AgentRole[] DocumentRoster =
+    {
+        AgentRole.Architect, AgentRole.SeniorDeveloper, AgentRole.Security,
+        AgentRole.Developer, AgentRole.Tester, AgentRole.Devops, AgentRole.ProductOwner,
+    };
+
+    [Test]
+    public void Resolve_DocumentSubject_MatchesRolePhaseMapReviewAction()
+    {
+        foreach (var role in DocumentRoster)
+        {
+            var spec = ReviewerSelectionHelper.Resolve(role.ToWire(), null, "document", null);
+            spec.Role.Should().Be(role);
+            spec.Action.Should().Be(RolePhaseMap.GetReviewActionForRole(role),
+                $"the document reviewer action for {role.ToWire()} comes from RolePhaseMap");
+        }
+    }
+
+    [Test]
+    public void Resolve_DiffSubject_PinsTheFiveDiffPairs()
+    {
+        ReviewerSelectionHelper.Resolve("senior_developer", null, "diff", null).Action.Should().Be(AgentAction.CodeReview);
+        ReviewerSelectionHelper.Resolve("developer", null, "diff", null).Action.Should().Be(AgentAction.CodeReview);
+        ReviewerSelectionHelper.Resolve("architect", null, "diff", null).Action.Should().Be(AgentAction.CodeReviewArchitecture);
+        ReviewerSelectionHelper.Resolve("security", null, "diff", null).Action.Should().Be(AgentAction.CodeReviewSecurity);
+        ReviewerSelectionHelper.Resolve("tester", null, "diff", null).Action.Should().Be(AgentAction.CodeReviewCoverage);
+    }
+
+    [Test]
+    public void Resolve_DevopsOnDiff_ThrowsRoleNotOnDiffPanel()
+    {
+        var act = () => ReviewerSelectionHelper.Resolve("devops", null, "diff", null);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be(ReviewerSelectionHelper.RoleNotOnDiffPanelCode);
+    }
+
+    [Test]
+    public void Resolve_ProductOwnerOnDiff_ThrowsRoleNotOnDiffPanel()
+    {
+        var act = () => ReviewerSelectionHelper.Resolve("product_owner", null, "diff", null);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be(ReviewerSelectionHelper.RoleNotOnDiffPanelCode);
+    }
+
+    [Test]
+    public void Resolve_UnknownRole_ThrowsInvalidReviewer()
+    {
+        var act = () => ReviewerSelectionHelper.Resolve("nobody", null, "document", null);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be(ReviewerSelectionHelper.InvalidReviewerCode);
+    }
+
+    [Test]
+    public void Resolve_IneligibleActionOverride_ThrowsInvalidReviewer()
+    {
+        // deploy is devops-only — tester is not eligible for it.
+        var act = () => ReviewerSelectionHelper.Resolve("tester", "deploy", "document", null);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be(ReviewerSelectionHelper.InvalidReviewerCode);
+    }
+
+    [Test]
+    public void Resolve_UnknownActionOverride_ThrowsInvalidReviewer()
+    {
+        var act = () => ReviewerSelectionHelper.Resolve("architect", "not-an-action", "document", null);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be(ReviewerSelectionHelper.InvalidReviewerCode);
+    }
+
+    [Test]
+    public void Resolve_ActionOverride_WinsOverDerivation()
+    {
+        // architect is eligible for code-review-architecture; the override selects it
+        // even for a document subject.
+        var spec = ReviewerSelectionHelper.Resolve("architect", "code-review-architecture", "document", null);
+        spec.Action.Should().Be(AgentAction.CodeReviewArchitecture);
+    }
+
+    [Test]
+    public void AllDispatchablePairs_AreTwelveAndAllEligible()
+    {
+        ReviewerSelectionHelper.AllDispatchablePairs.Should().HaveCount(12);
+        ReviewerSelectionHelper.AllDispatchablePairs.Should().OnlyContain(
+            p => RolePhaseMap.IsRoleEligibleForPhase(p.Action, p.Role));
+    }
+
+    [Test]
+    public void ResolvePanelRoster_EmptyRules_FallsBackToSingleArchitect()
+    {
+        var roster = ReviewerSelectionHelper.ResolvePanelRoster("");
+        roster.Should().ContainSingle().Which.Should().Be(AgentRole.Architect.ToWire());
+    }
+
+    [Test]
+    public void ResolvePanelRoster_PanelRules_ReturnsFullRoster()
+    {
+        var json = AcceptanceRulesJson.Serialize(AcceptanceDefaults.For(DocumentTypeKey.Plan));
+        var roster = ReviewerSelectionHelper.ResolvePanelRoster(json);
+        roster.Should().BeEquivalentTo(AcceptanceDefaults.PanelRoster);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleReviewerWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/SingleReviewerWorkflowStructureTests.cs
@@ -1,0 +1,90 @@
+using Elsa.Expressions.Models;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities.Flowchart.Activities;
+using Elsa.Workflows.Runtime.Activities;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-7 — structural pins for <see cref="SingleReviewerWorkflow"/> (AC1 graph
+/// half + the no-laundering structural pin, AC9 definition-id surface).
+/// </summary>
+[TestFixture]
+public class SingleReviewerWorkflowStructureTests
+{
+    private static Flowchart Flowchart() =>
+        WorkflowTestHelper.GetFlowchart(WorkflowTestHelper.BuildWorkflow(new SingleReviewerWorkflow()));
+
+    [Test]
+    public void Workflow_HasStableDefinitionId()
+    {
+        var builder = WorkflowTestHelper.BuildWorkflow(new SingleReviewerWorkflow());
+        builder.Object.DefinitionId.Should().Be("review-single-reviewer");
+    }
+
+    [Test]
+    public void Workflow_HasExactlyOneLlmCallDispatch()
+    {
+        var llm = Flowchart().Activities.OfType<DispatchWorkflow>()
+            .Where(d => ReadLiteralDefId(d) == "llm-call")
+            .Select(d => d.Id)
+            .ToList();
+
+        llm.Should().BeEquivalentTo(new[] { "DispatchReviewerCall" },
+            "the single-reviewer producer makes exactly ONE mediated llm-call");
+    }
+
+    [Test]
+    public void Repair_LoopsBackToTheSameDispatchNode()
+    {
+        Flowchart().Connections.Any(c =>
+            c.Source.Activity.Id == "BuildRepairFeedback" && c.Target.Activity.Id == "DispatchReviewerCall")
+            .Should().BeTrue("the bounded repair ring re-runs the SAME dispatch node");
+    }
+
+    [Test]
+    public void ValidationGate_RoutesTrueToEnvelope_FalseToRepairGate()
+    {
+        var fc = Flowchart();
+        fc.Connections.Any(c => c.Source.Activity.Id == "ValidationGate" && c.Source.Port == "True" && c.Target.Activity.Id == "BuildEnvelope")
+            .Should().BeTrue("a valid review builds the envelope");
+        fc.Connections.Any(c => c.Source.Activity.Id == "ValidationGate" && c.Source.Port == "False" && c.Target.Activity.Id == "RepairGate")
+            .Should().BeTrue("an invalid review goes to the repair gate, never to success");
+    }
+
+    [Test]
+    public void NoLaundering_SuccessOutputsReachedOnlyThroughTheValidChain()
+    {
+        var fc = Flowchart();
+
+        // The success outputs node is reached ONLY from EmitValidated (the valid chain);
+        // no invalid/repair-exhaustion path may feed it.
+        var inbound = fc.Connections.Where(c => c.Target.Activity.Id == "SetOutputsSuccess").ToList();
+        inbound.Should().OnlyContain(c => c.Source.Activity.Id == "EmitValidated",
+            "the ONLY way to the success outputs is the valid produce→validate chain (no laundering)");
+
+        // The repair-exhaustion path terminates at the FAIL outputs, never success.
+        fc.Connections.Any(c => c.Source.Activity.Id == "RepairGate" && c.Source.Port == "False" && c.Target.Activity.Id == "SetFailureKind")
+            .Should().BeTrue("exhausted repair goes to the typed failure terminal");
+        fc.Connections.Any(c => c.Source.Activity.Id == "SetOutputsFail")
+            .Should().BeTrue("there is a dedicated failure-outputs terminal");
+    }
+
+    [Test]
+    public void EmitsProducedAndValidated_OnBothPaths()
+    {
+        var emitIds = Flowchart().Activities.OfType<Tamma.Activities.Documents.EmitDocumentEventActivity>()
+            .Select(a => a.Id).ToHashSet();
+        emitIds.Should().Contain(new[] { "EmitProduced", "EmitValidated", "EmitProducedFailed", "EmitValidatedFailed" });
+    }
+
+    private static string? ReadLiteralDefId(DispatchWorkflow dispatch)
+    {
+        var value = typeof(DispatchWorkflow).GetProperty("WorkflowDefinitionId")?.GetValue(dispatch);
+        var expr = value?.GetType().GetProperty("Expression")?.GetValue(value) as Expression;
+        return expr?.Value as string;
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TaxonomyDriftBuildTests.cs
@@ -180,6 +180,15 @@ public class TaxonomyDriftBuildTests
                 "input-driven repair re-dispatch of the same producer spec; validated at Init (39-6 D2/D3).",
             [("DocumentLifecycleWorkflow", "DispatchRevise")] =
                 "input-driven revise re-dispatch of the same producer spec; validated at Init (39-6 D2/D3).",
+            // Story 39-7 (D9) — the single-reviewer producer's one llm-call reads its
+            // (role, action) from the ReviewerRole/ReviewerAction workflow variables
+            // (default ""), resolved + validated fail-loud at Init via
+            // ReviewerSelectionHelper.Resolve. The panel + router workflows dispatch only
+            // the review-single-reviewer / review-panel sub-workflows (not llm-call), so
+            // they contribute ZERO llm-call dispatch pairs and appear nowhere here.
+            [("SingleReviewerWorkflow", "DispatchReviewerCall")] =
+                "input-driven (ReviewerRole/ReviewerAction workflow variables default to \"\"); the pair is " +
+                "resolved + validated fail-loud at Init via ReviewerSelectionHelper.Resolve (39-7 D3/D9).",
         };
 
     // Internal (not private): ContractBindingTests reuses the same enumeration so


### PR DESCRIPTION
## Story 39-7 — Review Producers (Epic 39, Wave 3)

Three dispatchable review-producer workflows feeding the 39-6 lifecycle's REVIEW stage, all yielding the unified 39-4 `Review` type. The defining property: **no defaulted verdicts, ever** — the `"concerns"` laundering fallback that `PlanReviewWorkflow` used is structurally gone.

### The three workflows
- **`SingleReviewerWorkflow`** (`"review-single-reviewer"`, AC1) — one policy-selected `(role, action)` `llm-call` per run, a bounded validation/repair ring, and exactly one **validated** `Review` envelope, or a typed failure on exhaustion (`validation-exhausted` / `llm-failed`). Structural pin: the success outputs are reachable **only** through the valid produce→validate chain; an invalid review routes to the repair gate and, on exhaustion, to the typed failure terminal — never to success.
- **`PanelReviewWorkflow`** (`"review-panel"`, AC2/6/7) — fans out N single-reviewer runs over a static 7-role roster with per-role membership gates, persists **every** member review (emitted inside each member run, before aggregation exists), and aggregates via a pure helper into an aggregate `Review` referencing its member ids (`aggregatedFrom`). Undecidable panels surface a **typed reason carrying all member reviews** — never a fabricated pessimistic aggregate.
- **`DocumentReviewWorkflow`** (`"document-review"`) — the thin router honoring 39-6 D10's definition-id + I/O contract; reads `ReviewerSelection.Mode` and dispatches the single or panel producer.

### Pure helpers (`Workflows/Helpers/`)
- `ReviewerSelectionHelper` — reviewer `(role, action)` derivation (document → `RolePhaseMap.GetReviewActionForRole`; diff → a local, drift-pinned code-review map), fail-loud taxonomy validation, `AllDispatchablePairs` (the 12-pair pin surface).
- `ReviewProducerHelper` — reply mapping: canonical `Review` → legacy cell-shape (`issues[]` + object verdict via `Review.FromLegacyVerdictJson`) → **violations, never a default review**; every mapped payload runs `ReviewDocumentType.Validate`; bounded repair variables.
- `ReviewPanelAggregation` — pure aggregation over `IReadOnlyList<Review>`: `Unanimous`/`Majority` rules + `MinimumUsableReviews`, the **blocking-issue veto as an invariant** (any member Critical issue → aggregate `RequestChanges`, structurally re-proven by validation), typed undecidable reasons. Default config = Unanimous + full-roster quorum → `AggregateVerdicts` parity.

### Parity harness (AC8 — 39-14's retirement evidence)
`ReviewParityTests` replays the recorded `PlanReviewDecisionTests` verdict fixtures: asserts behavioral parity where preserved (all-approve → approve; one-concerns / needs-discussion → non-approve) **and the two deliberate divergences asserted _as_ divergences** — empty panel → `EmptyPanel` undecidable (not the old empty-`All()`⇒approve bug); garbage/incomplete member → `BelowQuorum` undecidable (not laundered-to-`concerns`). Invariant across every fixture: **a set containing garbage never yields a new `Approve`**.

### AC9 — bounded diff, no caller migrated
`PlanReviewWorkflow.cs`, `TriagePanelReviewWorkflow.cs`, `Review.cs`, and `RolePhaseMap.cs` are **byte-identical / untouched** (verified via `git status`). Diff surface = the six new source files + `DocumentEvents.cs` (3 appended panel constants) + the two coverage-guard test files (+ one constant-pin count update 10→13, the unavoidable consequence of appending the constants).

### Events / data
`DOCUMENT.REVIEW_PANEL_STARTED / _COMPLETED / _UNDECIDABLE` added; per-member and aggregate envelopes ride `DOCUMENT.PRODUCED/VALIDATED` (documentType `"review"`). No EF entities; `has-pending-model-changes` clean. The single-reviewer data-driven dispatch joins the drift/contract-binding coverage guards (`ReviewProducerDispatchablePairs` for the 4 policy-only diff specializations).

### Verification (independently re-run)
- Builds: `Tamma.Core`, `Tamma.Activities`, `Tamma.ElsaServer`, `Tamma.Api`, and all three test projects — **green**.
- `Tamma.Core.Tests`: **390 passed**. `Tamma.Activities.Tests` (excl. CI-gated Execution): **2617 passed** (215 new review-producer / parity / structure / guard tests). Migration model clean. Four sensitive files confirmed untouched.
- `ReviewProducerExecutionTests` (full-runtime scenarios a–g, mirroring 39-6's harness) — compiles; `[Explicit]`/CI-gated; runs in CI's Postgres jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_