### PR TITLE
feat(39-18): Real-Time Channels — SignalR hubs + channel_outbox + engine publisher

### DIFF
--- a/.dev/decisions/story-39-18-realtime-channels-design.md
+++ b/.dev/decisions/story-39-18-realtime-channels-design.md
@@ -1,0 +1,118 @@
+# Story 39-18 — Real-Time Channels Design Decisions
+
+**Status**: Locked (2026-07-22)
+**Branch**: `claude/wiki-docs-sync-r31nvo`
+**Author**: implementation pass on the impl-plan.
+
+This ADR records the two decisions that could read as contradictory with
+prior choices unless written down: the SSE-vs-SignalR scope split (D1)
+and hosting BOTH hubs in `Tamma.Api` as a trust posture rather than a
+process boundary (D2). It also states the single-instance fan-out stance
+loudly, as the story requires.
+
+---
+
+## 1. SignalR for bidirectional channels; SSE stands for one-way streaming
+
+**Decision**: The two real-time channels use **SignalR (ASP.NET Core
+native)**, not raw WebSocket and not SSE. Server-side SignalR ships in the
+shared framework (`Microsoft.NET.Sdk.Web`) — `AddSignalR()` / `MapHub<T>()`
+need **no new server package**; only the test/client side takes
+`Microsoft.AspNetCore.SignalR.Client`.
+
+**Why this does not contradict CLAUDE.md's "SSE over WebSocket"**: that
+decision governs **one-way event streaming** and **stands unchanged** —
+`AdminTenantEventsSseEndpoint` and `/api/engine/events/state|logs` remain
+SSE. These channels are **bidirectional request/decision conversation**
+(the lifecycle sends an `AcceptanceRequest` and suspends; the orchestrator
+answers with a decision that resumes the gate), which SSE cannot carry.
+Two different problems, two different transports — no contradiction.
+
+**SignalR JSON protocol**: the hub's payload serializer is taught the
+`DocumentJson.Options` converters (the `DocumentState` wire enum + the
+millisecond ISO-8601 timestamp), so a `ChannelEnvelope` round-trips over
+the hub exactly as it does over the engine→API hop. `ChannelAudience` and
+the polymorphic `ChannelMessage` carry their own
+`[JsonConverter]`/`[JsonPolymorphic]` attributes, so they need no options
+help.
+
+## 2. Both hubs hosted in `Tamma.Api`; engine-internal surface honored as a TRUST POSTURE
+
+**Decision**: BOTH hubs live in `Tamma.Api`, as **two SEPARATE hub
+classes** (never one hub with per-method role checks):
+
+- `/hubs/orchestrator` — the workflow↔orchestrator channel. Gated by the
+  new `OrchestratorChannel` policy (authenticated AND (service-principal
+  OR the 39-8 D6 `tamma:principal-type = orchestrator` claim) — the same
+  trust class as `EngineServiceOnly`, i.e. the resume-family posture). A
+  tenant member/admin/owner JWT authenticates but is neither, so it is
+  **rejected** (AC5). This hub MUST be excluded from public API docs and
+  nginx exposure, exactly like the `/api/engine` callbacks.
+- `/hubs/user` — the user↔orchestrator/platform channel. `MemberAccess`;
+  groups (`tenant:{t}`, `user:{t}:{u}`) are derived server-side from the
+  JWT claims. No client method takes a group name, so a forged group-join
+  is structurally impossible (a reflection test pins this).
+
+**The story-vs-repo tension, resolved**: the story's technical note reads
+"the workflow/orchestrator hub sits on the engine-internal surface like
+the `*ResumeEndpoint` family." Taken literally that means hosting the hub
+in `Tamma.ElsaServer`. But the engine references only `Tamma.Activities`
+(no tenant DB, no user auth) and **already crosses to the API for durable
+writes** (`EventPersistenceMiddleware` → `POST /api/engine/events`). An
+engine-hosted hub could not persist or replay the `channel_outbox`.
+Resolution honoring the note's **intent**: workflows still "publish via the
+engine" — 39-6's `PublishAcceptanceRequestActivity` →
+`EngineChannelPublisher` (in `Tamma.Activities`) →
+`POST /api/engine/channel/outbox` (`EngineServiceOnly`) → outbox row +
+hub fan-out. The engine-internal trust posture is preserved via the
+dedicated policy + the separate hub + the nginx exclusion, not via the
+process boundary. If review insists on an engine-hosted hub, only the hub
+host and the transport swap change — the message set, outbox, and user
+hub are unaffected.
+
+## 3. Single-instance fan-out (said loudly)
+
+Fan-out is **in-process, single-instance**, the same as `ILlmRunStreamBus`.
+On a multi-pod deployment an agent connected to pod A misses a publish
+from pod B **at write time** — but the `channel_outbox` is the source of
+truth, so the DB-driven `ChannelOutboxSweeper` re-delivers it eventually,
+and connect-time replay covers reconnects. **The outbox makes
+single-instance safe, just slower on failover.** Cross-process fan-out
+(Redis backplane / Postgres LISTEN-NOTIFY) is the SAME deferred open
+decision as `ILlmRunStreamBus`'s — decided **once, for both** surfaces,
+not here.
+
+## 4. Transport is never the source of truth
+
+Every request/escalation/guidance/task message is persisted to
+`channel_outbox` **before** any hub send; consumers ack (idempotent,
+per-recipient); on reconnect, unacked rows replay in UUID-v7 (time) order.
+A duplicate hub delivery is safe by construction: consumers dedupe on
+message id, ack is idempotent, and a duplicate decision submission hits
+the 39-8 404/409 discipline — no double-resume. **No timeout anywhere
+converts an unanswered request into a decision** (AC7). A dead channel
+degrades to "decision arrives later," never to lost work.
+
+## 5. Access-token-in-query leakage is bounded to `/hubs`
+
+Browser WebSockets cannot set `Authorization`, so the JWT arrives as the
+`?access_token=` query param. The `JwtBearerEvents.OnMessageReceived` read
+of it is **scoped strictly to `/hubs` paths**, so the query token never
+lands on other routes (or their request logs).
+
+## 6. Deferrals recorded (dependency stories not yet landed)
+
+- **39-17 (`PersistedOrchestratorInbox`)** — DEFERRED. It implements 39-17's
+  `IOrchestratorInbox`, which does not exist yet. The `channel_outbox` this
+  story builds is exactly what that future inbox will read; the SignalR hub
+  is the delivery path this story ships.
+- **39-19 (chat)** — chat relay is OFF. `UserChannelHub.SendAgentMessage` /
+  `OrchestratorChannelHub.SendAgentReply` hand off to `IOrchestratorChatRelay`,
+  whose stand-in (`AgentOfflineChatRelay`) refuses with an agent-offline
+  result and records nothing. No `CHAT.*` events here; the outbox refuses a
+  direct conversation-kind enqueue. AC6 over feature completeness.
+- **39-20 (audience resolver)** — STUBBED fail-closed
+  (`InitiatorOnlyTaskAudienceResolver`): only the issue initiator sees
+  anything. 39-20 replaces the implementation behind the canonical
+  `ITaskAudienceResolver` shape; this story's tests run against a capturing
+  fake, so no test churn.

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ChannelEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ChannelEvents.cs
@@ -1,0 +1,34 @@
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-18 (Design Decision D8) — the ONLY DCB event family THIS story emits:
+/// <c>GUIDANCE.*</c>. Every other kind that crosses these channels is evented by its
+/// owning story (<c>APPROVAL.*</c> / <c>ESCALATION.*</c> — 39-8; <c>TASK.*</c> —
+/// 39-20; <c>CHAT.*</c> — 39-19), so the channels never invent a parallel audit
+/// trail (AC6). Type pattern follows <c>AGGREGATE.ACTION.STATUS</c> (mirrors
+/// <see cref="ApprovalEvents"/>'s <c>APPROVAL.*</c> naming).
+///
+/// <para>Emitted fail-loud by <c>ChannelOutboxService</c> via
+/// <c>IEventRepository.AppendAsync</c> when a guidance message is enqueued — the
+/// event IS part of the operation (the 39-8 disposition posture), not a best-effort
+/// side-car.</para>
+/// </summary>
+public static class ChannelEvents
+{
+    /// <summary>A guidance question was enqueued to the orchestrator. Informational (started) row.</summary>
+    public const string GuidanceRequested = "GUIDANCE.REQUESTED";
+
+    /// <summary>A guidance reply was provided. Normal (success) row.</summary>
+    public const string GuidanceProvided = "GUIDANCE.PROVIDED";
+
+    /// <summary>
+    /// Status convention: <c>GUIDANCE.REQUESTED</c> is an informational (started)
+    /// row; <c>GUIDANCE.PROVIDED</c> is a normal (success) row. Mirrors
+    /// <see cref="ApprovalEvents.StatusForEvent"/> / 39-6's <c>DocumentEvents</c>.
+    /// </summary>
+    public static string StatusForEvent(string type) => type switch
+    {
+        GuidanceRequested => "started",
+        _ => "success",
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EngineChannelPublisher.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EngineChannelPublisher.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-18 (D2, D8) — the engine→API channel publish hop. Implements 39-6's
+/// <see cref="IAcceptanceRequestPublisher"/> seam (REPLACING
+/// <see cref="LoggingAcceptanceRequestPublisher"/>) and the broader
+/// <see cref="IEngineChannelPublisher"/>: it wraps a message in a
+/// <see cref="ChannelEnvelope"/> and POSTs it to
+/// <c>POST /api/engine/channel/outbox</c> (<c>EngineServiceOnly</c>), where the API
+/// mints the durable outbox row(s) and best-effort fans out to the SignalR hub.
+///
+/// <para><b>Captive-dependency guard.</b> <see cref="TammaApiClient"/> is a typed
+/// HTTP transient — captured in a singleton it is unsafe. This publisher resolves the
+/// client per-call via <see cref="IServiceScopeFactory"/>, mirroring
+/// <see cref="Tamma.Activities.TenantLifecycle.EngineApiPlatformEventPublisher"/>.</para>
+///
+/// <para><b>Degraded, never throws into the workflow.</b> A transport failure is
+/// logged at ERROR and swallowed — the 39-8 gate still suspends (39-6 D6's contract),
+/// and because the outbox row is the API's to mint, an unreachable API leaves the
+/// request recoverable via the suspended bookmark + a re-publish admin action, never
+/// lost work.</para>
+/// </summary>
+public sealed class EngineChannelPublisher : IAcceptanceRequestPublisher, IEngineChannelPublisher
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<EngineChannelPublisher> _logger;
+
+    public EngineChannelPublisher(
+        IServiceScopeFactory scopeFactory,
+        ILogger<EngineChannelPublisher> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <inheritdoc/>
+    public Task PublishAsync(AcceptanceRequest request, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // The 39-5 AcceptanceRequest carries no tenant field, so the envelope's
+        // TenantId is left empty here; the engine→API hop relies on the API to
+        // scope the write (the EngineServiceOnly endpoint trusts the envelope /
+        // X-Tenant-Id — the AppendPlatformEvents precedent). Threading the tenant
+        // through 39-6's fixed publisher signature is a documented follow-up.
+        var envelope = new ChannelEnvelope(
+            MessageId: UuidV7.NewGuid(),
+            TenantId: Guid.Empty,
+            Audience: ChannelAudience.Orchestrator,
+            RecipientUserId: null,
+            Message: new AcceptanceRequested(request),
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        return PublishAsync(envelope, ct);
+    }
+
+    /// <inheritdoc/>
+    public async Task PublishAsync(ChannelEnvelope envelope, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        try
+        {
+            var envelopeJson = JsonSerializer.Serialize(envelope, DocumentJson.Options);
+            var tenantId = envelope.TenantId == Guid.Empty ? null : envelope.TenantId.ToString();
+
+            using var scope = _scopeFactory.CreateScope();
+            var api = scope.ServiceProvider.GetRequiredService<TammaApiClient>();
+
+            var ok = await api.PostChannelOutboxAsync(envelopeJson, tenantId, ct).ConfigureAwait(false);
+            if (!ok)
+            {
+                _logger.LogError(
+                    "channel_outbox.post_failed kind={Kind} audience={Audience} tenantId={TenantId} — " +
+                    "the gate still suspends; the request is recoverable via the suspended bookmark.",
+                    ChannelMessageKinds.KindOf(envelope.Message), envelope.Audience.ToWire(), envelope.TenantId);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Transport / serialization error — NEVER throw into the workflow.
+            _logger.LogError(
+                ex,
+                "channel_outbox.publish_error audience={Audience} tenantId={TenantId}",
+                envelope.Audience.ToWire(), envelope.TenantId);
+        }
+    }
+}
+
+/// <summary>
+/// Story 39-18 — the engine-side seam for publishing any <see cref="ChannelEnvelope"/>
+/// to the channel outbox (beyond 39-6's acceptance-request-only
+/// <see cref="IAcceptanceRequestPublisher"/>). Implemented by
+/// <see cref="EngineChannelPublisher"/>.
+/// </summary>
+public interface IEngineChannelPublisher
+{
+    /// <summary>Publish a channel envelope to the outbox via the engine→API hop.</summary>
+    Task PublishAsync(ChannelEnvelope envelope, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/TammaApiClient.cs
@@ -646,6 +646,53 @@ public class TammaApiClient
         }
     }
 
+    // ----- Channel outbox enqueue (Story 39-18, D2) --------------------
+
+    /// <summary>
+    /// Story 39-18 — enqueue a channel message to the tenant's <c>channel_outbox</c>
+    /// via <c>POST /api/engine/channel/outbox</c> (<c>EngineServiceOnly</c>). The
+    /// <paramref name="envelopeJson"/> is the <c>ChannelEnvelope</c> serialized with
+    /// <c>DocumentJson.Options</c> (the server deserializes it with the same options,
+    /// mints the outbox row(s), and best-effort publishes to the hub group).
+    ///
+    /// <para>Best-effort like <see cref="AppendEventsAsync"/>: a non-2xx or transport
+    /// failure returns <c>false</c> (the 39-6 gate still suspends; the request is
+    /// recoverable via the suspended bookmark). It never throws — the caller
+    /// (<c>EngineChannelPublisher</c>) logs ERROR and continues.</para>
+    /// </summary>
+    public virtual async Task<bool> PostChannelOutboxAsync(
+        string envelopeJson, string? tenantId = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(envelopeJson)) return true; // nothing to enqueue.
+
+        var url = $"{_baseUrl}/api/engine/channel/outbox";
+        var body = new { envelopeJson };
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = JsonContent.Create(body, options: JsonOpts),
+            };
+            AddTenantHeader(request, tenantId);
+            using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
+            await RecordHealthAsync(
+                response.IsSuccessStatusCode, (int)response.StatusCode, null, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Tamma API POST /api/engine/channel/outbox returned {Status}", (int)response.StatusCode);
+                return false;
+            }
+            return true;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Tamma API POST /api/engine/channel/outbox failed");
+            await RecordHealthAsync(false, null, ex.GetType().Name, ct).ConfigureAwait(false);
+            return false;
+        }
+    }
+
     // ----- Platform event append ----------------------------------------
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Auth/OrchestratorChannelHandler.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Auth/OrchestratorChannelHandler.cs
@@ -1,0 +1,54 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Tamma.Api.Endpoints;
+
+namespace Tamma.Api.Auth;
+
+/// <summary>
+/// Story 39-18 (D10) — the requirement gating the workflow↔orchestrator hub
+/// (<c>/hubs/orchestrator</c>). Authenticated AND (a service principal OR the 39-8 D6
+/// orchestrator claim). A tenant member/admin/owner JWT — which authenticates but is
+/// neither — FAILS it (AC5's "reject non-orchestrator principals"). Until 39-17 mints
+/// the orchestrator claim, tests mint it directly (the 39-8 pattern).
+/// </summary>
+public class OrchestratorChannelRequirement : IAuthorizationRequirement;
+
+/// <summary>
+/// Authorization handler for <see cref="OrchestratorChannelRequirement"/>. Succeeds
+/// for the same trust class as <c>EngineServiceOnly</c> (a resolved
+/// <see cref="ServiceAuthPrincipal"/> or the platform <c>"*"</c> permission claim) OR
+/// a principal carrying <c>tamma:principal-type = orchestrator</c>.
+/// </summary>
+public class OrchestratorChannelHandler(IHttpContextAccessor httpContextAccessor)
+    : AuthorizationHandler<OrchestratorChannelRequirement>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context,
+        OrchestratorChannelRequirement requirement)
+    {
+        // The orchestrator agent claim (39-8 D6) — the primary signal for the 39-17
+        // resident agent + the hub tests.
+        var principalType = context.User.FindFirst(ApprovalChannels.PrincipalTypeClaim)?.Value;
+        if (string.Equals(principalType, ApprovalChannels.OrchestratorPrincipalType, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        // Service-principal trust class (mirrors ServicePrincipalHandler): a resolved
+        // ServiceAuthPrincipal or the platform-wide "*" permission claim.
+        if (httpContextAccessor.HttpContext?.GetAuthPrincipal() is ServiceAuthPrincipal)
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        var permClaims = context.User.FindAll("permission").Select(c => c.Value);
+        if (permClaims.Contains("*"))
+        {
+            context.Succeed(requirement);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/ChannelEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/ChannelEndpoints.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Tamma.Api.Services.Channels;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data;
+
+namespace Tamma.Api.Endpoints;
+
+/// <summary>
+/// Story 39-18 (D2) — the engine→API channel enqueue seam. The lifecycle engine
+/// (<c>Tamma.ElsaServer</c>) registers no outbox repository, so it publishes channel
+/// messages through this fail-loud HTTP hop (mirrors <c>POST /api/engine/events</c>).
+/// Gated <c>EngineServiceOnly</c> (service principal) — a user JWT never reaches it,
+/// closing the forgery vector, exactly like the events/documents engine callbacks.
+/// </summary>
+public static class ChannelEndpoints
+{
+    /// <summary>The engine POST body: the <c>ChannelEnvelope</c> serialized with <c>DocumentJson.Options</c>.</summary>
+    public sealed record EnqueueRequest([property: JsonPropertyName("envelopeJson")] string EnvelopeJson);
+
+    // ================================================================
+    // POST /api/engine/channel/outbox   (EngineServiceOnly)
+    // ================================================================
+
+    public static async Task<IResult> EnqueueFromEngine(
+        [FromBody] EnqueueRequest req,
+        [FromServices] ChannelOutboxService service,
+        [FromServices] ITenantContext tenantContext,
+        [FromServices] ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger("Tamma.Api.ChannelEndpoints");
+
+        if (req is null || string.IsNullOrWhiteSpace(req.EnvelopeJson))
+            return Results.BadRequest(new { error = "envelopeJson is required" });
+
+        ChannelEnvelope? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<ChannelEnvelope>(req.EnvelopeJson, DocumentJson.Options);
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "channel enqueue: envelopeJson failed to deserialize");
+            return Results.BadRequest(new { error = "envelopeJson is not a valid ChannelEnvelope" });
+        }
+        if (envelope is null)
+            return Results.BadRequest(new { error = "envelopeJson deserialized to null" });
+
+        // Server-derives the authoritative tenant. This is EngineServiceOnly (a trusted
+        // service principal), so — like AppendPlatformEvents — the envelope's TenantId
+        // is trusted for the body-carried cross-tenant path; a present X-Tenant-Id
+        // (ITenantContext) wins when set.
+        var tenantId = tenantContext.TenantId is { } ambient && ambient != Guid.Empty
+            ? ambient
+            : envelope.TenantId;
+        if (tenantId == Guid.Empty)
+            return Results.BadRequest(new { error = "no tenant could be resolved for the channel message" });
+
+        var scoped = envelope with { TenantId = tenantId };
+
+        try
+        {
+            var rows = await service.EnqueueAsync(scoped);
+            return Results.Json(
+                new { ok = true, enqueued = rows.Count },
+                statusCode: StatusCodes.Status202Accepted);
+        }
+        catch (TammaError ex) when (ex.Code == "CHANNEL.MESSAGE.INVALID")
+        {
+            logger.LogWarning("channel enqueue rejected: {Message}", ex.Message);
+            return Results.BadRequest(new { error = "channel_message_invalid", detail = ex.Message });
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentDecisionEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentDecisionEndpoints.cs
@@ -26,17 +26,6 @@ namespace Tamma.Api.Endpoints;
 /// </summary>
 public static class DocumentDecisionEndpoints
 {
-    /// <summary>The decision kinds the gate accepts (the closed 39-5 discriminator set). Anything
-    /// else is 400'd up front so the caller never forwards a kind that would silently route the
-    /// gate — the <c>AllowedDesignDecisions</c> posture.</summary>
-    private static readonly HashSet<string> AllowedDecisionKinds =
-        new(StringComparer.OrdinalIgnoreCase) { "accept", "request-revision", "reject", "escalate" };
-
-    private static readonly JsonSerializerOptions DecisionJsonOptions = new()
-    {
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
-
     /// <summary>
     /// Public decision request. The decider + channel are intentionally ABSENT — they are
     /// derived from the authenticated principal (D6/D7), never trusted from the client.
@@ -69,27 +58,23 @@ public static class DocumentDecisionEndpoints
 
         if (sessionId == Guid.Empty)
             return Results.BadRequest(new { error = "sessionId is required" });
-        if (string.IsNullOrWhiteSpace(req.Kind) || !AllowedDecisionKinds.Contains(req.Kind.Trim()))
+        if (!DocumentDecisionSubmissionService.IsAllowedKind(req.Kind))
             return Results.BadRequest(new { error = "kind must be one of: accept, request-revision, reject, escalate" });
-
-        // Build the 39-5 AcceptanceDecision server-side from the validated kind.
-        var decision = BuildDecision(req);
-        var decisionJson = JsonSerializer.Serialize(decision, DecisionJsonOptions);
 
         // SECURITY (IDOR) — scope the resume to the caller's ambient tenant; the engine folds it
         // into the bookmark name so a caller can only resolve a gate in its OWN tenant.
-        var tenantId = tenantContext.TenantId?.ToString();
+        var tenantId = tenantContext.TenantId;
 
         // D7 — decider derived server-side (non-repudiation). D6 — channel derived from the
-        // authenticated principal, NEVER read from the body.
+        // authenticated principal, NEVER read from the body. Both the build + the resume live in
+        // the shared DocumentDecisionSubmissionService so the hub (39-18) drives the SAME path.
         var deciderId = ResolveApprover(principal);
         var channel = ApprovalChannels.Derive(principal);
+        var submission = new DocumentDecisionSubmissionService(elsa);
 
         try
         {
-            var result = await elsa.ResumeDocumentDecisionAsync(
-                sessionId, tenantId, decisionJson, req.Feedback,
-                deciderId, deciderId, channel.ToWire(), rulesReference: null);
+            var result = await submission.SubmitAsync(sessionId, req, tenantId, deciderId, channel);
 
             if (result.GateNotFound)
             {
@@ -186,34 +171,6 @@ public static class DocumentDecisionEndpoints
     // ================================================================
     // Server-side derivations (copied from AdlEndpoints — I2)
     // ================================================================
-
-    /// <summary>
-    /// Build the 39-5 <see cref="AcceptanceDecision"/> from the validated public request. A
-    /// human REJECT passes through (it clamps to Escalate only on the orchestrator channel, which
-    /// 39-6's guardrail applies); an escalate reason wire is parsed, defaulting to
-    /// <c>AcceptorJudgment</c> when a human simply chose to escalate.
-    /// </summary>
-    internal static AcceptanceDecision BuildDecision(DecisionRequest req) =>
-        req.Kind.Trim().ToLowerInvariant() switch
-        {
-            "accept" => new AcceptanceDecision.Accept(),
-            "request-revision" => new AcceptanceDecision.RequestRevision(req.Notes ?? req.Feedback ?? string.Empty),
-            "reject" => new AcceptanceDecision.Reject(req.Reason ?? req.Feedback ?? string.Empty),
-            _ => new AcceptanceDecision.Escalate(
-                ParseEscalationReason(req.Reason),
-                req.Detail ?? req.Feedback ?? req.Reason ?? string.Empty),
-        };
-
-    private static AcceptanceEscalationReason ParseEscalationReason(string? wire)
-    {
-        if (!string.IsNullOrWhiteSpace(wire))
-        {
-            foreach (var reason in Enum.GetValues<AcceptanceEscalationReason>())
-                if (string.Equals(reason.ToWire(), wire, StringComparison.OrdinalIgnoreCase))
-                    return reason;
-        }
-        return AcceptanceEscalationReason.AcceptorJudgment;
-    }
 
     /// <summary>
     /// Derive the decider identity from the authenticated principal (I2):

--- a/apps/tamma-elsa/src/Tamma.Api/Hubs/IOrchestratorChannelClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Hubs/IOrchestratorChannelClient.cs
@@ -1,0 +1,16 @@
+using Tamma.Core.Documents.Channels;
+
+namespace Tamma.Api.Hubs;
+
+/// <summary>
+/// Story 39-18 (D5) — the typed server→client contract for the workflow↔orchestrator
+/// hub. One method: <see cref="Receive"/> — the <c>kind</c> discriminator on the
+/// envelope's message tells the orchestrator agent what arrived (acceptance request,
+/// escalation, guidance query). There is deliberately NO client method that takes a
+/// group name (forged group-join is structurally impossible).
+/// </summary>
+public interface IOrchestratorChannelClient
+{
+    /// <summary>Deliver a channel envelope to the connected orchestrator agent.</summary>
+    Task Receive(ChannelEnvelope envelope);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Hubs/IUserChannelClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Hubs/IUserChannelClient.cs
@@ -1,0 +1,16 @@
+using Tamma.Core.Documents.Channels;
+
+namespace Tamma.Api.Hubs;
+
+/// <summary>
+/// Story 39-18 (D5) — the typed server→client contract for the user↔orchestrator
+/// hub. One method: <see cref="Receive"/> carries Task View traffic
+/// (<c>task-assigned</c>) and chat relay (<c>agent-conversation</c>); the <c>kind</c>
+/// discriminates. No client method takes a group name — per-user isolation is derived
+/// server-side from the principal.
+/// </summary>
+public interface IUserChannelClient
+{
+    /// <summary>Deliver a channel envelope to a connected dashboard user.</summary>
+    Task Receive(ChannelEnvelope envelope);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Hubs/OrchestratorChannelHub.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Hubs/OrchestratorChannelHub.cs
@@ -1,0 +1,233 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Tamma.Api.Auth;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Services.Channels;
+using Tamma.Api.Services.Documents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Hubs;
+
+/// <summary>
+/// Story 39-18 (D2/D5/D7) — the workflow↔orchestrator SignalR hub. Engine/agent
+/// traffic only: gated by the <c>OrchestratorChannel</c> policy (service-principal OR
+/// orchestrator-claim; a tenant member/admin/owner JWT fails it). Groups are derived
+/// from the connection's claims ONLY — no client method takes a group name, so a
+/// forged group-join is structurally impossible (D5).
+///
+/// <para>Decision methods DELEGATE to the 39-8 idempotent resume surface via the
+/// shared <see cref="DocumentDecisionSubmissionService"/> — the hub NEVER applies a
+/// decision or mutates outbox/decision state itself (D7). The 404/409 gate-not-waiting
+/// result is returned to the caller so the agent observes idempotency outcomes.</para>
+/// </summary>
+[Authorize("OrchestratorChannel")]
+public sealed class OrchestratorChannelHub : Hub<IOrchestratorChannelClient>
+{
+    // Connect-time replay is bounded — an orchestrator that has been offline a long
+    // time drains its backlog across reconnects rather than in one unbounded read.
+    private const int ReplayLimit = 500;
+
+    private readonly IChannelOutboxRepository _outbox;
+    private readonly DocumentDecisionSubmissionService _decisions;
+    private readonly EscalationDispositionService _escalations;
+    private readonly ChannelOutboxService _channels;
+    private readonly IOrchestratorChatRelay _chat;
+    private readonly ILogger<OrchestratorChannelHub> _logger;
+
+    public OrchestratorChannelHub(
+        IChannelOutboxRepository outbox,
+        DocumentDecisionSubmissionService decisions,
+        EscalationDispositionService escalations,
+        ChannelOutboxService channels,
+        IOrchestratorChatRelay chat,
+        ILogger<OrchestratorChannelHub> logger)
+    {
+        _outbox = outbox;
+        _decisions = decisions;
+        _escalations = escalations;
+        _channels = channels;
+        _chat = chat;
+        _logger = logger;
+    }
+
+    /// <summary>The orchestrator group for a tenant. Derived server-side, never from a client.</summary>
+    public static string GroupFor(Guid tenantId) => $"orchestrator:{tenantId}";
+
+    public override async Task OnConnectedAsync()
+    {
+        var tenantId = ResolveTenantId();
+        if (tenantId == Guid.Empty)
+        {
+            // The policy admitted the principal but no tenant could be derived — abort
+            // rather than joining a wildcard group.
+            _logger.LogWarning("OrchestratorChannelHub connect with no derivable tenant id; aborting.");
+            Context.Abort();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, GroupFor(tenantId));
+        await ReplayUnackedAsync(tenantId);
+        await base.OnConnectedAsync();
+    }
+
+    /// <summary>Idempotently ack a delivered orchestrator-audience row.</summary>
+    public async Task<AckResult> Ack(Guid messageId)
+    {
+        var tenantId = ResolveTenantId();
+        if (tenantId == Guid.Empty) return new AckResult(false);
+        var acked = await _outbox.AckAsync(tenantId, messageId, recipientUserId: null);
+        return new AckResult(acked);
+    }
+
+    /// <summary>
+    /// Submit a 39-5 decision JSON for the suspended gate on <paramref name="sessionId"/>.
+    /// Delegates to the shared resume service with the server-derived orchestrator
+    /// channel (D7). The hub applies nothing itself; the 404/409 result is returned.
+    /// </summary>
+    public Task<DecisionSubmitResult> SubmitDecision(Guid sessionId, string decisionJson, string? feedback)
+    {
+        var tenantId = NullableTenant();
+        var deciderId = ResolveDecider();
+        // Channel is server-derived from the connection principal (→ orchestrator).
+        var channel = ApprovalChannels.Derive(Context.User ?? new ClaimsPrincipal());
+        var kind = ParseDecisionKind(decisionJson);
+        return _decisions.ResumeAsync(sessionId, decisionJson, feedback, tenantId, deciderId, channel, kind);
+    }
+
+    /// <summary>Disposition an escalation. Delegates to 39-8's <see cref="EscalationDispositionService"/>.</summary>
+    public async Task<EscalationDispositionSubmitResult> SubmitEscalationDisposition(
+        string escalationId, string disposition, string? note)
+    {
+        var tenantId = NullableTenant();
+        var deciderId = ResolveDecider();
+        var channel = ApprovalChannels.Derive(Context.User ?? new ClaimsPrincipal());
+
+        Tamma.Core.Documents.EscalationDisposition parsed;
+        try
+        {
+            parsed = EscalationDispositionExtensions.Parse(disposition);
+        }
+        catch (TammaError)
+        {
+            return new EscalationDispositionSubmitResult(false, NotFound: false, AlreadyResolved: false, Invalid: true, 0);
+        }
+
+        var result = await _escalations.DispositionAsync(tenantId, escalationId, parsed, note, deciderId, channel);
+        return result.Outcome switch
+        {
+            EscalationDispositionOutcome.NotFound => new EscalationDispositionSubmitResult(false, true, false, false, 0),
+            EscalationDispositionOutcome.AlreadyResolved => new EscalationDispositionSubmitResult(false, false, true, false, 0),
+            _ => new EscalationDispositionSubmitResult(true, false, false, false, result.DurationMs),
+        };
+    }
+
+    /// <summary>
+    /// Answer a guidance query. Enqueues the reply outbox row + <c>GUIDANCE.PROVIDED</c>
+    /// event (via <see cref="ChannelOutboxService"/>) and publishes back to the
+    /// requesting workflow's watchers.
+    /// </summary>
+    public async Task SubmitGuidanceReply(Guid queryId, string reply)
+    {
+        var tenantId = ResolveTenantId();
+        if (tenantId == Guid.Empty) return;
+
+        var envelope = new ChannelEnvelope(
+            MessageId: UuidV7.NewGuid(),
+            TenantId: tenantId,
+            Audience: ChannelAudience.Orchestrator,
+            RecipientUserId: null,
+            Message: new GuidanceReply(queryId, reply),
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        await _channels.EnqueueAsync(envelope, Context.ConnectionAborted);
+    }
+
+    /// <summary>
+    /// The agent→user chat leg. Hands off to 39-19's chat service (records SENT, then
+    /// relays). Until 39-19 lands the stand-in refuses with an agent-offline result.
+    /// </summary>
+    public async Task<ChatRelayResult> SendAgentReply(AgentConversationMessage message)
+    {
+        var tenantId = ResolveTenantId();
+        if (tenantId == Guid.Empty) return ChatRelayResult.Offline;
+        return await _chat.RelayAgentReplyAsync(tenantId, message, Context.ConnectionAborted);
+    }
+
+    // ── internals ─────────────────────────────────────────────────────────
+
+    private async Task ReplayUnackedAsync(Guid tenantId)
+    {
+        var rows = await _outbox.ListUnackedAsync(tenantId, ChannelAudience.Orchestrator.ToWire(), recipientUserId: null, ReplayLimit);
+        foreach (var row in rows)
+        {
+            ChannelEnvelope? envelope;
+            try
+            {
+                envelope = JsonSerializer.Deserialize<ChannelEnvelope>(row.PayloadJson, DocumentJson.Options);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "channel_outbox replay: row {MessageId} has an undeserializable payload; skipping.", row.Id);
+                continue;
+            }
+            if (envelope is null) continue;
+
+            await Clients.Caller.Receive(envelope);
+            await _outbox.MarkDeliveredAsync(tenantId, row.Id);
+        }
+    }
+
+    private Guid ResolveTenantId()
+    {
+        var claim = Context.User?.FindFirst("tenantId")?.Value;
+        if (Guid.TryParse(claim, out var fromClaim) && fromClaim != Guid.Empty)
+            return fromClaim;
+
+        // Pure service-principal fallback (no tenantId claim): a required `tenant`
+        // query-string value. Orchestrator-claim principals carry their tenant in the
+        // claim set (the 39-17 contract), so this only serves the service path.
+        var http = Context.GetHttpContext();
+        var query = http?.Request.Query["tenant"].ToString();
+        return Guid.TryParse(query, out var fromQuery) ? fromQuery : Guid.Empty;
+    }
+
+    private Guid? NullableTenant()
+    {
+        var tenantId = ResolveTenantId();
+        return tenantId == Guid.Empty ? null : tenantId;
+    }
+
+    private string ResolveDecider() =>
+        Context.User?.FindFirst("email")?.Value
+        ?? Context.User?.FindFirst(ClaimTypes.Email)?.Value
+        ?? Context.User?.FindFirst("name")?.Value
+        ?? Context.UserIdentifier
+        ?? "orchestrator";
+
+    private static string ParseDecisionKind(string decisionJson)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(decisionJson);
+            return doc.RootElement.TryGetProperty("kind", out var k) && k.ValueKind == JsonValueKind.String
+                ? k.GetString() ?? "unknown"
+                : "unknown";
+        }
+        catch (JsonException)
+        {
+            return "unknown";
+        }
+    }
+}
+
+/// <summary>Idempotent ack outcome — <c>Acked=true</c> only when THIS call transitioned the row.</summary>
+public sealed record AckResult(bool Acked);
+
+/// <summary>Escalation disposition outcome surfaced to the hub caller (maps to 200/400/404/409).</summary>
+public sealed record EscalationDispositionSubmitResult(
+    bool Resolved, bool NotFound, bool AlreadyResolved, bool Invalid, long DurationMs);

--- a/apps/tamma-elsa/src/Tamma.Api/Hubs/UserChannelHub.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Hubs/UserChannelHub.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Tamma.Api.Auth;
+using Tamma.Api.Services.Channels;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Hubs;
+
+/// <summary>
+/// Story 39-18 (D5/D9) — the user↔orchestrator/platform SignalR hub. Dashboard users
+/// only: gated by <c>MemberAccess</c> (any authenticated tenant member). Groups —
+/// <c>tenant:{t}</c> and <c>user:{t}:{u}</c> — are computed from the JWT claims in
+/// <see cref="OnConnectedAsync"/>; NO client method takes a group name, so a client
+/// can never subscribe itself into another tenant's or user's traffic (forged join is
+/// structurally impossible).
+///
+/// <para>There is deliberately NO task-action method (D7): acting on a task travels
+/// today's REST resume endpoints, not the hub. The only client→server method is the
+/// user→agent chat leg, which stamps the user id from the claims (never the payload)
+/// and hands off to 39-19's chat service (agent-offline stand-in until it lands).</para>
+/// </summary>
+[Authorize("MemberAccess")]
+public sealed class UserChannelHub : Hub<IUserChannelClient>
+{
+    private const int ReplayLimit = 500;
+
+    private readonly IChannelOutboxRepository _outbox;
+    private readonly IOrchestratorChatRelay _chat;
+    private readonly ILogger<UserChannelHub> _logger;
+
+    public UserChannelHub(
+        IChannelOutboxRepository outbox,
+        IOrchestratorChatRelay chat,
+        ILogger<UserChannelHub> logger)
+    {
+        _outbox = outbox;
+        _chat = chat;
+        _logger = logger;
+    }
+
+    /// <summary>The tenant-wide group for a tenant.</summary>
+    public static string TenantGroupFor(Guid tenantId) => $"tenant:{tenantId}";
+
+    /// <summary>The per-user group — the grain task/chat traffic targets.</summary>
+    public static string UserGroupFor(Guid tenantId, Guid userId) => $"user:{tenantId}:{userId}";
+
+    public override async Task OnConnectedAsync()
+    {
+        var (tenantId, userId) = ResolvePrincipal();
+        if (tenantId == Guid.Empty || userId == Guid.Empty)
+        {
+            _logger.LogWarning("UserChannelHub connect with no derivable tenant/user id; aborting.");
+            Context.Abort();
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, TenantGroupFor(tenantId));
+        await Groups.AddToGroupAsync(Context.ConnectionId, UserGroupFor(tenantId, userId));
+        await ReplayUnackedAsync(tenantId, userId);
+        await base.OnConnectedAsync();
+    }
+
+    /// <summary>Idempotently ack a delivered row addressed to THIS user (per-user ack).</summary>
+    public async Task<AckResult> Ack(Guid messageId)
+    {
+        var (tenantId, userId) = ResolvePrincipal();
+        if (tenantId == Guid.Empty || userId == Guid.Empty) return new AckResult(false);
+        var acked = await _outbox.AckAsync(tenantId, messageId, userId);
+        return new AckResult(acked);
+    }
+
+    /// <summary>
+    /// The user→agent chat leg. Stamps <see cref="AgentConversationMessage.UserId"/>
+    /// from the connection claims (NEVER trusts the payload), then hands to 39-19's
+    /// chat service (records RECEIVED + enqueues toward the orchestrator). Until 39-19
+    /// lands the stand-in refuses with an agent-offline result.
+    /// </summary>
+    public async Task<ChatRelayResult> SendAgentMessage(AgentConversationMessage message)
+    {
+        var (tenantId, userId) = ResolvePrincipal();
+        if (tenantId == Guid.Empty || userId == Guid.Empty) return ChatRelayResult.Offline;
+
+        // Server-stamp the user id + direction — the payload's own fields are ignored.
+        var stamped = message with { UserId = userId, Direction = "user->agent" };
+        return await _chat.RelayUserMessageAsync(tenantId, userId, stamped, Context.ConnectionAborted);
+    }
+
+    // ── internals ─────────────────────────────────────────────────────────
+
+    private async Task ReplayUnackedAsync(Guid tenantId, Guid userId)
+    {
+        var rows = await _outbox.ListUnackedAsync(tenantId, ChannelAudience.User.ToWire(), userId, ReplayLimit);
+        foreach (var row in rows)
+        {
+            ChannelEnvelope? envelope;
+            try
+            {
+                envelope = JsonSerializer.Deserialize<ChannelEnvelope>(row.PayloadJson, DocumentJson.Options);
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "channel_outbox replay: row {MessageId} has an undeserializable payload; skipping.", row.Id);
+                continue;
+            }
+            if (envelope is null) continue;
+
+            await Clients.Caller.Receive(envelope);
+            await _outbox.MarkDeliveredAsync(tenantId, row.Id);
+        }
+    }
+
+    private (Guid TenantId, Guid UserId) ResolvePrincipal()
+    {
+        var user = Context.User;
+        var tenantRaw = user?.FindFirst("tenantId")?.Value;
+        var userId = user?.GetUserId() ?? Guid.Empty;
+        var tenantId = Guid.TryParse(tenantRaw, out var t) ? t : Guid.Empty;
+        return (tenantId, userId);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Middleware/TenantContextMiddleware.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Middleware/TenantContextMiddleware.cs
@@ -97,6 +97,13 @@ public class TenantContextMiddleware(RequestDelegate next)
         "/api/convention-templates",
         "/health",
         "/swagger",
+        // Story 39-18 — the real-time channel hubs. A hub connection self-scopes:
+        // OnConnectedAsync derives the tenant (and, on the user hub, the user) from
+        // the authenticated principal's claims and joins the corresponding group.
+        // The SignalR negotiate/connect requests must therefore bypass DB-backed
+        // tenant resolution (which would 404 `tenant_not_found` before the hub ever
+        // runs) — the same self-scoping posture as the engine callbacks.
+        "/hubs",
     };
 
     public async Task InvokeAsync(

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -411,6 +411,36 @@ builder.Services.AddScoped<Tamma.Core.Documents.Policy.IAcceptanceRulesResolver>
 builder.Services.AddScoped<Tamma.Api.Services.AcceptanceRules.GetAcceptanceRulesToolFactory>();
 // Story 39-8 — the escalation disposition surface (appends ESCALATION.RESOLVED, FAIL-LOUD).
 builder.Services.AddScoped<Tamma.Api.Services.Documents.EscalationDispositionService>();
+// Story 39-8 / 39-18 (D7) — the shared document-decision submission path. BOTH the
+// REST endpoint and the orchestrator hub drive the SAME 39-8 idempotent resume
+// surface through this service (the hub never applies a decision itself).
+builder.Services.AddScoped<Tamma.Api.Services.Documents.DocumentDecisionSubmissionService>();
+
+// ── Story 39-18: Real-time channels (SignalR hubs + outbox) ──
+// D1 — SignalR ships in the shared framework (no new server package). Its JSON
+// protocol is taught the DocumentJson converters (DocumentState wire enum +
+// millisecond timestamps) so ChannelEnvelope payloads round-trip exactly like the
+// engine→API hop; ChannelAudience / the polymorphic ChannelMessage carry their own
+// [JsonConverter]/[JsonPolymorphic] attributes.
+builder.Services.AddSignalR().AddJsonProtocol(o =>
+{
+    foreach (var converter in Tamma.Core.Documents.DocumentJson.Options.Converters)
+        o.PayloadSerializerOptions.Converters.Add(converter);
+});
+// The per-tenant channel outbox (source of truth; transport is not — AC6).
+builder.Services.AddScoped<Tamma.Data.Repositories.IChannelOutboxRepository,
+    Tamma.Data.Repositories.ChannelOutboxRepository>();
+builder.Services.AddScoped<Tamma.Api.Services.Channels.ChannelOutboxService>();
+// D9 — 39-20's audience resolver, STUBBED fail-closed (initiator-only) until it lands.
+builder.Services.AddScoped<Tamma.Api.Services.Access.ITaskAudienceResolver,
+    Tamma.Api.Services.Access.InitiatorOnlyTaskAudienceResolver>();
+// D8 — chat relay is OFF until 39-19's OrchestratorChatService lands: the stand-in
+// refuses every message with an agent-offline result and records nothing.
+builder.Services.AddScoped<Tamma.Api.Services.Channels.IOrchestratorChatRelay,
+    Tamma.Api.Services.Channels.AgentOfflineChatRelay>();
+// D6 — the slow sweeper re-publishes stale unacked rows (crash / missed-reconnect).
+builder.Services.AddSingleton<Tamma.Api.Services.Channels.ChannelOutboxSweeperOptions>();
+builder.Services.AddHostedService<Tamma.Api.Services.Channels.ChannelOutboxSweeper>();
 builder.Services.AddProviderHealthServices();
 builder.Services.AddDiagnosticsServices();
 builder.Services.AddSanitizationServices();
@@ -1430,6 +1460,20 @@ if (!string.IsNullOrEmpty(jwtSecret))
         {
             OnMessageReceived = ctx =>
             {
+                // Story 39-18 (D10) — browser WebSockets cannot set Authorization, so
+                // SignalR sends the JWT as the `access_token` query param. Accept it
+                // ONLY under /hubs paths (the standard ASP.NET pattern, scoped so the
+                // query token never leaks onto other routes / their logs).
+                if (string.IsNullOrEmpty(ctx.Token) &&
+                    ctx.HttpContext.Request.Path.StartsWithSegments("/hubs"))
+                {
+                    var queryToken = ctx.Request.Query["access_token"].ToString();
+                    if (!string.IsNullOrEmpty(queryToken))
+                    {
+                        ctx.Token = queryToken;
+                    }
+                }
+
                 if (string.IsNullOrEmpty(ctx.Token) &&
                     ctx.Request.Cookies.TryGetValue("tamma_session", out var cookieJwt) &&
                     !string.IsNullOrEmpty(cookieJwt))
@@ -1449,6 +1493,9 @@ if (!string.IsNullOrEmpty(jwtSecret))
     // I4 / Story 32-5 Finding C2 — handler for the EngineServiceOnly policy
     // (service-principal-only: engine→API callbacks + POST /api/v1/llm/call).
     builder.Services.AddScoped<IAuthorizationHandler, ServicePrincipalHandler>();
+    // Story 39-18 (D10) — handler for the OrchestratorChannel policy (the
+    // workflow↔orchestrator hub: service-principal OR orchestrator-claim only).
+    builder.Services.AddScoped<IAuthorizationHandler, OrchestratorChannelHandler>();
 
     builder.Services.AddAuthorization(options =>
     {
@@ -1587,6 +1634,17 @@ if (!string.IsNullOrEmpty(jwtSecret))
             p.RequireAuthenticatedUser();
             p.AddRequirements(new ServicePrincipalRequirement());
         });
+        // Story 39-18 (D10) — the workflow↔orchestrator hub gate. Authenticated AND
+        // (service principal OR the 39-8 D6 orchestrator claim). A tenant
+        // member/admin/owner JWT authenticates but is neither, so it is rejected
+        // (AC5's "reject non-orchestrator principals"). Same trust class as
+        // EngineServiceOnly (the resume-family posture), applied to the hub.
+        options.AddPolicy("OrchestratorChannel", p =>
+        {
+            p.AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme, "ApiKey");
+            p.RequireAuthenticatedUser();
+            p.AddRequirements(new OrchestratorChannelRequirement());
+        });
         // Story 16-5 AC 7: DELETE /api/workflows/* must be owner-only.
         // workflows:delete maps to ["owner"] in the permission matrix.
         options.AddPolicy("WorkflowsDelete", p =>
@@ -1654,7 +1712,7 @@ else if (builder.Environment.IsDevelopment())
         // Register all named policies with permissive default
         foreach (var name in new[] { "AdminAccess", "OwnerAccess", "PlatformOwnerAccess", "MemberAccess", "SettingsView",
             "SettingsManage", "PromptManage", "ConventionManage", "PlatformsManage", "AgentManage", "PricingManage", "AcceptanceRulesManage", "WorkflowsView", "WorkflowsManage", "WorkflowsDelete", "DashboardView", "ApiKeysManage",
-            "SelfOrApiKeysManage", "SelfOrUsersView", "AuthenticatedAny", "EngineServiceOnly" })
+            "SelfOrApiKeysManage", "SelfOrUsersView", "AuthenticatedAny", "EngineServiceOnly", "OrchestratorChannel" })
         {
             options.AddPolicy(name, p => p.AddRequirements(new Tamma.Api.Infrastructure.AllowAnonymousRequirement()));
         }
@@ -2786,6 +2844,14 @@ engine.MapPost("/documents", DocumentEndpoints.PersistFromEngine)
 engine.MapPost("/documents/{documentId:guid}/status", DocumentEndpoints.SetStatusFromEngine)
     .RequireAuthorization("EngineServiceOnly");
 
+// ── Story 39-18: engine→API channel enqueue seam (D2) ──
+// The lifecycle engine publishes AcceptanceRequest / escalation / guidance messages
+// here; the API mints the durable channel_outbox row(s) + best-effort SignalR fan-out.
+// Gated EngineServiceOnly (same rationale as /events): the service principal only, so
+// a user JWT can never forge a channel message into another tenant's stream.
+engine.MapPost("/channel/outbox", ChannelEndpoints.EnqueueFromEngine)
+    .RequireAuthorization("EngineServiceOnly");
+
 // ── User dashboard: Repos & Workflow Runs (Story 21-4) ──
 // Tenant-facing read surface behind the SPA's /repos + /runs destinations.
 // Tenant is resolved strictly from ITenantContext inside each handler (no
@@ -3289,6 +3355,23 @@ using (var scope = app.Services.CreateScope())
         throw;
     }
 }
+
+// ── Story 39-18: Real-time channel hubs (D2/D5/D10) ──
+// Two SEPARATE hubs (never one hub with per-method role checks):
+//  - /hubs/orchestrator — the workflow↔orchestrator channel. Engine-internal TRUST
+//    POSTURE (not a process boundary): gated by the OrchestratorChannel policy (the
+//    same service-principal/orchestrator-only class as EngineServiceOnly — the
+//    resume-family posture). MUST be excluded from public API docs + nginx exposure
+//    (like the /api/engine callbacks); only the tenant's orchestrator agent / tests
+//    connect here.
+//  - /hubs/user — the user↔orchestrator/platform channel. MemberAccess; groups are
+//    derived server-side from the principal (tenant + per-user), never client-joinable.
+// Browser clients authenticate via the ?access_token= query param (scoped to /hubs in
+// the JwtBearer OnMessageReceived above); the single-instance fan-out caveat is the
+// inherited ILlmRunStreamBus stance (see the ADR) — the outbox makes it safe, slower
+// on failover.
+app.MapHub<Tamma.Api.Hubs.OrchestratorChannelHub>("/hubs/orchestrator");
+app.MapHub<Tamma.Api.Hubs.UserChannelHub>("/hubs/user");
 
 Log.Information("Tamma API starting up...");
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Access/ITaskAudienceResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Access/ITaskAudienceResolver.cs
@@ -1,0 +1,57 @@
+namespace Tamma.Api.Services.Access;
+
+/// <summary>
+/// Story 39-20's canonical audience-resolution seam (Story 39-18 Design Decision D9).
+/// Task delivery is ROLE-ADDRESSED (design review 2026-07-21): a task fans out to
+/// every role-holder the resolver says may see it, not one user. 39-18 STUBS this
+/// fail-closed behind <see cref="InitiatorOnlyTaskAudienceResolver"/> until 39-20
+/// lands; 39-20 replaces the implementation (owning the canonical
+/// <see cref="TaskRef"/>/<see cref="AudienceMember"/> shapes), so 39-18's tests run
+/// against a capturing fake with no churn.
+/// </summary>
+public interface ITaskAudienceResolver
+{
+    /// <summary>
+    /// Whether <paramref name="userId"/> may see <paramref name="task"/> (initiator or
+    /// repo access — the per-user scoping that makes task delivery per-user, not merely
+    /// per-tenant).
+    /// </summary>
+    Task<bool> CanSeeAsync(Guid userId, TaskRef task);
+
+    /// <summary>
+    /// The eligible audience for <paramref name="task"/> addressed to role
+    /// <paramref name="roleWire"/> — every role-holder the task fans out to (one outbox
+    /// row per member, D4).
+    /// </summary>
+    Task<IReadOnlyList<AudienceMember>> EligibleAudienceAsync(TaskRef task, string roleWire);
+}
+
+/// <summary>
+/// The canonical task reference the audience is resolved against (39-20 owns this
+/// shape; 39-18 pins it for the stub). Carries the tenant, the issue initiator, and
+/// the repo/issue coordinates repo-access resolution needs.
+/// </summary>
+public sealed record TaskRef(Guid TenantId, Guid? InitiatorUserId, string? RepoKey, string? IssueId);
+
+/// <summary>One resolved audience member (a user id + the role it holds).</summary>
+public sealed record AudienceMember(Guid UserId, string RoleWire);
+
+/// <summary>
+/// Story 39-18 (D9) — the fail-closed default stub for 39-20's resolver: ONLY the
+/// issue initiator sees anything. Until 39-20 (repo-access resolution) or 39-19's
+/// stricter <c>ConservativeAudienceResolver</c> lands, nobody extra is admitted — the
+/// safe direction. There is exactly ONE default stub, never two.
+/// </summary>
+public sealed class InitiatorOnlyTaskAudienceResolver : ITaskAudienceResolver
+{
+    public Task<bool> CanSeeAsync(Guid userId, TaskRef task)
+        => Task.FromResult(task.InitiatorUserId is { } initiator && initiator == userId);
+
+    public Task<IReadOnlyList<AudienceMember>> EligibleAudienceAsync(TaskRef task, string roleWire)
+    {
+        IReadOnlyList<AudienceMember> audience = task.InitiatorUserId is { } initiator
+            ? new[] { new AudienceMember(initiator, roleWire) }
+            : Array.Empty<AudienceMember>();
+        return Task.FromResult(audience);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Channels/ChannelOutboxService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Channels/ChannelOutboxService.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.SignalR;
+using Tamma.Activities.Documents;
+using Tamma.Api.Hubs;
+using Tamma.Api.Services.Access;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Channels;
+
+/// <summary>
+/// Story 39-18 (D4/D6/D7/D8) — the write path for the channel outbox. Validates the
+/// kind→audience pairing (fail-loud), fans out role-addressed task messages to one
+/// row per resolver-approved recipient (<see cref="ITaskAudienceResolver"/>),
+/// persists BEFORE any hub send (the transport is never the source of truth — AC6),
+/// emits <c>GUIDANCE.*</c> fail-loud, refuses a direct conversation-kind enqueue (chat
+/// is 39-19's, D8), THEN best-effort publishes to the hub group (never throws into the
+/// caller — the <c>ILlmRunStreamBus</c> producer invariant: a hub send to zero
+/// connections is a silent no-op, which is exactly the degraded case).
+/// </summary>
+public sealed class ChannelOutboxService
+{
+    private readonly IChannelOutboxRepository _outbox;
+    private readonly IEventRepository _events;
+    private readonly ITaskAudienceResolver _audience;
+    private readonly IHubContext<OrchestratorChannelHub, IOrchestratorChannelClient> _orchestratorHub;
+    private readonly IHubContext<UserChannelHub, IUserChannelClient> _userHub;
+    private readonly ILogger<ChannelOutboxService> _logger;
+
+    public ChannelOutboxService(
+        IChannelOutboxRepository outbox,
+        IEventRepository events,
+        ITaskAudienceResolver audience,
+        IHubContext<OrchestratorChannelHub, IOrchestratorChannelClient> orchestratorHub,
+        IHubContext<UserChannelHub, IUserChannelClient> userHub,
+        ILogger<ChannelOutboxService> logger)
+    {
+        _outbox = outbox;
+        _events = events;
+        _audience = audience;
+        _orchestratorHub = orchestratorHub;
+        _userHub = userHub;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Persist + best-effort publish a channel envelope. Fans out user-audience
+    /// task messages to per-recipient rows. Returns the persisted rows (for tests /
+    /// callers). Throws <see cref="TammaError"/> (<c>CHANNEL.MESSAGE.INVALID</c>) on a
+    /// bad kind→audience pairing or a direct conversation-kind enqueue.
+    /// </summary>
+    public async Task<IReadOnlyList<ChannelOutboxMessage>> EnqueueAsync(ChannelEnvelope envelope, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (envelope.TenantId == Guid.Empty)
+            throw Invalid("tenant", "A channel message requires a non-empty tenant id (server-derived).");
+
+        var kind = ChannelMessageKinds.KindOf(envelope.Message);
+
+        // D8 — conversation kinds are minted ONLY by 39-19's chat service (which has
+        // already recorded them). A direct conversation enqueue is refused so nothing
+        // can cross un-evented (AC6).
+        if (kind == ChannelMessageKinds.AgentConversation)
+            throw Invalid(kind, "Conversation kinds are recorded + enqueued only by the 39-19 chat service, never directly.");
+
+        // Server-derive-and-validate the audience: the canonical audience for the kind
+        // must match the envelope's audience (never trusted blindly from a payload).
+        var canonical = ChannelMessageKinds.AudienceFor(kind)
+            ?? throw Invalid(kind, $"'{kind}' is not a direct-enqueue channel kind.");
+        if (envelope.Audience != canonical)
+            throw Invalid(kind,
+                $"kind '{kind}' must travel on the '{canonical.ToWire()}' channel, not '{envelope.Audience.ToWire()}'.");
+
+        var rows = envelope.Audience == ChannelAudience.User
+            ? await PersistUserFanOutAsync(envelope, kind, ct)
+            : new[] { await PersistSingleAsync(envelope, kind, envelope.RecipientUserId, ct) };
+
+        // GUIDANCE.* is THIS story's only event family (D8) — fail-loud (the event IS
+        // part of the operation), appended AFTER the row persists, BEFORE publish.
+        await MaybeEmitGuidanceAsync(envelope, kind);
+
+        // Best-effort hub publish — never throws into the caller (degraded = the row waits).
+        foreach (var row in rows)
+            await PublishBestEffortAsync(row, envelope, ct);
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Re-publish a stale outbox row (the sweeper path): deserialize the stored
+    /// envelope and best-effort push it to the hub group again. Covers
+    /// crash-between-persist-and-publish and missed reconnect races. Never throws.
+    /// </summary>
+    public async Task RepublishAsync(ChannelOutboxMessage row, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(row);
+        ChannelEnvelope? envelope;
+        try
+        {
+            envelope = JsonSerializer.Deserialize<ChannelEnvelope>(row.PayloadJson, DocumentJson.Options);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "channel_outbox sweeper: row {MessageId} payload undeserializable; skipping.", row.Id);
+            return;
+        }
+        if (envelope is null) return;
+        await PublishBestEffortAsync(row, envelope, ct);
+    }
+
+    // ── persistence ─────────────────────────────────────────────────────────
+
+    private async Task<ChannelOutboxMessage> PersistSingleAsync(
+        ChannelEnvelope envelope, string kind, Guid? recipientUserId, CancellationToken ct)
+    {
+        var perRecipient = envelope with { RecipientUserId = recipientUserId };
+        var row = new ChannelOutboxMessage
+        {
+            Id = envelope.MessageId,
+            TenantId = envelope.TenantId,
+            Audience = envelope.Audience.ToWire(),
+            RecipientUserId = recipientUserId,
+            Kind = kind,
+            PayloadJson = JsonSerializer.Serialize(perRecipient, DocumentJson.Options),
+            DecisionSessionId = DecisionSessionIdOf(envelope.Message),
+            CreatedAt = envelope.CreatedAt.UtcDateTime,
+        };
+        return await _outbox.EnqueueAsync(row, ct);
+    }
+
+    private async Task<ChannelOutboxMessage[]> PersistUserFanOutAsync(
+        ChannelEnvelope envelope, string kind, CancellationToken ct)
+    {
+        // Only role-addressed task messages fan out; any other user-audience kind is a
+        // single directed row. Today only task-assigned is role-addressed.
+        if (envelope.Message is not TaskAssigned task)
+            return new[] { await PersistSingleAsync(envelope, kind, envelope.RecipientUserId, ct) };
+
+        var taskRef = new TaskRef(envelope.TenantId, InitiatorUserId: null, RepoKey: null, IssueId: task.IssueId);
+        var members = await _audience.EligibleAudienceAsync(taskRef, task.AssignedRole);
+
+        var rows = new List<ChannelOutboxMessage>(members.Count);
+        var seen = new HashSet<Guid>();
+        foreach (var member in members)
+        {
+            if (!seen.Add(member.UserId)) continue; // one row per user, even across roles.
+            // Each recipient gets its own row (per-user ack) with a distinct message id
+            // so acks/dedup are per-recipient, not shared.
+            var perRecipient = envelope with { MessageId = UuidV7.NewGuid(), RecipientUserId = member.UserId };
+            var row = new ChannelOutboxMessage
+            {
+                Id = perRecipient.MessageId,
+                TenantId = envelope.TenantId,
+                Audience = envelope.Audience.ToWire(),
+                RecipientUserId = member.UserId,
+                Kind = kind,
+                PayloadJson = JsonSerializer.Serialize(perRecipient, DocumentJson.Options),
+                DecisionSessionId = task.DecisionSessionId,
+                CreatedAt = envelope.CreatedAt.UtcDateTime,
+            };
+            rows.Add(await _outbox.EnqueueAsync(row, ct));
+        }
+
+        if (rows.Count == 0)
+            _logger.LogInformation(
+                "channel_outbox task fan-out resolved zero recipients for issue {Issue} role {Role} — nothing enqueued (fail-closed).",
+                task.IssueId, task.AssignedRole);
+
+        return rows.ToArray();
+    }
+
+    // ── guidance events (D8) ────────────────────────────────────────────────
+
+    private async Task MaybeEmitGuidanceAsync(ChannelEnvelope envelope, string kind)
+    {
+        switch (envelope.Message)
+        {
+            case GuidanceQuery q:
+                await AppendGuidanceAsync(envelope, ChannelEvents.GuidanceRequested, q.CorrelationId, new Dictionary<string, object?>
+                {
+                    ["queryId"] = q.QueryId.ToString(),
+                    ["question"] = Bounded(q.Question, 512),
+                    ["correlationId"] = q.CorrelationId,
+                });
+                break;
+            case GuidanceReply r:
+                await AppendGuidanceAsync(envelope, ChannelEvents.GuidanceProvided, correlationId: null, new Dictionary<string, object?>
+                {
+                    ["queryId"] = r.QueryId.ToString(),
+                    ["replyDigest"] = Bounded(r.Reply, 256),
+                });
+                break;
+        }
+    }
+
+    private async Task AppendGuidanceAsync(
+        ChannelEnvelope envelope, string type, string? correlationId, Dictionary<string, object?> data)
+    {
+        var tags = new Dictionary<string, string?>
+        {
+            ["tenantId"] = envelope.TenantId.ToString(),
+        };
+        if (!string.IsNullOrWhiteSpace(correlationId)) tags["correlationId"] = correlationId;
+        if (envelope.RecipientUserId is { } uid) tags["userId"] = uid.ToString();
+
+        // FAIL-LOUD — the event IS part of the operation (the 39-8 disposition posture),
+        // not a best-effort side-car; an append failure propagates.
+        await _events.AppendAsync(new DomainEvent
+        {
+            Type = type,
+            TenantId = envelope.TenantId,
+            Tags = JsonSerializer.Serialize(tags),
+            Metadata = """{"workflowVersion":"1.0.0","eventSource":"system"}""",
+            Data = JsonSerializer.Serialize(data),
+        });
+    }
+
+    // ── publish ─────────────────────────────────────────────────────────────
+
+    private async Task PublishBestEffortAsync(ChannelOutboxMessage row, ChannelEnvelope envelope, CancellationToken ct)
+    {
+        try
+        {
+            var perRecipient = envelope with { MessageId = row.Id, RecipientUserId = row.RecipientUserId };
+            if (envelope.Audience == ChannelAudience.Orchestrator)
+            {
+                await _orchestratorHub.Clients
+                    .Group(OrchestratorChannelHub.GroupFor(envelope.TenantId))
+                    .Receive(perRecipient);
+            }
+            else if (row.RecipientUserId is { } recipient)
+            {
+                await _userHub.Clients
+                    .Group(UserChannelHub.UserGroupFor(envelope.TenantId, recipient))
+                    .Receive(perRecipient);
+            }
+
+            // Deliberately do NOT mark the row delivered here. A SignalR group send to
+            // zero connections is a silent no-op — the transport cannot confirm anyone
+            // actually received it. The row stays `pending` (degraded-mode contract,
+            // AC7) and is transitioned to `delivered` only by the hub's connect-time
+            // replay (OnConnectedAsync → Receive → MarkDeliveredAsync), which fires
+            // exactly when a real consumer is on the wire. Ack is idempotent and the
+            // sweeper re-publishes stale rows, so a live consumer that received the
+            // write-time push still settles the row via its Ack.
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // A hub send to zero connections is a silent no-op; a genuine publish error
+            // must not throw into the caller — the row stays pending and the sweeper /
+            // connect-time replay delivers it.
+            _logger.LogWarning(ex,
+                "channel_outbox publish best-effort failed for row {MessageId} (row stays pending; replay/sweeper covers it).",
+                row.Id);
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static Guid? DecisionSessionIdOf(ChannelMessage message) => message switch
+    {
+        AcceptanceRequested a => a.Request.DecisionSessionId,
+        TaskAssigned t => t.DecisionSessionId,
+        _ => null,
+    };
+
+    private static string Bounded(string value, int max) =>
+        string.IsNullOrEmpty(value) || value.Length <= max ? value : value[..max];
+
+    private static TammaError Invalid(string field, string message) =>
+        new(
+            "CHANNEL.MESSAGE.INVALID",
+            message,
+            new Dictionary<string, object?> { ["field"] = field },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Channels/ChannelOutboxSweeper.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Channels/ChannelOutboxSweeper.cs
@@ -1,0 +1,130 @@
+using Microsoft.Extensions.Options;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Services.Channels;
+
+/// <summary>
+/// Options for <see cref="ChannelOutboxSweeper"/>. Mirrors <c>OutboxSmtpSenderOptions</c>'
+/// poll-cadence + <c>RunOnStartup</c> test gate.
+/// </summary>
+public sealed class ChannelOutboxSweeperOptions
+{
+    /// <summary>How often the sweeper walks tenants with stale rows. Default 15s.</summary>
+    public TimeSpan PollInterval { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// A <c>delivered</c> row whose <c>DeliveredAt</c> is older than this is treated as
+    /// stale (a missed reconnect race) and re-published. <c>pending</c> rows (never
+    /// delivered — crash between persist and publish) are always stale. Default 60s.
+    /// </summary>
+    public TimeSpan StaleAfter { get; set; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>Max rows re-published per tenant per pass (bounds one cycle's work).</summary>
+    public int BatchPerTenant { get; set; } = 200;
+
+    /// <summary>
+    /// When <c>false</c> the sweeper does not start its poll loop — the shared test
+    /// fixture gate so outbox-row-state assertions don't race the loop. Mirrors
+    /// <c>OutboxSmtpSenderOptions.RunOnStartup</c>.
+    /// </summary>
+    public bool RunOnStartup { get; set; } = true;
+}
+
+/// <summary>
+/// Story 39-18 (D6) — the slow sweeper. Re-publishes stale <c>pending</c>/<c>delivered</c>
+/// -but-unacked channel rows across tenants, covering crash-between-persist-and-publish
+/// and missed reconnect races (a SignalR group send to zero subscribers is a silent
+/// no-op — the outbox is why single-instance is safe, just slower on failover). No
+/// timeout here ever converts an unanswered request into a decision (AC7). Copies
+/// <c>OutboxSmtpSender</c>'s options/<c>RunOnStartup</c> shape.
+/// </summary>
+public sealed class ChannelOutboxSweeper : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ChannelOutboxSweeperOptions _options;
+    private readonly ILogger<ChannelOutboxSweeper> _logger;
+
+    public ChannelOutboxSweeper(
+        IServiceProvider serviceProvider,
+        ChannelOutboxSweeperOptions options,
+        ILogger<ChannelOutboxSweeper> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _options = options;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!_options.RunOnStartup)
+        {
+            _logger.LogDebug("ChannelOutboxSweeper gated off (RunOnStartup=false); skipping poll loop.");
+            return;
+        }
+
+        _logger.LogInformation("ChannelOutboxSweeper started. Poll interval={Interval}", _options.PollInterval);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await SweepOnceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ChannelOutboxSweeper cycle failed");
+            }
+
+            try
+            {
+                await Task.Delay(_options.PollInterval, stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        _logger.LogInformation("ChannelOutboxSweeper stopped");
+    }
+
+    /// <summary>
+    /// One sweep pass: for each tenant with unacked rows, re-publish the stale ones.
+    /// Exposed for tests so they don't race the polling timer.
+    /// </summary>
+    public async Task<int> SweepOnceAsync(CancellationToken ct)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var outbox = scope.ServiceProvider.GetRequiredService<IChannelOutboxRepository>();
+        var service = scope.ServiceProvider.GetRequiredService<ChannelOutboxService>();
+
+        var staleBefore = DateTime.UtcNow - _options.StaleAfter;
+        var republished = 0;
+
+        var tenants = await outbox.ListTenantsWithPendingAsync(ct);
+        foreach (var tenantId in tenants)
+        {
+            if (ct.IsCancellationRequested) break;
+            try
+            {
+                var stale = await outbox.ListStaleAsync(tenantId, staleBefore, _options.BatchPerTenant, ct);
+                foreach (var row in stale)
+                {
+                    await service.RepublishAsync(row, ct);
+                    republished++;
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // One tenant's transient failure must not starve the rest of the pass.
+                _logger.LogWarning(ex, "ChannelOutboxSweeper: tenant {TenantId} sweep failed", tenantId);
+            }
+        }
+
+        return republished;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Channels/IOrchestratorChatRelay.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Channels/IOrchestratorChatRelay.cs
@@ -1,0 +1,45 @@
+using Tamma.Core.Documents.Channels;
+
+namespace Tamma.Api.Services.Channels;
+
+/// <summary>
+/// Story 39-18 — the seam the hubs' chat legs hand off to. In the finished system
+/// this is 39-19's <c>OrchestratorChatService</c> (the SOLE chat recorder/entry
+/// point: record <c>CHAT.MESSAGE.RECEIVED</c> → agent turn → record
+/// <c>CHAT.MESSAGE.SENT</c> → relay). Until 39-19 lands, chat relay is OFF: the
+/// registered <see cref="AgentOfflineChatRelay"/> refuses every message and records
+/// nothing (D8 / the risk note — AC6 over feature completeness). This story emits NO
+/// <c>CHAT.*</c> events and the outbox refuses a direct conversation-kind enqueue.
+/// </summary>
+public interface IOrchestratorChatRelay
+{
+    /// <summary>
+    /// Relay a user→agent message. <paramref name="userId"/> is server-stamped from
+    /// the connection claims (never trusted from the payload).
+    /// </summary>
+    Task<ChatRelayResult> RelayUserMessageAsync(Guid tenantId, Guid userId, AgentConversationMessage message, CancellationToken ct);
+
+    /// <summary>Relay an agent→user reply (from the orchestrator hub's chat leg).</summary>
+    Task<ChatRelayResult> RelayAgentReplyAsync(Guid tenantId, AgentConversationMessage message, CancellationToken ct);
+}
+
+/// <summary>Outcome of a chat relay attempt. <c>Accepted=false</c> + <c>Reason</c> when the agent is offline.</summary>
+public sealed record ChatRelayResult(bool Accepted, string? Reason)
+{
+    public static ChatRelayResult Offline { get; } =
+        new(false, "agent-offline: chat relay is disabled until Story 39-19's OrchestratorChatService lands.");
+}
+
+/// <summary>
+/// The stand-in registered until 39-19 lands: refuses every chat message with an
+/// agent-offline result and records nothing (no <c>CHAT.*</c>, no outbox row) — so
+/// nothing can cross un-evented (AC6) structurally.
+/// </summary>
+public sealed class AgentOfflineChatRelay : IOrchestratorChatRelay
+{
+    public Task<ChatRelayResult> RelayUserMessageAsync(Guid tenantId, Guid userId, AgentConversationMessage message, CancellationToken ct)
+        => Task.FromResult(ChatRelayResult.Offline);
+
+    public Task<ChatRelayResult> RelayAgentReplyAsync(Guid tenantId, AgentConversationMessage message, CancellationToken ct)
+        => Task.FromResult(ChatRelayResult.Offline);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Documents/DocumentDecisionSubmissionService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Documents/DocumentDecisionSubmissionService.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Tamma.Api.Endpoints;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Api.Services.Documents;
+
+/// <summary>
+/// Story 39-8 / 39-18 (D7) — the SHARED document-decision submission path. The
+/// decision-build + kind validation + channel-carried resume logic lives HERE, in
+/// ONE place, so BOTH the public REST endpoint (<c>DocumentDecisionEndpoints.ResumeDecision</c>)
+/// AND the workflow↔orchestrator hub (<c>OrchestratorChannelHub.SubmitDecision</c>)
+/// drive the SAME 39-8 idempotent resume surface — the hub never applies anything
+/// itself (canon: "decisions land only via the idempotent resume surface").
+///
+/// <para>The service is constructed with an <see cref="IElsaWorkflowService"/> so the
+/// hub can resolve it from DI; the REST endpoint constructs it inline with the
+/// <see cref="IElsaWorkflowService"/> passed to the handler, preserving the endpoint's
+/// existing signature (and its tests). Channel derivation stays server-side at the
+/// call site (<c>ApprovalChannels.Derive</c>); this service never reads a channel or
+/// decider from a client body.</para>
+/// </summary>
+public sealed class DocumentDecisionSubmissionService
+{
+    /// <summary>The decision kinds the gate accepts (the closed 39-5 discriminator set).</summary>
+    public static readonly IReadOnlySet<string> AllowedDecisionKinds =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "accept", "request-revision", "reject", "escalate" };
+
+    private static readonly JsonSerializerOptions DecisionJsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private readonly IElsaWorkflowService _elsa;
+
+    public DocumentDecisionSubmissionService(IElsaWorkflowService elsa)
+    {
+        _elsa = elsa ?? throw new ArgumentNullException(nameof(elsa));
+    }
+
+    /// <summary>Whether <paramref name="kind"/> is one of the closed decision kinds.</summary>
+    public static bool IsAllowedKind(string? kind) =>
+        !string.IsNullOrWhiteSpace(kind) && AllowedDecisionKinds.Contains(kind.Trim());
+
+    /// <summary>
+    /// Build the 39-5 <see cref="AcceptanceDecision"/> from the validated public
+    /// request. A human REJECT passes through (it clamps to Escalate only on the
+    /// orchestrator channel, which 39-6's guardrail applies); an escalate reason wire
+    /// is parsed, defaulting to <c>AcceptorJudgment</c> when a human simply chose to
+    /// escalate.
+    /// </summary>
+    public static AcceptanceDecision BuildDecision(DocumentDecisionEndpoints.DecisionRequest req) =>
+        req.Kind.Trim().ToLowerInvariant() switch
+        {
+            "accept" => new AcceptanceDecision.Accept(),
+            "request-revision" => new AcceptanceDecision.RequestRevision(req.Notes ?? req.Feedback ?? string.Empty),
+            "reject" => new AcceptanceDecision.Reject(req.Reason ?? req.Feedback ?? string.Empty),
+            _ => new AcceptanceDecision.Escalate(
+                ParseEscalationReason(req.Reason),
+                req.Detail ?? req.Feedback ?? req.Reason ?? string.Empty),
+        };
+
+    /// <summary>Serialize a 39-5 decision to the canonical decision JSON.</summary>
+    public static string SerializeDecision(AcceptanceDecision decision) =>
+        JsonSerializer.Serialize(decision, DecisionJsonOptions);
+
+    /// <summary>
+    /// Submit a decision built from the typed public request (the REST path). Builds
+    /// the 39-5 decision JSON server-side, then forwards to the 39-8 resume surface.
+    /// </summary>
+    public Task<DecisionSubmitResult> SubmitAsync(
+        Guid sessionId, DocumentDecisionEndpoints.DecisionRequest req,
+        Guid? tenantId, string deciderId, ApprovalChannel channel)
+    {
+        var decision = BuildDecision(req);
+        var decisionJson = SerializeDecision(decision);
+        var kind = req.Kind.Trim().ToLowerInvariant();
+        return ResumeAsync(sessionId, decisionJson, req.Feedback, tenantId, deciderId, channel, kind);
+    }
+
+    /// <summary>
+    /// The ONE place a decision reaches 39-8's idempotent resume surface. Callers
+    /// supply an already-built <paramref name="decisionJson"/> (the hub path) or use
+    /// <see cref="SubmitAsync(Guid, DocumentDecisionEndpoints.DecisionRequest, Guid?, string, ApprovalChannel)"/>
+    /// which builds it. Returns the resume result verbatim (incl. the 404/409
+    /// gate-not-waiting discipline) so the caller can surface idempotency outcomes.
+    /// </summary>
+    public async Task<DecisionSubmitResult> ResumeAsync(
+        Guid sessionId, string decisionJson, string? feedback,
+        Guid? tenantId, string deciderId, ApprovalChannel channel, string kind)
+    {
+        var result = await _elsa.ResumeDocumentDecisionAsync(
+            sessionId, tenantId?.ToString(), decisionJson, feedback,
+            deciderId, deciderId, channel.ToWire(), rulesReference: null);
+
+        return new DecisionSubmitResult(
+            result.Resumed, result.GateNotFound, result.WorkflowInstanceId, kind, channel.ToWire());
+    }
+
+    private static AcceptanceEscalationReason ParseEscalationReason(string? wire)
+    {
+        if (!string.IsNullOrWhiteSpace(wire))
+        {
+            foreach (var reason in Enum.GetValues<AcceptanceEscalationReason>())
+                if (string.Equals(reason.ToWire(), wire, StringComparison.OrdinalIgnoreCase))
+                    return reason;
+        }
+        return AcceptanceEscalationReason.AcceptorJudgment;
+    }
+}
+
+/// <summary>
+/// Result of a document-decision submission through the shared service — the 39-8
+/// resume outcome plus the server-derived kind/channel for the caller's response.
+/// </summary>
+public sealed record DecisionSubmitResult(
+    bool Resumed, bool GateNotFound, string? WorkflowInstanceId, string Kind, string Channel);

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Channels/ChannelAudience.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Channels/ChannelAudience.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+using Tamma.Api.Services.Agents;
+using Tamma.Core;
+
+namespace Tamma.Core.Documents.Channels;
+
+/// <summary>
+/// Story 39-18 (Design Decision D3) — the two real-time channels a
+/// <see cref="ChannelEnvelope"/> can travel on. Deliberately DISTINCT from 39-8's
+/// three-member <see cref="ApprovalChannel"/> (which classifies who RESUMED a
+/// decision — orchestrator/user/api); this two-member enum names WHERE a message
+/// travels:
+/// <list type="bullet">
+///   <item><c>orchestrator</c> — the workflow↔orchestrator channel (engine/agent
+///     traffic, service-principal/orchestrator-only, tenant-partitioned).</item>
+///   <item><c>user</c> — the user↔orchestrator/platform channel (dashboard users,
+///     tenant + per-user folded groups derived server-side from the principal).</item>
+/// </list>
+/// </summary>
+[JsonConverter(typeof(WireEnumJsonConverter<ChannelAudience>))]
+public enum ChannelAudience
+{
+    [Wire("orchestrator")] Orchestrator,
+    [Wire("user")]         User,
+}
+
+/// <summary><see cref="ChannelAudience"/> wire helper.</summary>
+public static class ChannelAudienceExtensions
+{
+    /// <summary>The canonical wire string for <paramref name="audience"/>.</summary>
+    public static string ToWire(this ChannelAudience audience) => EnumWire<ChannelAudience>.ToWire(audience);
+
+    /// <summary>
+    /// Case-sensitive parse of a <see cref="ChannelAudience"/> wire string.
+    /// Throws <see cref="TammaError"/> (<c>CHANNEL.AUDIENCE.INVALID</c>) on an
+    /// unknown token — a bad audience fails loud on the boundary.
+    /// </summary>
+    public static ChannelAudience ParseAudience(string wire)
+    {
+        if (EnumWire<ChannelAudience>.TryParse(wire, out var value))
+            return value;
+        throw new TammaError(
+            "CHANNEL.AUDIENCE.INVALID",
+            $"Unknown channel audience wire value '{wire}'.",
+            new Dictionary<string, object?> { ["audience"] = wire },
+            retryable: false,
+            severity: TammaErrorSeverity.High);
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Channels/ChannelMessages.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Channels/ChannelMessages.cs
@@ -1,0 +1,176 @@
+using System.Text.Json.Serialization;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Documents.Channels;
+
+/// <summary>
+/// Story 39-18 (AC1, Design Decision D3) — the CLOSED, drift-tested channel
+/// message set carried over the two SignalR channels. Serialized polymorphically
+/// with a <c>kind</c> discriminator through <see cref="DocumentJson.Options"/>; the
+/// derived set is closed and count-pinned (exactly 8 kinds) by
+/// <c>ChannelMessageContractTests</c>. Every wire property carries an explicit
+/// <c>[JsonPropertyName]</c> (39-2's D8 discipline).
+///
+/// <para>39-5's canonical <see cref="AcceptanceRequest"/> / <see cref="AcceptanceDecision"/>
+/// are REUSED by reference (wrapped in <see cref="AcceptanceRequested"/> /
+/// <see cref="DecisionProvided"/>), never redefined — one record, one home.</para>
+///
+/// <para>The transport is never the source of truth (AC6): every request/escalation/
+/// guidance/task message is persisted to <c>channel_outbox</c> BEFORE any hub send,
+/// and decisions land ONLY through 39-8's idempotent resume surface.</para>
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(AcceptanceRequested), "acceptance-request")]
+[JsonDerivedType(typeof(DecisionProvided), "acceptance-decision")]
+[JsonDerivedType(typeof(TaskAssigned), "task-assigned")]
+[JsonDerivedType(typeof(EscalationRaised), "escalation-raised")]
+[JsonDerivedType(typeof(EscalationDisposition), "escalation-disposition")]
+[JsonDerivedType(typeof(GuidanceQuery), "guidance-query")]
+[JsonDerivedType(typeof(GuidanceReply), "guidance-reply")]
+[JsonDerivedType(typeof(AgentConversationMessage), "agent-conversation")]
+public abstract record ChannelMessage;
+
+/// <summary>
+/// The accept stage's <see cref="AcceptanceRequest"/> published on the
+/// workflow↔orchestrator channel (wraps 39-5's canonical record by reference).
+/// </summary>
+public sealed record AcceptanceRequested(
+    [property: JsonPropertyName("request")] AcceptanceRequest Request) : ChannelMessage;
+
+/// <summary>
+/// A decision the orchestrator/human answered with (wraps 39-5's canonical
+/// <see cref="AcceptanceDecision"/> + the server-derived decider + the rules
+/// version reference the decision was made under). The hub NEVER applies this
+/// itself — decisions land through the 39-8 resume surface (D7).
+/// </summary>
+public sealed record DecisionProvided(
+    [property: JsonPropertyName("decision")] AcceptanceDecision Decision,
+    [property: JsonPropertyName("decider")] string Decider,
+    [property: JsonPropertyName("rulesReference")] string? RulesReference) : ChannelMessage;
+
+/// <summary>
+/// The orchestrator's assignment notification on the user channel. Role-addressed
+/// (design review 2026-07-21): the payload carries the ASSIGNED ROLE, never a single
+/// assignee. Delivery is per-recipient via outbox fan-out — the actual recipient is
+/// the outbox row's <c>RecipientUserId</c> (one row per audience member from
+/// <c>ITaskAudienceResolver</c>), NOT a field in this payload.
+/// </summary>
+public sealed record TaskAssigned(
+    [property: JsonPropertyName("taskId")] Guid TaskId,
+    [property: JsonPropertyName("decisionSessionId")] Guid DecisionSessionId,
+    [property: JsonPropertyName("assignedRole")] string AssignedRole,
+    [property: JsonPropertyName("basis")] string Basis /* AssignmentBasis wire */,
+    [property: JsonPropertyName("documentTypeKey")] string DocumentTypeKey,
+    [property: JsonPropertyName("documentId")] Guid DocumentId,
+    [property: JsonPropertyName("issueId")] string IssueId,
+    [property: JsonPropertyName("autonomyLevel")] int AutonomyLevel,
+    [property: JsonPropertyName("rulesReference")] string? RulesReference) : ChannelMessage;
+
+/// <summary>
+/// The 39-8 escalation lineage payload — one shape, shared with the
+/// <c>ESCALATION.TRIGGERED</c> event data. <see cref="LineageJson"/> carries the
+/// serialized document lineage (never a bare failure string).
+/// </summary>
+public sealed record EscalationRaised(
+    [property: JsonPropertyName("escalationId")] string EscalationId,
+    [property: JsonPropertyName("outcome")] string Outcome,
+    [property: JsonPropertyName("lineageJson")] string LineageJson,
+    [property: JsonPropertyName("issueId")] string IssueId,
+    [property: JsonPropertyName("rulesReference")] string? RulesReference) : ChannelMessage;
+
+/// <summary>
+/// A human disposition of an escalation relayed onto the channel. <see cref="Disposition"/>
+/// is an <c>EscalationDisposition</c> wire string (resolved/overridden/abandoned).
+/// </summary>
+public sealed record EscalationDisposition(
+    [property: JsonPropertyName("escalationId")] string EscalationId,
+    [property: JsonPropertyName("disposition")] string Disposition,
+    [property: JsonPropertyName("note")] string? Note) : ChannelMessage;
+
+/// <summary>An orchestrator/workflow guidance question. Recorded via <c>GUIDANCE.REQUESTED</c> (D8).</summary>
+public sealed record GuidanceQuery(
+    [property: JsonPropertyName("queryId")] Guid QueryId,
+    [property: JsonPropertyName("correlationId")] string CorrelationId,
+    [property: JsonPropertyName("question")] string Question,
+    [property: JsonPropertyName("contextJson")] string? ContextJson) : ChannelMessage;
+
+/// <summary>The paired reply to a <see cref="GuidanceQuery"/>. Recorded via <c>GUIDANCE.PROVIDED</c> (D8).</summary>
+public sealed record GuidanceReply(
+    [property: JsonPropertyName("queryId")] Guid QueryId,
+    [property: JsonPropertyName("reply")] string Reply) : ChannelMessage;
+
+/// <summary>
+/// One turn of user↔agent conversation. <see cref="Direction"/> is
+/// <c>"user-&gt;agent"</c> or <c>"agent-&gt;user"</c>. Conversation kinds are minted
+/// ONLY by 39-19's chat service (which records <c>CHAT.*</c>); the outbox refuses a
+/// direct conversation enqueue outside that path (D8).
+/// </summary>
+public sealed record AgentConversationMessage(
+    [property: JsonPropertyName("conversationId")] Guid ConversationId,
+    [property: JsonPropertyName("userId")] Guid UserId,
+    [property: JsonPropertyName("direction")] string Direction,
+    [property: JsonPropertyName("text")] string Text) : ChannelMessage;
+
+/// <summary>
+/// The transport envelope. <see cref="MessageId"/> is a UUID v7 (time-ordered
+/// replay without a sequence column); <see cref="Message"/> is the polymorphic
+/// payload; <see cref="RecipientUserId"/> is <c>null</c> for the tenant's
+/// orchestrator agent and a specific user for a fanned-out user-audience row.
+/// </summary>
+public sealed record ChannelEnvelope(
+    [property: JsonPropertyName("messageId")] Guid MessageId,
+    [property: JsonPropertyName("tenantId")] Guid TenantId,
+    [property: JsonPropertyName("audience")] ChannelAudience Audience,
+    [property: JsonPropertyName("recipientUserId")] Guid? RecipientUserId,
+    [property: JsonPropertyName("message")] ChannelMessage Message,
+    [property: JsonPropertyName("createdAt")] DateTimeOffset CreatedAt);
+
+/// <summary>
+/// Story 39-18 — the canonical <c>kind</c> ↔ <see cref="ChannelAudience"/> pairing
+/// (server-derived, never trusted from a payload). <c>ChannelOutboxService</c> uses
+/// this to fail-loud (<c>CHANNEL.MESSAGE.INVALID</c>) on a mismatched pairing and to
+/// refuse a direct conversation-kind enqueue (chat is 39-19's, D8).
+/// </summary>
+public static class ChannelMessageKinds
+{
+    public const string AcceptanceRequest = "acceptance-request";
+    public const string AcceptanceDecision = "acceptance-decision";
+    public const string TaskAssigned = "task-assigned";
+    public const string EscalationRaised = "escalation-raised";
+    public const string EscalationDisposition = "escalation-disposition";
+    public const string GuidanceQuery = "guidance-query";
+    public const string GuidanceReply = "guidance-reply";
+    public const string AgentConversation = "agent-conversation";
+
+    /// <summary>The discriminator <c>kind</c> for a concrete <see cref="ChannelMessage"/>.</summary>
+    public static string KindOf(ChannelMessage message) => message switch
+    {
+        Channels.AcceptanceRequested => AcceptanceRequest,
+        Channels.DecisionProvided => AcceptanceDecision,
+        Channels.TaskAssigned => TaskAssigned,
+        Channels.EscalationRaised => EscalationRaised,
+        Channels.EscalationDisposition => EscalationDisposition,
+        Channels.GuidanceQuery => GuidanceQuery,
+        Channels.GuidanceReply => GuidanceReply,
+        Channels.AgentConversationMessage => AgentConversation,
+        _ => throw new ArgumentOutOfRangeException(nameof(message), message.GetType().Name, "Unknown channel message kind."),
+    };
+
+    /// <summary>
+    /// The canonical audience a kind travels on, or <c>null</c> when the kind is not
+    /// a direct-enqueue kind (conversation kinds are minted only by 39-19's chat
+    /// service, so a direct enqueue of them is refused).
+    /// </summary>
+    public static ChannelAudience? AudienceFor(string kind) => kind switch
+    {
+        AcceptanceRequest => ChannelAudience.Orchestrator,
+        AcceptanceDecision => ChannelAudience.Orchestrator,
+        EscalationRaised => ChannelAudience.Orchestrator,
+        EscalationDisposition => ChannelAudience.Orchestrator,
+        GuidanceQuery => ChannelAudience.Orchestrator,
+        GuidanceReply => ChannelAudience.Orchestrator,
+        TaskAssigned => ChannelAudience.User,
+        // agent-conversation is NOT a direct-enqueue kind (D8).
+        _ => null,
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Entities/ChannelOutboxMessage.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Entities/ChannelOutboxMessage.cs
@@ -1,0 +1,79 @@
+namespace Tamma.Data.Entities;
+
+/// <summary>
+/// Story 39-18 (Design Decision D4) — a single channel message persisted in the
+/// per-tenant store-and-forward <c>channel_outbox</c>. Copied in shape from
+/// <see cref="EmailOutboxMessage"/> (status transitions, lease semantics) minus the
+/// SMTP fields.
+///
+/// <para>The outbox is the SOURCE OF TRUTH the transport is not (AC6): every
+/// request/escalation/guidance/task message is persisted here BEFORE any hub send,
+/// a disconnected consumer receives its unacked rows on reconnect by replay, and ack
+/// is idempotent — so a duplicate hub delivery can never double-process.</para>
+///
+/// <para>Status transitions:</para>
+/// <list type="bullet">
+///   <item><description><c>pending</c> — persisted, not yet delivered to any live
+///     connection (the degraded case: a hub send to zero connections is a silent
+///     no-op, so the row simply waits).</description></item>
+///   <item><description><c>pending</c> → <c>delivered</c> — pushed to a live
+///     consumer (write-time push or connect-time replay).</description></item>
+///   <item><description><c>delivered</c> → <c>acked</c> — the consumer acked
+///     (idempotent; acking an acked row is a no-op).</description></item>
+/// </list>
+/// One row per RECIPIENT: user-audience messages fan out at WRITE time to one row per
+/// 39-20-eligible recipient, so ack is per-user.
+/// </summary>
+public class ChannelOutboxMessage
+{
+    /// <summary>
+    /// Primary key AND the <see cref="Tamma.Core.Documents.Channels.ChannelEnvelope"/>
+    /// message id — a UUID v7, so ordering by <see cref="Id"/> is time-ordered replay
+    /// without a separate sequence column.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>Owning tenant (the channel is per-tenant). Required.</summary>
+    public Guid TenantId { get; set; }
+
+    /// <summary>The <c>ChannelAudience</c> wire string (<c>orchestrator</c> | <c>user</c>).</summary>
+    public string Audience { get; set; } = null!;
+
+    /// <summary>
+    /// The recipient user. <c>null</c> = the tenant's orchestrator agent
+    /// (orchestrator-audience rows). Set to a specific user for a fanned-out
+    /// user-audience row so ack is per-user.
+    /// </summary>
+    public Guid? RecipientUserId { get; set; }
+
+    /// <summary>The <c>ChannelMessage</c> discriminator kind (e.g. <c>acceptance-request</c>).</summary>
+    public string Kind { get; set; } = null!;
+
+    /// <summary>
+    /// The full <c>ChannelEnvelope</c> serialized via <c>DocumentJson.Options</c>
+    /// (jsonb). Stored whole so replay is a clean deserialize — the transport just
+    /// re-sends it. The denormalized columns above make the row queryable without
+    /// parsing the payload.
+    /// </summary>
+    public string PayloadJson { get; set; } = "{}";
+
+    /// <summary>
+    /// The 39-8 decision-session id this row correlates to (when the payload carries
+    /// one — acceptance requests / task assignments). Denormalized for correlation.
+    /// </summary>
+    public Guid? DecisionSessionId { get; set; }
+
+    /// <summary>One of <c>pending | delivered | acked</c>.</summary>
+    public string Status { get; set; } = "pending";
+
+    /// <summary>Number of delivery attempts (bumped on each publish). 0 on insert.</summary>
+    public int Attempts { get; set; }
+
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>Set when <see cref="Status"/> transitions to <c>delivered</c>.</summary>
+    public DateTime? DeliveredAt { get; set; }
+
+    /// <summary>Set when <see cref="Status"/> transitions to <c>acked</c>.</summary>
+    public DateTime? AckedAt { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722211145_AddChannelOutbox.Designer.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722211145_AddChannelOutbox.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tamma.Data;
@@ -11,9 +12,11 @@ using Tamma.Data;
 namespace Tamma.Data.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722211145_AddChannelOutbox")]
+    partial class AddChannelOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722211145_AddChannelOutbox.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Migrations/Tenant/20260722211145_AddChannelOutbox.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tamma.Data.Migrations.Tenant
+{
+    /// <inheritdoc />
+    public partial class AddChannelOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "channel_outbox",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TenantId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Audience = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    RecipientUserId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Kind = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    PayloadJson = table.Column<string>(type: "jsonb", nullable: false, defaultValueSql: "'{}'::jsonb"),
+                    DecisionSessionId = table.Column<Guid>(type: "uuid", nullable: true),
+                    Status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false, defaultValue: "pending"),
+                    Attempts = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "now()"),
+                    DeliveredAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    AckedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_channel_outbox", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_channel_outbox_tenant_audience_status",
+                table: "channel_outbox",
+                columns: new[] { "TenantId", "Audience", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_channel_outbox_tenant_recipient_status",
+                table: "channel_outbox",
+                columns: new[] { "TenantId", "RecipientUserId", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "channel_outbox");
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/ChannelOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/ChannelOutboxRepository.cs
@@ -1,0 +1,144 @@
+using Microsoft.EntityFrameworkCore;
+using Tamma.Data.Abstractions;
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// EF-backed <see cref="IChannelOutboxRepository"/>. Strictly tenant-scoped: every
+/// operation routes through <see cref="ITenantDbContextFactory"/> so the read/write
+/// hits the per-tenant DB, and carries an explicit <c>TenantId</c> predicate
+/// (defence-in-depth for the shared-DB phase; the per-tenant schema is the real
+/// isolation plane). Mirrors <see cref="EmailOutboxRepository"/>.
+/// </summary>
+public class ChannelOutboxRepository(
+    ITenantDbContextFactory tenantDbFactory,
+    ControlPlaneDbContext cp) : IChannelOutboxRepository
+{
+    public async Task<ChannelOutboxMessage> EnqueueAsync(ChannelOutboxMessage msg, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(msg);
+        if (msg.TenantId == Guid.Empty)
+            throw new ArgumentException("ChannelOutboxRepository requires a non-empty TenantId.", nameof(msg));
+        if (msg.Id == Guid.Empty)
+            throw new ArgumentException("ChannelOutboxMessage.Id (the envelope message id) must be set by the caller.", nameof(msg));
+
+        var now = DateTime.UtcNow;
+        msg.Status = "pending";
+        msg.Attempts = 0;
+        msg.DeliveredAt = null;
+        msg.AckedAt = null;
+        if (msg.CreatedAt == default) msg.CreatedAt = now;
+
+        await using var db = await tenantDbFactory.CreateAsync(msg.TenantId, ct);
+        db.ChannelOutbox.Add(msg);
+        await db.SaveChangesAsync(ct);
+        return msg;
+    }
+
+    public async Task<List<ChannelOutboxMessage>> ListUnackedAsync(
+        Guid tenantId, string audience, Guid? recipientUserId, int limit, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        return await db.ChannelOutbox
+            .Where(m => m.TenantId == tenantId
+                && m.Audience == audience
+                && m.RecipientUserId == recipientUserId
+                && m.Status != "acked")
+            .OrderBy(m => m.Id)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
+
+    public async Task MarkDeliveredAsync(Guid tenantId, Guid messageId, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var row = await db.ChannelOutbox
+            .Where(m => m.Id == messageId && m.TenantId == tenantId)
+            .FirstOrDefaultAsync(ct);
+        if (row is null || row.Status == "acked") return;
+
+        row.Status = "delivered";
+        row.DeliveredAt = DateTime.UtcNow;
+        row.Attempts += 1;
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task<bool> AckAsync(Guid tenantId, Guid messageId, Guid? recipientUserId, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        var row = await db.ChannelOutbox
+            .Where(m => m.Id == messageId
+                && m.TenantId == tenantId
+                && m.RecipientUserId == recipientUserId)
+            .FirstOrDefaultAsync(ct);
+
+        // Idempotent: missing row, wrong recipient, or an already-acked row → false.
+        if (row is null || row.Status == "acked") return false;
+
+        row.Status = "acked";
+        row.AckedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<List<ChannelOutboxMessage>> ListStaleAsync(
+        Guid tenantId, DateTime staleBefore, int limit, CancellationToken ct = default)
+    {
+        if (tenantId == Guid.Empty)
+            throw new ArgumentException("Tenant id is required.", nameof(tenantId));
+
+        await using var db = await tenantDbFactory.CreateAsync(tenantId, ct);
+        return await db.ChannelOutbox
+            .Where(m => m.TenantId == tenantId
+                && m.Status != "acked"
+                && (m.Status == "pending"
+                    || (m.DeliveredAt != null && m.DeliveredAt < staleBefore)))
+            .OrderBy(m => m.Id)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<Guid>> ListTenantsWithPendingAsync(CancellationToken ct = default)
+    {
+        // Snapshot the active tenant set up-front (cheap single SELECT bounded by
+        // the tenants table), then keep the ones with at least one unacked row.
+        // Mirrors EmailOutboxRepository.ClaimNextPendingFromAnyTenantAsync's fan-out.
+        var activeTenantIds = await cp.Tenants
+            .AsNoTracking()
+            .Where(t => t.DeletedAt == null)
+            .OrderBy(t => t.Id)
+            .Select(t => t.Id)
+            .ToListAsync(ct);
+
+        var withPending = new List<Guid>();
+        foreach (var tid in activeTenantIds)
+        {
+            if (ct.IsCancellationRequested) break;
+            try
+            {
+                await using var db = await tenantDbFactory.CreateAsync(tid, ct);
+                var any = await db.ChannelOutbox
+                    .AnyAsync(m => m.TenantId == tid && m.Status != "acked", ct);
+                if (any) withPending.Add(tid);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A tenant mid-deletion / transient connection failure must not
+                // starve the rest of the drain pass; the next cycle retries.
+                continue;
+            }
+        }
+
+        return withPending;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Data/Repositories/IChannelOutboxRepository.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/Repositories/IChannelOutboxRepository.cs
@@ -1,0 +1,68 @@
+using Tamma.Data.Entities;
+
+namespace Tamma.Data.Repositories;
+
+/// <summary>
+/// Story 39-18 (D4/D6) — persistence port for the per-tenant channel
+/// store-and-forward outbox. Pure CRUD; delivery/scheduling policy lives in
+/// <c>ChannelOutboxService</c> (write-time push) and <c>ChannelOutboxSweeper</c>
+/// (re-publish of stale rows). Mirrors <see cref="IEmailOutboxRepository"/>'s
+/// strictly-tenant-scoped shape: every operation requires a <c>tenantId</c> so the
+/// implementation routes to the correct per-tenant DB.
+///
+/// <para>Ack is idempotent (acking an acked row is a no-op returning <c>false</c>),
+/// so a duplicate hub delivery can never double-process — the transport is never the
+/// source of truth (AC6).</para>
+/// </summary>
+public interface IChannelOutboxRepository
+{
+    /// <summary>
+    /// Insert a new message in <c>pending</c> state into the tenant's outbox and
+    /// return the persisted row. <see cref="ChannelOutboxMessage.Id"/> is the
+    /// <c>ChannelEnvelope</c> message id (UUID v7) and MUST be set by the caller.
+    /// </summary>
+    Task<ChannelOutboxMessage> EnqueueAsync(ChannelOutboxMessage msg, CancellationToken ct = default);
+
+    /// <summary>
+    /// List a consumer's unacked rows (<c>pending</c> or <c>delivered</c>) ordered by
+    /// <see cref="ChannelOutboxMessage.Id"/> (UUID v7 = time order) — the connect-time
+    /// replay set. Scoped to (<paramref name="tenantId"/>, <paramref name="audience"/>,
+    /// <paramref name="recipientUserId"/>): an orchestrator consumer passes
+    /// <c>recipientUserId = null</c>; a user consumer passes its own id, so user A's
+    /// list never returns user B's rows.
+    /// </summary>
+    Task<List<ChannelOutboxMessage>> ListUnackedAsync(
+        Guid tenantId, string audience, Guid? recipientUserId, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Mark a row <c>delivered</c> (stamping <see cref="ChannelOutboxMessage.DeliveredAt"/>
+    /// and bumping <see cref="ChannelOutboxMessage.Attempts"/>). No-op if the row is
+    /// already <c>acked</c>.
+    /// </summary>
+    Task MarkDeliveredAsync(Guid tenantId, Guid messageId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Idempotently ack a row: flips it to <c>acked</c> and stamps
+    /// <see cref="ChannelOutboxMessage.AckedAt"/>. Returns <c>true</c> when THIS call
+    /// transitioned the row, <c>false</c> when the row was missing, already acked, or
+    /// not owned by <paramref name="recipientUserId"/> (per-recipient ack).
+    /// </summary>
+    Task<bool> AckAsync(Guid tenantId, Guid messageId, Guid? recipientUserId, CancellationToken ct = default);
+
+    /// <summary>
+    /// List stale unacked rows for the sweeper: <c>pending</c> rows (never delivered —
+    /// crash between persist and publish) and <c>delivered</c> rows whose
+    /// <see cref="ChannelOutboxMessage.DeliveredAt"/> is older than
+    /// <paramref name="staleBefore"/> (missed reconnect race). Ordered by
+    /// <see cref="ChannelOutboxMessage.Id"/>.
+    /// </summary>
+    Task<List<ChannelOutboxMessage>> ListStaleAsync(
+        Guid tenantId, DateTime staleBefore, int limit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cross-tenant drain support — the active tenant ids that have at least one
+    /// unacked (<c>pending</c>/<c>delivered</c>) row, so the sweeper can walk tenants
+    /// without a static enumeration (mirrors the email repo's drain-pass precedent).
+    /// </summary>
+    Task<IReadOnlyList<Guid>> ListTenantsWithPendingAsync(CancellationToken ct = default);
+}

--- a/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TammaModelConfiguration.cs
@@ -1995,6 +1995,44 @@ internal static class TammaModelConfiguration
             // explicit in the repository APIs.
         });
 
+        // ── ChannelOutboxMessage (Story 39-18, D4) ──
+        // The workflow↔orchestrator / user↔orchestrator channel store-and-forward
+        // outbox. Mirrors email_outbox (status transitions, lease semantics) minus
+        // SMTP; PayloadJson is the whole ChannelEnvelope as jsonb for clean replay.
+        modelBuilder.Entity<ChannelOutboxMessage>(entity =>
+        {
+            entity.ToTable("channel_outbox");
+            entity.HasKey(e => e.Id);
+            // Id IS the ChannelEnvelope message id (UUID v7) — client-set, NO
+            // gen_random_uuid() default so ordering by Id is time-ordered replay.
+            entity.Property(e => e.TenantId).IsRequired();
+            entity.Property(e => e.Audience).IsRequired().HasMaxLength(20);
+            entity.Property(e => e.Kind).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.PayloadJson)
+                .HasColumnName("PayloadJson").HasColumnType("jsonb")
+                .IsRequired().HasDefaultValueSql("'{}'::jsonb");
+            entity.Property(e => e.Status).IsRequired().HasMaxLength(20).HasDefaultValue("pending");
+            entity.Property(e => e.Attempts).HasDefaultValue(0);
+            entity.Property(e => e.CreatedAt).HasDefaultValueSql("now()");
+
+            // Per-recipient unacked replay (connect-time + sweeper) and the
+            // per-audience drain the sweeper walks.
+            entity.HasIndex(e => new { e.TenantId, e.RecipientUserId, e.Status })
+                .HasDatabaseName("IX_channel_outbox_tenant_recipient_status");
+            entity.HasIndex(e => new { e.TenantId, e.Audience, e.Status })
+                .HasDatabaseName("IX_channel_outbox_tenant_audience_status");
+
+            if (omitTenantIdColumn)
+            {
+                entity.Ignore(e => e.TenantId);
+            }
+
+            // No query filter — the outbox is shared infra; tenant scoping is
+            // explicit in the repository APIs (the per-tenant schema is the real
+            // isolation plane, the repository carries a TenantId predicate).
+            ApplyTenantFilter(entity, fixedTenantId, e => e.TenantId);
+        });
+
         // ── Analytics usage fact tables (Story 36-1) ──
         // Per-tenant dimensional usage/cost/performance store. Schema-only here
         // (Story 36-2 owns population). Mirrors ConfigurePlatformAnalyticsHourly

--- a/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
+++ b/apps/tamma-elsa/src/Tamma.Data/TenantDbContext.cs
@@ -66,6 +66,7 @@ public class TenantDbContext : DbContext
     public DbSet<Entities.DomainEvent> DomainEvents => Set<Entities.DomainEvent>();
     public DbSet<QueuedTask> QueuedTasks => Set<QueuedTask>();
     public DbSet<EmailOutboxMessage> EmailOutbox => Set<EmailOutboxMessage>();
+    public DbSet<ChannelOutboxMessage> ChannelOutbox => Set<ChannelOutboxMessage>();
     public DbSet<BudgetConfig> BudgetConfigs => Set<BudgetConfig>();
 
     // Story 36-1 — per-tenant dimensional analytics fact tables (hourly +

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -157,13 +157,23 @@ Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorE
         Tamma.Activities.Analytics.NullAnalyticsPricingConfig>(builder.Services);
 builder.Services.AddSingleton<Tamma.Activities.Analytics.DimensionalProjectionMetrics>();
 
-// Story 39-6 (D6) — the ACCEPT stage publishes the AcceptanceRequest through this
-// seam. The default no-op logging publisher keeps the 39-8 gate suspending (the
-// request "waits, never defaulted"); Story 39-18 swaps in the outbox+SignalR
-// delivery behind the same interface.
+// Story 39-6 (D6) → Story 39-18 (D2) — the ACCEPT stage publishes the
+// AcceptanceRequest through this seam. Story 39-18 REPLACES the no-op logging
+// publisher with the real EngineChannelPublisher: it POSTs the ChannelEnvelope to
+// POST /api/engine/channel/outbox (EngineServiceOnly) where the API mints the
+// durable outbox row + best-effort SignalR fan-out. A transport failure is logged
+// ERROR and swallowed (the gate still suspends — the request "waits, never
+// defaulted"). Registered as BOTH IAcceptanceRequestPublisher (39-6's seam) and
+// IEngineChannelPublisher (the broader envelope seam) via one instance.
+builder.Services.AddSingleton<Tamma.Activities.Documents.EngineChannelPublisher>();
 Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
-    .TryAddSingleton<Tamma.Activities.Documents.IAcceptanceRequestPublisher,
-        Tamma.Activities.Documents.LoggingAcceptanceRequestPublisher>(builder.Services);
+    .TryAddSingleton<Tamma.Activities.Documents.IAcceptanceRequestPublisher>(
+        builder.Services,
+        sp => sp.GetRequiredService<Tamma.Activities.Documents.EngineChannelPublisher>());
+Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions
+    .TryAddSingleton<Tamma.Activities.Documents.IEngineChannelPublisher>(
+        builder.Services,
+        sp => sp.GetRequiredService<Tamma.Activities.Documents.EngineChannelPublisher>());
 
 // Round-2 review M3 — bridge that polls platform_events for new
 // TENANT.CLEANUP.REQUESTED rows and re-publishes the matching Elsa

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelDecisionRoutingTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelDecisionRoutingTests.cs
@@ -1,0 +1,142 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Hubs;
+using Tamma.Api.Services;
+using Tamma.Api.Services.Channels;
+using Tamma.Api.Services.Documents;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Channels;
+
+/// <summary>
+/// Story 39-18 (AC2 decision half, AC4 no-double-resume half, D7) — the orchestrator
+/// hub's decision methods DELEGATE to the SAME 39-8 resume surface the REST endpoint
+/// uses, with the server-derived <c>orchestrator</c> channel, and never mutate state
+/// themselves. Runs locally (Moq'd IElsaWorkflowService / event repo).
+/// </summary>
+[TestFixture]
+public class ChannelDecisionRoutingTests
+{
+    private Mock<IElsaWorkflowService> _elsa = null!;
+    private Mock<IChannelOutboxRepository> _outbox = null!;
+    private Mock<IEventRepository> _events = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _elsa = new Mock<IElsaWorkflowService>();
+        _outbox = new Mock<IChannelOutboxRepository>();
+        _events = new Mock<IEventRepository>();
+    }
+
+    private OrchestratorChannelHub BuildHub(ClaimsPrincipal principal)
+    {
+        var decisions = new DocumentDecisionSubmissionService(_elsa.Object);
+        var escalations = new EscalationDispositionService(_events.Object, NullLogger<EscalationDispositionService>.Instance);
+        // ChannelOutboxService is not exercised by the decision methods; a stub is fine.
+        var channels = new ChannelOutboxService(
+            _outbox.Object, _events.Object,
+            new Api.Services.Access.InitiatorOnlyTaskAudienceResolver(),
+            Mock.Of<IHubContext<OrchestratorChannelHub, IOrchestratorChannelClient>>(),
+            Mock.Of<IHubContext<UserChannelHub, IUserChannelClient>>(),
+            NullLogger<ChannelOutboxService>.Instance);
+
+        var hub = new OrchestratorChannelHub(
+            _outbox.Object, decisions, escalations, channels,
+            new AgentOfflineChatRelay(), NullLogger<OrchestratorChannelHub>.Instance);
+
+        var ctx = new Mock<HubCallerContext>();
+        ctx.SetupGet(c => c.User).Returns(principal);
+        ctx.SetupGet(c => c.ConnectionId).Returns("conn-1");
+        ctx.SetupGet(c => c.UserIdentifier).Returns("orchestrator-agent");
+        ctx.SetupGet(c => c.ConnectionAborted).Returns(CancellationToken.None);
+        hub.Context = ctx.Object;
+        return hub;
+    }
+
+    private static ClaimsPrincipal Orchestrator(Guid tenantId) =>
+        new(new ClaimsIdentity(new[]
+        {
+            new Claim(ApprovalChannels.PrincipalTypeClaim, ApprovalChannels.OrchestratorPrincipalType),
+            new Claim("tenantId", tenantId.ToString()),
+            new Claim("email", "orchestrator@tamma"),
+        }, "AuthenticationTypes.Federation"));
+
+    [Test]
+    public async Task SubmitDecision_ForwardsToResumeService_WithServerDerivedOrchestratorChannel()
+    {
+        var tenant = Guid.NewGuid();
+        var session = Guid.NewGuid();
+        string? capturedChannel = null;
+        string? capturedTenant = null;
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .Callback<Guid, string?, string, string?, string?, string?, string, string?>(
+                (_, t, _, _, _, _, ch, _) => { capturedTenant = t; capturedChannel = ch; })
+            .ReturnsAsync(new MergeApprovalResumeResult(true, false, "wf-1"));
+
+        var hub = BuildHub(Orchestrator(tenant));
+        var result = await hub.SubmitDecision(session, """{"kind":"accept"}""", "ship it");
+
+        result.Resumed.Should().BeTrue();
+        result.GateNotFound.Should().BeFalse();
+        result.Channel.Should().Be("orchestrator", "the channel is derived from the orchestrator principal, never the payload");
+        result.Kind.Should().Be("accept");
+        capturedChannel.Should().Be("orchestrator");
+        capturedTenant.Should().Be(tenant.ToString());
+    }
+
+    [Test]
+    public async Task SubmitDecision_SecondSubmitForSameSession_SurfacesGateNotFound_NoDoubleResume()
+    {
+        var session = Guid.NewGuid();
+        _elsa
+            .Setup(s => s.ResumeDocumentDecisionAsync(
+                session, It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string?>()))
+            .ReturnsAsync(new MergeApprovalResumeResult(false, true, null));
+
+        var hub = BuildHub(Orchestrator(Guid.NewGuid()));
+        var result = await hub.SubmitDecision(session, """{"kind":"accept"}""", null);
+
+        result.Resumed.Should().BeFalse();
+        result.GateNotFound.Should().BeTrue("a duplicate submit hits the 39-8 404/409 discipline — no double-resume");
+        // The hub never touched outbox/decision state itself.
+        _outbox.VerifyNoOtherCalls();
+    }
+
+    [Test]
+    public async Task SubmitEscalationDisposition_DelegatesToEscalationService()
+    {
+        // No ESCALATION.TRIGGERED exists → the disposition service returns NotFound,
+        // proving the hub delegated to it (rather than applying anything itself).
+        _events
+            .Setup(e => e.QueryAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int>()))
+            .ReturnsAsync(new List<DomainEvent>());
+
+        var hub = BuildHub(Orchestrator(Guid.NewGuid()));
+        var result = await hub.SubmitEscalationDisposition("esc-404", "resolved", null);
+
+        result.NotFound.Should().BeTrue();
+        result.Resolved.Should().BeFalse();
+        _events.Verify(e => e.QueryAsync(It.IsAny<Guid?>(), "ESCALATION.TRIGGERED", null, It.IsAny<int>()), Times.AtLeastOnce);
+    }
+
+    [Test]
+    public async Task SubmitEscalationDisposition_InvalidDisposition_ReturnsInvalid_NoServiceCall()
+    {
+        var hub = BuildHub(Orchestrator(Guid.NewGuid()));
+        var result = await hub.SubmitEscalationDisposition("esc-1", "not-a-disposition", null);
+
+        result.Invalid.Should().BeTrue();
+        _events.Verify(e => e.QueryAsync(It.IsAny<Guid?>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<int>()), Times.Never);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelHubAuthTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelHubAuthTests.cs
@@ -1,0 +1,109 @@
+using System.Reflection;
+using System.Security.Claims;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Hubs;
+
+namespace Tamma.Api.Tests.Channels;
+
+/// <summary>
+/// Story 39-18 (AC5 — auth + forged-join halves). The <c>OrchestratorChannel</c>
+/// policy admits only a service principal / orchestrator-claim (a member/admin/owner
+/// JWT is rejected), and NO hub method has a parameter that could influence group
+/// membership (a build-time refusal of forged group-join, D5). Runs locally.
+/// </summary>
+[TestFixture]
+public class ChannelHubAuthTests
+{
+    private static OrchestratorChannelHandler Handler()
+        => new(Mock.Of<IHttpContextAccessor>()); // no HttpContext → no ServiceAuthPrincipal; falls to claim checks.
+
+    private static async Task<bool> Evaluate(ClaimsPrincipal principal)
+    {
+        var requirement = new OrchestratorChannelRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { requirement }, principal, resource: null);
+        await Handler().HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Test]
+    public async Task OrchestratorClaim_Passes()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+        {
+            new Claim(ApprovalChannels.PrincipalTypeClaim, ApprovalChannels.OrchestratorPrincipalType),
+        }, "test"));
+        (await Evaluate(principal)).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ServicePrincipalStarPermission_Passes()
+    {
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim("permission", "*") }, "ApiKey"));
+        (await Evaluate(principal)).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task MemberOwnerAdminJwt_IsRejected()
+    {
+        foreach (var role in new[] { "member", "admin", "owner" })
+        {
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("role", role),
+                new Claim("tenantId", Guid.NewGuid().ToString()),
+            }, "test"));
+            (await Evaluate(principal)).Should().BeFalse($"a tenant {role} JWT is not an orchestrator principal (AC5)");
+        }
+    }
+
+    // ── forged-join refusal, made a build-time property (D5) ─────────────────
+
+    [TestCase(typeof(OrchestratorChannelHub))]
+    [TestCase(typeof(UserChannelHub))]
+    public void NoHubMethod_HasAParameterThatCouldInfluenceGroupMembership(Type hubType)
+    {
+        var declared = hubType
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName);
+
+        foreach (var method in declared)
+        {
+            // No client-invokable join surface: no method is named to join/subscribe...
+            method.Name.Should().NotContainEquivalentOf("group");
+            method.Name.Should().NotContainEquivalentOf("subscribe");
+            method.Name.Should().NotContainEquivalentOf("join");
+
+            // ...and no parameter is a group/tenant/recipient selector a client could
+            // pass to steer delivery (groups are derived from claims ONLY).
+            foreach (var p in method.GetParameters())
+            {
+                var pn = (p.Name ?? string.Empty).ToLowerInvariant();
+                pn.Should().NotContain("group");
+                pn.Should().NotContain("tenant");
+                pn.Should().NotContain("recipient");
+                pn.Should().NotContain("audience");
+            }
+        }
+    }
+
+    [Test]
+    public void UserChannelHub_HasNoTaskActionMethod_D7()
+    {
+        // Acting on a task travels the REST resume surface, not the hub. The only
+        // client→server methods are Ack + SendAgentMessage.
+        var methods = typeof(UserChannelHub)
+            .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName && m.Name != nameof(UserChannelHub.OnConnectedAsync))
+            .Select(m => m.Name)
+            .ToList();
+
+        methods.Should().BeEquivalentTo(new[] { nameof(UserChannelHub.Ack), nameof(UserChannelHub.SendAgentMessage) });
+        methods.Should().NotContain(n => n.Contains("Decision") || n.Contains("Resume") || n.Contains("Task"));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelHubIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelHubIntegrationTests.cs
@@ -1,0 +1,276 @@
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.Http.Connections.Client;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Auth;
+using Tamma.Api.Endpoints;
+using Tamma.Api.Hubs;
+using Tamma.Api.Services.Channels;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Channels;
+
+/// <summary>
+/// Story 39-18 (AC3/AC4/AC5 runtime/AC7) — SignalR hub integration over
+/// <see cref="WebApplicationFactory{TEntryPoint}"/> (Testcontainers Postgres via the
+/// shared <c>ApiTestFixture</c>). Uses an in-memory outbox fake + a test auth scheme
+/// so the suite exercises the HUB mechanics deterministically: two-tenant isolation,
+/// degraded mode (no consumer → the row waits), and connect-time replay-without-loss.
+/// Docker-gated (the shared fixture boots a container; CI runs it).
+/// </summary>
+[TestFixture]
+public class ChannelHubIntegrationTests
+{
+    private WebApplicationFactory<Program> _factory = null!;
+    private InMemoryChannelOutbox _outbox = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _outbox = new InMemoryChannelOutbox();
+        _factory = ApiTestFixture.Factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Development");
+            builder.ConfigureTestServices(services =>
+            {
+                services.RemoveAll<IChannelOutboxRepository>();
+                services.AddSingleton<IChannelOutboxRepository>(_outbox);
+                services.RemoveAll<IEventRepository>();
+                services.AddScoped<IEventRepository, NoopEventRepository>();
+
+                services.AddAuthentication(TestChannelAuthHandler.Scheme)
+                    .AddScheme<AuthenticationSchemeOptions, TestChannelAuthHandler>(TestChannelAuthHandler.Scheme, _ => { });
+                services.AddHttpContextAccessor();
+                services.AddScoped<IAuthorizationHandler, OrchestratorChannelHandler>();
+                services.AddAuthorization(options =>
+                {
+                    options.AddPolicy("OrchestratorChannel", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestChannelAuthHandler.Scheme);
+                        p.RequireAuthenticatedUser();
+                        p.AddRequirements(new OrchestratorChannelRequirement());
+                    });
+                    options.AddPolicy("MemberAccess", p =>
+                    {
+                        p.AddAuthenticationSchemes(TestChannelAuthHandler.Scheme);
+                        p.RequireAuthenticatedUser();
+                    });
+                });
+            });
+        });
+    }
+
+    [TearDown]
+    public void TearDown() => _factory?.Dispose();
+
+    private HubConnection Connect(string path, string token, Action<ChannelEnvelope> onReceive)
+    {
+        var conn = new HubConnectionBuilder()
+            .WithUrl($"http://localhost{path}?access_token={Uri.EscapeDataString(token)}", options =>
+            {
+                options.Transports = HttpTransportType.LongPolling;
+                options.HttpMessageHandlerFactory = _ => _factory.Server.CreateHandler();
+            })
+            .AddJsonProtocol(o =>
+            {
+                foreach (var c in DocumentJson.Options.Converters)
+                    o.PayloadSerializerOptions.Converters.Add(c);
+            })
+            .Build();
+        conn.On("Receive", (ChannelEnvelope env) => onReceive(env));
+        return conn;
+    }
+
+    private static ChannelEnvelope OrchestratorEnvelope(Guid tenant) => new(
+        UuidV7.NewGuid(), tenant, ChannelAudience.Orchestrator, null,
+        new EscalationRaised("esc-1", "rounds-exhausted", "{}", "issue-1", null),
+        DateTimeOffset.UtcNow);
+
+    [Test]
+    public async Task TwoTenantIsolation_EnqueueIntoA_ZeroDeliveriesToB()
+    {
+        var tenantA = Guid.NewGuid();
+        var tenantB = Guid.NewGuid();
+        var toA = new ConcurrentBag<ChannelEnvelope>();
+        var toB = new ConcurrentBag<ChannelEnvelope>();
+
+        await using var a = Connect("/hubs/orchestrator", $"orch|{tenantA}", toA.Add);
+        await using var b = Connect("/hubs/orchestrator", $"orch|{tenantB}", toB.Add);
+        await a.StartAsync();
+        await b.StartAsync();
+
+        using var scope = _factory.Services.CreateScope();
+        var svc = scope.ServiceProvider.GetRequiredService<ChannelOutboxService>();
+        await svc.EnqueueAsync(OrchestratorEnvelope(tenantA));
+
+        await Task.Delay(500);
+        toB.Should().BeEmpty("a tenant-A publish must never reach a tenant-B connection (AC5 tenant grain)");
+        toA.Should().ContainSingle();
+    }
+
+    [Test]
+    public async Task DegradedMode_NoConsumer_RowWaitsPending_ThenDeliversOnConnect()
+    {
+        var tenant = Guid.NewGuid();
+
+        // Enqueue with NO consumer connected — the row must persist pending (nothing lost).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var svc = scope.ServiceProvider.GetRequiredService<ChannelOutboxService>();
+            await svc.EnqueueAsync(OrchestratorEnvelope(tenant));
+        }
+        _outbox.RowsFor(tenant).Should().ContainSingle().Which.Status.Should().Be("pending");
+
+        // Connect — the unacked row replays on connect.
+        var received = new ConcurrentBag<ChannelEnvelope>();
+        await using var conn = Connect("/hubs/orchestrator", $"orch|{tenant}", received.Add);
+        await conn.StartAsync();
+        await Task.Delay(500);
+
+        received.Should().ContainSingle("connect-time replay delivers the waiting row");
+        _outbox.RowsFor(tenant).Single().Status.Should().Be("delivered");
+    }
+
+    [Test]
+    public async Task ReplayWithoutLoss_AckRemovesFromUnacked()
+    {
+        var tenant = Guid.NewGuid();
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var svc = scope.ServiceProvider.GetRequiredService<ChannelOutboxService>();
+            await svc.EnqueueAsync(OrchestratorEnvelope(tenant));
+        }
+
+        var received = new ConcurrentBag<ChannelEnvelope>();
+        await using var conn = Connect("/hubs/orchestrator", $"orch|{tenant}", received.Add);
+        await conn.StartAsync();
+        await Task.Delay(500);
+
+        var env = received.Should().ContainSingle().Subject;
+        var ackResult = await conn.InvokeAsync<AckResult>("Ack", env.MessageId);
+        ackResult.Acked.Should().BeTrue();
+        // A second ack is idempotent (no double-process).
+        (await conn.InvokeAsync<AckResult>("Ack", env.MessageId)).Acked.Should().BeFalse();
+    }
+
+    // ── in-memory outbox fake (deterministic; no per-tenant DB needed) ────────
+
+    private sealed class InMemoryChannelOutbox : IChannelOutboxRepository
+    {
+        private readonly ConcurrentDictionary<Guid, ChannelOutboxMessage> _rows = new();
+
+        public IReadOnlyList<ChannelOutboxMessage> RowsFor(Guid tenantId) =>
+            _rows.Values.Where(r => r.TenantId == tenantId).OrderBy(r => r.Id).ToList();
+
+        public Task<ChannelOutboxMessage> EnqueueAsync(ChannelOutboxMessage msg, CancellationToken ct = default)
+        {
+            msg.Status = "pending";
+            _rows[msg.Id] = msg;
+            return Task.FromResult(msg);
+        }
+
+        public Task<List<ChannelOutboxMessage>> ListUnackedAsync(
+            Guid tenantId, string audience, Guid? recipientUserId, int limit, CancellationToken ct = default)
+            => Task.FromResult(_rows.Values
+                .Where(r => r.TenantId == tenantId && r.Audience == audience
+                    && r.RecipientUserId == recipientUserId && r.Status != "acked")
+                .OrderBy(r => r.Id).Take(limit).ToList());
+
+        public Task MarkDeliveredAsync(Guid tenantId, Guid messageId, CancellationToken ct = default)
+        {
+            if (_rows.TryGetValue(messageId, out var r) && r.Status != "acked")
+            {
+                r.Status = "delivered";
+                r.DeliveredAt = DateTime.UtcNow;
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> AckAsync(Guid tenantId, Guid messageId, Guid? recipientUserId, CancellationToken ct = default)
+        {
+            if (_rows.TryGetValue(messageId, out var r) && r.RecipientUserId == recipientUserId && r.Status != "acked")
+            {
+                r.Status = "acked";
+                r.AckedAt = DateTime.UtcNow;
+                return Task.FromResult(true);
+            }
+            return Task.FromResult(false);
+        }
+
+        public Task<List<ChannelOutboxMessage>> ListStaleAsync(Guid tenantId, DateTime staleBefore, int limit, CancellationToken ct = default)
+            => Task.FromResult(_rows.Values
+                .Where(r => r.TenantId == tenantId && r.Status != "acked")
+                .OrderBy(r => r.Id).Take(limit).ToList());
+
+        public Task<IReadOnlyList<Guid>> ListTenantsWithPendingAsync(CancellationToken ct = default)
+            => Task.FromResult((IReadOnlyList<Guid>)_rows.Values
+                .Where(r => r.Status != "acked").Select(r => r.TenantId).Distinct().ToList());
+    }
+
+    private sealed class NoopEventRepository : IEventRepository
+    {
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) => Task.FromResult(evt);
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => Task.FromResult<DomainEvent?>(null);
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit) => Task.FromResult(new List<DomainEvent>());
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => Task.FromResult<DomainEvent?>(null);
+        public Task ClearAsync(Guid tenantId) => Task.CompletedTask;
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(Guid tenantId, string? typePrefix, int limit, int offset)
+            => Task.FromResult(((IReadOnlyList<DomainEvent>)new List<DomainEvent>(), 0));
+    }
+
+    // ── test auth scheme: access_token → principal ───────────────────────────
+
+    private sealed class TestChannelAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+    {
+        public const string Scheme = "TestChannel";
+
+        public TestChannelAuthHandler(IOptionsMonitor<AuthenticationSchemeOptions> options,
+            ILoggerFactory logger, UrlEncoder encoder) : base(options, logger, encoder) { }
+
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+        {
+            var token = Request.Query["access_token"].ToString();
+            if (string.IsNullOrEmpty(token))
+                return Task.FromResult(AuthenticateResult.NoResult());
+
+            var parts = token.Split('|');
+            var claims = new List<Claim>();
+            if (parts[0] == "orch" && parts.Length >= 2)
+            {
+                claims.Add(new Claim(ApprovalChannels.PrincipalTypeClaim, ApprovalChannels.OrchestratorPrincipalType));
+                claims.Add(new Claim("tenantId", parts[1]));
+            }
+            else if (parts[0] == "user" && parts.Length >= 3)
+            {
+                claims.Add(new Claim("tenantId", parts[1]));
+                claims.Add(new Claim(System.IdentityModel.Tokens.Jwt.JwtRegisteredClaimNames.Sub, parts[2]));
+                claims.Add(new Claim("role", "member"));
+            }
+            else
+            {
+                return Task.FromResult(AuthenticateResult.Fail("bad token"));
+            }
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, Scheme));
+            return Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme)));
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelOutboxRepositoryTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelOutboxRepositoryTests.cs
@@ -1,0 +1,137 @@
+using System.Text.Json.Nodes;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using NUnit.Framework;
+using Tamma.Api.Tests.Documents;
+using Tamma.Core.Documents;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Pooling;
+using Tamma.Data.Repositories;
+using Testcontainers.PostgreSql;
+
+namespace Tamma.Api.Tests.Channels;
+
+/// <summary>
+/// Story 39-18 (AC4 storage half) — Postgres 17 Testcontainer proof of the outbox
+/// repository: enqueue + list-unacked ordering by UUID-v7 id, idempotent per-recipient
+/// ack (second ack false, row unchanged), recipient scoping (user A never sees user
+/// B's rows), and jsonb payload round-trip through the real column. Docker-gated (CI
+/// runs it; the local run without Docker skips at container start).
+/// </summary>
+[TestFixture]
+public class ChannelOutboxRepositoryTests
+{
+    private PostgreSqlContainer _postgres = null!;
+    private string _baseConnectionString = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _postgres = new PostgreSqlBuilder()
+            .WithImage("postgres:17-alpine")
+            .WithDatabase("channel_outbox_test")
+            .WithUsername("tamma").WithPassword("tamma")
+            .Build();
+        await _postgres.StartAsync();
+        _baseConnectionString = _postgres.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown() => await _postgres.DisposeAsync();
+
+    private string CsFor(string schema) =>
+        new NpgsqlConnectionStringBuilder(_baseConnectionString) { SearchPath = schema }.ConnectionString;
+
+    private async Task<(ChannelOutboxRepository Repo, Guid Tenant)> NewRepoAsync()
+    {
+        var tenant = Guid.NewGuid();
+        var schema = TenantNaming.SchemaName(tenant);
+        await new EfTenantDbMigrator().MigrateTenantAppAsync(CsFor(schema));
+        var factory = new DocumentTestData.SchemaRoutingFactory(_baseConnectionString).Map(tenant, schema);
+        var cpOpts = new DbContextOptionsBuilder<ControlPlaneDbContext>().UseNpgsql(_baseConnectionString).Options;
+        var repo = new ChannelOutboxRepository(factory, new ControlPlaneDbContext(cpOpts));
+        return (repo, tenant);
+    }
+
+    private static ChannelOutboxMessage Row(Guid tenant, Guid? recipient, string kind, string payload) => new()
+    {
+        Id = UuidV7.NewGuid(),
+        TenantId = tenant,
+        Audience = recipient is null ? "orchestrator" : "user",
+        RecipientUserId = recipient,
+        Kind = kind,
+        PayloadJson = payload,
+    };
+
+    [Test]
+    public async Task Enqueue_ListUnacked_OrderedByUuidV7Id()
+    {
+        var (repo, tenant) = await NewRepoAsync();
+        var a = await repo.EnqueueAsync(Row(tenant, null, "escalation-raised", "{}"));
+        var b = await repo.EnqueueAsync(Row(tenant, null, "escalation-raised", "{}"));
+        var c = await repo.EnqueueAsync(Row(tenant, null, "escalation-raised", "{}"));
+
+        var listed = await repo.ListUnackedAsync(tenant, "orchestrator", null, 100);
+
+        listed.Select(r => r.Id).Should().ContainInOrder(a.Id, b.Id, c.Id);
+        listed.Should().OnlyContain(r => r.Status == "pending");
+    }
+
+    [Test]
+    public async Task Ack_IsIdempotent_SecondAckFalse_RowUnchanged()
+    {
+        var (repo, tenant) = await NewRepoAsync();
+        var row = await repo.EnqueueAsync(Row(tenant, null, "guidance-query", "{}"));
+
+        (await repo.AckAsync(tenant, row.Id, null)).Should().BeTrue("first ack transitions the row");
+        (await repo.AckAsync(tenant, row.Id, null)).Should().BeFalse("acking an acked row is a no-op");
+
+        var remaining = await repo.ListUnackedAsync(tenant, "orchestrator", null, 100);
+        remaining.Should().NotContain(r => r.Id == row.Id, "an acked row is no longer unacked");
+    }
+
+    [Test]
+    public async Task ListUnacked_RecipientScoping_UserANeverSeesUserBRows()
+    {
+        var (repo, tenant) = await NewRepoAsync();
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var rowA = await repo.EnqueueAsync(Row(tenant, userA, "task-assigned", "{}"));
+        await repo.EnqueueAsync(Row(tenant, userB, "task-assigned", "{}"));
+
+        var forA = await repo.ListUnackedAsync(tenant, "user", userA, 100);
+
+        forA.Should().ContainSingle().Which.Id.Should().Be(rowA.Id);
+        // And B's ack of A's row is refused (per-recipient ack).
+        (await repo.AckAsync(tenant, rowA.Id, userB)).Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PayloadJson_RoundTripsThroughJsonbColumn()
+    {
+        var (repo, tenant) = await NewRepoAsync();
+        const string payload = """{"messageId":"x","nested":{"b":2,"a":1},"list":[3,2,1]}""";
+        var row = await repo.EnqueueAsync(Row(tenant, null, "guidance-query", payload));
+
+        var back = (await repo.ListUnackedAsync(tenant, "orchestrator", null, 100)).Single(r => r.Id == row.Id);
+
+        // jsonb re-serializes (whitespace stripped, keys reordered) — compare parsed.
+        JsonNode.DeepEquals(JsonNode.Parse(back.PayloadJson), JsonNode.Parse(payload)).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task ListStale_ReturnsPendingAndOldDelivered()
+    {
+        var (repo, tenant) = await NewRepoAsync();
+        var pending = await repo.EnqueueAsync(Row(tenant, null, "escalation-raised", "{}"));
+        var delivered = await repo.EnqueueAsync(Row(tenant, null, "escalation-raised", "{}"));
+        await repo.MarkDeliveredAsync(tenant, delivered.Id);
+
+        // Everything delivered before "now + 1min" is stale; pending is always stale.
+        var stale = await repo.ListStaleAsync(tenant, DateTime.UtcNow.AddMinutes(1), 100);
+
+        stale.Select(r => r.Id).Should().Contain(new[] { pending.Id, delivered.Id });
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelOutboxServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Channels/ChannelOutboxServiceTests.cs
@@ -1,0 +1,171 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Api.Hubs;
+using Tamma.Api.Services.Access;
+using Tamma.Api.Services.Channels;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Api.Tests.Channels;
+
+/// <summary>
+/// Story 39-18 (AC4 write half, AC6, AC3 scoping half) — the outbox write path:
+/// persist BEFORE publish, guidance events fail-loud, conversation kinds refused,
+/// task fan-out per resolver-approved recipient, kind→audience mismatch rejected.
+/// Runs locally (Moq'd repository / hub contexts / event repo).
+/// </summary>
+[TestFixture]
+public class ChannelOutboxServiceTests
+{
+    private Mock<IChannelOutboxRepository> _outbox = null!;
+    private Mock<IEventRepository> _events = null!;
+    private FakeAudienceResolver _audience = null!;
+    private Mock<IHubContext<OrchestratorChannelHub, IOrchestratorChannelClient>> _orchestratorHub = null!;
+    private Mock<IHubContext<UserChannelHub, IUserChannelClient>> _userHub = null!;
+    private Mock<IOrchestratorChannelClient> _orchestratorClient = null!;
+    private Mock<IUserChannelClient> _userClient = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _outbox = new Mock<IChannelOutboxRepository>();
+        _outbox.Setup(r => r.EnqueueAsync(It.IsAny<ChannelOutboxMessage>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChannelOutboxMessage m, CancellationToken _) => m);
+        _events = new Mock<IEventRepository>();
+        _events.Setup(e => e.AppendAsync(It.IsAny<DomainEvent>()))
+            .ReturnsAsync((DomainEvent e) => e);
+        _audience = new FakeAudienceResolver();
+
+        _orchestratorClient = new Mock<IOrchestratorChannelClient>();
+        var orchClients = new Mock<IHubClients<IOrchestratorChannelClient>>();
+        orchClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_orchestratorClient.Object);
+        _orchestratorHub = new Mock<IHubContext<OrchestratorChannelHub, IOrchestratorChannelClient>>();
+        _orchestratorHub.SetupGet(h => h.Clients).Returns(orchClients.Object);
+
+        _userClient = new Mock<IUserChannelClient>();
+        var userClients = new Mock<IHubClients<IUserChannelClient>>();
+        userClients.Setup(c => c.Group(It.IsAny<string>())).Returns(_userClient.Object);
+        _userHub = new Mock<IHubContext<UserChannelHub, IUserChannelClient>>();
+        _userHub.SetupGet(h => h.Clients).Returns(userClients.Object);
+    }
+
+    private ChannelOutboxService Build() => new(
+        _outbox.Object, _events.Object, _audience,
+        _orchestratorHub.Object, _userHub.Object, NullLogger<ChannelOutboxService>.Instance);
+
+    private static ChannelEnvelope Envelope(ChannelMessage message, ChannelAudience audience, Guid? tenant = null) =>
+        new(UuidV7.NewGuid(), tenant ?? Guid.NewGuid(), audience, null, message, DateTimeOffset.UtcNow);
+
+    [Test]
+    public async Task Enqueue_PersistsBeforePublish_HubThrowLeavesRowPending_NoExceptionToCaller()
+    {
+        // Publish throws — persist must already have happened, and the caller must not see it.
+        _orchestratorClient.Setup(c => c.Receive(It.IsAny<ChannelEnvelope>()))
+            .ThrowsAsync(new InvalidOperationException("hub down"));
+
+        var svc = Build();
+        var envelope = Envelope(new EscalationRaised("esc-1", "rounds-exhausted", "{}", "issue-1", null), ChannelAudience.Orchestrator);
+
+        var act = async () => await svc.EnqueueAsync(envelope);
+
+        await act.Should().NotThrowAsync("a hub publish failure never throws into the caller");
+        _outbox.Verify(r => r.EnqueueAsync(It.IsAny<ChannelOutboxMessage>(), It.IsAny<CancellationToken>()), Times.Once, "persist happens BEFORE publish");
+        _outbox.Verify(r => r.MarkDeliveredAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never, "publish threw before delivered was marked — the row stays pending");
+    }
+
+    [Test]
+    public async Task Enqueue_GuidanceQuery_AppendsGuidanceRequested()
+    {
+        var svc = Build();
+        var envelope = Envelope(new GuidanceQuery(Guid.NewGuid(), "corr-1", "what?", null), ChannelAudience.Orchestrator);
+
+        await svc.EnqueueAsync(envelope);
+
+        _events.Verify(e => e.AppendAsync(It.Is<DomainEvent>(d => d.Type == "GUIDANCE.REQUESTED")), Times.Once);
+    }
+
+    [Test]
+    public async Task Enqueue_GuidanceQuery_EventAppendFailure_IsFailLoud()
+    {
+        _events.Setup(e => e.AppendAsync(It.Is<DomainEvent>(d => d.Type == "GUIDANCE.REQUESTED")))
+            .ThrowsAsync(new InvalidOperationException("event store down"));
+        var svc = Build();
+        var envelope = Envelope(new GuidanceQuery(Guid.NewGuid(), "corr-1", "what?", null), ChannelAudience.Orchestrator);
+
+        var act = async () => await svc.EnqueueAsync(envelope);
+
+        await act.Should().ThrowAsync<InvalidOperationException>("the GUIDANCE event IS part of the operation (fail-loud)");
+    }
+
+    [Test]
+    public async Task Enqueue_DirectConversationKind_IsRefused()
+    {
+        var svc = Build();
+        var envelope = Envelope(new AgentConversationMessage(Guid.NewGuid(), Guid.NewGuid(), "user->agent", "hi"), ChannelAudience.User);
+
+        var act = async () => await svc.EnqueueAsync(envelope);
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("CHANNEL.MESSAGE.INVALID");
+        _outbox.Verify(r => r.EnqueueAsync(It.IsAny<ChannelOutboxMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
+    public async Task Enqueue_KindAudienceMismatch_Throws()
+    {
+        var svc = Build();
+        // acceptance-request's canonical audience is orchestrator; sending it as User is a mismatch.
+        var envelope = Envelope(new GuidanceQuery(Guid.NewGuid(), "c", "q", null), ChannelAudience.User);
+
+        var act = async () => await svc.EnqueueAsync(envelope);
+
+        var ex = await act.Should().ThrowAsync<TammaError>();
+        ex.Which.Code.Should().Be("CHANNEL.MESSAGE.INVALID");
+    }
+
+    [Test]
+    public async Task Enqueue_TaskAssigned_FansOutOneRowPerApprovedRecipient()
+    {
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        _audience.Members = new[] { new AudienceMember(userA, "senior_developer"), new AudienceMember(userB, "senior_developer") };
+
+        var svc = Build();
+        var task = new TaskAssigned(Guid.NewGuid(), Guid.NewGuid(), "senior_developer", "repo-access", "decomposition", Guid.NewGuid(), "issue-1", 70, null);
+        var envelope = Envelope(task, ChannelAudience.User);
+
+        await svc.EnqueueAsync(envelope);
+
+        _outbox.Verify(r => r.EnqueueAsync(
+            It.Is<ChannelOutboxMessage>(m => m.RecipientUserId == userA), It.IsAny<CancellationToken>()), Times.Once);
+        _outbox.Verify(r => r.EnqueueAsync(
+            It.Is<ChannelOutboxMessage>(m => m.RecipientUserId == userB), It.IsAny<CancellationToken>()), Times.Once);
+        _outbox.Verify(r => r.EnqueueAsync(It.IsAny<ChannelOutboxMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task Enqueue_TaskAssigned_NoApprovedRecipients_WritesNoRow()
+    {
+        _audience.Members = Array.Empty<AudienceMember>();
+        var svc = Build();
+        var task = new TaskAssigned(Guid.NewGuid(), Guid.NewGuid(), "senior_developer", "initiator", "decomposition", Guid.NewGuid(), "issue-1", 70, null);
+        var envelope = Envelope(task, ChannelAudience.User);
+
+        await svc.EnqueueAsync(envelope);
+
+        _outbox.Verify(r => r.EnqueueAsync(It.IsAny<ChannelOutboxMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private sealed class FakeAudienceResolver : ITaskAudienceResolver
+    {
+        public IReadOnlyList<AudienceMember> Members { get; set; } = Array.Empty<AudienceMember>();
+        public Task<bool> CanSeeAsync(Guid userId, TaskRef task) => Task.FromResult(Members.Any(m => m.UserId == userId));
+        public Task<IReadOnlyList<AudienceMember>> EligibleAudienceAsync(TaskRef task, string roleWire) => Task.FromResult(Members);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Tamma.Api.Tests.csproj
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Tamma.Api.Tests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <!-- Story 39-18 — SignalR client for the channel hub integration suites
+         (WebApplicationFactory + Testcontainers). Server-side SignalR ships in the
+         shared framework; only the test/client side needs this package. -->
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Channels/ChannelMessageContractTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Channels/ChannelMessageContractTests.cs
@@ -1,0 +1,169 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Channels;
+using Tamma.Core.Documents.Policy;
+
+namespace Tamma.Core.Tests.Documents.Channels;
+
+/// <summary>
+/// Story 39-18 (AC1) — the CLOSED channel message set is drift-tested: polymorphic
+/// round-trip per kind with pinned <c>kind</c> strings, the derived-set count pin
+/// (exactly 8), the <see cref="ChannelAudience"/> wire pins (exactly 2), envelope
+/// round-trip fidelity, and the opaque lineage payload preserved through the wire.
+/// </summary>
+[TestFixture]
+public class ChannelMessageContractTests
+{
+    private static readonly JsonSerializerOptions Options = DocumentJson.Options;
+
+    // ── the eight pinned kinds ──────────────────────────────────────────────
+
+    private static IEnumerable<TestCaseData> Kinds()
+    {
+        yield return new TestCaseData(new AcceptanceRequested(SampleRequest()), "acceptance-request");
+        yield return new TestCaseData(new DecisionProvided(new AcceptanceDecision.Accept(), "orchestrator-agent", "sys@1"), "acceptance-decision");
+        yield return new TestCaseData(new TaskAssigned(Guid.NewGuid(), Guid.NewGuid(), "senior_developer", "initiator", "decomposition", Guid.NewGuid(), "issue-1", 70, "sys@1"), "task-assigned");
+        yield return new TestCaseData(new EscalationRaised("esc-1", "rounds-exhausted", """{"issueId":"issue-1"}""", "issue-1", "sys@1"), "escalation-raised");
+        yield return new TestCaseData(new Tamma.Core.Documents.Channels.EscalationDisposition("esc-1", "resolved", "handled"), "escalation-disposition");
+        yield return new TestCaseData(new GuidanceQuery(Guid.NewGuid(), "corr-1", "what now?", null), "guidance-query");
+        yield return new TestCaseData(new GuidanceReply(Guid.NewGuid(), "do this"), "guidance-reply");
+        yield return new TestCaseData(new AgentConversationMessage(Guid.NewGuid(), Guid.NewGuid(), "user->agent", "hi"), "agent-conversation");
+    }
+
+    [TestCaseSource(nameof(Kinds))]
+    public void Message_RoundTrips_WithPinnedKind(ChannelMessage message, string expectedKind)
+    {
+        var json = JsonSerializer.Serialize<ChannelMessage>(message, Options);
+
+        // The discriminator on the wire is the pinned kind string.
+        var node = JsonNode.Parse(json)!;
+        node["kind"]!.GetValue<string>().Should().Be(expectedKind);
+        ChannelMessageKinds.KindOf(message).Should().Be(expectedKind);
+
+        // Deserializes back to the SAME derived type, and re-serializes to the SAME
+        // JSON (semantic round-trip — robust against record list-reference equality).
+        var back = JsonSerializer.Deserialize<ChannelMessage>(json, Options);
+        back.Should().BeOfType(message.GetType());
+        var reserialized = JsonSerializer.Serialize<ChannelMessage>(back!, Options);
+        JsonNode.DeepEquals(JsonNode.Parse(reserialized), JsonNode.Parse(json)).Should().BeTrue();
+    }
+
+    [Test]
+    public void DerivedSet_IsClosed_ExactlyEight()
+    {
+        var derived = typeof(ChannelMessage)
+            .GetCustomAttributes<JsonDerivedTypeAttribute>()
+            .ToList();
+
+        derived.Should().HaveCount(8, "the channel message set is closed at 8 kinds (AC1)");
+        derived.Select(d => (string)d.TypeDiscriminator!).Should().BeEquivalentTo(new[]
+        {
+            "acceptance-request", "acceptance-decision", "task-assigned", "escalation-raised",
+            "escalation-disposition", "guidance-query", "guidance-reply", "agent-conversation",
+        });
+    }
+
+    [Test]
+    public void ChannelAudience_WireValues_AreExactlyTwo()
+    {
+        Enum.GetValues<ChannelAudience>().Should().HaveCount(2);
+        ChannelAudience.Orchestrator.ToWire().Should().Be("orchestrator");
+        ChannelAudience.User.ToWire().Should().Be("user");
+    }
+
+    // ── envelope fidelity ───────────────────────────────────────────────────
+
+    [Test]
+    public void Envelope_RoundTrip_PreservesIdentityAndRecipient()
+    {
+        var recipient = Guid.NewGuid();
+        var envelope = new ChannelEnvelope(
+            MessageId: UuidV7.NewGuid(),
+            TenantId: Guid.NewGuid(),
+            Audience: ChannelAudience.User,
+            RecipientUserId: recipient,
+            Message: new TaskAssigned(Guid.NewGuid(), Guid.NewGuid(), "senior_developer", "repo-access", "decomposition", Guid.NewGuid(), "issue-9", 80, null),
+            CreatedAt: DateTimeOffset.UtcNow);
+
+        var json = JsonSerializer.Serialize(envelope, Options);
+        var back = JsonSerializer.Deserialize<ChannelEnvelope>(json, Options)!;
+
+        back.MessageId.Should().Be(envelope.MessageId);
+        back.TenantId.Should().Be(envelope.TenantId);
+        back.Audience.Should().Be(ChannelAudience.User);
+        back.RecipientUserId.Should().Be(recipient);
+        back.Message.Should().BeOfType<TaskAssigned>();
+    }
+
+    [Test]
+    public void EscalationRaised_LineageJson_SurvivesTheWire()
+    {
+        const string lineage = """{"issueId":"issue-1","types":[],"unlinkedReviews":[],"outcome":"escalated"}""";
+        var envelope = new ChannelEnvelope(
+            UuidV7.NewGuid(), Guid.NewGuid(), ChannelAudience.Orchestrator, null,
+            new EscalationRaised("esc-42", "always-escalate-class", lineage, "issue-1", null),
+            DateTimeOffset.UtcNow);
+
+        var json = JsonSerializer.Serialize(envelope, Options);
+        var back = JsonSerializer.Deserialize<ChannelEnvelope>(json, Options)!;
+
+        var raised = back.Message.Should().BeOfType<EscalationRaised>().Subject;
+        JsonNode.DeepEquals(JsonNode.Parse(raised.LineageJson), JsonNode.Parse(lineage)).Should().BeTrue();
+    }
+
+    // ── audience map (server-derive-and-validate) ───────────────────────────
+
+    [Test]
+    public void AudienceFor_MapsKinds_AndRefusesConversation()
+    {
+        ChannelMessageKinds.AudienceFor("acceptance-request").Should().Be(ChannelAudience.Orchestrator);
+        ChannelMessageKinds.AudienceFor("task-assigned").Should().Be(ChannelAudience.User);
+        ChannelMessageKinds.AudienceFor("guidance-query").Should().Be(ChannelAudience.Orchestrator);
+        // agent-conversation is not a direct-enqueue kind (D8) — no audience.
+        ChannelMessageKinds.AudienceFor("agent-conversation").Should().BeNull();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static AcceptanceRequest SampleRequest()
+    {
+        var producer = new DocumentProducer
+        {
+            Role = "senior_developer",
+            Action = "decompose-issue",
+            WorkflowDefinitionId = "document-lifecycle",
+        };
+        var doc = SampleEnvelope("decomposition", producer);
+        var review = SampleEnvelope("review", producer);
+        return new AcceptanceRequest
+        {
+            DecisionSessionId = UuidV7.NewGuid(),
+            Document = doc,
+            Review = review,
+            Lineage = new[] { doc },
+            RoundsUsed = 1,
+            Rules = new ResolvedAcceptanceRules(
+                AcceptanceDefaults.Rules, AcceptanceRulesSource.SystemDefault, 1, "decomposition", DateTimeOffset.UtcNow),
+            IssueId = "issue-1",
+        };
+    }
+
+    private static DocumentEnvelope SampleEnvelope(string type, DocumentProducer producer) => new()
+    {
+        Id = UuidV7.NewGuid(),
+        Type = type,
+        SchemaVersion = 1,
+        IssueId = "issue-1",
+        CorrelationId = "corr-1",
+        ProducedBy = producer,
+        State = DocumentState.Draft,
+        CreatedAt = DateTimeOffset.UtcNow,
+        UpdatedAt = DateTimeOffset.UtcNow,
+        Payload = JsonDocument.Parse("{}").RootElement.Clone(),
+    };
+}


### PR DESCRIPTION
## Story 39-18 — Real-Time Channels (Epic 39, Wave 3)

Two SignalR hubs on `Tamma.Api`, backed by a per-tenant **`channel_outbox`** that is the source of truth — the transport is never authoritative, and decisions land **only** through 39-8's idempotent resume surface.

### What's in it
- **`OrchestratorChannelHub`** (`/hubs/orchestrator`) — service-principal/orchestrator-only, tenant-partitioned. **`UserChannelHub`** (`/hubs/user`) — `MemberAccess`; groups (`tenant:{t}`, `user:{t}:{u}`) derived **server-side from claims**, never client-joinable (a reflection pin proves no hub method takes a group name).
- **Closed `[JsonPolymorphic]` `ChannelMessage` set** (8 kinds) + `ChannelEnvelope` in `Tamma.Core/Documents/Channels/`, reusing 39-5's `AcceptanceRequest`/`AcceptanceDecision` by reference.
- **`channel_outbox` tenant table** (`AddChannelOutbox` migration) + repository — enqueue, list-unacked in UUID-v7 order, mark-delivered, **idempotent per-recipient ack**, stale sweep, cross-tenant drain. Tenant model only; `has-pending-model-changes` clean on both contexts.
- **`ChannelOutboxService`** — kind→audience validation (`CHANNEL.MESSAGE.INVALID`), role-addressed task fan-out to one row per resolver-approved recipient, **persist-before-publish**, fail-loud `GUIDANCE.*` events, best-effort hub publish that never throws into the caller.
- **`EngineChannelPublisher`** replaces 39-6's `LoggingAcceptanceRequestPublisher`: the engine publishes via `POST /api/engine/channel/outbox` (`EngineServiceOnly`).
- `OrchestratorChannel` auth policy + handler; `/hubs` `access_token` query auth; a `ChannelOutboxSweeper` background service; and the **D7 extraction** of `DocumentDecisionSubmissionService` shared by the REST endpoint and the hub (behavior-preserving).

### Two bugs caught by running the Docker-gated suites against a real Postgres before pushing
Rather than only building the CI-gated suites, I stood up a local Postgres and ran all 25 channel tests (22→25 after fixes):
1. **Degraded mode** — `PublishBestEffortAsync` marked the row `delivered` right after the group send, but a SignalR send to zero connections is a silent no-op. The row must stay `pending` (AC7) and become `delivered` only via the hub's connect-time replay. Removed the premature mark.
2. **SignalR negotiate `404 tenant_not_found`** — `TenantContextMiddleware` bound a DB tenant on `/hubs`, but a hub connection self-scopes (`OnConnectedAsync` derives the tenant from claims). Added `/hubs` to the tenant-free bypass — the same self-scoping posture as the engine callbacks. (This would have failed CI too.)

### Scope deferrals (dependency stories unlanded)
- **`PersistedOrchestratorInbox` → 39-17.** Not created; the `channel_outbox` this ships is exactly what that future inbox will read. The SignalR hub is the delivery path this story ships.
- **Chat relay → 39-19.** An agent-offline `AgentOfflineChatRelay` stand-in refuses and records nothing until `OrchestratorChatService` lands; the outbox refuses direct conversation-kind enqueue; no `CHAT.*` emitted.
- **Task audience → 39-20.** Fail-closed `InitiatorOnlyTaskAudienceResolver` stub.
- ADR at `.dev/decisions/story-39-18-realtime-channels-design.md` (SSE-vs-SignalR scope split, single-instance stance).

### Verification (independently re-run)
- Builds: all 8 projects green.
- `Tamma.Core.Tests`: **424 passed** (13 new `ChannelMessageContractTests`). `Tamma.Activities.Tests` (filtered): **2623 passed**. Migration clean on both contexts.
- **All 25 `Tamma.Api.Tests.Channels` tests pass against a real Postgres** (repository Testcontainers, service, decision-routing, hub-auth, and the WebApplicationFactory+SignalR integration suite) — the two fixes above verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_