### PR TITLE
feat(39-11): Document Store &amp; Lineage API — per-tenant document_instances + read endpoints

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDocumentEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDocumentEventActivity.cs
@@ -65,6 +65,15 @@ public class EmitDocumentEventActivity : Activity
     [Input(Description = "Optional structured JSON payload (e.g. outcome / lineage summary)")]
     public Input<string?> DataJson { get; set; } = new((string?)null);
 
+    // Story 39-11 (Design Decision D6) — additive, optional. When set to a valid
+    // Guid string, it becomes the emitted TammaEvent.Id so the durable
+    // domain_events row carries the SAME id the store stamps as
+    // correlating_event_id — the AC7 store↔stream linkage. Unset (the pre-39-11
+    // behaviour) leaves the auto-minted per-event id untouched. Purely additive:
+    // no existing tag/data mapping or event structure changes.
+    [Input(Description = "Optional pre-minted event id (Guid string) — the AC7 store↔stream linkage")]
+    public Input<string?> EventId { get; set; } = new((string?)null);
+
     [JsonConstructor]
     public EmitDocumentEventActivity() { }
 
@@ -88,6 +97,13 @@ public class EmitDocumentEventActivity : Activity
 
         var evt = BuildTammaEvent(
             type, documentId, documentType, round, issueId, correlationId, sessionId, tenantId, detail, dataJson);
+
+        // D6 — override the auto-minted id with the pre-minted transition event id
+        // when supplied, so the store's correlating_event_id resolves to THIS row.
+        var eventId = EventId.Get(context);
+        if (!string.IsNullOrWhiteSpace(eventId) && Guid.TryParse(eventId, out var preMinted))
+            evt.Id = preMinted;
+
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Core;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-11 (Design Decision D6) — persists a document instance to the tenant's
+/// <c>document_instances</c> store through the fail-loud engine→API hop
+/// (<c>TammaApiClient.PersistDocumentAsync</c> → <c>POST /api/engine/documents</c>).
+///
+/// <para>The lifecycle runs in <c>Tamma.ElsaServer</c>, which registers no
+/// repository, so the sanctioned engine→store path is HTTP to <c>Tamma.Api</c>.
+/// Unlike the best-effort event drain, a persist failure FAULTS this activity
+/// (<c>TammaError DOCUMENT.STORE.PERSIST_FAILED</c>) — the document is the
+/// lifecycle's product, not telemetry, so it is NEVER swallowed.</para>
+///
+/// <para><b>Scope note (deferred to 39-12).</b> This activity ships the engine seam;
+/// wiring persist+emit adjacently per transition into
+/// <c>DocumentLifecycleWorkflow</c>'s graph is deferred to 39-12 (the
+/// workflow-rewire pilot). The AC7 linkage — passing the pre-minted transition
+/// event Guid to BOTH the emit site (<c>EmitDocumentEventActivity.EventId</c>) and
+/// this activity's <see cref="CorrelatingEventId"/> — is the agreed seam.</para>
+/// </summary>
+[Activity(
+    "Tamma.Documents",
+    "Persist Document Instance",
+    "Persist a document instance to the tenant document_instances store (fail-loud engine→API hop)",
+    Kind = ActivityKind.Task
+)]
+public class PersistDocumentInstanceActivity : Activity
+{
+    private readonly ILogger<PersistDocumentInstanceActivity>? _logger;
+
+    [Input(Description = "Serialized DocumentEnvelope JSON (DocumentJson.Serialize output)")]
+    public Input<string> EnvelopeJson { get; set; } = default!;
+
+    [Input(Description = "Pre-minted correlating DOCUMENT.* event id (Guid string) — the AC7 linkage")]
+    public Input<string?> CorrelatingEventId { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (X-Tenant-Id) the store row is scoped to")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [JsonConstructor]
+    public PersistDocumentInstanceActivity() { }
+
+    public PersistDocumentInstanceActivity(ILogger<PersistDocumentInstanceActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var envelopeJson = EnvelopeJson.Get(context);
+        if (string.IsNullOrWhiteSpace(envelopeJson))
+            throw Failed("PersistDocumentInstanceActivity requires a non-empty EnvelopeJson.", null);
+
+        var client = context.GetService<TammaApiClient>()
+            ?? throw Failed(
+                "TammaApiClient is not registered — the engine cannot reach the document store.", null);
+
+        Guid? correlatingEventId = Guid.TryParse(CorrelatingEventId.Get(context), out var g) ? g : null;
+        var tenantId = TenantId.Get(context);
+
+        try
+        {
+            await client
+                .PersistDocumentAsync(
+                    new PersistDocumentRequest(envelopeJson, correlatingEventId),
+                    tenantId,
+                    context.CancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (TammaError)
+        {
+            throw; // already the fail-loud shape — never re-wrap/swallow.
+        }
+        catch (Exception ex)
+        {
+            throw Failed($"Failed to persist document instance: {ex.Message}", ex);
+        }
+
+        _logger?.LogInformation("Persisted document instance (tenant {Tenant})", tenantId);
+    }
+
+    private static TammaError Failed(string message, Exception? inner) => new(
+        "DOCUMENT.STORE.PERSIST_FAILED",
+        inner is null ? message : $"{message} ({inner.GetType().Name})",
+        new Dictionary<string, object?> { ["inner"] = inner?.Message },
+        retryable: true,
+        severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/TammaApiModels.cs
@@ -281,6 +281,25 @@ public record AppendEventsRequest(
 );
 
 /// <summary>
+/// Story 39-11 — POST body for <c>/api/engine/documents</c>. The envelope rides
+/// as a JSON string (serialized via <c>DocumentJson</c>) so the API
+/// re-deserializes through the same canonical options; the tenant is asserted by
+/// the <c>X-Tenant-Id</c> header. camelCase to match the API DTO binding.
+/// </summary>
+public record PersistDocumentRequest(
+    [property: JsonPropertyName("envelopeJson")] string EnvelopeJson,
+    [property: JsonPropertyName("correlatingEventId")] Guid? CorrelatingEventId
+);
+
+/// <summary>
+/// Story 39-11 — POST body for <c>/api/engine/documents/{documentId}/status</c>.
+/// </summary>
+public record SetDocumentStatusRequest(
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("correlatingEventId")] Guid? CorrelatingEventId
+);
+
+/// <summary>
 /// POST body for <c>/api/engine/platform-events</c> — a BATCH of platform
 /// events the Elsa engine forwards to the Tamma API for durable audit storage.
 /// </summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -565,6 +565,87 @@ public class TammaApiClient
         }
     }
 
+    // ----- Document store persist (Story 39-11, D6) --------------------
+
+    /// <summary>
+    /// Persist a document instance to the tenant's <c>document_instances</c> store
+    /// via <c>POST /api/engine/documents</c> (<c>EngineServiceOnly</c>).
+    ///
+    /// <para><b>FAIL-LOUD</b> — unlike the best-effort <see cref="AppendEventsAsync"/>
+    /// event drain, a non-2xx or transport failure THROWS. The document is the
+    /// lifecycle's product, not telemetry; the caller (persist activity) must fault,
+    /// not swallow.</para>
+    /// </summary>
+    public async Task PersistDocumentAsync(
+        Models.PersistDocumentRequest request,
+        string? tenantId = null,
+        CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/engine/documents";
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(request, options: JsonOpts),
+        };
+        AddTenantHeader(httpRequest, tenantId);
+        using var response = await _httpClient.SendAsync(httpRequest, ct).ConfigureAwait(false);
+        await RecordHealthAsync(
+            response.IsSuccessStatusCode, (int)response.StatusCode, null, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await SafeReadBodyAsync(response, ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Tamma API POST /api/engine/documents returned {Status}: {Body}",
+                (int)response.StatusCode, body);
+            throw new HttpRequestException(
+                $"Persist document failed: HTTP {(int)response.StatusCode}. {body}");
+        }
+    }
+
+    /// <summary>
+    /// Transition a persisted document's status via
+    /// <c>POST /api/engine/documents/{documentId}/status</c>
+    /// (<c>EngineServiceOnly</c>). FAIL-LOUD (non-2xx / transport throws).
+    /// </summary>
+    public async Task SetDocumentStatusAsync(
+        Guid documentId,
+        string status,
+        Guid? correlatingEventId,
+        string? tenantId = null,
+        CancellationToken ct = default)
+    {
+        var url = $"{_baseUrl}/api/engine/documents/{documentId}/status";
+        var body = new Models.SetDocumentStatusRequest(status, correlatingEventId);
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = JsonContent.Create(body, options: JsonOpts),
+        };
+        AddTenantHeader(httpRequest, tenantId);
+        using var response = await _httpClient.SendAsync(httpRequest, ct).ConfigureAwait(false);
+        await RecordHealthAsync(
+            response.IsSuccessStatusCode, (int)response.StatusCode, null, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            var responseBody = await SafeReadBodyAsync(response, ct).ConfigureAwait(false);
+            _logger.LogWarning(
+                "Tamma API POST /api/engine/documents/{Id}/status returned {Status}: {Body}",
+                documentId, (int)response.StatusCode, responseBody);
+            throw new HttpRequestException(
+                $"Set document status failed: HTTP {(int)response.StatusCode}. {responseBody}");
+        }
+    }
+
+    private static async Task<string> SafeReadBodyAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        try
+        {
+            return await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or IOException)
+        {
+            return "(response body unavailable)";
+        }
+    }
+
     // ----- Platform event append ----------------------------------------
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
@@ -40,7 +40,7 @@ public static class DocumentEndpoints
 
         var rows = await repo.ListByIssueAsync(tenantId, issueId, ct).ConfigureAwait(false);
         var lineage = LineageAssembler.Assemble(issueId, rows);
-        return Results.Json(lineage, DocumentJson.Options);
+        return Results.Json(lineage, DocumentJson.Options, statusCode: StatusCodes.Status200OK);
     }
 
     // ─── GET /api/documents/issues/{issueId}/latest (AC4) ─────────────────────
@@ -61,7 +61,7 @@ public static class DocumentEndpoints
 
         var rows = await repo.GetLatestAcceptedAsync(tenantId, issueId, ct).ConfigureAwait(false);
         var latest = LineageAssembler.AssembleLatest(issueId, rows);
-        return Results.Json(latest, DocumentJson.Options);
+        return Results.Json(latest, DocumentJson.Options, statusCode: StatusCodes.Status200OK);
     }
 
     // ─── GET /api/documents/{documentId} (AC5) ────────────────────────────────
@@ -83,7 +83,7 @@ public static class DocumentEndpoints
         if (row is null || row.TenantId != tenantId)
             return Results.NotFound(new { error = "document_not_found" });
 
-        return Results.Json(LineageAssembler.AssembleDocument(row), DocumentJson.Options);
+        return Results.Json(LineageAssembler.AssembleDocument(row), DocumentJson.Options, statusCode: StatusCodes.Status200OK);
     }
 
     // ─── POST /api/engine/documents (D6) ──────────────────────────────────────

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
@@ -1,0 +1,173 @@
+using System.Text.Json;
+using Tamma.Api.Services.Documents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Data;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 39-11 — the document store's HTTP surface: two tenant-facing lineage
+/// reads + a single-document fetch (<c>MemberAccess</c>, D9), plus the engine→API
+/// persist/status write seam (<c>EngineServiceOnly</c>, D6). Handlers follow the
+/// <see cref="ReposRunsEndpoints"/> posture: each opens with the verbatim
+/// fail-closed null-tenant guard, and the bare-id fetch re-checks entity-level
+/// tenant ownership after load (defence-in-depth against id guessing, AC5/AC6).
+///
+/// <para>Responses serialize through <see cref="DocumentJson.Options"/> so the
+/// wire contract (millisecond ISO timestamps, explicit property names) is
+/// deliberate and matches the shared <c>Tamma.Core</c> lineage DTOs.</para>
+/// </summary>
+public static class DocumentEndpoints
+{
+    // ─── GET /api/documents/issues/{issueId}/lineage (AC3) ────────────────────
+
+    /// <summary>
+    /// The full document trail for an issue, grouped by type in first-produced
+    /// order with reviews attached to their subject and a terminal outcome. An
+    /// issue with no documents is a valid state → 200 with empty <c>types</c>, NOT
+    /// 404.
+    /// </summary>
+    public static async Task<IResult> GetIssueLineage(
+        string issueId,
+        IDocumentInstanceRepository repo,
+        ITenantContext tc,
+        CancellationToken ct)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+            return Results.NotFound(new { error = "no_active_tenant" });
+
+        var rows = await repo.ListByIssueAsync(tenantId, issueId, ct).ConfigureAwait(false);
+        var lineage = LineageAssembler.Assemble(issueId, rows);
+        return Results.Json(lineage, DocumentJson.Options);
+    }
+
+    // ─── GET /api/documents/issues/{issueId}/latest (AC4) ─────────────────────
+
+    /// <summary>
+    /// The latest accepted instance per document type for an issue — exactly the
+    /// read 39-10's re-entry consumes in-process. Superseded and draft revisions
+    /// never appear.
+    /// </summary>
+    public static async Task<IResult> GetLatestAccepted(
+        string issueId,
+        IDocumentInstanceRepository repo,
+        ITenantContext tc,
+        CancellationToken ct)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+            return Results.NotFound(new { error = "no_active_tenant" });
+
+        var rows = await repo.GetLatestAcceptedAsync(tenantId, issueId, ct).ConfigureAwait(false);
+        var latest = LineageAssembler.AssembleLatest(issueId, rows);
+        return Results.Json(latest, DocumentJson.Options);
+    }
+
+    // ─── GET /api/documents/{documentId} (AC5) ────────────────────────────────
+
+    /// <summary>
+    /// A single document instance by id, with a defence-in-depth entity-level
+    /// tenant re-check after load (a guessed cross-tenant id reads nothing → 404).
+    /// </summary>
+    public static async Task<IResult> GetDocument(
+        Guid documentId,
+        IDocumentInstanceRepository repo,
+        ITenantContext tc,
+        CancellationToken ct)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+            return Results.NotFound(new { error = "no_active_tenant" });
+
+        var row = await repo.GetByIdAsync(tenantId, documentId, ct).ConfigureAwait(false);
+        if (row is null || row.TenantId != tenantId)
+            return Results.NotFound(new { error = "document_not_found" });
+
+        return Results.Json(LineageAssembler.AssembleDocument(row), DocumentJson.Options);
+    }
+
+    // ─── POST /api/engine/documents (D6) ──────────────────────────────────────
+
+    /// <summary>
+    /// Engine→API persist callback: deserialize the envelope, validate + write
+    /// through the repository (the SOLE writer). Fail-loud — a validation /
+    /// registry error surfaces as a 400 with the <see cref="TammaError.Code"/> so
+    /// the engine's persist activity faults (the document is the product, not
+    /// telemetry).
+    /// </summary>
+    public static async Task<IResult> PersistFromEngine(
+        PersistDocumentRequest req,
+        IDocumentInstanceRepository repo,
+        ITenantContext tc,
+        CancellationToken ct)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+            return Results.BadRequest(new { error = "no_active_tenant" });
+        if (string.IsNullOrWhiteSpace(req.EnvelopeJson))
+            return Results.BadRequest(new { error = "envelopeJson is required" });
+
+        DocumentEnvelope envelope;
+        try
+        {
+            envelope = DocumentJson.Deserialize(req.EnvelopeJson);
+        }
+        catch (JsonException ex)
+        {
+            return Results.BadRequest(new { error = "invalid_envelope", detail = ex.Message });
+        }
+
+        try
+        {
+            var row = await repo.InsertAsync(tenantId, envelope, req.CorrelatingEventId, ct)
+                .ConfigureAwait(false);
+            return Results.Created(
+                $"/api/documents/{row.Id}",
+                new { id = row.Id, revision = row.Revision, status = row.Status });
+        }
+        catch (TammaError err)
+        {
+            return Results.BadRequest(new { error = err.Code, detail = err.Message });
+        }
+    }
+
+    // ─── POST /api/engine/documents/{documentId}/status (D6) ──────────────────
+
+    /// <summary>
+    /// Engine→API status-transition callback. Parses the wire status, transitions
+    /// through the repository, maps a <see cref="TammaError"/> (unknown status /
+    /// illegal 'superseded' / not-found) to a 400 with its code.
+    /// </summary>
+    public static async Task<IResult> SetStatusFromEngine(
+        Guid documentId,
+        SetDocumentStatusRequest req,
+        IDocumentInstanceRepository repo,
+        ITenantContext tc,
+        CancellationToken ct)
+    {
+        if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
+            return Results.BadRequest(new { error = "no_active_tenant" });
+
+        try
+        {
+            var status = DocumentInstanceStatusExtensions.Parse(req.Status);
+            var row = await repo.SetStatusAsync(tenantId, documentId, status, req.CorrelatingEventId, ct)
+                .ConfigureAwait(false);
+            return Results.Ok(new { id = row.Id, status = row.Status });
+        }
+        catch (TammaError err)
+        {
+            return Results.BadRequest(new { error = err.Code, detail = err.Message });
+        }
+    }
+}
+
+/// <summary>
+/// Engine→API persist request (D6). The envelope rides as a JSON string
+/// (serialized via <see cref="DocumentJson"/>) so the API re-deserializes through
+/// the same canonical options; the tenant is asserted by the <c>X-Tenant-Id</c>
+/// header (never the body).
+/// </summary>
+public sealed record PersistDocumentRequest(string EnvelopeJson, Guid? CorrelatingEventId);
+
+/// <summary>Engine→API status-transition request (D6).</summary>
+public sealed record SetDocumentStatusRequest(string Status, Guid? CorrelatingEventId);

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -2777,6 +2777,15 @@ engine.MapPost("/platform-events", EngineEndpoints.AppendPlatformEvents)
 // from the TS contract.
 engine.MapGet("/agent-available", EngineEndpoints.AgentAvailable);
 
+// ── Story 39-11: engine→API document store write seam (D6) ──
+// The lifecycle engine (Tamma.ElsaServer) registers no repository, so it persists
+// documents through this fail-loud HTTP hop (mirrors /events). Gated
+// EngineServiceOnly (same rationale as /events): the service principal only.
+engine.MapPost("/documents", DocumentEndpoints.PersistFromEngine)
+    .RequireAuthorization("EngineServiceOnly");
+engine.MapPost("/documents/{documentId:guid}/status", DocumentEndpoints.SetStatusFromEngine)
+    .RequireAuthorization("EngineServiceOnly");
+
 // ── User dashboard: Repos & Workflow Runs (Story 21-4) ──
 // Tenant-facing read surface behind the SPA's /repos + /runs destinations.
 // Tenant is resolved strictly from ITenantContext inside each handler (no
@@ -2793,6 +2802,21 @@ app.MapGet("/api/v1/runs", ReposRunsEndpoints.ListRuns).RequireAuthorization("Me
 // only; same fail-closed tenant scoping, no economics.
 app.MapGet("/api/v1/runs/summary", ReposRunsEndpoints.GetRunsSummary).RequireAuthorization("MemberAccess");
 app.MapGet("/api/v1/runs/{runId:guid}", ReposRunsEndpoints.GetRunDetail).RequireAuthorization("MemberAccess");
+
+// ── Story 39-11: Document store lineage reads ──
+// Tenant-facing document trail + latest-accepted-state reads + single-document
+// fetch. Mapped PER-ROUTE with MemberAccess (D9 / AC5 — story wins for its own
+// routes), independent of 39-8's `/api/documents` MapGroup (AuthenticatedAny) for
+// the decision-resume surface below: the {documentId:guid} constraint + distinct
+// literal segments (issues/, decisions/, escalations/) keep them from colliding.
+// Fail-closed null-tenant guard + entity-level TenantId re-check live in the
+// handlers (ReposRunsEndpoints posture).
+app.MapGet("/api/documents/issues/{issueId}/lineage", DocumentEndpoints.GetIssueLineage)
+    .RequireAuthorization("MemberAccess");
+app.MapGet("/api/documents/issues/{issueId}/latest", DocumentEndpoints.GetLatestAccepted)
+    .RequireAuthorization("MemberAccess");
+app.MapGet("/api/documents/{documentId:guid}", DocumentEndpoints.GetDocument)
+    .RequireAuthorization("MemberAccess");
 
 // ── Workflows ──
 var workflows = app.MapGroup("/api/workflows").RequireAuthorization("WorkflowsView");

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Documents/LineageAssembler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Documents/LineageAssembler.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Services.Documents;
+
+/// <summary>
+/// Story 39-11 (Design Decisions D7/D8) — the pure, static mapper from
+/// <c>Tamma.Data</c> <see cref="DocumentInstance"/> rows onto the shared
+/// <c>Tamma.Core</c> lineage DTOs. It lives in <c>Tamma.Api</c> (not Core) because
+/// it bridges the Data entity → Core DTO boundary, and Core cannot reference Data.
+///
+/// <para><b>Review linkage (D8).</b> A Review's subject resolves parent-first
+/// (envelope <c>parent_document_id</c>), then a tolerant body probe
+/// (<see cref="ResolveReviewSubject"/>). A review that resolves to no in-response
+/// subject lands in <c>unlinkedReviews</c> — surfaced, never dropped.</para>
+///
+/// <para><b>Corruption tripwire (D5).</b> Every stored body is re-parsed and
+/// re-validated against its type; a stored-invalid body (should be unreachable —
+/// the write path validated it) throws <c>DOCUMENT.STORE.CORRUPT_BODY</c> rather
+/// than handing out an un-typed blob.</para>
+/// </summary>
+public static class LineageAssembler
+{
+    private static readonly string ReviewTypeWire = DocumentTypeKey.Review.ToWire();
+    private static readonly string SupersededWire = DocumentInstanceStatus.Superseded.ToWire();
+    private static readonly string AcceptedWire = DocumentInstanceStatus.Accepted.ToWire();
+    private static readonly string EscalatedWire = DocumentInstanceStatus.Escalated.ToWire();
+
+    /// <summary>
+    /// Assemble the full lineage response (AC3). Types are grouped in first-produced
+    /// order, revisions ascending; reviews attach to their subject; the terminal
+    /// outcome is derived from row statuses (never events, per 39-8's split).
+    /// </summary>
+    public static IssueDocumentLineage Assemble(string issueId, IReadOnlyList<DocumentInstance> rows)
+    {
+        var reviews = new List<DocumentInstance>();
+        var subjects = new List<DocumentInstance>();
+        foreach (var r in rows)
+        {
+            if (string.Equals(r.DocumentType, ReviewTypeWire, StringComparison.Ordinal))
+                reviews.Add(r);
+            else
+                subjects.Add(r);
+        }
+
+        // Build review entries + resolve each review's subject id (parent-first,
+        // then body probe). Group by resolved subject id.
+        var reviewsBySubject = new Dictionary<Guid, List<LineageDocumentEntry>>();
+        var unresolvedReviewIds = new HashSet<Guid>();
+        var reviewEntries = new Dictionary<Guid, LineageDocumentEntry>();
+        var reviewSubject = new Dictionary<Guid, Guid?>();
+        foreach (var review in reviews)
+        {
+            var entry = ToEntry(review, Array.Empty<LineageDocumentEntry>());
+            reviewEntries[review.Id] = entry;
+            var subjectId = review.ParentDocumentId ?? ResolveReviewSubject(entry.Body);
+            reviewSubject[review.Id] = subjectId;
+            if (subjectId is Guid sid)
+            {
+                if (!reviewsBySubject.TryGetValue(sid, out var list))
+                    reviewsBySubject[sid] = list = new List<LineageDocumentEntry>();
+                list.Add(entry);
+            }
+            else
+            {
+                unresolvedReviewIds.Add(review.Id);
+            }
+        }
+
+        // Build subject entries (attaching their reviews) and group by type in
+        // first-produced order, revisions ascending.
+        var typeOrder = new List<string>();
+        var byType = new Dictionary<string, List<LineageDocumentEntry>>(StringComparer.Ordinal);
+        var subjectIds = new HashSet<Guid>(subjects.Select(s => s.Id));
+        foreach (var subject in subjects)
+        {
+            var attached = reviewsBySubject.TryGetValue(subject.Id, out var revs)
+                ? (IReadOnlyList<LineageDocumentEntry>)revs
+                : Array.Empty<LineageDocumentEntry>();
+            var entry = ToEntry(subject, attached);
+            if (!byType.TryGetValue(subject.DocumentType, out var trail))
+            {
+                byType[subject.DocumentType] = trail = new List<LineageDocumentEntry>();
+                typeOrder.Add(subject.DocumentType);
+            }
+            trail.Add(entry);
+        }
+
+        var types = typeOrder
+            .Select(t => new DocumentTypeTrail(
+                t, byType[t].OrderBy(e => e.Revision).ToList()))
+            .ToList();
+
+        // Any review whose resolved subject is NOT a subject row in this response
+        // (or resolved to nothing) is surfaced, never dropped (D8).
+        var unlinked = reviews
+            .Where(r => unresolvedReviewIds.Contains(r.Id)
+                || (reviewSubject[r.Id] is Guid sid && !subjectIds.Contains(sid)))
+            .Select(r => reviewEntries[r.Id])
+            .ToList();
+
+        return new IssueDocumentLineage(issueId, types, unlinked, DeriveOutcome(rows, types));
+    }
+
+    /// <summary>
+    /// Assemble the latest-accepted-per-type response (AC4). Input rows are already
+    /// the latest-accepted set (repository <c>GetLatestAcceptedAsync</c>).
+    /// </summary>
+    public static LatestAcceptedDocuments AssembleLatest(
+        string issueId, IReadOnlyList<DocumentInstance> rows)
+    {
+        var docs = rows
+            .Select(r => ToEntry(r, Array.Empty<LineageDocumentEntry>()))
+            .OrderBy(e => e.CreatedAt)
+            .ToList();
+        return new LatestAcceptedDocuments(issueId, docs);
+    }
+
+    /// <summary>
+    /// Project a single stored row to a <see cref="LineageDocumentEntry"/> (no
+    /// attached reviews) for the bare-id fetch (AC5). Re-validates the body (D5).
+    /// </summary>
+    public static LineageDocumentEntry AssembleDocument(DocumentInstance row) =>
+        ToEntry(row, Array.Empty<LineageDocumentEntry>());
+
+    /// <summary>
+    /// Outcome (D-terminal): <c>escalated</c> if any non-superseded row is
+    /// escalated; <c>accepted</c> if there is ≥1 type and every type's latest
+    /// revision is accepted; else <c>in-progress</c>.
+    /// </summary>
+    private static string DeriveOutcome(
+        IReadOnlyList<DocumentInstance> rows, IReadOnlyList<DocumentTypeTrail> types)
+    {
+        if (rows.Any(r => !string.Equals(r.Status, SupersededWire, StringComparison.Ordinal)
+                && string.Equals(r.Status, EscalatedWire, StringComparison.Ordinal)))
+            return "escalated";
+
+        if (types.Count > 0 && types.All(t =>
+        {
+            var latest = t.Revisions[^1]; // revisions are ascending
+            return string.Equals(latest.Status, AcceptedWire, StringComparison.Ordinal);
+        }))
+            return "accepted";
+
+        return "in-progress";
+    }
+
+    /// <summary>
+    /// Tolerant body probe for a Review's subject reference (39-4's Review shape:
+    /// <c>{ "subject": { "documentId": "&lt;guid&gt;" } }</c>). Returns null when
+    /// absent or unparseable — the review is not dropped, it is surfaced unlinked.
+    /// </summary>
+    internal static Guid? ResolveReviewSubject(JsonElement body)
+    {
+        if (body.ValueKind != JsonValueKind.Object) return null;
+        if (!body.TryGetProperty("subject", out var subject) || subject.ValueKind != JsonValueKind.Object)
+            return null;
+        if (!subject.TryGetProperty("documentId", out var docId) || docId.ValueKind != JsonValueKind.String)
+            return null;
+        return Guid.TryParse(docId.GetString(), out var g) ? g : null;
+    }
+
+    private static LineageDocumentEntry ToEntry(DocumentInstance row, IReadOnlyList<LineageDocumentEntry> reviews)
+    {
+        var body = ParseAndRevalidate(row);
+        return new LineageDocumentEntry(
+            row.Id,
+            row.DocumentType,
+            row.IssueId,
+            row.ProducedByRole,
+            row.ProducedByAction,
+            row.Revision,
+            row.Status,
+            row.SupersedesDocumentId,
+            row.ParentDocumentId,
+            row.CorrelatingEventId,
+            new DateTimeOffset(DateTime.SpecifyKind(row.CreatedAt, DateTimeKind.Utc)),
+            new DateTimeOffset(DateTime.SpecifyKind(row.UpdatedAt, DateTimeKind.Utc)),
+            body,
+            reviews);
+    }
+
+    /// <summary>
+    /// Re-parse + re-validate the stored body (D5 corruption tripwire). A stored
+    /// body that does not parse or fails its type's validation throws
+    /// <c>DOCUMENT.STORE.CORRUPT_BODY</c> — the "typed edges" note enforced on read.
+    /// </summary>
+    private static JsonElement ParseAndRevalidate(DocumentInstance row)
+    {
+        JsonElement body;
+        try
+        {
+            using var doc = JsonDocument.Parse(row.BodyJson);
+            body = doc.RootElement.Clone();
+        }
+        catch (JsonException ex)
+        {
+            throw Corrupt(row, ex.Message);
+        }
+
+        var validation = DocumentTypeRegistry.Resolve(row.DocumentType).Validate(body);
+        if (!validation.IsValid)
+            throw Corrupt(row, string.Join("; ", validation.Violations.Select(v => v.Code)));
+
+        return body;
+    }
+
+    private static TammaError Corrupt(DocumentInstance row, string detail) => new(
+        "DOCUMENT.STORE.CORRUPT_BODY",
+        $"Stored document '{row.Id}' ({row.DocumentType}) has an invalid body — the store " +
+        $"must never hand out an un-typed blob (stream wins; re-project). Detail: {detail}",
+        new Dictionary<string, object?>
+        {
+            ["documentId"] = row.Id,
+            ["type"] = row.DocumentType,
+        },
+        retryable: false,
+        severity: TammaErrorSeverity.Critical);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Lineage/IssueDocumentLineage.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Lineage/IssueDocumentLineage.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// Story 39-11 (Design Decision D7) — the SHARED lineage response DTOs backing the
+/// read endpoints (<c>GET /api/documents/issues/{issueId}/lineage</c> +
+/// <c>/latest</c>). They live in <c>Tamma.Core</c> so 39-8's escalation payload can
+/// serialize a slice of the same shapes without duplicating them (technical note).
+///
+/// <para><b>Naming.</b> The root record is <see cref="IssueDocumentLineage"/> —
+/// deliberately NOT <c>DocumentLineage</c>, which 39-6 already owns for its in-run
+/// drafts/reviews/rounds record. The two are different granularities and must not
+/// collide. Every wire property carries an explicit <c>[JsonPropertyName]</c> and
+/// serializes through <see cref="DocumentJson.Options"/> (39-2 D8 discipline).</para>
+/// </summary>
+public sealed record LineageDocumentEntry(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("documentType")] string DocumentType,
+    [property: JsonPropertyName("issueId")] string IssueId,
+    [property: JsonPropertyName("producedByRole")] string ProducedByRole,
+    [property: JsonPropertyName("producedByAction")] string ProducedByAction,
+    [property: JsonPropertyName("revision")] int Revision,
+    [property: JsonPropertyName("status")] string Status,
+    [property: JsonPropertyName("supersedesDocumentId")] Guid? SupersedesDocumentId,
+    [property: JsonPropertyName("parentDocumentId")] Guid? ParentDocumentId,
+    [property: JsonPropertyName("correlatingEventId")] Guid? CorrelatingEventId,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt,
+    [property: JsonPropertyName("updatedAt")] DateTimeOffset UpdatedAt,
+    [property: JsonPropertyName("body")] JsonElement Body,
+    [property: JsonPropertyName("reviews")] IReadOnlyList<LineageDocumentEntry> Reviews);
+
+/// <summary>
+/// One document type's revision trail (all revisions ascending), grouped in
+/// first-produced order within the issue.
+/// </summary>
+public sealed record DocumentTypeTrail(
+    [property: JsonPropertyName("documentType")] string DocumentType,
+    [property: JsonPropertyName("revisions")] IReadOnlyList<LineageDocumentEntry> Revisions);
+
+/// <summary>
+/// The full document trail for an issue (AC3): every type's revision trail, any
+/// reviews that could not be attached to a subject in-response
+/// (<see cref="UnlinkedReviews"/> — surfaced, never dropped, D8), and the terminal
+/// <see cref="Outcome"/> (<c>"accepted"</c> | <c>"escalated"</c> |
+/// <c>"in-progress"</c>).
+/// </summary>
+public sealed record IssueDocumentLineage(
+    [property: JsonPropertyName("issueId")] string IssueId,
+    [property: JsonPropertyName("types")] IReadOnlyList<DocumentTypeTrail> Types,
+    [property: JsonPropertyName("unlinkedReviews")] IReadOnlyList<LineageDocumentEntry> UnlinkedReviews,
+    [property: JsonPropertyName("outcome")] string Outcome);
+
+/// <summary>
+/// The latest-accepted-per-type state for an issue (AC4) — exactly the read
+/// 39-10's re-entry consumes. At most one entry per document type; superseded and
+/// draft revisions never appear.
+/// </summary>
+public sealed record LatestAcceptedDocuments(
+    [property: JsonPropertyName("issueId")] string IssueId,
+    [property: JsonPropertyName("documents")] IReadOnlyList<LineageDocumentEntry> Documents);

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Store/DocumentInstanceStatus.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Store/DocumentInstanceStatus.cs
@@ -1,0 +1,89 @@
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents;
+
+/// <summary>
+/// Story 39-11 — the closed status vocabulary of a persisted
+/// <c>document_instances</c> row (Design Decision D3). This is the STORE's status
+/// dimension, distinct from 39-2's lifecycle <see cref="DocumentState"/>: it adds
+/// two store-only members the state machine has no equivalent for —
+/// <see cref="InReview"/> (a document waiting on a review round) and
+/// <see cref="Superseded"/> (a prior revision retired by the single write door,
+/// D4). The set is count-pinned at 7 by <c>DocumentInstanceStatusTests</c>; the
+/// CHECK constraint <c>ck_document_instances_status</c> mirrors these exact wire
+/// strings.
+///
+/// <para>Note the underscore in <c>in_review</c> — the only multi-word wire
+/// string; every other member's wire is a single lowercase token.</para>
+/// </summary>
+public enum DocumentInstanceStatus
+{
+    [Wire("draft")]      Draft,
+    [Wire("validated")]  Validated,
+    [Wire("in_review")]  InReview,
+    [Wire("accepted")]   Accepted,
+    [Wire("rejected")]   Rejected,
+    [Wire("superseded")] Superseded,
+    [Wire("escalated")]  Escalated,
+}
+
+public static class DocumentInstanceStatusExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="status"/>.</summary>
+    public static string ToWire(this DocumentInstanceStatus status) =>
+        EnumWire<DocumentInstanceStatus>.ToWire(status);
+
+    /// <summary>
+    /// Resolve a wire string to a <see cref="DocumentInstanceStatus"/>
+    /// (case-sensitive, ordinal).
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.STORE.UNKNOWN_STATUS</c> for null, empty, or unknown input.
+    /// </exception>
+    public static DocumentInstanceStatus Parse(string input)
+    {
+        if (!string.IsNullOrWhiteSpace(input) &&
+            EnumWire<DocumentInstanceStatus>.TryParse(input, out var status))
+            return status;
+
+        throw new TammaError(
+            "DOCUMENT.STORE.UNKNOWN_STATUS",
+            $"Unknown document instance status: '{input}'. Valid statuses: " +
+            $"{string.Join(", ", Enum.GetValues<DocumentInstanceStatus>().Select(s => s.ToWire()))}.",
+            new Dictionary<string, object?> { ["input"] = input },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+
+    /// <summary>
+    /// The total map from 39-2's lifecycle <see cref="DocumentState"/> onto the
+    /// store status set (Design Decision D3): <c>Draft→draft</c>,
+    /// <c>Validated→validated</c>, <c>Reviewed→in_review</c>,
+    /// <c>Accepted→accepted</c>, <c>Rejected→rejected</c>,
+    /// <c>Escalated→escalated</c>. It NEVER yields <see cref="Superseded"/> — that
+    /// is a store-only status, set exclusively by the supersession write (D4), so
+    /// no state transition can produce it.
+    /// </summary>
+    /// <exception cref="TammaError">
+    /// Code <c>DOCUMENT.STORE.UNKNOWN_STATUS</c> for an unmapped
+    /// <see cref="DocumentState"/> (unreachable while the enum has its 6 members —
+    /// a fail-loud guard against a future member landing unmapped).
+    /// </exception>
+    public static DocumentInstanceStatus FromState(DocumentState state) => state switch
+    {
+        DocumentState.Draft => DocumentInstanceStatus.Draft,
+        DocumentState.Validated => DocumentInstanceStatus.Validated,
+        DocumentState.Reviewed => DocumentInstanceStatus.InReview,
+        DocumentState.Accepted => DocumentInstanceStatus.Accepted,
+        DocumentState.Rejected => DocumentInstanceStatus.Rejected,
+        DocumentState.Escalated => DocumentInstanceStatus.Escalated,
+        _ => throw new TammaError(
+            "DOCUMENT.STORE.UNKNOWN_STATUS",
+            $"No store status mapping for document state '{state}'. FromState must be " +
+            "total over every DocumentState member.",
+            new Dictionary<string, object?> { ["state"] = state.ToString() },
+            retryable: false,
+            severity: TammaErrorSeverity.Critical),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/DependencyInjection.cs
@@ -158,6 +158,9 @@ public static class DependencyInjection
         // Story 39-5 — tenant-resident acceptance-rules overrides.
         services.AddScoped<IAcceptanceRulesRepository, AcceptanceRulesRepository>();
         services.AddScoped<IConventionRepository, ConventionRepository>();
+        // Story 39-11 — the sole writer/reader of the tenant-resident
+        // document_instances store (immutable revisions + supersession).
+        services.AddScoped<IDocumentInstanceRepository, DocumentInstanceRepository>();
         services.AddScoped<IProviderHealthRepository, ProviderHealthRepository>();
         services.AddScoped<IDiagnosticsRepository, DiagnosticsRepository>();
         services.AddScoped<ISanitizationRepository, SanitizationRepository>();

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/DocumentInstance.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/DocumentInstance.cs
@@ -1,0 +1,90 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 39-11 — one persisted work-document instance (one revision) in the
+/// tenant-resident <c>document_instances</c> table.
+///
+/// <para><b>This is a read-optimized product layer over the DCB stream, NOT a new
+/// event store.</b> Every lifecycle transition already emits a <c>DOCUMENT.*</c>
+/// event (39-6); this table is the queryable document PRODUCT built in the same
+/// operation flow. It is rebuildable at any time (truncate + re-write from the
+/// events), and if the store and the stream ever disagree, the STREAM WINS
+/// (Story 37-1's "truncate + re-project" doctrine). Each row back-references the
+/// correlating transition event via <see cref="CorrelatingEventId"/> so an auditor
+/// can cross-check store ↔ stream mechanically (AC7).</para>
+///
+/// <para>Envelope fields are COLUMNS (39-2 <see cref="Tamma.Core.Documents.DocumentEnvelope"/>);
+/// the typed document body rides <see cref="BodyJson"/> as JSONB, validated by the
+/// 39-3/39-4 type registry BEFORE write. Immutability is by API absence: the sole
+/// writer (<c>IDocumentInstanceRepository</c>) offers no body-update and no delete —
+/// a revise round inserts a NEW row (<c>revision+1</c>) and flips the prior row to
+/// <c>superseded</c> (Design Decision D4).</para>
+/// </summary>
+public class DocumentInstance
+{
+    /// <summary>
+    /// Primary key — the envelope's UUID v7 identity, set CLIENT-SIDE from the
+    /// envelope (NO <c>gen_random_uuid()</c> default). The envelope id IS the row
+    /// id, so the store row and the DCB event's <c>documentId</c> tag are the same
+    /// value.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>The document type key — a <c>DocumentTypeKey</c> wire string.</summary>
+    public string DocumentType { get; set; } = null!;
+
+    /// <summary>The mandatory lineage anchor (39-2: a string DCB tag, non-nullable — D11).</summary>
+    public string IssueId { get; set; } = null!;
+
+    /// <summary>Producer provenance — the agent role wire string.</summary>
+    public string ProducedByRole { get; set; } = null!;
+
+    /// <summary>Producer provenance — the agent action wire string.</summary>
+    public string ProducedByAction { get; set; } = null!;
+
+    /// <summary>Producer provenance — the workflow definition id (kebab token).</summary>
+    public string? ProducedByWorkflow { get; set; }
+
+    /// <summary>The payload schema version this instance was validated against.</summary>
+    public int SchemaVersion { get; set; }
+
+    /// <summary>The correlation id lineage anchor (how AC7's auditor pivots to the event stream).</summary>
+    public string? CorrelationId { get; set; }
+
+    /// <summary>1-based revision within the supersession chain (D4).</summary>
+    public int Revision { get; set; }
+
+    /// <summary>
+    /// The store status wire string (a <c>DocumentInstanceStatus</c> wire — CHECK
+    /// constrained to the 7-value set, D3).
+    /// </summary>
+    public string Status { get; set; } = null!;
+
+    /// <summary>The prior revision this row supersedes (null on revision 1). Self-FK (D4).</summary>
+    public Guid? SupersedesDocumentId { get; set; }
+
+    /// <summary>The subject document for a Review instance (how the lineage resolves it, D8).</summary>
+    public Guid? ParentDocumentId { get; set; }
+
+    /// <summary>
+    /// The pre-minted <c>DOCUMENT.*</c> transition event id this write correlates to
+    /// (AC7 linkage). Equals <c>domain_events."Id"</c> for the same transition.
+    /// </summary>
+    public Guid? CorrelatingEventId { get; set; }
+
+    /// <summary>
+    /// Transitional tenant predicate column (Doc 01 §1.4). The per-tenant schema is
+    /// the real isolation plane; this carries the shared-DB phase and the
+    /// defence-in-depth entity-level re-check.
+    /// </summary>
+    public Guid? TenantId { get; set; }
+
+    /// <summary>The typed document body as JSONB (envelope payload raw JSON).</summary>
+    public string BodyJson { get; set; } = "{}";
+
+    /// <summary>When this revision was produced (envelope <c>createdAt</c>).</summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>When this row was last touched (status transitions bump it).</summary>
+    public DateTime UpdatedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722180002_AddDocumentInstances.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722180002_AddDocumentInstances.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722180002_AddDocumentInstances")]
+    partial class AddDocumentInstances
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722180002_AddDocumentInstances.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722180002_AddDocumentInstances.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddDocumentInstances : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "document_instances",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    document_type = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    issue_id = table.Column<string>(type: "text", nullable: false),
+                    produced_by_role = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    produced_by_action = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    produced_by_workflow = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    schema_version = table.Column<int>(type: "integer", nullable: false),
+                    correlation_id = table.Column<string>(type: "text", nullable: true),
+                    revision = table.Column<int>(type: "integer", nullable: false),
+                    status = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    supersedes_document_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    parent_document_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    correlating_event_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    tenant_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    body = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_document_instances", x => x.id);
+                    table.CheckConstraint("ck_document_instances_status", "status IN ('draft','validated','in_review','accepted','rejected','superseded','escalated')");
+                    table.ForeignKey(
+                        name: "FK_document_instances_document_instances_supersedes_document_id",
+                        column: x => x.supersedes_document_id,
+                        principalTable: "document_instances",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_document_instances_issue_created",
+                table: "document_instances",
+                columns: new[] { "issue_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_document_instances_issue_type_status",
+                table: "document_instances",
+                columns: new[] { "issue_id", "document_type", "status" });
+
+            migrationBuilder.CreateIndex(
+                name: "UX_document_instances_supersedes",
+                table: "document_instances",
+                column: "supersedes_document_id",
+                unique: true,
+                filter: "supersedes_document_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "document_instances");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/DocumentInstanceRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/DocumentInstanceRepository.cs
@@ -1,0 +1,194 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 39-11 — the sole writer/reader of <c>document_instances</c> (AC2).
+/// Tenant-scoped in the <see cref="ConventionRepository"/> style: routes through
+/// <see cref="ITenantDbContextFactory"/> with the ambient <see cref="ITenantContext"/>
+/// tenant, and carries an explicit <c>TenantId</c> predicate on every read/write
+/// (defence-in-depth for the shared-DB phase; the per-tenant schema is the real
+/// isolation plane).
+/// </summary>
+public class DocumentInstanceRepository(
+    ITenantDbContextFactory tenantDbFactory,
+    ITenantContext tenantContext) : IDocumentInstanceRepository
+{
+    private Guid RequireTenantId() => tenantContext.TenantId
+        ?? throw new InvalidOperationException(
+            "DocumentInstanceRepository requires an ambient tenant id. document_instances " +
+            "is tenant-resident; the per-tenant DB factory routes reads/writes through the " +
+            "calling tenant's physical database (single-user binds a personal tenant up-front).");
+
+    public async Task<DocumentInstance> InsertAsync(
+        Guid tenantId, DocumentEnvelope envelope, Guid? correlatingEventId, CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        // D5 — write-time validation is the registry, fail-loud. Resolve throws
+        // DOCUMENT.TYPE.UNKNOWN / DOCUMENT.TYPE.NOT_REGISTERED on a bad key; a
+        // failing body throws DOCUMENT.STORE.INVALID_BODY. The store cannot contain
+        // a document it cannot validate — nothing is persisted on a violation.
+        var documentType = DocumentTypeRegistry.Resolve(envelope.Type);
+        var validation = documentType.Validate(envelope.Payload);
+        if (!validation.IsValid)
+            throw new TammaError(
+                "DOCUMENT.STORE.INVALID_BODY",
+                $"Document body failed '{envelope.Type}' validation: " +
+                string.Join("; ", validation.Violations.Select(v => $"{v.Code}: {v.Message}")),
+                new Dictionary<string, object?>
+                {
+                    ["type"] = envelope.Type,
+                    ["documentId"] = envelope.Id,
+                    ["violations"] = validation.Violations
+                        .Select(v => new { code = v.Code, message = v.Message }).ToArray(),
+                },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+
+        var dbTenant = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(dbTenant, ct);
+
+        var now = DateTime.UtcNow;
+        var revision = 1;
+
+        // D4 — supersession is a branch of insert, in one transaction. Load the
+        // prior (tenant-checked) row and flip it to superseded; the unique filtered
+        // index on supersedes_document_id keeps the chain linear (two rows can't
+        // supersede the same prior — a concurrent second superseding insert 23505s).
+        if (envelope.SupersedesDocumentId is Guid priorId)
+        {
+            var prior = await db.Documents.IgnoreQueryFilters()
+                .FirstOrDefaultAsync(d => d.Id == priorId && d.TenantId == tenantId, ct);
+            if (prior is null)
+                throw new TammaError(
+                    "DOCUMENT.STORE.NOT_FOUND",
+                    $"Cannot supersede document '{priorId}': no such row in this tenant's store.",
+                    new Dictionary<string, object?> { ["documentId"] = priorId },
+                    retryable: false,
+                    severity: TammaErrorSeverity.High);
+
+            revision = prior.Revision + 1;
+            prior.Status = DocumentInstanceStatus.Superseded.ToWire();
+            prior.UpdatedAt = now;
+        }
+
+        var row = new DocumentInstance
+        {
+            Id = envelope.Id,
+            DocumentType = envelope.Type,
+            IssueId = envelope.IssueId,
+            ProducedByRole = envelope.ProducedBy.Role,
+            ProducedByAction = envelope.ProducedBy.Action,
+            ProducedByWorkflow = envelope.ProducedBy.WorkflowDefinitionId,
+            SchemaVersion = envelope.SchemaVersion,
+            CorrelationId = envelope.CorrelationId,
+            Revision = revision,
+            Status = DocumentInstanceStatusExtensions.FromState(envelope.State).ToWire(),
+            SupersedesDocumentId = envelope.SupersedesDocumentId,
+            ParentDocumentId = envelope.ParentDocumentId,
+            CorrelatingEventId = correlatingEventId,
+            TenantId = tenantId,
+            BodyJson = envelope.Payload.GetRawText(),
+            CreatedAt = DateTime.SpecifyKind(envelope.CreatedAt.UtcDateTime, DateTimeKind.Utc),
+            UpdatedAt = now,
+        };
+
+        db.Documents.Add(row);
+        await db.SaveChangesAsync(ct);
+        return row;
+    }
+
+    public async Task<DocumentInstance> SetStatusAsync(
+        Guid tenantId, Guid documentId, DocumentInstanceStatus status,
+        Guid? correlatingEventId, CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        // Superseded is set exclusively by the revision write (D4) — never a
+        // status transition. Reject loud rather than corrupt the chain invariant.
+        if (status == DocumentInstanceStatus.Superseded)
+            throw new TammaError(
+                "DOCUMENT.STORE.ILLEGAL_STATUS",
+                "SetStatusAsync cannot set 'superseded' — supersession is set only by the " +
+                "revision write (InsertAsync with a supersedesDocumentId).",
+                new Dictionary<string, object?> { ["documentId"] = documentId },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+
+        var dbTenant = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(dbTenant, ct);
+
+        var row = await db.Documents.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(d => d.Id == documentId && d.TenantId == tenantId, ct);
+        if (row is null)
+            throw new TammaError(
+                "DOCUMENT.STORE.NOT_FOUND",
+                $"No document '{documentId}' in this tenant's store.",
+                new Dictionary<string, object?> { ["documentId"] = documentId },
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+
+        row.Status = status.ToWire();
+        if (correlatingEventId is not null)
+            row.CorrelatingEventId = correlatingEventId;
+        row.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return row;
+    }
+
+    public async Task<DocumentInstance?> GetByIdAsync(Guid tenantId, Guid documentId, CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        var dbTenant = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(dbTenant, ct);
+        return await db.Documents.IgnoreQueryFilters()
+            .FirstOrDefaultAsync(d => d.Id == documentId && d.TenantId == tenantId, ct);
+    }
+
+    public async Task<IReadOnlyList<DocumentInstance>> ListByIssueAsync(
+        Guid tenantId, string issueId, CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        var dbTenant = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(dbTenant, ct);
+        return await db.Documents.IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId && d.IssueId == issueId)
+            .OrderBy(d => d.CreatedAt).ThenBy(d => d.Revision)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<DocumentInstance>> GetLatestAcceptedAsync(
+        Guid tenantId, string issueId, CancellationToken ct)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id required.", nameof(tenantId));
+
+        var acceptedWire = DocumentInstanceStatus.Accepted.ToWire();
+        var dbTenant = RequireTenantId();
+        await using var db = await tenantDbFactory.CreateAsync(dbTenant, ct);
+
+        var accepted = await db.Documents.IgnoreQueryFilters()
+            .Where(d => d.TenantId == tenantId && d.IssueId == issueId && d.Status == acceptedWire)
+            .ToListAsync(ct);
+
+        // Highest revision per document type (D10). The single write door + the
+        // unique filtered supersedes index make at most one non-superseded accepted
+        // row per chain, so this is deterministic (≤1 per type).
+        return accepted
+            .GroupBy(d => d.DocumentType, StringComparer.Ordinal)
+            .Select(g => g.OrderByDescending(d => d.Revision).First())
+            .OrderBy(d => d.CreatedAt)
+            .ToList();
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IDocumentInstanceRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IDocumentInstanceRepository.cs
@@ -1,0 +1,51 @@
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 39-11 — the SOLE writer + reader of the tenant-resident
+/// <c>document_instances</c> store. No other code touches the <c>Documents</c>
+/// DbSet (AC2). Immutability is by API absence: there is NO body-update and NO
+/// delete method; a revise round is a branch of <see cref="InsertAsync"/> (D4).
+/// </summary>
+public interface IDocumentInstanceRepository
+{
+    /// <summary>
+    /// The ONLY row-creating method (Design Decisions D4/D5). Validates the
+    /// envelope body against the 39-2/39-3/39-4 type registry BEFORE persisting
+    /// (invalid → <c>DOCUMENT.STORE.INVALID_BODY</c>, nothing persisted); an
+    /// unknown/unregistered type key bubbles the registry error. Supersession is a
+    /// branch, not an update: <c>envelope.SupersedesDocumentId == null</c> →
+    /// <c>revision = 1</c>; non-null → load the prior (tenant-checked) row, insert
+    /// with <c>revision = prior.Revision + 1</c>, and flip the prior row to
+    /// <c>superseded</c> in the SAME transaction. The row carries
+    /// <paramref name="correlatingEventId"/> (the AC7 store↔stream linkage).
+    /// </summary>
+    Task<DocumentInstance> InsertAsync(
+        Guid tenantId, DocumentEnvelope envelope, Guid? correlatingEventId, CancellationToken ct);
+
+    /// <summary>
+    /// Transition an existing row's status ONLY (never body, never revision). Throws
+    /// <c>DOCUMENT.STORE.ILLEGAL_STATUS</c> on <see cref="DocumentInstanceStatus.Superseded"/>
+    /// (supersession is set exclusively by the revision write, D4) and
+    /// <c>DOCUMENT.STORE.NOT_FOUND</c> on a missing/foreign row. Stamps
+    /// <paramref name="correlatingEventId"/> when supplied (the AC7 linkage).
+    /// </summary>
+    Task<DocumentInstance> SetStatusAsync(
+        Guid tenantId, Guid documentId, DocumentInstanceStatus status,
+        Guid? correlatingEventId, CancellationToken ct);
+
+    /// <summary>Single-document fetch, tenant-checked. Null when missing or foreign.</summary>
+    Task<DocumentInstance?> GetByIdAsync(Guid tenantId, Guid documentId, CancellationToken ct);
+
+    /// <summary>Every revision of every type for the issue, oldest-first (lineage source).</summary>
+    Task<IReadOnlyList<DocumentInstance>> ListByIssueAsync(Guid tenantId, string issueId, CancellationToken ct);
+
+    /// <summary>
+    /// Design Decision D10 — the 39-10 lockstep in-process read: the single latest
+    /// ACCEPTED instance per document type (≤1 per type). Superseded / draft /
+    /// in_review / rejected / escalated rows never appear.
+    /// </summary>
+    Task<IReadOnlyList<DocumentInstance>> GetLatestAcceptedAsync(Guid tenantId, string issueId, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1340,6 +1340,87 @@ internal static class TammaModelConfiguration
     }
 
     /// <summary>
+    /// Story 39-11 — configure the tenant-resident <c>document_instances</c> table
+    /// (the read-optimized document product layer over the DCB stream). Called
+    /// ONLY from <see cref="ConfigureTenantEntities"/> — the CP context never sees
+    /// this table (document instances are tenant data). Copies the sectioned shape
+    /// of <see cref="ConfigureAuditEntities"/>.
+    ///
+    /// <para>Every column carries an explicit snake_case <c>HasColumnName</c>
+    /// (Design Decision D1, per AC1's column list). <c>id</c> is CLIENT-SET from the
+    /// envelope's UUID v7 — NO <c>gen_random_uuid()</c> default. The status CHECK
+    /// pins the 7-value store vocabulary (D3); the unique filtered index on
+    /// <c>supersedes_document_id</c> keeps the supersession chain linear (D4).</para>
+    /// </summary>
+    public static void ConfigureDocumentEntities(
+        ModelBuilder modelBuilder, Guid? fixedTenantId = null)
+    {
+        modelBuilder.Entity<DocumentInstance>(entity =>
+        {
+            entity.ToTable("document_instances", t =>
+            {
+                // Store status is a closed 7-value enum (D3) — a buggy writer can't
+                // stash junk. Mirrors DocumentInstanceStatus's wire strings exactly.
+                t.HasCheckConstraint(
+                    "ck_document_instances_status",
+                    "status IN ('draft','validated','in_review','accepted','rejected','superseded','escalated')");
+            });
+            entity.HasKey(e => e.Id);
+            // Client-set id = the envelope's UUID v7 (NO gen_random_uuid() default);
+            // the envelope id IS the row id (AC7 store↔stream linkage).
+            entity.Property(e => e.Id).HasColumnName("id");
+            entity.Property(e => e.DocumentType).HasColumnName("document_type").IsRequired().HasMaxLength(64);
+            entity.Property(e => e.IssueId).HasColumnName("issue_id").IsRequired();
+            entity.Property(e => e.ProducedByRole).HasColumnName("produced_by_role").IsRequired().HasMaxLength(64);
+            entity.Property(e => e.ProducedByAction).HasColumnName("produced_by_action").IsRequired().HasMaxLength(64);
+            entity.Property(e => e.ProducedByWorkflow).HasColumnName("produced_by_workflow").HasMaxLength(128);
+            entity.Property(e => e.SchemaVersion).HasColumnName("schema_version").IsRequired();
+            entity.Property(e => e.CorrelationId).HasColumnName("correlation_id");
+            entity.Property(e => e.Revision).HasColumnName("revision").IsRequired();
+            entity.Property(e => e.Status).HasColumnName("status").IsRequired().HasMaxLength(16);
+            entity.Property(e => e.SupersedesDocumentId).HasColumnName("supersedes_document_id");
+            entity.Property(e => e.ParentDocumentId).HasColumnName("parent_document_id");
+            entity.Property(e => e.CorrelatingEventId).HasColumnName("correlating_event_id");
+            entity.Property(e => e.TenantId).HasColumnName("tenant_id");
+            entity.Property(e => e.BodyJson)
+                .HasColumnName("body").HasColumnType("jsonb")
+                .IsRequired().HasDefaultValueSql("'{}'::jsonb");
+            entity.Property(e => e.CreatedAt)
+                .HasColumnName("created_at").HasColumnType("timestamp with time zone");
+            entity.Property(e => e.UpdatedAt)
+                .HasColumnName("updated_at").HasColumnType("timestamp with time zone");
+
+            // Lineage render hot path (AC1): grouped-by-issue reads filtered by
+            // type + status; and the first-produced ordering read.
+            entity.HasIndex(e => new { e.IssueId, e.DocumentType, e.Status })
+                .HasDatabaseName("IX_document_instances_issue_type_status");
+            entity.HasIndex(e => new { e.IssueId, e.CreatedAt })
+                .HasDatabaseName("IX_document_instances_issue_created");
+
+            // Supersession self-reference (D4): the prior revision. Restrict so a
+            // superseded row can't be deleted out from under its successor
+            // (immutable history — there is no delete API anyway).
+            entity.HasOne<DocumentInstance>()
+                .WithMany()
+                .HasForeignKey(e => e.SupersedesDocumentId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            // Chain linearity (D4): at most ONE row may supersede a given prior.
+            // Filtered so the many revision-1 rows (supersedes IS NULL) don't
+            // collide on a single NULL.
+            entity.HasIndex(e => e.SupersedesDocumentId)
+                .IsUnique()
+                .HasFilter("supersedes_document_id IS NOT NULL")
+                .HasDatabaseName("UX_document_instances_supersedes");
+
+            // Tenant-context defence-in-depth: the established no-op filter seam
+            // (schema + connection is the real isolation plane; the repository
+            // carries an explicit TenantId predicate for the shared-DB phase).
+            ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
+        });
+    }
+
+    /// <summary>
     /// Story 37-1 — configure the <c>audit_projector_cursor</c> table. Lives in
     /// the control plane only.
     ///
@@ -1931,6 +2012,12 @@ internal static class TammaModelConfiguration
         // domain_events stream. The SAME table shape is also configured on the
         // CP context for platform-scope rows — one physical schema, two homes.
         ConfigureAuditEntities(modelBuilder, fixedTenantId);
+
+        // ── Document instances (Story 39-11) ──
+        // Tenant-resident read-optimized document product layer over the DCB
+        // stream. Tenant model ONLY — the CP context never carries this table
+        // (document instances are tenant data).
+        ConfigureDocumentEntities(modelBuilder, fixedTenantId);
 
         // ── Agent role selections (Story 32-2) ──
         // SaaS tenant-keyed role→agent selections. The SAME table shape is also

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -82,6 +82,11 @@ public class TenantDbContext : DbContext
     // live in the CP audit_records.
     public DbSet<AuditRecord> AuditRecords => Set<AuditRecord>();
 
+    // Story 39-11 — tenant-resident document instances (the read-optimized
+    // document product layer over this tenant's domain_events stream). Written
+    // exclusively through IDocumentInstanceRepository; rebuildable from events.
+    public DbSet<DocumentInstance> Documents => Set<DocumentInstance>();
+
     /// <summary>
     /// Tenant-scoped API keys (Story 28-7). The tenant DB api_keys table
     /// is locked to <c>Scope = 'tenant'</c> via a CHECK constraint; user /

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/DocumentEngineWriteSeamTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/DocumentEngineWriteSeamTests.cs
@@ -1,0 +1,127 @@
+using System.Net;
+using System.Text;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall;
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC7/AC8, D6 — Activities half) — the FAIL-LOUD document persist
+/// seam <see cref="PersistDocumentInstanceActivity"/> rides. Unlike the best-effort
+/// event drain, <see cref="TammaApiClient.PersistDocumentAsync"/> /
+/// <see cref="TammaApiClient.SetDocumentStatusAsync"/> THROW on a non-2xx or
+/// transport failure — so the activity (which never catches to swallow) faults
+/// loudly. The document is the lifecycle's product, not telemetry.
+///
+/// <para>Per the repo convention (Elsa's <c>ActivityExecutionContext</c> cannot be
+/// cheaply constructed — see <c>CallLlmInlineActivityThinClientTests</c>), the seam
+/// is proven at the client method the activity delegates to.</para>
+/// </summary>
+[TestFixture]
+public class DocumentEngineWriteSeamTests
+{
+    private static TammaApiClient BuildClient(StubHandler handler)
+    {
+        var http = new HttpClient(handler);
+        var cfg = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Tamma:ApiUrl"] = "http://tamma.test" })
+            .Build();
+        return new TammaApiClient(http, NullLogger<TammaApiClient>.Instance, cfg);
+    }
+
+    [Test]
+    public async Task PersistDocumentAsync_Faults_On5xx_NeverSwallows()
+    {
+        var client = BuildClient(new StubHandler(HttpStatusCode.InternalServerError, "boom"));
+
+        var act = async () => await client.PersistDocumentAsync(
+            new PersistDocumentRequest("{}", Guid.NewGuid()), "tenant");
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task PersistDocumentAsync_Faults_On400_CodedBody()
+    {
+        var client = BuildClient(new StubHandler(HttpStatusCode.BadRequest,
+            "{\"error\":\"DOCUMENT.STORE.INVALID_BODY\"}"));
+
+        var act = async () => await client.PersistDocumentAsync(
+            new PersistDocumentRequest("{}", null), "tenant");
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task PersistDocumentAsync_Succeeds_On201_SendsTenantHeader()
+    {
+        var handler = new StubHandler(HttpStatusCode.Created, "{\"ok\":true}");
+        var client = BuildClient(handler);
+
+        await client.PersistDocumentAsync(new PersistDocumentRequest("{}", null), "tenant-1");
+
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be("/api/engine/documents");
+        handler.LastRequest.Headers.GetValues("X-Tenant-Id").Should().ContainSingle().Which.Should().Be("tenant-1");
+    }
+
+    [Test]
+    public async Task SetDocumentStatusAsync_Faults_On5xx()
+    {
+        var client = BuildClient(new StubHandler(HttpStatusCode.InternalServerError, "boom"));
+
+        var act = async () => await client.SetDocumentStatusAsync(
+            Guid.NewGuid(), "accepted", Guid.NewGuid(), "tenant");
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task SetDocumentStatusAsync_Faults_OnTransportException()
+    {
+        var client = BuildClient(new StubHandler(new HttpRequestException("connection refused")));
+
+        var act = async () => await client.SetDocumentStatusAsync(
+            Guid.NewGuid(), "accepted", null, "tenant");
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Test]
+    public async Task SetDocumentStatusAsync_Succeeds_On200_TargetsStatusRoute()
+    {
+        var docId = Guid.NewGuid();
+        var handler = new StubHandler(HttpStatusCode.OK, "{\"ok\":true}");
+        var client = BuildClient(handler);
+
+        await client.SetDocumentStatusAsync(docId, "accepted", null, "tenant");
+
+        handler.LastRequest!.RequestUri!.AbsolutePath.Should().Be($"/api/engine/documents/{docId}/status");
+    }
+
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage? _response;
+        private readonly Exception? _exception;
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public StubHandler(HttpStatusCode status, string body)
+            => _response = new HttpResponseMessage(status)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/json"),
+            };
+
+        public StubHandler(Exception exception) => _exception = exception;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            if (_exception is not null) throw _exception;
+            return Task.FromResult(_response!);
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentEndpointsGuardTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentEndpointsGuardTests.cs
@@ -1,0 +1,217 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC5/AC6/AC8) — guards on the document read endpoints
+/// (<see cref="DocumentEndpoints"/>). Handlers are called directly with a recording
+/// fake repository + a fake tenant context (the
+/// <see cref="Tamma.Api.Tests.Dashboard.ReposRunsEndpointsGuardTests"/> style).
+///
+/// <para>Coverage: null AND <see cref="Guid.Empty"/> tenant → <c>404
+/// no_active_tenant</c> BEFORE any repository call (fail-closed); a bare-id fetch
+/// whose row belongs to another tenant → <c>404 document_not_found</c>; happy-path
+/// projection pins.</para>
+/// </summary>
+[TestFixture]
+public class DocumentEndpointsGuardTests
+{
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    // ── Fail-closed: null / empty tenant on all three reads ────────────────────
+
+    [Test]
+    public async Task GetIssueLineage_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingRepo();
+        var result = await DocumentEndpoints.GetIssueLineage(
+            "i", repo, new DocumentTestData.FakeTenantContext(null), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.ListByIssueCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetIssueLineage_EmptyTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingRepo();
+        var result = await DocumentEndpoints.GetIssueLineage(
+            "i", repo, new DocumentTestData.FakeTenantContext(Guid.Empty), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.ListByIssueCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetLatestAccepted_NullTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingRepo();
+        var result = await DocumentEndpoints.GetLatestAccepted(
+            "i", repo, new DocumentTestData.FakeTenantContext(null), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.GetLatestAcceptedCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task GetDocument_EmptyTenant_FailsClosed_WithoutCallingRepo()
+    {
+        var repo = new RecordingRepo();
+        var result = await DocumentEndpoints.GetDocument(
+            Guid.NewGuid(), repo, new DocumentTestData.FakeTenantContext(Guid.Empty), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("no_active_tenant");
+        repo.GetByIdCalled.Should().BeFalse();
+    }
+
+    // ── Entity-level re-check on the bare-id fetch ─────────────────────────────
+
+    [Test]
+    public async Task GetDocument_ForeignTenantRow_Returns404_DocumentNotFound()
+    {
+        var foreign = Guid.NewGuid();
+        var docId = Guid.NewGuid();
+        var repo = new RecordingRepo
+        {
+            // The repo is asked with the caller's tenant but a stale/foreign row
+            // surfaces — the entity-level re-check must reject it.
+            RowById = DocumentTestData.Row(docId, "i", DocumentTestData.DecompositionType, "accepted", 1,
+                DocumentTestData.ValidDecompositionBody, foreign),
+        };
+
+        var result = await DocumentEndpoints.GetDocument(
+            docId, repo, new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("document_not_found");
+    }
+
+    [Test]
+    public async Task GetDocument_UnknownRow_Returns404()
+    {
+        var repo = new RecordingRepo { RowById = null };
+        var result = await DocumentEndpoints.GetDocument(
+            Guid.NewGuid(), repo, new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(404);
+        ErrorOf(result).Should().Be("document_not_found");
+    }
+
+    // ── Happy-path projections ─────────────────────────────────────────────────
+
+    [Test]
+    public async Task GetIssueLineage_ConcreteTenant_ProjectsTrail()
+    {
+        var repo = new RecordingRepo
+        {
+            IssueRows =
+            {
+                DocumentTestData.Row(Guid.NewGuid(), "issue-9", DocumentTestData.DecompositionType,
+                    "accepted", 1, DocumentTestData.ValidDecompositionBody, _tenant),
+            },
+        };
+
+        var result = await DocumentEndpoints.GetIssueLineage(
+            "issue-9", repo, new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(200);
+        repo.RequestedTenant.Should().Be(_tenant);
+        var root = await CaptureJson(result);
+        root.GetProperty("issueId").GetString().Should().Be("issue-9");
+        root.GetProperty("outcome").GetString().Should().Be("accepted");
+        root.GetProperty("types").GetArrayLength().Should().Be(1);
+        root.GetProperty("types")[0].GetProperty("documentType").GetString()
+            .Should().Be(DocumentTestData.DecompositionType);
+    }
+
+    [Test]
+    public async Task GetDocument_OwnedRow_ProjectsEntry()
+    {
+        var docId = Guid.NewGuid();
+        var repo = new RecordingRepo
+        {
+            RowById = DocumentTestData.Row(docId, "i", DocumentTestData.DecompositionType, "accepted", 2,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        var result = await DocumentEndpoints.GetDocument(
+            docId, repo, new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(200);
+        var root = await CaptureJson(result);
+        root.GetProperty("id").GetGuid().Should().Be(docId);
+        root.GetProperty("revision").GetInt32().Should().Be(2);
+        root.GetProperty("status").GetString().Should().Be("accepted");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static int? StatusOf(IResult result) => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    private static string? ErrorOf(IResult result)
+    {
+        var value = (result as IValueHttpResult)?.Value;
+        return value?.GetType().GetProperty("error")?.GetValue(value) as string;
+    }
+
+    private static async Task<JsonElement> CaptureJson(IResult result)
+    {
+        await using var services = new ServiceCollection().AddLogging().BuildServiceProvider();
+        var ctx = new DefaultHttpContext { RequestServices = services };
+        using var stream = new MemoryStream();
+        ctx.Response.Body = stream;
+        await result.ExecuteAsync(ctx);
+        stream.Position = 0;
+        using var doc = await JsonDocument.ParseAsync(stream);
+        return doc.RootElement.Clone();
+    }
+
+    private sealed class RecordingRepo : IDocumentInstanceRepository
+    {
+        public bool ListByIssueCalled { get; private set; }
+        public bool GetLatestAcceptedCalled { get; private set; }
+        public bool GetByIdCalled { get; private set; }
+        public Guid? RequestedTenant { get; private set; }
+        public List<DocumentInstance> IssueRows { get; } = new();
+        public List<DocumentInstance> LatestRows { get; } = new();
+        public DocumentInstance? RowById { get; set; }
+
+        public Task<IReadOnlyList<DocumentInstance>> ListByIssueAsync(Guid tenantId, string issueId, CancellationToken ct)
+        {
+            ListByIssueCalled = true;
+            RequestedTenant = tenantId;
+            return Task.FromResult<IReadOnlyList<DocumentInstance>>(IssueRows);
+        }
+
+        public Task<IReadOnlyList<DocumentInstance>> GetLatestAcceptedAsync(Guid tenantId, string issueId, CancellationToken ct)
+        {
+            GetLatestAcceptedCalled = true;
+            RequestedTenant = tenantId;
+            return Task.FromResult<IReadOnlyList<DocumentInstance>>(LatestRows);
+        }
+
+        public Task<DocumentInstance?> GetByIdAsync(Guid tenantId, Guid documentId, CancellationToken ct)
+        {
+            GetByIdCalled = true;
+            RequestedTenant = tenantId;
+            return Task.FromResult(RowById);
+        }
+
+        public Task<DocumentInstance> InsertAsync(Guid tenantId, DocumentEnvelope envelope, Guid? correlatingEventId, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task<DocumentInstance> SetStatusAsync(Guid tenantId, Guid documentId, DocumentInstanceStatus status, Guid? correlatingEventId, CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentEngineWriteSeamTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentEngineWriteSeamTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC7/AC8, D6 — Api half) — the engine→API persist/status seam.
+/// <see cref="DocumentEndpoints.PersistFromEngine"/> maps the wire envelope onto
+/// <c>InsertAsync</c> and surfaces a <see cref="TammaError"/> as a 400 with its
+/// code; <see cref="DocumentEndpoints.SetStatusFromEngine"/> parses + transitions
+/// and maps registry/store errors to 400. (The Activities-side fail-loud client is
+/// covered by <c>Tamma.Activities.Tests.Documents.DocumentEngineWriteSeamTests</c>.)
+/// </summary>
+[TestFixture]
+public class DocumentEngineWriteSeamTests
+{
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [Test]
+    public async Task PersistFromEngine_NullTenant_Returns400()
+    {
+        var repo = new RecordingWriteRepo();
+        var env = DocumentJson.Serialize(DocumentTestData.DecompositionEnvelope("i"));
+
+        var result = await DocumentEndpoints.PersistFromEngine(
+            new PersistDocumentRequest(env, null), repo,
+            new DocumentTestData.FakeTenantContext(null), CancellationToken.None);
+
+        StatusOf(result).Should().Be(400);
+        repo.InsertCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PersistFromEngine_MapsEnvelopeOntoInsert_Returns201()
+    {
+        var eventId = Guid.NewGuid();
+        var envelope = DocumentTestData.DecompositionEnvelope("issue-7");
+        var repo = new RecordingWriteRepo
+        {
+            InsertResult = DocumentTestData.Row(envelope.Id, "issue-7", DocumentTestData.DecompositionType,
+                "draft", 1, DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        var result = await DocumentEndpoints.PersistFromEngine(
+            new PersistDocumentRequest(DocumentJson.Serialize(envelope), eventId), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(201);
+        repo.InsertCalled.Should().BeTrue();
+        repo.RequestedTenant.Should().Be(_tenant);
+        repo.RequestedEnvelope!.Id.Should().Be(envelope.Id);
+        repo.RequestedEnvelope.IssueId.Should().Be("issue-7");
+        repo.RequestedCorrelatingEventId.Should().Be(eventId);
+    }
+
+    [Test]
+    public async Task PersistFromEngine_RepoTammaError_MapsToCoded400()
+    {
+        var repo = new RecordingWriteRepo
+        {
+            ThrowOnInsert = new TammaError("DOCUMENT.STORE.INVALID_BODY", "bad body"),
+        };
+        var env = DocumentJson.Serialize(DocumentTestData.DecompositionEnvelope("i"));
+
+        var result = await DocumentEndpoints.PersistFromEngine(
+            new PersistDocumentRequest(env, null), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(400);
+        ErrorOf(result).Should().Be("DOCUMENT.STORE.INVALID_BODY");
+    }
+
+    [Test]
+    public async Task PersistFromEngine_InvalidEnvelopeJson_Returns400()
+    {
+        var repo = new RecordingWriteRepo();
+        var result = await DocumentEndpoints.PersistFromEngine(
+            new PersistDocumentRequest("{ not valid", null), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(400);
+        ErrorOf(result).Should().Be("invalid_envelope");
+        repo.InsertCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SetStatusFromEngine_UnknownStatus_MapsToCoded400()
+    {
+        var repo = new RecordingWriteRepo();
+        var result = await DocumentEndpoints.SetStatusFromEngine(
+            Guid.NewGuid(), new SetDocumentStatusRequest("bogus", null), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(400);
+        ErrorOf(result).Should().Be("DOCUMENT.STORE.UNKNOWN_STATUS");
+        repo.SetStatusCalled.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task SetStatusFromEngine_Success_Returns200()
+    {
+        var docId = Guid.NewGuid();
+        var eventId = Guid.NewGuid();
+        var repo = new RecordingWriteRepo
+        {
+            SetStatusResult = DocumentTestData.Row(docId, "i", DocumentTestData.DecompositionType,
+                "accepted", 1, DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        var result = await DocumentEndpoints.SetStatusFromEngine(
+            docId, new SetDocumentStatusRequest("accepted", eventId), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(200);
+        repo.SetStatusCalled.Should().BeTrue();
+        repo.RequestedStatus.Should().Be(DocumentInstanceStatus.Accepted);
+        repo.RequestedCorrelatingEventId.Should().Be(eventId);
+    }
+
+    [Test]
+    public async Task SetStatusFromEngine_RepoTammaError_MapsToCoded400()
+    {
+        var repo = new RecordingWriteRepo
+        {
+            ThrowOnSetStatus = new TammaError("DOCUMENT.STORE.NOT_FOUND", "missing"),
+        };
+
+        var result = await DocumentEndpoints.SetStatusFromEngine(
+            Guid.NewGuid(), new SetDocumentStatusRequest("accepted", null), repo,
+            new DocumentTestData.FakeTenantContext(_tenant), CancellationToken.None);
+
+        StatusOf(result).Should().Be(400);
+        ErrorOf(result).Should().Be("DOCUMENT.STORE.NOT_FOUND");
+    }
+
+    private static int? StatusOf(IResult result) => (result as IStatusCodeHttpResult)?.StatusCode;
+
+    private static string? ErrorOf(IResult result)
+    {
+        var value = (result as IValueHttpResult)?.Value;
+        return value?.GetType().GetProperty("error")?.GetValue(value) as string;
+    }
+
+    private sealed class RecordingWriteRepo : IDocumentInstanceRepository
+    {
+        public bool InsertCalled { get; private set; }
+        public bool SetStatusCalled { get; private set; }
+        public Guid? RequestedTenant { get; private set; }
+        public DocumentEnvelope? RequestedEnvelope { get; private set; }
+        public Guid? RequestedCorrelatingEventId { get; private set; }
+        public DocumentInstanceStatus? RequestedStatus { get; private set; }
+        public DocumentInstance? InsertResult { get; set; }
+        public DocumentInstance? SetStatusResult { get; set; }
+        public TammaError? ThrowOnInsert { get; set; }
+        public TammaError? ThrowOnSetStatus { get; set; }
+
+        public Task<DocumentInstance> InsertAsync(Guid tenantId, DocumentEnvelope envelope, Guid? correlatingEventId, CancellationToken ct)
+        {
+            InsertCalled = true;
+            RequestedTenant = tenantId;
+            RequestedEnvelope = envelope;
+            RequestedCorrelatingEventId = correlatingEventId;
+            if (ThrowOnInsert is not null) throw ThrowOnInsert;
+            return Task.FromResult(InsertResult!);
+        }
+
+        public Task<DocumentInstance> SetStatusAsync(Guid tenantId, Guid documentId, DocumentInstanceStatus status, Guid? correlatingEventId, CancellationToken ct)
+        {
+            SetStatusCalled = true;
+            RequestedTenant = tenantId;
+            RequestedStatus = status;
+            RequestedCorrelatingEventId = correlatingEventId;
+            if (ThrowOnSetStatus is not null) throw ThrowOnSetStatus;
+            return Task.FromResult(SetStatusResult!);
+        }
+
+        public Task<DocumentInstance?> GetByIdAsync(Guid tenantId, Guid documentId, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task<IReadOnlyList<DocumentInstance>> ListByIssueAsync(Guid tenantId, string issueId, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task<IReadOnlyList<DocumentInstance>> GetLatestAcceptedAsync(Guid tenantId, string issueId, CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentInstanceRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentInstanceRepositoryTests.cs
@@ -1,0 +1,195 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Data;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC2/AC4/AC8) — Postgres 17 Testcontainer proof of the write path:
+/// registry validation before write, immutable revisions + supersession chain
+/// linearity, status-only transitions, the latest-accepted filter matrix, and the
+/// CHECK constraint. EF InMemory models neither the filtered unique index nor the
+/// CHECK, so a real Postgres is the only proof. Docker-gated (CI runs it).
+/// </summary>
+[TestFixture]
+public class DocumentInstanceRepositoryTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("document_store_api_test")
+            .WithUsername("tamma").WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    private async Task<(DocumentInstanceRepository Repo, Guid Tenant, string Schema)> NewRepoAsync()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+        var factory = new DocumentTestData.SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var repo = new DocumentInstanceRepository(factory, new DocumentTestData.FakeTenantContext(tenant));
+        return (repo, tenant, schema);
+    }
+
+    private async Task<int> CountRowsAsync(string schema)
+    {
+        var opts = new DbContextOptionsBuilder<TenantDbContext>().UseNpgsql(CsFor(schema)).Options;
+        await using var ctx = new TenantDbContext(opts, Guid.NewGuid());
+        return await ctx.Documents.IgnoreQueryFilters().CountAsync();
+    }
+
+    [Test]
+    public async Task InsertAsync_InvalidBody_Throws_And_PersistsNothing()
+    {
+        var (repo, tenant, schema) = await NewRepoAsync();
+        var envelope = DocumentTestData.DecompositionEnvelope("i", body: "{}");
+
+        var act = async () => await repo.InsertAsync(tenant, envelope, null, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("DOCUMENT.STORE.INVALID_BODY");
+        (await CountRowsAsync(schema)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task InsertAsync_UnknownType_Throws_And_PersistsNothing()
+    {
+        var (repo, tenant, schema) = await NewRepoAsync();
+        var envelope = DocumentTestData.DecompositionEnvelope("i") with { Type = "not-a-type" };
+
+        var act = async () => await repo.InsertAsync(tenant, envelope, null, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("DOCUMENT.TYPE.UNKNOWN");
+        (await CountRowsAsync(schema)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task InsertAsync_RevisionChain_SupersedesPrior_BodyUnchanged()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+        var r1 = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", DocumentState.Accepted), null, CancellationToken.None);
+        r1.Revision.Should().Be(1);
+
+        var supersedingEnvelope = DocumentTestData.DecompositionEnvelope(
+            "i", DocumentState.Accepted, supersedesDocumentId: r1.Id);
+        var r2 = await repo.InsertAsync(tenant, supersedingEnvelope, null, CancellationToken.None);
+
+        r2.Revision.Should().Be(2);
+        var priorReloaded = await repo.GetByIdAsync(tenant, r1.Id, CancellationToken.None);
+        priorReloaded!.Status.Should().Be("superseded");
+        priorReloaded.BodyJson.Should().Be(r1.BodyJson, "the prior body is never mutated");
+    }
+
+    [Test]
+    public async Task InsertAsync_SecondSupersedeOfSamePrior_ViolatesUniqueIndex()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+        var r1 = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i"), null, CancellationToken.None);
+        await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", supersedesDocumentId: r1.Id), null, CancellationToken.None);
+
+        var act = async () => await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", supersedesDocumentId: r1.Id), null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DbUpdateException>(
+            "the unique filtered index keeps the supersession chain linear");
+    }
+
+    [Test]
+    public async Task SetStatusAsync_TransitionsStatusOnly_NeverBody()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+        var row = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i"), null, CancellationToken.None);
+
+        var updated = await repo.SetStatusAsync(
+            tenant, row.Id, DocumentInstanceStatus.Validated, Guid.NewGuid(), CancellationToken.None);
+
+        updated.Status.Should().Be("validated");
+        updated.BodyJson.Should().Be(row.BodyJson);
+    }
+
+    [Test]
+    public async Task SetStatusAsync_RejectsSuperseded()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+        var row = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i"), null, CancellationToken.None);
+
+        var act = async () => await repo.SetStatusAsync(
+            tenant, row.Id, DocumentInstanceStatus.Superseded, null, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("DOCUMENT.STORE.ILLEGAL_STATUS");
+    }
+
+    [Test]
+    public async Task SetStatusAsync_MissingRow_ThrowsNotFound()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+        var act = async () => await repo.SetStatusAsync(
+            tenant, Guid.NewGuid(), DocumentInstanceStatus.Accepted, null, CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>()).Which.Code.Should().Be("DOCUMENT.STORE.NOT_FOUND");
+    }
+
+    [Test]
+    public async Task GetLatestAcceptedAsync_ExcludesNonAccepted_AndReturnsOnePerType()
+    {
+        var (repo, tenant, _) = await NewRepoAsync();
+
+        // Accepted r1, superseded by accepted r2 → only r2 is the latest accepted.
+        var r1 = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", DocumentState.Accepted), null, CancellationToken.None);
+        var r2 = await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", DocumentState.Accepted, supersedesDocumentId: r1.Id),
+            null, CancellationToken.None);
+        // A draft row (never in latest-accepted).
+        await repo.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope("i", DocumentState.Draft), null, CancellationToken.None);
+
+        var latest = await repo.GetLatestAcceptedAsync(tenant, "i", CancellationToken.None);
+
+        latest.Should().ContainSingle("≤1 per type; superseded/draft never appear");
+        latest[0].Id.Should().Be(r2.Id);
+    }
+
+    [Test]
+    public async Task CheckConstraint_RejectsJunkStatus_ViaRawSql()
+    {
+        var (_, _, schema) = await NewRepoAsync();
+        await using var conn = new NpgsqlConnection(CsFor(schema));
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText =
+            "INSERT INTO document_instances " +
+            "(id, document_type, issue_id, produced_by_role, produced_by_action, schema_version, revision, status, body, created_at, updated_at) " +
+            "VALUES (@id, 'decomposition', 'i', 'senior_developer', 'decompose-issue', 1, 1, 'bogus', '{}'::jsonb, now(), now())";
+        cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+
+        var act = async () => await cmd.ExecuteNonQueryAsync();
+
+        (await act.Should().ThrowAsync<PostgresException>()).Which.SqlState.Should().Be("23514");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentInstanceRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentInstanceRepositoryTests.cs
@@ -98,7 +98,8 @@ public class DocumentInstanceRepositoryTests
         r2.Revision.Should().Be(2);
         var priorReloaded = await repo.GetByIdAsync(tenant, r1.Id, CancellationToken.None);
         priorReloaded!.Status.Should().Be("superseded");
-        priorReloaded.BodyJson.Should().Be(r1.BodyJson, "the prior body is never mutated");
+        DocumentTestData.SameJson(priorReloaded.BodyJson, r1.BodyJson)
+            .Should().BeTrue("the prior body is never mutated (jsonb re-serializes, so compare semantically)");
     }
 
     [Test]
@@ -128,7 +129,8 @@ public class DocumentInstanceRepositoryTests
             tenant, row.Id, DocumentInstanceStatus.Validated, Guid.NewGuid(), CancellationToken.None);
 
         updated.Status.Should().Be("validated");
-        updated.BodyJson.Should().Be(row.BodyJson);
+        DocumentTestData.SameJson(updated.BodyJson, row.BodyJson)
+            .Should().BeTrue("SetStatus never touches the body (jsonb re-serializes, so compare semantically)");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentStoreIsolationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentStoreIsolationTests.cs
@@ -1,0 +1,74 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Npgsql;
+using Tamma.Core.Documents;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC6/AC8) — two-schema cross-tenant isolation proof (the
+/// <c>TenantAnalyticsIntegrationTests</c> pattern). Tenant A's documents are
+/// invisible to tenant B through every repository read: the per-tenant schema is
+/// the isolation plane, and the explicit <c>TenantId</c> predicate is
+/// defence-in-depth. Docker-gated (CI runs it).
+/// </summary>
+[TestFixture]
+public class DocumentStoreIsolationTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("document_store_isolation_test")
+            .WithUsername("tamma").WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    [Test]
+    public async Task TenantA_Documents_AreInvisibleToTenantB()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var schemaA = TenantNaming.SchemaName(tenantA);
+        var schemaB = TenantNaming.SchemaName(tenantB);
+
+        var migrator = new EfTenantDbMigrator();
+        await migrator.MigrateTenantAppAsync(CsFor(schemaA));
+        await migrator.MigrateTenantAppAsync(CsFor(schemaB));
+
+        var factory = new DocumentTestData.SchemaRoutingFactory(_baseConnectionString)
+            .Map(tenantA, schemaA)
+            .Map(tenantB, schemaB);
+        var repoA = new DocumentInstanceRepository(factory, new DocumentTestData.FakeTenantContext(tenantA));
+        var repoB = new DocumentInstanceRepository(factory, new DocumentTestData.FakeTenantContext(tenantB));
+
+        var aDoc = await repoA.InsertAsync(
+            tenantA, DocumentTestData.DecompositionEnvelope("issue-X", DocumentState.Accepted), null, CancellationToken.None);
+        await repoB.InsertAsync(
+            tenantB, DocumentTestData.DecompositionEnvelope("issue-Y", DocumentState.Accepted), null, CancellationToken.None);
+
+        // B's lineage read for A's issue → empty.
+        (await repoB.ListByIssueAsync(tenantB, "issue-X", CancellationToken.None)).Should().BeEmpty();
+        // B fetching A's document id → null.
+        (await repoB.GetByIdAsync(tenantB, aDoc.Id, CancellationToken.None)).Should().BeNull();
+        // A sees only A.
+        var aRows = await repoA.ListByIssueAsync(tenantA, "issue-X", CancellationToken.None);
+        aRows.Should().ContainSingle().Which.Id.Should().Be(aDoc.Id);
+        (await repoA.ListByIssueAsync(tenantA, "issue-Y", CancellationToken.None)).Should().BeEmpty();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentStoreStreamConsistencyTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentStoreStreamConsistencyTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Npgsql;
+using Tamma.Core.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC7/AC8) — store↔stream consistency. A pre-minted event Guid is
+/// appended to <c>domain_events</c> as a <c>DOCUMENT.ACCEPTED</c> row (via
+/// <see cref="EventRepository"/>) and stamped onto the store row's
+/// <c>correlating_event_id</c>. An auditor can then cross-check store ↔ stream
+/// mechanically: the row's linkage resolves to an existing event of the right type
+/// whose tags match the row's issue/type. Docker-gated (CI runs it).
+/// </summary>
+[TestFixture]
+public class DocumentStoreStreamConsistencyTests
+{
+    // DocumentEvents.Accepted (Tamma.Activities.Documents) — consumed here as the
+    // correlating_event_id linkage type only.
+    private const string DocumentAccepted = "DOCUMENT.ACCEPTED";
+
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("document_store_consistency_test")
+            .WithUsername("tamma").WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    [Test]
+    public async Task AcceptedRow_CorrelatingEventId_ResolvesToMatchingStreamEvent()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+
+        var factory = new DocumentTestData.SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var tc = new DocumentTestData.FakeTenantContext(tenant);
+        var docs = new DocumentInstanceRepository(factory, tc);
+        var events = new EventRepository(factory, tc);
+
+        const string issueId = "issue-42";
+        const string documentType = "decomposition";
+
+        // 1) Pre-mint the transition event id, append the DOCUMENT.ACCEPTED event.
+        var eventId = Guid.NewGuid();
+        await events.AppendAsync(new DomainEvent
+        {
+            Id = eventId,
+            Type = DocumentAccepted,
+            TenantId = tenant,
+            Tags = JsonSerializer.Serialize(new Dictionary<string, string?>
+            {
+                ["issueId"] = issueId,
+                ["documentType"] = documentType,
+            }),
+        });
+
+        // 2) Insert the document + stamp the SAME event id as its acceptance linkage.
+        var row = await docs.InsertAsync(
+            tenant, DocumentTestData.DecompositionEnvelope(issueId), null, CancellationToken.None);
+        var accepted = await docs.SetStatusAsync(
+            tenant, row.Id, DocumentInstanceStatus.Accepted, eventId, CancellationToken.None);
+
+        // 3) The row's linkage resolves to the stream event, same type + tags.
+        accepted.CorrelatingEventId.Should().Be(eventId);
+        var streamEvent = await events.GetByIdAsync(accepted.CorrelatingEventId!.Value);
+        streamEvent.Should().NotBeNull();
+        streamEvent!.Type.Should().Be(DocumentAccepted);
+
+        var tags = JsonSerializer.Deserialize<Dictionary<string, string?>>(streamEvent.Tags)!;
+        tags["issueId"].Should().Be(accepted.IssueId);
+        tags["documentType"].Should().Be(accepted.DocumentType);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentTestData.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentTestData.cs
@@ -49,6 +49,18 @@ internal static class DocumentTestData
         return doc.RootElement.Clone();
     }
 
+    /// <summary>
+    /// Semantic JSON equality. The <c>body</c> column is <c>jsonb</c>, which Postgres
+    /// re-serializes on read (whitespace stripped, object keys reordered), so a row
+    /// read back never matches the raw <c>GetRawText()</c> text of the in-memory
+    /// insert result byte-for-byte. Compare the parsed values instead — the store's
+    /// contract is that the body is preserved as a document, not as exact bytes.
+    /// </summary>
+    public static bool SameJson(string a, string b) =>
+        System.Text.Json.Nodes.JsonNode.DeepEquals(
+            System.Text.Json.Nodes.JsonNode.Parse(a),
+            System.Text.Json.Nodes.JsonNode.Parse(b));
+
     /// <summary>Build a stored row (assembler/guard tests — no DB).</summary>
     public static DocumentInstance Row(
         Guid id, string issueId, string type, string status, int revision,

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentTestData.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/DocumentTestData.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tamma.Core.Documents;
+using Tamma.Data;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 — shared builders for the document store suites: valid typed bodies
+/// (from the registered 39-3/39-4 type examples), <see cref="DocumentInstance"/>
+/// rows for the pure assembler/guard tests, and <see cref="DocumentEnvelope"/>s for
+/// the repository integration tests.
+/// </summary>
+internal static class DocumentTestData
+{
+    public const string DecompositionType = "decomposition";
+    public const string ReviewType = "review";
+
+    /// <summary>A valid decomposition body (39-3's valid two-task-chain example).</summary>
+    public const string ValidDecompositionBody =
+        """
+        {
+          "summary": "Split rate limiting into middleware then config, preserving per-tenant protection.",
+          "subtasks": [
+            { "id": "ST-1", "title": "Token-bucket middleware", "description": "Limiter keyed by tenant id", "acceptanceCriteria": "over-limit requests get 429", "estimateHours": 6, "complexity": "medium", "dependsOn": [] },
+            { "id": "ST-2", "title": "Per-tenant config", "description": "Read the limit from tenant config", "acceptanceCriteria": "limit is configurable", "estimateHours": 4, "complexity": "low", "dependsOn": ["ST-1"] }
+          ]
+        }
+        """;
+
+    /// <summary>A valid review body whose subject documentId points at <paramref name="subjectDocumentId"/>.</summary>
+    public static string ValidReviewBody(Guid subjectDocumentId) =>
+        $$"""
+        {
+          "subject": { "kind": "document", "documentId": "{{subjectDocumentId:D}}", "documentType": "decomposition" },
+          "decision": "request-changes",
+          "summary": "The plan is sound but omits migration ordering.",
+          "issues": [
+            { "severity": "critical", "category": "correctness", "description": "Migration runs before the table exists", "suggestedFix": "Reorder task ST-2 before ST-1" }
+          ]
+        }
+        """;
+
+    public static JsonElement Payload(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>Build a stored row (assembler/guard tests — no DB).</summary>
+    public static DocumentInstance Row(
+        Guid id, string issueId, string type, string status, int revision,
+        string body, Guid tenantId,
+        Guid? supersedesDocumentId = null, Guid? parentDocumentId = null,
+        Guid? correlatingEventId = null, DateTime? createdAt = null,
+        string role = "senior_developer", string action = "decompose-issue")
+    {
+        var created = createdAt ?? DateTime.UtcNow;
+        return new DocumentInstance
+        {
+            Id = id,
+            IssueId = issueId,
+            DocumentType = type,
+            Status = status,
+            Revision = revision,
+            BodyJson = body,
+            TenantId = tenantId,
+            SupersedesDocumentId = supersedesDocumentId,
+            ParentDocumentId = parentDocumentId,
+            CorrelatingEventId = correlatingEventId,
+            ProducedByRole = role,
+            ProducedByAction = action,
+            ProducedByWorkflow = "issue-decomposition",
+            SchemaVersion = 1,
+            CorrelationId = "corr-1",
+            CreatedAt = created,
+            UpdatedAt = created,
+        };
+    }
+
+    /// <summary>Build a decomposition envelope in a chosen state (repository tests).</summary>
+    public static DocumentEnvelope DecompositionEnvelope(
+        string issueId, DocumentState state = DocumentState.Draft,
+        Guid? supersedesDocumentId = null, string body = ValidDecompositionBody,
+        DateTimeOffset? now = null)
+    {
+        var draft = DocumentEnvelope.CreateDraft(
+            DocumentTypeKey.Decomposition, 1, issueId, "corr-1",
+            DocumentProducer.Create("senior_developer", "decompose-issue", "issue-decomposition"),
+            Payload(body),
+            supersedesDocumentId: supersedesDocumentId,
+            now: now);
+        return state == DocumentState.Draft ? draft : draft with { State = state };
+    }
+
+    /// <summary>A fake tenant context bound to a fixed (or absent) tenant id.</summary>
+    public sealed class FakeTenantContext(Guid? id) : ITenantContext
+    {
+        public Guid? TenantId { get; private set; } = id;
+        public void SetTenantId(Guid tenantId) => TenantId = tenantId;
+        public void ClearTenantId() => TenantId = null;
+    }
+
+    /// <summary>Routes each tenant id to its own search-path schema connection.</summary>
+    public sealed class SchemaRoutingFactory(string baseCs) : ITenantDbContextFactory
+    {
+        private readonly Dictionary<Guid, string> _schemas = new();
+
+        public SchemaRoutingFactory Map(Guid tenantId, string schema)
+        {
+            _schemas[tenantId] = schema;
+            return this;
+        }
+
+        public ValueTask<TenantDbContext> CreateAsync(Guid tenantId, CancellationToken ct = default)
+        {
+            if (!_schemas.TryGetValue(tenantId, out var schema))
+                throw new InvalidOperationException($"Tenant {tenantId} not reachable.");
+
+            var cs = new Npgsql.NpgsqlConnectionStringBuilder(baseCs) { SearchPath = schema }.ConnectionString;
+            var opts = new Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<TenantDbContext>()
+                .UseNpgsql(cs).Options;
+            return new ValueTask<TenantDbContext>(new TenantDbContext(opts, tenantId));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/LineageAssemblerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Documents/LineageAssemblerTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Documents;
+using Tamma.Core;
+using Tamma.Data.Entities;
+
+namespace Tamma.Api.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 (AC3/AC8) — pure tests for <see cref="LineageAssembler"/>: grouping
+/// + ordering, review linkage (parent-first + body-probe fallback), unresolvable
+/// reviews surfaced in <c>unlinkedReviews</c>, the outcome matrix, and the corrupt-
+/// body tripwire (D5).
+/// </summary>
+[TestFixture]
+public class LineageAssemblerTests
+{
+    private readonly Guid _tenant = Guid.NewGuid();
+
+    [Test]
+    public void Assemble_groups_types_in_first_produced_order_revisions_ascending()
+    {
+        var t0 = new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc);
+        var findings = Guid.NewGuid();
+        var decompR1 = Guid.NewGuid();
+        var decompR2 = Guid.NewGuid();
+
+        // findings produced first, then two decomposition revisions.
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(findings, "issue-1", DocumentTestData.DecompositionType, "accepted", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant, createdAt: t0),
+            DocumentTestData.Row(decompR2, "issue-1", "review", "accepted", 2,
+                DocumentTestData.ValidReviewBody(decompR1), _tenant, createdAt: t0.AddMinutes(3)),
+            DocumentTestData.Row(decompR1, "issue-1", DocumentTestData.DecompositionType, "superseded", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant, createdAt: t0.AddMinutes(1)),
+        };
+
+        var lineage = LineageAssembler.Assemble("issue-1", rows);
+
+        lineage.IssueId.Should().Be("issue-1");
+        // Types in first-produced order: findings' decomposition row at t0 is the
+        // first decomposition; there is exactly one non-review type here.
+        lineage.Types.Should().ContainSingle();
+        lineage.Types[0].DocumentType.Should().Be(DocumentTestData.DecompositionType);
+        lineage.Types[0].Revisions.Select(r => r.Revision).Should().ContainInOrder(1, 1);
+    }
+
+    [Test]
+    public void Assemble_attaches_review_to_subject_via_parent_document_id()
+    {
+        var subjectId = Guid.NewGuid();
+        var reviewId = Guid.NewGuid();
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(subjectId, "i", DocumentTestData.DecompositionType, "accepted", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+            // No body subject.documentId match — parent_document_id carries it.
+            DocumentTestData.Row(reviewId, "i", "review", "accepted", 1,
+                DocumentTestData.ValidReviewBody(Guid.NewGuid()), _tenant, parentDocumentId: subjectId),
+        };
+
+        var lineage = LineageAssembler.Assemble("i", rows);
+
+        lineage.UnlinkedReviews.Should().BeEmpty();
+        var subject = lineage.Types.Single().Revisions.Single();
+        subject.Reviews.Should().ContainSingle().Which.Id.Should().Be(reviewId);
+    }
+
+    [Test]
+    public void Assemble_falls_back_to_body_probe_when_no_parent()
+    {
+        var subjectId = Guid.NewGuid();
+        var reviewId = Guid.NewGuid();
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(subjectId, "i", DocumentTestData.DecompositionType, "accepted", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+            // parent null → resolves via body subject.documentId.
+            DocumentTestData.Row(reviewId, "i", "review", "accepted", 1,
+                DocumentTestData.ValidReviewBody(subjectId), _tenant),
+        };
+
+        var lineage = LineageAssembler.Assemble("i", rows);
+
+        lineage.UnlinkedReviews.Should().BeEmpty();
+        lineage.Types.Single().Revisions.Single().Reviews.Single().Id.Should().Be(reviewId);
+    }
+
+    [Test]
+    public void Assemble_surfaces_unresolvable_review_in_unlinkedReviews_never_dropped()
+    {
+        var reviewId = Guid.NewGuid();
+        var rows = new List<DocumentInstance>
+        {
+            // A review whose subject (both parent + body) points at a doc NOT in
+            // this response.
+            DocumentTestData.Row(reviewId, "i", "review", "accepted", 1,
+                DocumentTestData.ValidReviewBody(Guid.NewGuid()), _tenant),
+        };
+
+        var lineage = LineageAssembler.Assemble("i", rows);
+
+        lineage.Types.Should().BeEmpty();
+        lineage.UnlinkedReviews.Should().ContainSingle().Which.Id.Should().Be(reviewId);
+    }
+
+    [Test]
+    public void Outcome_is_accepted_when_every_latest_per_type_is_accepted()
+    {
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(Guid.NewGuid(), "i", DocumentTestData.DecompositionType, "accepted", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        LineageAssembler.Assemble("i", rows).Outcome.Should().Be("accepted");
+    }
+
+    [Test]
+    public void Outcome_is_escalated_when_any_non_superseded_row_is_escalated()
+    {
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(Guid.NewGuid(), "i", DocumentTestData.DecompositionType, "escalated", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        LineageAssembler.Assemble("i", rows).Outcome.Should().Be("escalated");
+    }
+
+    [Test]
+    public void Outcome_is_in_progress_when_a_type_latest_is_not_accepted()
+    {
+        var rows = new List<DocumentInstance>
+        {
+            DocumentTestData.Row(Guid.NewGuid(), "i", DocumentTestData.DecompositionType, "draft", 1,
+                DocumentTestData.ValidDecompositionBody, _tenant),
+        };
+
+        LineageAssembler.Assemble("i", rows).Outcome.Should().Be("in-progress");
+    }
+
+    [Test]
+    public void Empty_issue_yields_empty_types_and_in_progress()
+    {
+        var lineage = LineageAssembler.Assemble("i", new List<DocumentInstance>());
+        lineage.Types.Should().BeEmpty();
+        lineage.Outcome.Should().Be("in-progress");
+    }
+
+    [Test]
+    public void Assemble_throws_corrupt_body_on_invalid_stored_body()
+    {
+        var rows = new List<DocumentInstance>
+        {
+            // Registered type, but the stored body fails validation (should be
+            // unreachable — write validates — hence the tripwire).
+            DocumentTestData.Row(Guid.NewGuid(), "i", DocumentTestData.DecompositionType, "accepted", 1,
+                "{}", _tenant),
+        };
+
+        var act = () => LineageAssembler.Assemble("i", rows);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.STORE.CORRUPT_BODY");
+    }
+
+    [Test]
+    public void AssembleDocument_projects_a_single_row()
+    {
+        var id = Guid.NewGuid();
+        var row = DocumentTestData.Row(id, "i", DocumentTestData.DecompositionType, "accepted", 3,
+            DocumentTestData.ValidDecompositionBody, _tenant);
+
+        var entry = LineageAssembler.AssembleDocument(row);
+
+        entry.Id.Should().Be(id);
+        entry.Revision.Should().Be(3);
+        entry.Status.Should().Be("accepted");
+        entry.Reviews.Should().BeEmpty();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentInstanceStatusTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/DocumentInstanceStatusTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Story 39-11 — drift pins for the store status vocabulary (Design Decision D3).
+/// The 7-member set + exact wire strings underpin the <c>ck_document_instances_status</c>
+/// CHECK and the AC1/AC2/AC4 status filters; <see cref="DocumentInstanceStatusExtensions.FromState"/>
+/// must be total over 39-2's <see cref="DocumentState"/> and never yield
+/// <see cref="DocumentInstanceStatus.Superseded"/> (a store-only status set solely
+/// by the revision write, D4).
+/// </summary>
+[TestFixture]
+public class DocumentInstanceStatusTests
+{
+    [Test]
+    public void Vocabulary_has_exactly_seven_members()
+    {
+        // Pinned by D3: adding/removing a member is a conscious edit that must also
+        // update the CHECK constraint + migration. The 'in_review' + 'superseded'
+        // store-only members are the two beyond the six lifecycle states.
+        Enum.GetValues<DocumentInstanceStatus>().Should().HaveCount(7);
+    }
+
+    [TestCase(DocumentInstanceStatus.Draft, "draft")]
+    [TestCase(DocumentInstanceStatus.Validated, "validated")]
+    [TestCase(DocumentInstanceStatus.InReview, "in_review")]
+    [TestCase(DocumentInstanceStatus.Accepted, "accepted")]
+    [TestCase(DocumentInstanceStatus.Rejected, "rejected")]
+    [TestCase(DocumentInstanceStatus.Superseded, "superseded")]
+    [TestCase(DocumentInstanceStatus.Escalated, "escalated")]
+    public void ToWire_and_Parse_round_trip_exact_strings(DocumentInstanceStatus status, string wire)
+    {
+        status.ToWire().Should().Be(wire);
+        DocumentInstanceStatusExtensions.Parse(wire).Should().Be(status);
+    }
+
+    [Test]
+    public void InReview_wire_carries_the_underscore()
+    {
+        // The only multi-word wire string — a drift here would silently break the
+        // CHECK constraint match.
+        DocumentInstanceStatus.InReview.ToWire().Should().Be("in_review");
+    }
+
+    [TestCase("in-review")]  // wrong separator
+    [TestCase("Accepted")]   // wrong casing (ordinal)
+    [TestCase("bogus")]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void Parse_throws_on_unknown_input(string input)
+    {
+        var act = () => DocumentInstanceStatusExtensions.Parse(input);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.STORE.UNKNOWN_STATUS");
+    }
+
+    [Test]
+    public void FromState_is_total_over_every_DocumentState_and_never_superseded()
+    {
+        foreach (var state in Enum.GetValues<DocumentState>())
+        {
+            var mapped = DocumentInstanceStatusExtensions.FromState(state);
+            mapped.Should().NotBe(DocumentInstanceStatus.Superseded,
+                "superseded is store-only, set solely by the revision write (D4)");
+        }
+    }
+
+    [TestCase(DocumentState.Draft, DocumentInstanceStatus.Draft)]
+    [TestCase(DocumentState.Validated, DocumentInstanceStatus.Validated)]
+    [TestCase(DocumentState.Reviewed, DocumentInstanceStatus.InReview)]
+    [TestCase(DocumentState.Accepted, DocumentInstanceStatus.Accepted)]
+    [TestCase(DocumentState.Rejected, DocumentInstanceStatus.Rejected)]
+    [TestCase(DocumentState.Escalated, DocumentInstanceStatus.Escalated)]
+    public void FromState_maps_each_state_per_D3(DocumentState state, DocumentInstanceStatus expected)
+    {
+        DocumentInstanceStatusExtensions.FromState(state).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Story 39-11 — Document Store & Lineage API (Epic 39, Wave 3)

Durable per-tenant persistence for every work-document instance, written **exclusively** through `IDocumentInstanceRepository` with immutable revisions and a linear supersession chain, plus tenant-scoped lineage read endpoints and a fail-loud engine→API write seam.

### What's in it

**Storage (first Wave-3 Tenant migration)**
- New `document_instances` tenant table (`AddDocumentInstances` migration): envelope fields as snake_case columns, typed body as `jsonb`, a 7-value status CHECK, a self-FK supersession link (Restrict), and a **unique filtered index** keeping each supersession chain linear. Tenant model only; ControlPlane unchanged. `has-pending-model-changes` clean on **both** contexts.
- `DocumentInstanceStatus` — a `[Wire]` enum of the store's seven statuses with a total `FromState` map that never yields `superseded`.

**The single write door**
- `InsertAsync` validates the body through `DocumentTypeRegistry` **before** persisting (`DOCUMENT.STORE.INVALID_BODY`), and for a superseding envelope inserts the next revision and flips the prior row to `superseded` in one transaction. No body-update method, no delete method — **immutability by API absence**. `SetStatusAsync` transitions status only and refuses `superseded`. `GetLatestAcceptedAsync` (the 39-10 in-process re-entry read) returns ≤1 accepted, non-superseded row per type.

**Reads**
- `GET /api/documents/issues/{issueId}/lineage` — the full trail, reviews linked to their subject (parent-first, then tolerant body-probe; **unlinked reviews surfaced, never dropped**), terminal outcome derived from row statuses. Plus `/latest` (latest-accepted-per-type) and a single-document fetch. All `MemberAccess`-gated with a fail-closed null-tenant guard and an entity-level tenant re-check. Read re-validates bodies (`DOCUMENT.STORE.CORRUPT_BODY` tripwire).
- Lineage DTOs (`IssueDocumentLineage`) live in `Tamma.Core`, deliberately distinct from 39-6's in-run `DocumentLineage` record.

**Engine write seam**
- A fail-loud `TammaApiClient` hop (`PersistDocumentAsync` / `SetDocumentStatusAsync`, non-2xx throws) + `PersistDocumentInstanceActivity` (`DOCUMENT.STORE.PERSIST_FAILED`, never swallows — the document is the product, not telemetry) posting to `EngineServiceOnly` endpoints. The transition event's pre-minted Guid is stamped as `correlating_event_id` so store↔stream cross-checks are mechanical; `EmitDocumentEventActivity` gains an **additive** optional `EventId` input for that linkage.

### ⚠️ Two items for reviewer attention
1. **D3 — status set adds `rejected`.** The story's Architectural Context lists six statuses; 39-2's state machine, 39-6's `DOCUMENT.REJECTED`, and 39-8's reject terminal all require a `Rejected` store state. The CHECK set is the story's six **plus** `rejected` (additive; no listed value dropped). **Flagged for story-owner sign-off.**
2. **`DocumentLifecycleWorkflow` persist-node wiring deferred to 39-12.** To keep this PR focused on the store and avoid destabilizing the just-merged critical-path workflow, the actual persist/status graph nodes are deferred to 39-12 (the workflow-rewire pilot). This story ships the store, engine seam, repository, endpoints, and the additive `EventId` hook; `DocumentLifecycleWorkflow.cs` is **untouched**. AC7's store↔stream linkage is proven by the pre-mint+append consistency test and the engine-seam tests.

### Data / migrations
`Migrations/Tenant/20260722180002_AddDocumentInstances` (house shape: CreateTable + status CHECK + self-FK Restrict + `IX_document_instances_issue_type_status` + `IX_document_instances_issue_created` + `UX_document_instances_supersedes` filtered unique). Tenant only; ControlPlane unchanged; model clean.

### Verification (independently re-run)
- Builds: `Tamma.Core`, `Tamma.Data`, `Tamma.Activities`, `Tamma.ElsaServer`, `Tamma.Api`, and all three test projects — **green**.
- `Tamma.Core.Tests`: **411 passed** (21 new `DocumentInstanceStatus` drift/`FromState` pins). `Tamma.Activities.Tests` (excl. CI-gated): **2623 passed** (6 new engine-seam tests). Both contexts migration-clean; migration shape confirmed; `DocumentLifecycleWorkflow.cs` untouched; `EmitDocumentEventActivity` diff is +16/−0 (additive `EventId` only).
- `Tamma.Api.Tests` document suites (guard, lineage-assembler, repository, two-schema isolation, stream-consistency, engine-seam) build clean; they run under CI's Postgres jobs (the assembly uses an assembly-wide Postgres Testcontainer fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_