### PR TITLE
feat(39-10): Resumable-by-Design Standard — bookmarks, latest-state re-entry, structural gate

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
@@ -1,0 +1,156 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Attributes;
+using Elsa.Workflows.Models;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.Core;
+using Tamma.Core;
+using Tamma.Core.Documents.Resume;
+using CoreDocumentJson = Tamma.Core.Documents.DocumentJson;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-10 (Design Decision D6) — the ONE re-entry node the generic lifecycle's
+/// Init gains. Resolves <see cref="ILifecycleReEntryService"/> via
+/// <c>context.GetService&lt;T&gt;()</c> (the <c>EventPersistenceMiddleware</c>
+/// activity-service pattern), reconstructs the typed
+/// <see cref="LifecycleResumePosition"/> for the issue+type from durable truth, and
+/// surfaces it as <see cref="PositionJson"/> for the workflow's guard
+/// <c>FlowDecision</c>s. When the position skips produce it also surfaces the existing
+/// revision body (<see cref="ExistingDocumentJson"/>) so the guarded stage reviews /
+/// accepts the stored revision rather than re-producing.
+///
+/// <para>Emits <c>DOCUMENT.REENTERED</c> ONLY when <c>ResumeAt != Produce</c> — a
+/// fresh run is not a re-entry. A missing service is a fail-loud
+/// <c>DOCUMENT.REENTRY.SERVICE_UNREGISTERED</c> (D6) rather than a silent skip.</para>
+/// </summary>
+[Activity(
+    "Tamma.Documents",
+    "Compute Re-Entry Position",
+    "Reconstruct the lifecycle resume position for an issue+type from the document store + DCB events (39-10 crash re-entry)",
+    Kind = ActivityKind.Task
+)]
+public class ComputeReEntryPositionActivity : Activity
+{
+    private readonly ILogger<ComputeReEntryPositionActivity>? _logger;
+
+    [Input(Description = "Issue / requirement id (the re-entry lineage anchor)")]
+    public Input<string?> IssueId { get; set; } = new((string?)null);
+
+    [Input(Description = "Document type key being (re)produced")]
+    public Input<string?> DocumentType { get; set; } = new((string?)null);
+
+    [Input(Description = "Tenant id (empty / single-user → ambient tenant)")]
+    public Input<string?> TenantId { get; set; } = new((string?)null);
+
+    [Input(Description = "Correlation id (tag threading on DOCUMENT.REENTERED)")]
+    public Input<string?> CorrelationId { get; set; } = new((string?)null);
+
+    /// <summary>The serialized <see cref="LifecycleResumePosition"/> the guard FlowDecisions read.</summary>
+    [Output(Description = "Serialized LifecycleResumePosition (39-10)")]
+    public Output<string> PositionJson { get; set; } = default!;
+
+    /// <summary>The existing revision body (serialized DocumentEnvelope) when the position skips produce; else empty.</summary>
+    [Output(Description = "Existing document envelope JSON when skipping produce (else empty)")]
+    public Output<string> ExistingDocumentJson { get; set; } = default!;
+
+    [JsonConstructor]
+    public ComputeReEntryPositionActivity() { }
+
+    public ComputeReEntryPositionActivity(ILogger<ComputeReEntryPositionActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
+    {
+        var service = context.GetService<ILifecycleReEntryService>()
+            ?? throw new TammaError(
+                "DOCUMENT.REENTRY.SERVICE_UNREGISTERED",
+                "No ILifecycleReEntryService is registered in the engine service provider; the lifecycle " +
+                "cannot compute a crash re-entry position. Register LifecycleReEntryService (or the Null seam).",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+
+        var issueId = IssueId.Get(context) ?? "";
+        var documentType = DocumentType.Get(context) ?? "";
+        var tenantId = DocumentEvents.ParseTenantId(TenantId.Get(context));
+        var correlationId = CorrelationId.Get(context);
+
+        var position = await service
+            .ReconstructAsync(tenantId, issueId, documentType, context.CancellationToken)
+            .ConfigureAwait(false);
+
+        context.Set(PositionJson, JsonSerializer.Serialize(position, CoreDocumentJson.Options));
+
+        // Thread the existing body only when the position skips produce (Review/Accept/Complete).
+        var existingJson = string.Empty;
+        if (position.ResumeAt != LifecycleResumeStage.Produce && position.ExistingDocumentId is Guid docId)
+        {
+            var envelope = await service
+                .GetDocumentBodyAsync(tenantId, docId, context.CancellationToken)
+                .ConfigureAwait(false);
+            if (envelope is not null)
+                existingJson = CoreDocumentJson.Serialize(envelope);
+        }
+        context.Set(ExistingDocumentJson, existingJson);
+
+        // DOCUMENT.REENTERED — re-entry is an operation; operations emit events (D9).
+        // Emitted ONLY on an actual re-entry (a fresh Produce is not a re-entry).
+        if (position.ResumeAt != LifecycleResumeStage.Produce)
+        {
+            TammaEventEmitter.Emit(context, this, _logger,
+                BuildReenteredEvent(position, issueId, documentType, correlationId, tenantId));
+            _logger?.LogInformation(
+                "Re-entering {DocumentType} for issue {IssueId} at {ResumeAt}: {Basis}",
+                documentType, issueId, position.ResumeAt, position.Basis);
+        }
+    }
+
+    /// <summary>
+    /// Map a re-entry position onto its <c>DOCUMENT.REENTERED</c> event. Pure (no Elsa
+    /// context); exposed for unit testing the tag/data mapping.
+    /// </summary>
+    public static TammaEvent BuildReenteredEvent(
+        LifecycleResumePosition position,
+        string? issueId,
+        string? documentType,
+        string? correlationId,
+        Guid? tenantId)
+    {
+        var tags = new Dictionary<string, object?>();
+        if (!string.IsNullOrWhiteSpace(issueId)) tags["issueId"] = issueId;
+        if (!string.IsNullOrWhiteSpace(documentType)) tags["documentType"] = documentType;
+        if (!string.IsNullOrWhiteSpace(correlationId)) tags["correlationId"] = correlationId;
+        if (tenantId is Guid t) tags["tenantId"] = t.ToString("D");
+
+        var data = new Dictionary<string, object?>
+        {
+            ["resumeAt"] = position.ResumeAt.ToString(),
+            ["skippedStages"] = SkippedStages(position.ResumeAt),
+            ["basis"] = position.Basis,
+        };
+        if (position.ExistingDocumentId is Guid docId) data["existingDocumentId"] = docId.ToString();
+        if (position.ExistingRevision is int rev) data["revision"] = rev;
+
+        return new TammaEvent
+        {
+            EventType = DocumentEvents.Reentered,
+            Status = DocumentEvents.StatusForEvent(DocumentEvents.Reentered),
+            Tags = tags,
+            Data = data,
+        };
+    }
+
+    /// <summary>The stages a given re-entry skips (audit payload).</summary>
+    public static string[] SkippedStages(LifecycleResumeStage stage) => stage switch
+    {
+        LifecycleResumeStage.Review => new[] { "produce", "validate" },
+        LifecycleResumeStage.Accept => new[] { "produce", "validate", "review" },
+        LifecycleResumeStage.Complete => new[] { "produce", "validate", "review", "accept" },
+        _ => Array.Empty<string>(),
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/DocumentEvents.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/DocumentEvents.cs
@@ -46,6 +46,12 @@ public static class DocumentEvents
     public const string ReviewPanelCompleted = "DOCUMENT.REVIEW_PANEL_COMPLETED";
     public const string ReviewPanelUndecidable = "DOCUMENT.REVIEW_PANEL_UNDECIDABLE";
 
+    // Story 39-10 (Design Decision D9) — crash re-entry is an operation, so it emits
+    // an event. Recorded when a fresh instance re-enters an issue at a non-Produce
+    // stage (Review / Accept / Complete) instead of running from scratch — the
+    // Complete short-circuit emits THIS, never a second DOCUMENT.ACCEPTED. A success row.
+    public const string Reentered = "DOCUMENT.REENTERED";
+
     /// <summary>
     /// Parse a tenant id from the loose string form threaded through the workflow
     /// inputs. Returns <c>null</c> for empty / single-user / unparseable values

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ILifecycleReEntryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ILifecycleReEntryService.cs
@@ -1,0 +1,32 @@
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-10 (AC5, Design Decision D1) — the I/O half of re-entry: reconstructs a
+/// lifecycle's resume position for an issue+type from durable truth (the 39-11
+/// latest-accepted read + the 4-7 DCB event query), delegating the actual fold to the
+/// pure <see cref="LifecycleResumeCalculator"/>. It reads the document store and event
+/// stream IN-PROCESS (never HTTP) and NEVER inspects Elsa instance internals — Elsa
+/// state is an optimization, the store + events are the truth.
+/// </summary>
+public interface ILifecycleReEntryService
+{
+    /// <summary>
+    /// Reconstruct the typed resume position for <paramref name="documentTypeKey"/> on
+    /// <paramref name="issueId"/>. <paramref name="tenantId"/> may be null in single-user
+    /// mode (the ambient tenant is used).
+    /// </summary>
+    Task<LifecycleResumePosition> ReconstructAsync(
+        Guid? tenantId, string issueId, string documentTypeKey, CancellationToken ct);
+
+    /// <summary>
+    /// Fetch the persisted document body for <paramref name="documentId"/> as a
+    /// reconstructed envelope — the guard path threads it into the workflow when a
+    /// re-entry SKIPS produce (Review/Accept/Complete) so the existing revision is
+    /// reviewed/accepted rather than re-produced. Null when the row is missing/foreign.
+    /// </summary>
+    Task<DocumentEnvelope?> GetDocumentBodyAsync(
+        Guid? tenantId, Guid documentId, CancellationToken ct);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs
@@ -1,0 +1,87 @@
+using Tamma.Activities.ADL;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-10 (AC4, Design Decisions D2/D4) — the ONE canonical, tenant-folded
+/// bookmark-name builder every lifecycle suspend point routes through, generalizing
+/// the proven Clarify/Design/Merge per-workflow builders into a single reuse.
+///
+/// <para><b>One core, two sanctioned key shapes (D2).</b> <see cref="Compose"/> is
+/// the single composition core — <c>{gate}-{norm(tenant)}-{norm(seg)}…</c> with every
+/// segment (the tenant included) run through the SAME
+/// <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/> transform used by the
+/// merge/design gates, so suspend and resume compute byte-identical names and a
+/// cross-tenant resume can never resolve another tenant's bookmark (IDOR guard). Two
+/// typed wrappers sit on top:
+/// <list type="bullet">
+///   <item><see cref="ForStageGate"/> — the AC4 domain-keyed shape
+///   <c>(tenantId, issueId, documentType, gate)</c>, for lifecycle stage gates that
+///   must be recomputable from durable domain coordinates alone.</item>
+///   <item><see cref="ForDecisionSession"/> — the 39-8 accept-gate shape
+///   <c>(tenantId, sessionId)</c> where the 128-bit session id carries the
+///   unguessability. It is byte-identical to
+///   <see cref="WaitForDocumentDecisionActivity.DecisionBookmarkName"/> (which now
+///   delegates here). Determinism still holds: the session id is persisted in
+///   <c>LifecycleState</c> and on <c>APPROVAL.REQUESTED</c>, so a post-deploy resume
+///   recomputes the same name from durable state.</item>
+/// </list></para>
+/// </summary>
+public static class LifecycleBookmarks
+{
+    /// <summary>
+    /// The composition core (D2). Prefixes the <paramref name="gate"/> then appends
+    /// the tenant segment and every remaining <paramref name="segments"/> entry, each
+    /// normalized via <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/> so
+    /// hostile characters can't break the delimiter scheme or smuggle a collision.
+    /// </summary>
+    public static string Compose(string gate, string? tenantId, params string[] segments)
+    {
+        var parts = new List<string>(segments.Length + 2)
+        {
+            gate,
+            WaitForMergeApprovalActivity.NormalizeSegment(tenantId),
+        };
+        foreach (var segment in segments)
+            parts.Add(WaitForMergeApprovalActivity.NormalizeSegment(segment));
+        return string.Join("-", parts);
+    }
+
+    /// <summary>
+    /// The AC4 domain-keyed stage-gate name: same
+    /// <c>(tenantId, issueId, documentTypeKey, gate)</c> → same name on suspend and
+    /// resume, recomputable from domain coordinates alone.
+    /// </summary>
+    public static string ForStageGate(string? tenantId, string issueId, string documentTypeKey, string gate)
+        => Compose(gate, tenantId, issueId, documentTypeKey);
+
+    /// <summary>
+    /// The 39-8 accept-gate name, byte-identical to the pre-39-10
+    /// <c>document-decision-{norm(tenant)}-{session}</c> form. NOTE: the session id is
+    /// appended RAW (not through <see cref="WaitForMergeApprovalActivity.NormalizeSegment"/>)
+    /// so the output matches 39-8's original builder exactly — a Guid's canonical
+    /// string form is already delimiter-safe and unguessable, and the byte-parity pin
+    /// guards this.
+    /// </summary>
+    public static string ForDecisionSession(string? tenantId, Guid sessionId)
+    {
+        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
+        return $"document-decision-{tenant}-{sessionId}";
+    }
+
+    /// <summary>
+    /// Story 39-10 (D4) — the CANONICAL-gate registry as production data: each
+    /// sanctioned suspend-activity <see cref="Type"/> mapped to its gate prefix. The
+    /// structural build gate walks built graphs for activity nodes whose type is in
+    /// this dictionary — so "non-canonical bookmark name" becomes "suspend activity
+    /// type not in the registry", with no string-matching of names at test time.
+    /// Seeded with 39-8's <see cref="WaitForDocumentDecisionActivity"/>; the legacy
+    /// Clarify/Design/Merge waits stay OUT (their workflows are allowlisted, and
+    /// 39-13+ migrations retire them).
+    /// </summary>
+    public static IReadOnlyDictionary<Type, string> CanonicalSuspendActivities { get; } =
+        new Dictionary<Type, string>
+        {
+            [typeof(WaitForDocumentDecisionActivity)] = "document-decision",
+        };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleReEntryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleReEntryService.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-10 (AC5, Design Decisions D1/D7) — the REAL re-entry service. Reads
+/// (a) the latest ACCEPTED instance per type via 39-11's
+/// <see cref="IDocumentInstanceRepository.GetLatestAcceptedAsync"/> (in-process, never
+/// HTTP) and (b) the issue's <c>DOCUMENT.*</c>/<c>APPROVAL.*</c> events via the 4-7
+/// <see cref="IEventRepository.QueryEventsAsync"/> query surface, maps both onto the
+/// Core-visible neutral shapes, and delegates the fold to
+/// <see cref="LifecycleResumeCalculator"/>. Registered as the default
+/// <see cref="ILifecycleReEntryService"/> in both hosts now that 39-11 has merged;
+/// <see cref="NullLifecycleReEntryService"/> is the config-flag fallback (D7).
+/// </summary>
+public sealed class LifecycleReEntryService : ILifecycleReEntryService
+{
+    private readonly IDocumentInstanceRepository _documents;
+    private readonly IEventRepository _events;
+    private readonly ITenantContext _tenantContext;
+
+    /// <summary>Per-family cap on the 4-7 event read; a single issue's lifecycle
+    /// event slice is small, but the tenant-wide prefix scan is bounded defensively.</summary>
+    private const int MaxEventsPerFamily = 2000;
+
+    public LifecycleReEntryService(
+        IDocumentInstanceRepository documents,
+        IEventRepository events,
+        ITenantContext tenantContext)
+    {
+        _documents = documents;
+        _events = events;
+        _tenantContext = tenantContext;
+    }
+
+    public async Task<LifecycleResumePosition> ReconstructAsync(
+        Guid? tenantId, string issueId, string documentTypeKey, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(issueId))
+            return LifecycleResumePosition.Fresh(documentTypeKey, "No issue id supplied; running fresh.");
+
+        var tenant = ResolveTenant(tenantId);
+
+        // (a) 39-11 latest-accepted read (in-process repository method, per its AC4).
+        var accepted = await _documents.GetLatestAcceptedAsync(tenant, issueId, ct).ConfigureAwait(false);
+        var acceptedRef = accepted
+            .Where(d => string.Equals(d.DocumentType, documentTypeKey, StringComparison.Ordinal))
+            .Select(d => new AcceptedDocumentRef(d.Id, d.DocumentType, d.Revision))
+            .FirstOrDefault();
+
+        // (b) 4-7 DCB event slice, mapped to the neutral fold DTO, oldest-first.
+        var rows = await LoadEventRowsAsync(tenant, issueId, ct).ConfigureAwait(false);
+
+        return LifecycleResumeCalculator.Reconstruct(documentTypeKey, acceptedRef, rows);
+    }
+
+    public async Task<DocumentEnvelope?> GetDocumentBodyAsync(
+        Guid? tenantId, Guid documentId, CancellationToken ct)
+    {
+        if (documentId == Guid.Empty) return null;
+        var tenant = ResolveTenant(tenantId);
+        var row = await _documents.GetByIdAsync(tenant, documentId, ct).ConfigureAwait(false);
+        return row is null ? null : MapEnvelope(row);
+    }
+
+    // ── Tenant resolution ─────────────────────────────────────────────────
+
+    private Guid ResolveTenant(Guid? tenantId)
+    {
+        if (tenantId is Guid t && t != Guid.Empty) return t;
+        // Single-user binds a personal tenant up-front; the ambient context carries it.
+        return _tenantContext.TenantId
+            ?? throw new TammaError(
+                "DOCUMENT.REENTRY.NO_TENANT",
+                "Re-entry reconstruction requires a tenant id (explicit or ambient); none was available.",
+                retryable: false,
+                severity: TammaErrorSeverity.High);
+    }
+
+    // ── Event read + mapping ──────────────────────────────────────────────
+
+    private async Task<IReadOnlyList<ResumeEventRow>> LoadEventRowsAsync(
+        Guid tenant, string issueId, CancellationToken ct)
+    {
+        var document = await _events
+            .QueryEventsAsync(tenant, "DOCUMENT.", typeIsPrefix: true,
+                correlationId: null, actor: null, from: null, to: null,
+                cursor: null, limit: MaxEventsPerFamily)
+            .ConfigureAwait(false);
+        var approval = await _events
+            .QueryEventsAsync(tenant, "APPROVAL.", typeIsPrefix: true,
+                correlationId: null, actor: null, from: null, to: null,
+                cursor: null, limit: MaxEventsPerFamily)
+            .ConfigureAwait(false);
+
+        return document.Events.Concat(approval.Events)
+            .Select(e => (Event: e, Tags: ParseTags(e.Tags)))
+            .Where(x => string.Equals(ReadTag(x.Tags, "issueId"), issueId, StringComparison.Ordinal))
+            // Total order via the BIGSERIAL sequence — immune to same-ms CreatedAt collisions.
+            .OrderBy(x => x.Event.SequenceNumber)
+            .Select(x => MapRow(x.Event, x.Tags))
+            .ToList();
+    }
+
+    private static ResumeEventRow MapRow(DomainEvent e, JsonElement tags) => new(
+        Type: e.Type,
+        CreatedAtUtc: DateTime.SpecifyKind(e.CreatedAt, DateTimeKind.Utc),
+        DocumentId: ReadGuidTag(tags, "documentId"),
+        DocumentTypeKey: ReadTag(tags, "documentType"),
+        SessionId: ReadGuidTag(tags, "sessionId"),
+        Revision: ReadIntTag(tags, "round"));
+
+    private static JsonElement ParseTags(string? tagsJson)
+    {
+        if (string.IsNullOrWhiteSpace(tagsJson)) return default;
+        try
+        {
+            using var doc = JsonDocument.Parse(tagsJson);
+            return doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+
+    private static string? ReadTag(JsonElement tags, string name)
+        => tags.ValueKind == JsonValueKind.Object
+           && tags.TryGetProperty(name, out var v)
+           && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static Guid? ReadGuidTag(JsonElement tags, string name)
+        => Guid.TryParse(ReadTag(tags, name), out var g) ? g : null;
+
+    private static int? ReadIntTag(JsonElement tags, string name)
+    {
+        if (tags.ValueKind != JsonValueKind.Object || !tags.TryGetProperty(name, out var v))
+            return null;
+        return v.ValueKind switch
+        {
+            JsonValueKind.Number when v.TryGetInt32(out var n) => n,
+            JsonValueKind.String when int.TryParse(v.GetString(), out var s) => s,
+            _ => null,
+        };
+    }
+
+    // ── Store row → envelope reconstruction (guard path) ──────────────────
+
+    private static DocumentEnvelope MapEnvelope(DocumentInstance row)
+    {
+        JsonElement payload;
+        try
+        {
+            using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(row.BodyJson) ? "{}" : row.BodyJson);
+            payload = doc.RootElement.Clone();
+        }
+        catch (JsonException)
+        {
+            using var doc = JsonDocument.Parse("{}");
+            payload = doc.RootElement.Clone();
+        }
+
+        return new DocumentEnvelope
+        {
+            Id = row.Id,
+            Type = row.DocumentType,
+            SchemaVersion = row.SchemaVersion,
+            IssueId = row.IssueId,
+            CorrelationId = row.CorrelationId ?? string.Empty,
+            ParentDocumentId = row.ParentDocumentId,
+            SupersedesDocumentId = row.SupersedesDocumentId,
+            // Reconstruct the producer directly (no eligibility re-assertion — the row
+            // was already validated at write time).
+            ProducedBy = new DocumentProducer
+            {
+                Role = row.ProducedByRole,
+                Action = row.ProducedByAction,
+                WorkflowDefinitionId = string.IsNullOrWhiteSpace(row.ProducedByWorkflow) ? "llm-call" : row.ProducedByWorkflow!,
+            },
+            State = MapState(row.Status),
+            CreatedAt = DateTime.SpecifyKind(row.CreatedAt, DateTimeKind.Utc),
+            UpdatedAt = DateTime.SpecifyKind(row.UpdatedAt, DateTimeKind.Utc),
+            Payload = payload,
+        };
+    }
+
+    /// <summary>Reverse of <c>DocumentInstanceStatusExtensions.FromState</c> for the guard-path
+    /// reconstruction — the store status wire onto the envelope <see cref="DocumentState"/>.</summary>
+    private static DocumentState MapState(string? status) => status switch
+    {
+        "draft" => DocumentState.Draft,
+        "validated" => DocumentState.Validated,
+        "in_review" => DocumentState.Reviewed,
+        "accepted" => DocumentState.Accepted,
+        "rejected" => DocumentState.Rejected,
+        "escalated" => DocumentState.Escalated,
+        // 'superseded' has no envelope state of its own; treat as a validated draft
+        // for reconstruction purposes (the guard only re-enters non-superseded rows).
+        "superseded" => DocumentState.Validated,
+        _ => DocumentState.Draft,
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/NullLifecycleReEntryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/NullLifecycleReEntryService.cs
@@ -1,0 +1,25 @@
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// Story 39-10 (Design Decision D7) — the SAFE seam: always reports a fresh
+/// <see cref="LifecycleResumeStage.Produce"/> position and no existing body, so the
+/// lifecycle runs exactly as it did before re-entry existed (today's behaviour, zero
+/// risk). It is the config-flag fallback: a bad latest-accepted read can be disabled
+/// by swapping the DI registration to this Null seam WITHOUT touching any lifecycle
+/// code (the risk-note mitigation). The REAL <see cref="LifecycleReEntryService"/> is
+/// the default now that 39-11 has landed.
+/// </summary>
+public sealed class NullLifecycleReEntryService : ILifecycleReEntryService
+{
+    public Task<LifecycleResumePosition> ReconstructAsync(
+        Guid? tenantId, string issueId, string documentTypeKey, CancellationToken ct)
+        => Task.FromResult(LifecycleResumePosition.Fresh(
+            documentTypeKey, "Re-entry disabled (NullLifecycleReEntryService); running fresh."));
+
+    public Task<DocumentEnvelope?> GetDocumentBodyAsync(
+        Guid? tenantId, Guid documentId, CancellationToken ct)
+        => Task.FromResult<DocumentEnvelope?>(null);
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
@@ -125,10 +125,7 @@ public class WaitForDocumentDecisionActivity : Activity
     /// sides so the names always agree.
     /// </summary>
     public static string DecisionBookmarkName(string? tenantId, Guid sessionId)
-    {
-        var tenant = WaitForMergeApprovalActivity.NormalizeSegment(tenantId);
-        return $"document-decision-{tenant}-{sessionId}";
-    }
+        => LifecycleBookmarks.ForDecisionSession(tenantId, sessionId);
 
     protected override void Execute(ActivityExecutionContext context)
     {

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -248,6 +248,17 @@ builder.Services.AddSingleton<
 
 builder.Services.AddTammaData(connectionString, appConnectionString, controlPlaneConnectionString);
 
+// Story 39-10 (D1/D7) — crash re-entry. 39-11 has landed, so the REAL
+// LifecycleReEntryService is the default in the API host too (it shares the same
+// engine seam). Documents:ReEntryDisabled=true swaps in the Null seam without touching
+// the lifecycle.
+if (builder.Configuration.GetValue<bool>("Documents:ReEntryDisabled"))
+    builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
+        Tamma.Activities.Documents.NullLifecycleReEntryService>();
+else
+    builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
+        Tamma.Activities.Documents.LifecycleReEntryService>();
+
 // ── Story 28-4 / unified-tenancy Phase 3 — tenant connection pool ──
 //
 // The LRU-cached LruPooledTenantConnectionResolver is the ONLY tenant

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/LifecycleResumeCalculator.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/LifecycleResumeCalculator.cs
@@ -1,0 +1,161 @@
+namespace Tamma.Core.Documents.Resume;
+
+/// <summary>
+/// Story 39-10 (AC5, Design Decision D1) — the PURE, I/O-free re-entry
+/// reconstruction core. Folds the 39-11 latest-accepted read plus the ordered
+/// <c>DOCUMENT.*</c> / <c>APPROVAL.*</c> event slice for one issue+type into a typed
+/// <see cref="LifecycleResumePosition"/>, in the left-fold style of
+/// <c>ReplayReconstructor</c> (which stays the forensic full-replay fallback — this
+/// is the hot read model, not a second replayer).
+///
+/// <para><b>It never guesses.</b> When the store and the stream disagree — an
+/// accepted store row with no <c>DOCUMENT.ACCEPTED</c> event, or the converse — it
+/// throws <c>DOCUMENT.REENTRY.INCONSISTENT_STATE</c> (fail-loud, pointing at the 4-8
+/// replay surface) rather than picking a stage. Skipping a produce that was NOT
+/// accepted is worse than not skipping, so ambiguity is an error.</para>
+///
+/// <para>The event-type strings are mirrored here as local constants because Core
+/// cannot reference <c>Tamma.Activities</c> (where <c>DocumentEvents</c> /
+/// <c>ApprovalEvents</c> live); they are stable wire strings on the
+/// <c>AGGREGATE.ACTION.STATUS</c> convention.</para>
+/// </summary>
+public static class LifecycleResumeCalculator
+{
+    // Mirror of Tamma.Activities.Documents.DocumentEvents (39-6) — the DOCUMENT.* family read by re-entry.
+    private const string ProducedSuccess = "DOCUMENT.PRODUCED.SUCCESS";
+    private const string ValidatedSuccess = "DOCUMENT.VALIDATED.SUCCESS";
+    private const string ValidatedFailed = "DOCUMENT.VALIDATED.FAILED";
+    private const string Reviewed = "DOCUMENT.REVIEWED";
+    private const string RevisionStarted = "DOCUMENT.REVISION_STARTED";
+    private const string Accepted = "DOCUMENT.ACCEPTED";
+
+    // Mirror of Tamma.Activities.Documents.ApprovalEvents (39-8) — the accept-gate session recovery.
+    private const string ApprovalRequested = "APPROVAL.REQUESTED";
+    private const string ApprovalProvided = "APPROVAL.PROVIDED";
+
+    /// <summary>
+    /// Reconstruct the resume position for <paramref name="documentTypeKey"/> from the
+    /// latest-accepted read and the ordered (oldest-first) event slice.
+    /// </summary>
+    /// <param name="documentTypeKey">The document type being (re)produced.</param>
+    /// <param name="latestAccepted">The 39-11 latest-accepted ref for this type, or null.</param>
+    /// <param name="orderedEvents">The issue's <c>DOCUMENT.*</c>/<c>APPROVAL.*</c> events, oldest-first.</param>
+    /// <exception cref="TammaError">Code <c>DOCUMENT.REENTRY.INCONSISTENT_STATE</c> on store/stream disagreement.</exception>
+    public static LifecycleResumePosition Reconstruct(
+        string documentTypeKey,
+        AcceptedDocumentRef? latestAccepted,
+        IReadOnlyList<ResumeEventRow> orderedEvents)
+    {
+        if (string.IsNullOrWhiteSpace(documentTypeKey))
+            throw new ArgumentException("documentTypeKey is required for re-entry reconstruction.", nameof(documentTypeKey));
+
+        // Only events for THIS document type matter. A row with an unset DocumentTypeKey
+        // is treated as non-matching (fail-closed): the fold must not fold a foreign
+        // type's transition into this type's position.
+        var slice = orderedEvents
+            .Where(e => string.Equals(e.DocumentTypeKey, documentTypeKey, StringComparison.Ordinal))
+            .ToList();
+
+        var hasAcceptedEvent = slice.Any(e => e.Type == Accepted);
+        var storeAccepted = latestAccepted is not null;
+
+        // Store/stream disagreement is a hard error — re-entry never guesses (D1).
+        if (storeAccepted != hasAcceptedEvent)
+            throw Inconsistent(documentTypeKey, storeAccepted, hasAcceptedEvent);
+
+        if (storeAccepted)
+        {
+            return new LifecycleResumePosition
+            {
+                DocumentTypeKey = documentTypeKey,
+                ResumeAt = LifecycleResumeStage.Complete,
+                ExistingDocumentId = latestAccepted!.DocumentId,
+                ExistingRevision = latestAccepted.Revision,
+                Basis = $"{documentTypeKey} already accepted (revision {latestAccepted.Revision}); short-circuit to complete.",
+            };
+        }
+
+        // ── Left fold over the ordered slice ──────────────────────────────
+        Guid? latestDocId = null;
+        int? latestRevision = null;
+        var reviewReady = false;               // last validation was SUCCESS with no later REVIEWED/REVISION_STARTED
+        Guid? pendingApprovalSession = null;   // unanswered APPROVAL.REQUESTED session
+
+        foreach (var e in slice)
+        {
+            if (e.DocumentId is Guid id) latestDocId = id;
+            if (e.Revision is int rev) latestRevision = rev;
+
+            switch (e.Type)
+            {
+                case ValidatedSuccess:
+                    reviewReady = true;
+                    break;
+                case ValidatedFailed:
+                    reviewReady = false;
+                    break;
+                case Reviewed:
+                case RevisionStarted:
+                    // A landed review or a started revision means this draft is no
+                    // longer "produced-but-unreviewed".
+                    reviewReady = false;
+                    break;
+                case ApprovalRequested:
+                    pendingApprovalSession = e.SessionId;
+                    break;
+                case ApprovalProvided:
+                    pendingApprovalSession = null;
+                    break;
+                case ProducedSuccess:
+                    // Validation follows; readiness is driven off the validation row.
+                    break;
+            }
+        }
+
+        // Precedence: Accept (latest reachable stage) > Review > Produce.
+        if (pendingApprovalSession is Guid session && session != Guid.Empty)
+        {
+            return new LifecycleResumePosition
+            {
+                DocumentTypeKey = documentTypeKey,
+                ResumeAt = LifecycleResumeStage.Accept,
+                ExistingDocumentId = latestDocId,
+                ExistingRevision = latestRevision,
+                PendingDecisionSessionId = session,
+                Basis = $"{documentTypeKey} awaiting an undecided acceptance (session {session}); re-suspend on the recovered gate.",
+            };
+        }
+
+        if (reviewReady && latestDocId is Guid docId)
+        {
+            return new LifecycleResumePosition
+            {
+                DocumentTypeKey = documentTypeKey,
+                ResumeAt = LifecycleResumeStage.Review,
+                ExistingDocumentId = docId,
+                ExistingRevision = latestRevision,
+                Basis = $"{documentTypeKey} produced-but-unreviewed at revision {latestRevision ?? 0}; skip produce/validate and review it.",
+            };
+        }
+
+        return LifecycleResumePosition.Fresh(
+            documentTypeKey,
+            slice.Count == 0
+                ? $"No prior {documentTypeKey} lineage for this issue; run fresh."
+                : $"No resumable {documentTypeKey} sub-stage (mid-repair / mid-revision / non-accepted terminal); run fresh.");
+    }
+
+    private static TammaError Inconsistent(string documentTypeKey, bool storeAccepted, bool streamAccepted) => new(
+        "DOCUMENT.REENTRY.INCONSISTENT_STATE",
+        $"Re-entry reconstruction found the document store and the DCB event stream disagree for " +
+        $"type '{documentTypeKey}': store-accepted={storeAccepted}, stream-has-ACCEPTED={streamAccepted}. " +
+        "Re-entry refuses to guess a resume position — reconcile via the Story 4-8 replay surface.",
+        new Dictionary<string, object?>
+        {
+            ["documentTypeKey"] = documentTypeKey,
+            ["storeAccepted"] = storeAccepted,
+            ["streamAccepted"] = streamAccepted,
+        },
+        retryable: false,
+        severity: TammaErrorSeverity.High);
+}

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/LifecycleResumePosition.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/LifecycleResumePosition.cs
@@ -1,0 +1,91 @@
+using System.Text.Json.Serialization;
+
+namespace Tamma.Core.Documents.Resume;
+
+/// <summary>
+/// Story 39-10 (AC5) — the coarse lifecycle stage a re-entering instance resumes
+/// at, computed by <see cref="LifecycleResumeCalculator"/> from the 39-11
+/// latest-accepted read + the DCB event slice. Ordered from earliest to latest
+/// stage.
+/// </summary>
+public enum LifecycleResumeStage
+{
+    /// <summary>No usable prior work — run the full lifecycle fresh (the today-behaviour default).</summary>
+    Produce,
+
+    /// <summary>A draft was produced + validated but not yet reviewed — skip produce/validate, review it.</summary>
+    Review,
+
+    /// <summary>The accept gate was reached (APPROVAL.REQUESTED) but no decision landed — re-suspend on the recovered session.</summary>
+    Accept,
+
+    /// <summary>The document of this type is already accepted — short-circuit to the accepted terminal.</summary>
+    Complete,
+}
+
+/// <summary>
+/// Story 39-10 (AC5) — the TYPED resume position for one document type on one
+/// issue. Reconstructed from durable truth (document lineage + DCB events), NEVER
+/// from Elsa instance internals. Every wire property carries an explicit
+/// <c>[JsonPropertyName]</c> and is serialized with <see cref="DocumentJson.Options"/>.
+/// </summary>
+public sealed record LifecycleResumePosition
+{
+    [JsonPropertyName("documentTypeKey")]
+    public required string DocumentTypeKey { get; init; }
+
+    [JsonPropertyName("resumeAt")]
+    public required LifecycleResumeStage ResumeAt { get; init; }
+
+    /// <summary>The store/stream id of the revision to re-enter at (null for a fresh Produce).</summary>
+    [JsonPropertyName("existingDocumentId")]
+    public Guid? ExistingDocumentId { get; init; }
+
+    /// <summary>The 1-based revision of <see cref="ExistingDocumentId"/> (null for a fresh Produce).</summary>
+    [JsonPropertyName("existingRevision")]
+    public int? ExistingRevision { get; init; }
+
+    /// <summary>
+    /// The decision-session id recovered from an unanswered <c>APPROVAL.REQUESTED</c>
+    /// (only set for <see cref="LifecycleResumeStage.Accept"/> re-entry — the gate
+    /// re-suspends on the SAME session bookmark so a pre-crash resume still lands).
+    /// </summary>
+    [JsonPropertyName("pendingDecisionSessionId")]
+    public Guid? PendingDecisionSessionId { get; init; }
+
+    /// <summary>Human-readable derivation (e.g. "Decomposition accepted" / "produced-but-unreviewed at revision 2").</summary>
+    [JsonPropertyName("basis")]
+    public required string Basis { get; init; }
+
+    /// <summary>Convenience — a fresh Produce position (no prior usable work).</summary>
+    public static LifecycleResumePosition Fresh(string documentTypeKey, string basis) => new()
+    {
+        DocumentTypeKey = documentTypeKey,
+        ResumeAt = LifecycleResumeStage.Produce,
+        Basis = basis,
+    };
+}
+
+/// <summary>
+/// Story 39-10 (D1) — a NEUTRAL event DTO the pure calculator folds over. Core
+/// cannot see <c>Tamma.Data</c>'s <c>DomainEvent</c>, so the I/O service
+/// (<c>LifecycleReEntryService</c>) maps the persisted rows onto this shape before
+/// delegating. Carries only the fields the fold reads.
+/// </summary>
+public sealed record ResumeEventRow(
+    string Type,
+    DateTime CreatedAtUtc,
+    Guid? DocumentId,
+    string? DocumentTypeKey,
+    Guid? SessionId,
+    int? Revision);
+
+/// <summary>
+/// Story 39-10 (AC5) — the latest ACCEPTED document reference for one type (the
+/// 39-11 <c>GetLatestAcceptedAsync</c> result mapped to a Core-visible shape).
+/// <c>null</c> means "no accepted document of this type for this issue".
+/// </summary>
+public sealed record AcceptedDocumentRef(
+    Guid DocumentId,
+    string DocumentTypeKey,
+    int Revision);

--- a/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/ResumeBehavior.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/Resume/ResumeBehavior.cs
@@ -1,0 +1,55 @@
+namespace Tamma.Core.Documents.Resume;
+
+/// <summary>
+/// Story 39-10 (AC2, Design Decision D3) — the two resume modes a lifecycle
+/// workflow can declare. A workflow is resumable either because it SUSPENDS on a
+/// deterministic tenant-folded bookmark awaiting external input
+/// (<see cref="BookmarkSuspend"/>), or because — after a crash / restart / definition
+/// version bump — it RE-ENTERS from the latest accepted document state reconstructed
+/// from the store + DCB events (<see cref="LatestStateReEntry"/>), or both.
+/// </summary>
+public enum ResumeMode
+{
+    /// <summary>Suspends on a canonical bookmark (the generalized Clarify/Design pattern).</summary>
+    BookmarkSuspend,
+
+    /// <summary>Re-enters from the latest-accepted read + DCB events (never from Elsa internals).</summary>
+    LatestStateReEntry,
+
+    /// <summary>Both a bookmark suspend AND crash re-entry (the <c>DocumentLifecycleWorkflow</c> posture).</summary>
+    Both,
+}
+
+/// <summary>
+/// Story 39-10 (AC2, D3) — the STATIC, reflectable resume declaration a lifecycle
+/// workflow carries. Placed on the workflow class so the structural build gate
+/// (<c>ResumableStandardStructuralTests</c>) can enumerate it: "is this workflow
+/// resumable?" is answered by reflection, not by reading source. This is data a
+/// test enumerates, not a doc comment (AC2).
+///
+/// <para><see cref="SuspendActivities"/> names the canonical suspend-activity
+/// <see cref="Type"/>s the workflow registers (the "which builder" clause of AC2 —
+/// each canonical gate type owns exactly one bookmark builder). It is REQUIRED
+/// non-empty for <see cref="ResumeMode.BookmarkSuspend"/> / <see cref="ResumeMode.Both"/>
+/// (a bookmark-suspend workflow that names no suspend activity is a contradiction the
+/// gate rejects). A <c>Type[]</c> needs no Elsa reference, so this attribute lives in
+/// <c>Tamma.Core</c> with the rest of the document vocabulary (39-2 pattern).</para>
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+public sealed class ResumeBehaviorAttribute : Attribute
+{
+    public ResumeBehaviorAttribute(ResumeMode mode)
+    {
+        Mode = mode;
+    }
+
+    /// <summary>The declared resume mode.</summary>
+    public ResumeMode Mode { get; }
+
+    /// <summary>
+    /// The canonical suspend-activity types this workflow registers. REQUIRED
+    /// non-empty for <see cref="ResumeMode.BookmarkSuspend"/> / <see cref="ResumeMode.Both"/>;
+    /// left empty for a pure <see cref="ResumeMode.LatestStateReEntry"/> workflow.
+    /// </summary>
+    public Type[] SuspendActivities { get; init; } = Array.Empty<Type>();
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -175,6 +175,17 @@ Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorE
         builder.Services,
         sp => sp.GetRequiredService<Tamma.Activities.Documents.EngineChannelPublisher>());
 
+// Story 39-10 (D1/D7) — crash re-entry. 39-11 has landed, so the REAL
+// LifecycleReEntryService (over IDocumentInstanceRepository + IEventRepository) is the
+// default. The Null seam stays a config-flag fallback: set Documents:ReEntryDisabled=true
+// to disable a bad latest-accepted read by DI swap WITHOUT touching the lifecycle.
+if (builder.Configuration.GetValue<bool>("Documents:ReEntryDisabled"))
+    builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
+        Tamma.Activities.Documents.NullLifecycleReEntryService>();
+else
+    builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
+        Tamma.Activities.Documents.LifecycleReEntryService>();
+
 // Round-2 review M3 — bridge that polls platform_events for new
 // TENANT.CLEANUP.REQUESTED rows and re-publishes the matching Elsa
 // event so CleanUpFailedTenantWorkflow's starter trigger fires. The

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
@@ -13,6 +13,7 @@ using Tamma.Activities.Documents;
 using Tamma.Api.Services.Agents;
 using Tamma.Core.Documents;
 using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Resume;
 using Tamma.Core.Documents.Types;
 using Tamma.ElsaServer.Workflows.Helpers;
 using ExprContext = Elsa.Expressions.Models.ExpressionExecutionContext;
@@ -39,7 +40,18 @@ namespace Tamma.ElsaServer.Workflows;
 /// <c>llm-call</c> and NO branch that skips the decision (D5). The workflow exits as
 /// <c>accepted</c>, <c>rejected</c>, or one of the four typed <c>escalated</c>
 /// outcomes, each carrying full lineage (D7); parents switch on <c>status</c> first.</para>
+///
+/// <para><b>Story 39-10 (D6).</b> Resumable by construction: it SUSPENDS on the
+/// canonical <see cref="WaitForDocumentDecisionActivity"/> bookmark AND re-enters from
+/// the latest accepted state after a crash — declared <c>[ResumeBehavior(Both)]</c> and
+/// enforced by <c>ResumableStandardStructuralTests</c>. Init consults
+/// <see cref="ComputeReEntryPositionActivity"/> and routes idempotent guards:
+/// <c>Complete</c> short-circuits to the accepted terminal (emitting
+/// <c>DOCUMENT.REENTERED</c>, never a second <c>DOCUMENT.ACCEPTED</c>); <c>Review</c>
+/// skips produce/validate; <c>Accept</c> re-suspends on the recovered session; <c>Produce</c>
+/// runs fresh.</para>
 /// </summary>
+[ResumeBehavior(ResumeMode.Both, SuspendActivities = new[] { typeof(WaitForDocumentDecisionActivity) })]
 public class DocumentLifecycleWorkflow : WorkflowBase
 {
     /// <summary>The stable review-producer definition-id contract 39-7 adopts (D10).</summary>
@@ -98,6 +110,11 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         var decisionJson = builder.WithVariable<string>("DecisionJson", "");
         var decisionChannel = builder.WithVariable<string>("DecisionChannel", "orchestrator");
 
+        // ── Story 39-10 re-entry (D6) ──────────────────────────────────
+        var reEntryPositionJson = builder.WithVariable<string>("ReEntryPositionJson", "");
+        var reEntryDocJson = builder.WithVariable<string>("ReEntryDocumentJson", "");
+        var reEntryStage = builder.WithVariable<string>("ReEntryStage", "produce");
+
         // ── Terminal outputs ───────────────────────────────────────────
         var outStatus = builder.WithVariable<string>("OutStatus", "");
         var outOutcome = builder.WithVariable<string>("OutOutcome", "");
@@ -150,6 +167,70 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             })
         };
         init.SetDisplayText("Init");
+
+        // ================================================================
+        // RE-ENTRY (39-10, D6) — reconstruct resume position + idempotent guards
+        // ================================================================
+        var computeReEntry = new ComputeReEntryPositionActivity
+        {
+            Id = "ComputeReEntryPosition", Name = "Compute Re-Entry Position",
+            IssueId = new(ctx => issueId.Get(ctx)),
+            DocumentType = new(ctx => documentType.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+            CorrelationId = new(ctx => correlationId.Get(ctx)),
+            PositionJson = new(reEntryPositionJson),
+            ExistingDocumentJson = new(reEntryDocJson),
+        };
+        computeReEntry.SetDisplayText("Compute Re-Entry Position");
+
+        var applyReEntry = new SetVariable
+        {
+            Id = "ApplyReEntry", Name = "Apply Re-Entry",
+            Variable = reEntryStage,
+            Value = new(ctx =>
+            {
+                var position = DocumentLifecycleHelper.DeserializeReEntryPosition(reEntryPositionJson.Get(ctx));
+                if (position is null)
+                    return "produce";
+
+                var existingJson = reEntryDocJson.Get(ctx);
+                DocumentEnvelope? existing = null;
+                if (!string.IsNullOrWhiteSpace(existingJson))
+                {
+                    try { existing = DocumentJson.Deserialize(existingJson); }
+                    catch (JsonException) { existing = null; }
+                }
+
+                var state = DocumentLifecycleHelper.Deserialize(stateJson.Get(ctx));
+                state = DocumentLifecycleHelper.ApplyReEntry(state, position, existing);
+                stateJson.Set(ctx, DocumentLifecycleHelper.Serialize(state));
+                UpdateCurrent(ctx, state, currentDocId, currentDocJson, currentRound);
+
+                // Accept re-entry re-suspends on the SAME recovered decision session (D6).
+                if (position.ResumeAt == LifecycleResumeStage.Accept &&
+                    position.PendingDecisionSessionId is Guid recovered && recovered != Guid.Empty)
+                    sessionId.Set(ctx, recovered.ToString());
+
+                return position.ResumeAt switch
+                {
+                    LifecycleResumeStage.Complete => "complete",
+                    LifecycleResumeStage.Accept => "accept",
+                    LifecycleResumeStage.Review => "review",
+                    _ => "produce",
+                };
+            })
+        };
+        applyReEntry.SetDisplayText("Apply Re-Entry");
+
+        var reEntryCompleteGate = new FlowDecision(ctx => reEntryStage.Get(ctx) == "complete")
+        { Id = "ReEntryCompleteGate", Name = "Already Accepted?" };
+        reEntryCompleteGate.SetDisplayText("Already Accepted?");
+        var reEntryReviewGate = new FlowDecision(ctx => reEntryStage.Get(ctx) == "review")
+        { Id = "ReEntryReviewGate", Name = "Re-enter At Review?" };
+        reEntryReviewGate.SetDisplayText("Re-enter At Review?");
+        var reEntryAcceptGate = new FlowDecision(ctx => reEntryStage.Get(ctx) == "accept")
+        { Id = "ReEntryAcceptGate", Name = "Re-enter At Accept?" };
+        reEntryAcceptGate.SetDisplayText("Re-enter At Accept?");
 
         // ================================================================
         // PRODUCE — dispatch llm-call (agentRole/action/variables + documentType/issueId)
@@ -559,6 +640,26 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             stateJson, DocumentState.Escalated, outStatus, outOutcome, outDocId, outLifecycleResult,
             currentDocId, currentDocJson, currentRound, TerminalKind.Escalated, escalateOutcome);
 
+        // 39-10 (D6) — Complete short-circuit terminal: the document of this type is ALREADY
+        // accepted. Emits NO second DOCUMENT.ACCEPTED (DOCUMENT.REENTERED was emitted by
+        // ComputeReEntryPosition) and does NOT re-transition the already-accepted envelope.
+        var finalizeReenteredComplete = new SetVariable
+        {
+            Id = "FinalizeReenteredComplete", Name = "Finalize Reentered Complete",
+            Variable = outStatus,
+            Value = new(ctx =>
+            {
+                var state = DocumentLifecycleHelper.Deserialize(stateJson.Get(ctx));
+                var docId = state.Current?.Id ?? Guid.Empty;
+                var result = DocumentLifecycleHelper.BuildAccepted(state, docId);
+                outOutcome.Set(ctx, result.Outcome?.ToWire() ?? "");
+                outDocId.Set(ctx, result.DocumentId?.ToString() ?? "");
+                outLifecycleResult.Set(ctx, JsonSerializer.Serialize(result, DocumentJson.Options));
+                return result.Status;
+            })
+        };
+        finalizeReenteredComplete.SetDisplayText("Finalize Reentered Complete");
+
         var setOutputs = new Sequence
         {
             Id = "SetOutputs", Name = "Set Outputs",
@@ -586,6 +687,8 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             Activities =
             {
                 init,
+                computeReEntry, applyReEntry,
+                reEntryCompleteGate, reEntryReviewGate, reEntryAcceptGate, finalizeReenteredComplete,
                 dispatchProduce, ingestProduce, emitProduced,
                 validateDraft, emitValidated, validationGate,
                 repairCheck, prepareRepair, dispatchRepair, ingestRepair,
@@ -602,7 +705,18 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             },
             Connections =
             {
-                Connect(init, dispatchProduce),
+                // 39-10 re-entry gate chain (D6): Init → compute → apply → guards.
+                Connect(init, computeReEntry),
+                Connect(computeReEntry, applyReEntry),
+                Connect(applyReEntry, reEntryCompleteGate),
+                ConnectOutcome(reEntryCompleteGate, "True", finalizeReenteredComplete),
+                ConnectOutcome(reEntryCompleteGate, "False", reEntryReviewGate),
+                ConnectOutcome(reEntryReviewGate, "True", emitReviewRequested),
+                ConnectOutcome(reEntryReviewGate, "False", reEntryAcceptGate),
+                ConnectOutcome(reEntryAcceptGate, "True", buildAcceptanceRequest),
+                ConnectOutcome(reEntryAcceptGate, "False", dispatchProduce),
+                Connect(finalizeReenteredComplete, setOutputs),
+
                 Connect(dispatchProduce, ingestProduce),
                 Connect(ingestProduce, emitProduced),
                 Connect(emitProduced, validateDraft),

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/DocumentLifecycleHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/DocumentLifecycleHelper.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Tamma.Activities;
 using Tamma.Core;
 using Tamma.Core.Documents;
 using Tamma.Core.Documents.Policy;
+using Tamma.Core.Documents.Resume;
 using Tamma.Core.Documents.Types;
 
 namespace Tamma.ElsaServer.Workflows.Helpers;
@@ -501,6 +503,128 @@ public static class DocumentLifecycleHelper
             RepairAttemptsUsed: state.RepairAttempts,
             LastViolations: state.LastViolations,
             RulesReference: state.RulesReference);
+    }
+
+    // ====================================================================
+    // Story 39-10 (D6/D10) — crash re-entry guards
+    // ====================================================================
+
+    /// <summary>
+    /// The tolerant read-back of a re-entry position payload (D10). Mirrors the
+    /// <c>ClarifyResumeReadBackTests</c> matrix: the position JSON may arrive as a
+    /// <see cref="string"/> or a <see cref="JsonElement"/> (in-process vs serializing
+    /// runtime), and every boolean flag coerces via <see cref="ResumeInput.AsBool"/>
+    /// (never <c>is true</c>). A missing/garbage payload fail-closes to a fresh Produce.
+    /// </summary>
+    public sealed record ReEntryReadResult(
+        LifecycleResumePosition? Position, bool SkipProduce, bool SkipReview, bool ShortCircuitAccepted)
+    {
+        public static readonly ReEntryReadResult Fresh = new(null, false, false, false);
+
+        /// <summary>The coarse resume stage (Produce when there is no usable position).</summary>
+        public LifecycleResumeStage Stage => Position?.ResumeAt ?? LifecycleResumeStage.Produce;
+    }
+
+    /// <summary>Deserialize a re-entry position from its JSON form (null on empty/garbage).</summary>
+    public static LifecycleResumePosition? DeserializeReEntryPosition(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<LifecycleResumePosition>(json, DocumentJson.Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Read a re-entry position + derived skip flags from a resume/output dictionary,
+    /// tolerant of serialization (D10). When <c>PositionJson</c> is present the flags are
+    /// DERIVED from the position; otherwise explicit boolean flags
+    /// (<c>SkipProduce</c>/<c>SkipReview</c>/<c>ShortCircuit</c>) are read via
+    /// <see cref="ResumeInput.AsBool"/>. Missing everything → fresh Produce (fail-closed).
+    /// </summary>
+    public static ReEntryReadResult ReadReEntryPosition(IDictionary<string, object>? input)
+    {
+        if (input is null) return ReEntryReadResult.Fresh;
+
+        LifecycleResumePosition? position = null;
+        if (input.TryGetValue("PositionJson", out var raw))
+            position = DeserializeReEntryPosition(CoerceJson(raw));
+
+        if (position is not null)
+            return new ReEntryReadResult(
+                position, ShouldSkipProduce(position), ShouldSkipReview(position), ShouldShortCircuitAccepted(position));
+
+        return new ReEntryReadResult(
+            null, ReadFlag(input, "SkipProduce"), ReadFlag(input, "SkipReview"), ReadFlag(input, "ShortCircuit"));
+    }
+
+    private static bool ReadFlag(IDictionary<string, object> input, string key)
+        => input.TryGetValue(key, out var v) && ResumeInput.AsBool(v);
+
+    private static string? CoerceJson(object? raw) => raw switch
+    {
+        null => null,
+        string s => s,
+        JsonElement je => je.ValueKind == JsonValueKind.String ? je.GetString() : je.GetRawText(),
+        _ => raw.ToString(),
+    };
+
+    /// <summary>Re-entry skips the produce+validate stage for any non-Produce position.</summary>
+    public static bool ShouldSkipProduce(LifecycleResumePosition? position)
+        => position is not null && position.ResumeAt
+            is LifecycleResumeStage.Review or LifecycleResumeStage.Accept or LifecycleResumeStage.Complete;
+
+    /// <summary>Re-entry skips the review stage once past it (Accept/Complete).</summary>
+    public static bool ShouldSkipReview(LifecycleResumePosition? position)
+        => position is not null && position.ResumeAt
+            is LifecycleResumeStage.Accept or LifecycleResumeStage.Complete;
+
+    /// <summary>An already-accepted document short-circuits to the accepted terminal (no re-emit).</summary>
+    public static bool ShouldShortCircuitAccepted(LifecycleResumePosition? position)
+        => position is not null && position.ResumeAt == LifecycleResumeStage.Complete;
+
+    /// <summary>
+    /// Fold a reconstructed re-entry position into the freshly-seeded loop state (D6). A
+    /// Produce position (or a missing existing body) is a passthrough — today's behaviour.
+    /// A skip-produce position appends the stored revision as the current draft (in its
+    /// stored state) so the guarded stage reviews/accepts it instead of re-producing;
+    /// an Accept position additionally synthesizes a recovered review envelope so the
+    /// acceptance request can be rebuilt.
+    /// </summary>
+    public static LifecycleState ApplyReEntry(
+        LifecycleState state, LifecycleResumePosition position, DocumentEnvelope? existing)
+    {
+        if (position.ResumeAt == LifecycleResumeStage.Produce || existing is null)
+            return state;
+
+        var round = Math.Max(0, (position.ExistingRevision ?? 1) - 1);
+        var withDraft = AppendDraft(state, existing) with { Round = round };
+
+        if (position.ResumeAt == LifecycleResumeStage.Accept)
+        {
+            // Fresh-dispatch Accept re-entry needs a review envelope for the acceptance
+            // request. (The surviving-bookmark AC8 path resumes the live gate directly and
+            // does NOT pass through here.) Synthesize a minimal recovered review.
+            var reviewer = new DocumentProducer
+            {
+                Role = state.ProducerRole,
+                Action = state.ProducerAction,
+                WorkflowDefinitionId = "document-review",
+            };
+            using var doc = JsonDocument.Parse(
+                "{\"decision\":\"approve\",\"summary\":\"recovered on re-entry\",\"issues\":[]}");
+            var review = DocumentEnvelope.CreateDraft(
+                DocumentTypeKey.Review, 1, state.IssueId,
+                string.IsNullOrWhiteSpace(state.CorrelationId) ? state.IssueId : state.CorrelationId,
+                reviewer, doc.RootElement, now: DateTimeOffset.UtcNow);
+            withDraft = AppendReview(withDraft, review);
+        }
+
+        return withDraft;
     }
 
     // ====================================================================

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/LifecycleBookmarksTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/LifecycleBookmarksTests.cs
@@ -1,0 +1,79 @@
+using Elsa.Workflows;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-10 (AC4/AC8) — the ONE canonical tenant-folded bookmark builder
+/// (<see cref="LifecycleBookmarks"/>): determinism, tenant folding, hostile-character
+/// normalization, the registry contract, and the byte-parity pin that keeps
+/// <see cref="WaitForDocumentDecisionActivity.DecisionBookmarkName"/> byte-identical to
+/// its 39-8 output after delegating here.
+/// </summary>
+[TestFixture]
+public class LifecycleBookmarksTests
+{
+    [Test]
+    public void ForStageGate_IsDeterministic_AndFoldsTenant()
+    {
+        var tenantA = Guid.NewGuid().ToString();
+        var tenantB = Guid.NewGuid().ToString();
+
+        var a1 = LifecycleBookmarks.ForStageGate(tenantA, "issue-1", "decomposition", "accept-gate");
+        var a2 = LifecycleBookmarks.ForStageGate(tenantA, "issue-1", "decomposition", "accept-gate");
+        var b1 = LifecycleBookmarks.ForStageGate(tenantB, "issue-1", "decomposition", "accept-gate");
+
+        a1.Should().Be(a2, "same inputs → byte-identical name (suspend/resume parity)");
+        a1.Should().NotBe(b1, "folding the tenant is the IDOR guard — different tenants get disjoint names");
+        a1.Should().StartWith("accept-gate-");
+    }
+
+    [Test]
+    public void Compose_NullTenant_UsesStablePlaceholder()
+    {
+        LifecycleBookmarks.Compose("gate", null, "seg")
+            .Should().Be("gate-none-seg");
+    }
+
+    [Test]
+    public void Compose_NormalizesHostileSegments()
+    {
+        // '/', '-', spaces and upper-case all fold through NormalizeSegment so a segment
+        // cannot break the '-' delimiter scheme or smuggle a collision.
+        var name = LifecycleBookmarks.Compose("gate", "Tenant/A", "Owner/Repo", "ISSUE 1");
+        name.Should().Be("gate-tenant_a-owner_repo-issue_1");
+    }
+
+    [Test]
+    public void ForDecisionSession_IsByteIdenticalTo_DecisionBookmarkName()
+    {
+        var session = Guid.NewGuid();
+        foreach (var tenant in new[] { null, "", "Tenant-A", Guid.NewGuid().ToString() })
+        {
+            LifecycleBookmarks.ForDecisionSession(tenant, session)
+                .Should().Be(WaitForDocumentDecisionActivity.DecisionBookmarkName(tenant, session),
+                    "the 39-8 gate builder must delegate here byte-for-byte");
+        }
+    }
+
+    [Test]
+    public void ForDecisionSession_MatchesLegacyFormat()
+    {
+        var session = Guid.Parse("0192a8b0-2222-7abc-8def-000000000002");
+        LifecycleBookmarks.ForDecisionSession(null, session)
+            .Should().Be($"document-decision-none-{session}");
+    }
+
+    [Test]
+    public void CanonicalSuspendActivities_IsNonEmpty_AndEveryTypeIsAnElsaActivity()
+    {
+        LifecycleBookmarks.CanonicalSuspendActivities.Should().NotBeEmpty();
+        LifecycleBookmarks.CanonicalSuspendActivities.Keys
+            .Should().OnlyContain(t => typeof(IActivity).IsAssignableFrom(t),
+                "every canonical suspend type must be an Elsa activity");
+        LifecycleBookmarks.CanonicalSuspendActivities.Should()
+            .ContainKey(typeof(WaitForDocumentDecisionActivity));
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/LifecycleReEntryServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/LifecycleReEntryServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Resume;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// Story 39-10 (AC5 I/O half, D1/D7) — the re-entry SERVICE reads the latest-accepted
+/// instance via 39-11's repository method (never HTTP), maps the DCB event slice to the
+/// neutral fold DTO, and delegates to the pure calculator. The Null seam always yields
+/// Produce (D7).
+/// </summary>
+[TestFixture]
+public class LifecycleReEntryServiceTests
+{
+    private const string Type = "decomposition";
+    private const string Issue = "issue-1";
+    private static readonly Guid Tenant = Guid.Parse("0192a8b0-9999-7abc-8def-000000000009");
+    private static readonly Guid Doc = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001");
+    private static readonly Guid Session = Guid.Parse("0192a8b0-2222-7abc-8def-000000000002");
+
+    private static Mock<ITenantContext> TenantCtx()
+    {
+        var m = new Mock<ITenantContext>();
+        m.SetupGet(t => t.TenantId).Returns(Tenant);
+        return m;
+    }
+
+    private static DomainEvent Ev(string type, long seq, string? documentType = Type,
+        Guid? documentId = null, Guid? session = null, int? round = null)
+    {
+        var tags = new Dictionary<string, object?> { ["issueId"] = Issue };
+        if (documentType is not null) tags["documentType"] = documentType;
+        if (documentId is Guid d) tags["documentId"] = d.ToString();
+        if (session is Guid s) tags["sessionId"] = s.ToString();
+        if (round is int r) tags["round"] = r;
+        return new DomainEvent
+        {
+            Id = Guid.NewGuid(),
+            Type = type,
+            TenantId = Tenant,
+            Tags = System.Text.Json.JsonSerializer.Serialize(tags),
+            CreatedAt = new DateTime(2026, 7, 23, 0, 0, (int)seq, DateTimeKind.Utc),
+            SequenceNumber = seq,
+        };
+    }
+
+    private static Mock<IEventRepository> Events(IReadOnlyList<DomainEvent> document, IReadOnlyList<DomainEvent> approval)
+    {
+        var m = new Mock<IEventRepository>();
+        m.Setup(r => r.QueryEventsAsync(Tenant, "DOCUMENT.", true, null, null, null, null, null, It.IsAny<int>(), false))
+            .ReturnsAsync((document, (int?)document.Count));
+        m.Setup(r => r.QueryEventsAsync(Tenant, "APPROVAL.", true, null, null, null, null, null, It.IsAny<int>(), false))
+            .ReturnsAsync((approval, (int?)approval.Count));
+        return m;
+    }
+
+    [Test]
+    public async Task Reconstruct_ProducedAndValidated_ReadsLatestAccepted_AndYieldsReview()
+    {
+        var docs = new Mock<IDocumentInstanceRepository>();
+        docs.Setup(d => d.GetLatestAcceptedAsync(Tenant, Issue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<DocumentInstance>());
+
+        var events = Events(
+            new[] { Ev("DOCUMENT.PRODUCED.SUCCESS", 1, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.VALIDATED.SUCCESS", 2, documentId: Doc, round: 0) },
+            Array.Empty<DomainEvent>());
+
+        var svc = new LifecycleReEntryService(docs.Object, events.Object, TenantCtx().Object);
+        var p = await svc.ReconstructAsync(Tenant, Issue, Type, CancellationToken.None);
+
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Review);
+        p.ExistingDocumentId.Should().Be(Doc);
+        // The 39-11 repository method — not any HTTP call — is the latest-accepted source.
+        docs.Verify(d => d.GetLatestAcceptedAsync(Tenant, Issue, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
+    public async Task Reconstruct_Accepted_YieldsComplete()
+    {
+        var accepted = new DocumentInstance
+        {
+            Id = Doc, DocumentType = Type, IssueId = Issue, Revision = 1,
+            Status = "accepted", ProducedByRole = "senior_developer", ProducedByAction = "decompose-issue",
+            SchemaVersion = 1, BodyJson = "{}", TenantId = Tenant,
+        };
+        var docs = new Mock<IDocumentInstanceRepository>();
+        docs.Setup(d => d.GetLatestAcceptedAsync(Tenant, Issue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { accepted });
+
+        var events = Events(
+            new[] { Ev("DOCUMENT.PRODUCED.SUCCESS", 1, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.VALIDATED.SUCCESS", 2, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.REVIEWED", 3, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.ACCEPTED", 4, documentId: Doc, round: 0) },
+            Array.Empty<DomainEvent>());
+
+        var svc = new LifecycleReEntryService(docs.Object, events.Object, TenantCtx().Object);
+        var p = await svc.ReconstructAsync(Tenant, Issue, Type, CancellationToken.None);
+
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Complete);
+        p.ExistingDocumentId.Should().Be(Doc);
+    }
+
+    [Test]
+    public async Task Reconstruct_UnansweredApproval_RecoversSession_Accept()
+    {
+        var docs = new Mock<IDocumentInstanceRepository>();
+        docs.Setup(d => d.GetLatestAcceptedAsync(Tenant, Issue, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<DocumentInstance>());
+
+        var events = Events(
+            new[] { Ev("DOCUMENT.PRODUCED.SUCCESS", 1, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.VALIDATED.SUCCESS", 2, documentId: Doc, round: 0),
+                    Ev("DOCUMENT.REVIEWED", 3, documentId: Doc, round: 0) },
+            new[] { Ev("APPROVAL.REQUESTED", 4, documentId: Doc, session: Session) });
+
+        var svc = new LifecycleReEntryService(docs.Object, events.Object, TenantCtx().Object);
+        var p = await svc.ReconstructAsync(Tenant, Issue, Type, CancellationToken.None);
+
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Accept);
+        p.PendingDecisionSessionId.Should().Be(Session);
+    }
+
+    [Test]
+    public async Task GetDocumentBody_ReconstructsEnvelopeFromStoreRow()
+    {
+        var row = new DocumentInstance
+        {
+            Id = Doc, DocumentType = Type, IssueId = Issue, Revision = 1, Status = "validated",
+            ProducedByRole = "senior_developer", ProducedByAction = "decompose-issue",
+            ProducedByWorkflow = "llm-call", SchemaVersion = 1, CorrelationId = "corr-1",
+            BodyJson = "{\"summary\":\"x\"}", TenantId = Tenant,
+            CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+        };
+        var docs = new Mock<IDocumentInstanceRepository>();
+        docs.Setup(d => d.GetByIdAsync(Tenant, Doc, It.IsAny<CancellationToken>())).ReturnsAsync(row);
+
+        var svc = new LifecycleReEntryService(docs.Object, new Mock<IEventRepository>().Object, TenantCtx().Object);
+        var env = await svc.GetDocumentBodyAsync(Tenant, Doc, CancellationToken.None);
+
+        env.Should().NotBeNull();
+        env!.Id.Should().Be(Doc);
+        env.Type.Should().Be(Type);
+        env.Payload.GetProperty("summary").GetString().Should().Be("x");
+    }
+
+    [Test]
+    public async Task NullService_AlwaysYieldsProduce()
+    {
+        var svc = new NullLifecycleReEntryService();
+        var p = await svc.ReconstructAsync(Tenant, Issue, Type, CancellationToken.None);
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+        (await svc.GetDocumentBodyAsync(Tenant, Doc, CancellationToken.None)).Should().BeNull();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleExecutionTests.cs
@@ -271,6 +271,10 @@ public class DocumentLifecycleExecutionTests
         services.AddLogging();
         services.AddSingleton(publisher);
         services.AddSingleton<IAcceptanceRequestPublisher>(publisher);
+        // Story 39-10 — the lifecycle's Init now consults ILifecycleReEntryService. These
+        // scenarios are all fresh dispatches, so the Null seam (always Produce) preserves
+        // the pre-39-10 behaviour. LifecycleReEntryIntegrationTests wires the real service.
+        services.AddSingleton<ILifecycleReEntryService, NullLifecycleReEntryService>();
 
         services.AddElsa(elsa =>
         {

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
@@ -219,7 +219,10 @@ public class DocumentLifecycleWorkflowStructureTests
             "DOCUMENT.REVIEW_PANEL_STARTED",
             "DOCUMENT.REVIEW_PANEL_COMPLETED",
             "DOCUMENT.REVIEW_PANEL_UNDECIDABLE",
-        }, "the DOCUMENT.* catalogue is the ten Story 39-6 event types plus the three Story 39-7 panel markers");
+            // Story 39-10 — crash re-entry marker (D9 conscious pin bump).
+            "DOCUMENT.REENTERED",
+        }, "the DOCUMENT.* catalogue is the ten Story 39-6 event types, the three Story 39-7 panel markers, " +
+           "and the Story 39-10 DOCUMENT.REENTERED re-entry marker");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryGuardTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryGuardTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Resume;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-10 (AC6) — the idempotent step guards (Elsa-free): re-entering an
+/// ALREADY-ACCEPTED lineage yields zero produce decisions, zero review decisions, and
+/// an event plan containing NO second <c>DOCUMENT.ACCEPTED</c> — exactly
+/// <c>DOCUMENT.REENTERED</c>. Driven over the same lineage the calculator reconstructs
+/// (the "drive the lifecycle twice over the same accepted lineage" contract).
+/// </summary>
+[TestFixture]
+public class LifecycleReEntryGuardTests
+{
+    private const string Type = "decomposition";
+    private static readonly Guid Doc = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001");
+    private static readonly Guid Session = Guid.Parse("0192a8b0-2222-7abc-8def-000000000002");
+
+    private static ResumeEventRow Row(string type, int seq, Guid? docId = null, int? rev = null, Guid? session = null)
+        => new(type, new DateTime(2026, 7, 23, 0, 0, seq, DateTimeKind.Utc), docId, Type, session, rev);
+
+    private static readonly ResumeEventRow[] AcceptedLineage =
+    {
+        Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+        Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+        Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+        Row("APPROVAL.REQUESTED", 4, Doc, 0, Session),
+        Row("APPROVAL.PROVIDED", 5, Doc, 0, Session),
+        Row("DOCUMENT.ACCEPTED", 6, Doc, 0),
+    };
+
+    [Test]
+    public void SecondPassOverAcceptedLineage_SkipsProduceAndReview()
+    {
+        var accepted = new AcceptedDocumentRef(Doc, Type, 1);
+        var position = LifecycleResumeCalculator.Reconstruct(Type, accepted, AcceptedLineage);
+
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Complete);
+        DocumentLifecycleHelper.ShouldSkipProduce(position).Should().BeTrue("an accepted document is never re-produced");
+        DocumentLifecycleHelper.ShouldSkipReview(position).Should().BeTrue("an accepted document is never re-reviewed");
+        DocumentLifecycleHelper.ShouldShortCircuitAccepted(position).Should().BeTrue();
+    }
+
+    [Test]
+    public void CompleteReEntry_EmitsReentered_NotASecondAccepted()
+    {
+        var accepted = new AcceptedDocumentRef(Doc, Type, 1);
+        var position = LifecycleResumeCalculator.Reconstruct(Type, accepted, AcceptedLineage);
+
+        var evt = ComputeReEntryPositionActivity.BuildReenteredEvent(position, "issue-1", Type, "corr-1", null);
+        evt.EventType.Should().Be(DocumentEvents.Reentered);
+        evt.EventType.Should().NotBe(DocumentEvents.Accepted, "the short-circuit must not re-emit acceptance");
+        evt.Status.Should().Be("success");
+
+        ComputeReEntryPositionActivity.SkippedStages(LifecycleResumeStage.Complete)
+            .Should().BeEquivalentTo(new[] { "produce", "validate", "review", "accept" });
+    }
+
+    [Test]
+    public void ReviewReEntry_SkipsProduceButNotReview()
+    {
+        var lineage = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+        };
+        var position = LifecycleResumeCalculator.Reconstruct(Type, null, lineage);
+
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Review);
+        DocumentLifecycleHelper.ShouldSkipProduce(position).Should().BeTrue();
+        DocumentLifecycleHelper.ShouldSkipReview(position).Should().BeFalse("Review re-entry still reviews the existing revision");
+        DocumentLifecycleHelper.ShouldShortCircuitAccepted(position).Should().BeFalse();
+    }
+
+    [Test]
+    public void FreshProduce_EmitsNoReentered()
+    {
+        var position = LifecycleResumeCalculator.Reconstruct(Type, null, Array.Empty<ResumeEventRow>());
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+        DocumentLifecycleHelper.ShouldSkipProduce(position).Should().BeFalse();
+        ComputeReEntryPositionActivity.SkippedStages(LifecycleResumeStage.Produce).Should().BeEmpty();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryIntegrationTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryIntegrationTests.cs
@@ -1,0 +1,422 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Json;
+using Elsa.Extensions;
+using Elsa.Workflows;
+using Elsa.Workflows.Activities;
+using Elsa.Workflows.Management.Activities.SetOutput;
+using Elsa.Workflows.Models;
+using Elsa.Workflows.Runtime;
+using Elsa.Workflows.Runtime.Messages;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.Core;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Policy;
+using Tamma.Data;
+using Tamma.Data.Entities;
+using Tamma.Data.Repositories;
+using Tamma.ElsaServer.Endpoints;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-10 (AC6/AC7/AC8, Design Decision D8) — crash re-entry + bookmark-resume
+/// through the REAL Elsa runtime, extending the 39-6 execution-harness intent with the
+/// REAL <see cref="LifecycleReEntryService"/> over faked 39-11 repos that stand in for
+/// the durable store + stream a prior (crashed) run left behind.
+///
+/// <para>Scenarios: (i) AC7 — a fresh dispatch for an issue whose prior work reached
+/// produced+validated (review pending) RE-ENTERS at Review, does NOT re-produce, runs
+/// to Accepted, and the run's stream carries exactly ONE <c>DOCUMENT.ACCEPTED</c> plus a
+/// <c>DOCUMENT.REENTERED</c>; variant — a prior ACCEPTED doc short-circuits to Complete
+/// with <c>DOCUMENT.REENTERED</c> and NO duplicate acceptance. (ii) AC8 — a fresh run
+/// suspends on the accept gate and resumes via the
+/// <see cref="DocumentDecisionResumeEndpoint"/> resume seam with the re-entry service
+/// wired (the canonical bookmark path).</para>
+///
+/// <para><b>CI-only</b>: the class name contains <c>Integration</c> (skipped by the fast
+/// local filter) and <c>[Explicit]</c> keeps it out of the default gate, matching how
+/// 39-6's execution suite is gated. The full-runtime + faked-store wiring proves the
+/// WIRING; the property-level correctness lives in the unit suites.</para>
+/// </summary>
+[TestFixture]
+[Explicit("Full Elsa workflow-runtime re-entry integration — runs in the CI jobs, skipped in the fast local gate")]
+public class LifecycleReEntryIntegrationTests
+{
+    private static readonly Guid Tenant = Guid.Parse("0192a8b0-9999-7abc-8def-000000000009");
+    private const string Issue = "issue-42";
+    private const string Type = "decomposition";
+    private static readonly Guid ExistingDoc = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001");
+
+    // ── (i) AC7 — crash → fresh dispatch re-enters at Review, exactly one ACCEPTED ──
+
+    [Test]
+    public async Task Crash_FreshDispatch_ReEntersAtReview_NoReproduce_ExactlyOneAccepted()
+    {
+        var docs = new FakeDocuments(latestAccepted: Array.Empty<DocumentInstance>(),
+            byId: new() { [ExistingDoc] = ValidatedRow() });
+        var events = new FakeEvents(
+            document: new[]
+            {
+                Ev("DOCUMENT.PRODUCED.SUCCESS", 1, ExistingDoc, 0),
+                Ev("DOCUMENT.VALIDATED.SUCCESS", 2, ExistingDoc, 0),
+            },
+            approval: Array.Empty<DomainEvent>());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, docs, events);
+
+        // Review stub approves; the fresh instance re-enters at Review and suspends on accept.
+        Reviews.Enqueue(ApproveReview());
+
+        var request = await RunToSuspendAsync(provider);
+        request.Should().NotBeNull("re-entry at Review must review the existing revision then suspend on the accept gate");
+
+        var result = await ResumeAsync(provider, request!.DecisionSessionId, Accept());
+        Status(result).Should().Be(DocumentLifecycleResult.StatusAccepted);
+
+        var stream = CapturedTypes(capture);
+        stream.Should().Contain(DocumentEvents.Reentered, "the re-entry must record DOCUMENT.REENTERED");
+        stream.Should().NotContain(DocumentEvents.ProducedSuccess, "produce is skipped on Review re-entry");
+        stream.Count(t => t == DocumentEvents.Accepted).Should().Be(1, "exactly one acceptance per document");
+    }
+
+    [Test]
+    public async Task Crash_AfterAccept_FreshDispatch_ShortCircuitsToComplete_NoDuplicateAcceptance()
+    {
+        var docs = new FakeDocuments(
+            latestAccepted: new[] { AcceptedRow() },
+            byId: new() { [ExistingDoc] = AcceptedRow() });
+        var events = new FakeEvents(
+            document: new[]
+            {
+                Ev("DOCUMENT.PRODUCED.SUCCESS", 1, ExistingDoc, 0),
+                Ev("DOCUMENT.VALIDATED.SUCCESS", 2, ExistingDoc, 0),
+                Ev("DOCUMENT.REVIEWED", 3, ExistingDoc, 0),
+                Ev("DOCUMENT.ACCEPTED", 4, ExistingDoc, 0),
+            },
+            approval: Array.Empty<DomainEvent>());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, docs, events);
+
+        var result = await RunToCompletionAsync(provider);
+
+        Status(result).Should().Be(DocumentLifecycleResult.StatusAccepted, "an accepted doc short-circuits to complete");
+        var stream = CapturedTypes(capture);
+        stream.Should().Contain(DocumentEvents.Reentered);
+        stream.Should().NotContain(DocumentEvents.Accepted, "the short-circuit must NOT re-emit DOCUMENT.ACCEPTED");
+        stream.Should().NotContain(DocumentEvents.ProducedSuccess);
+    }
+
+    // ── (ii) AC8 — fresh run suspends on the accept gate, resumes via the seam ──
+
+    [Test]
+    public async Task FreshRun_SuspendsOnAcceptGate_ResumesViaEndpoint_ToAccepted()
+    {
+        var docs = new FakeDocuments(Array.Empty<DocumentInstance>(), new());
+        var events = new FakeEvents(Array.Empty<DomainEvent>(), Array.Empty<DomainEvent>());
+
+        var capture = new CapturingHandler();
+        await using var provider = BuildProvider(capture, docs, events);
+
+        // Fresh issue → Produce path; the llm-call + review stubs drive it to the accept gate.
+        Llm.Enqueue(ValidDecomposition());
+        Reviews.Enqueue(ApproveReview());
+
+        var request = await RunToSuspendAsync(provider);
+        request.Should().NotBeNull("a fresh run publishes an AcceptanceRequest and suspends on the canonical bookmark");
+
+        var result = await ResumeAsync(provider, request!.DecisionSessionId, Accept());
+        Status(result).Should().Be(DocumentLifecycleResult.StatusAccepted);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // Harness (mirrors DocumentLifecycleExecutionTests; self-contained)
+    // ════════════════════════════════════════════════════════════════════
+
+    private static readonly ConcurrentQueue<string> Llm = new();
+    private static readonly ConcurrentQueue<string> Reviews = new();
+
+    [SetUp]
+    public void Reset() { Llm.Clear(); Reviews.Clear(); }
+
+    private static async Task<AcceptanceRequest?> RunToSuspendAsync(IServiceProvider provider)
+    {
+        var publisher = provider.GetRequiredService<CapturingPublisher>();
+        var runtime = provider.GetRequiredService<IWorkflowRuntime>();
+        var client = await runtime.CreateClientAsync();
+        await client.CreateAndRunInstanceAsync(new CreateAndRunWorkflowInstanceRequest
+        {
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId("document-lifecycle"),
+            Input = LifecycleInput(),
+        });
+        return publisher.Last;
+    }
+
+    private static async Task<IDictionary<string, object>> RunToCompletionAsync(IServiceProvider provider)
+    {
+        var runtime = provider.GetRequiredService<IWorkflowRuntime>();
+        var client = await runtime.CreateClientAsync();
+        await client.CreateAndRunInstanceAsync(new CreateAndRunWorkflowInstanceRequest
+        {
+            WorkflowDefinitionHandle = WorkflowDefinitionHandle.ByDefinitionId("document-lifecycle"),
+            Input = LifecycleInput(),
+        });
+        var state = await client.ExportStateAsync();
+        return state.Output ?? new Dictionary<string, object>();
+    }
+
+    private static async Task<IDictionary<string, object>> ResumeAsync(
+        IServiceProvider provider, Guid session, string decisionJson)
+    {
+        var bookmarkStore = provider.GetRequiredService<IBookmarkStore>();
+        var runtime = provider.GetRequiredService<IWorkflowRuntime>();
+        var loggerFactory = provider.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
+
+        var name = WaitForDocumentDecisionActivity.DecisionBookmarkName(Tenant.ToString(), session);
+        var bookmarks = (await bookmarkStore.FindManyAsync(
+            new Elsa.Workflows.Runtime.Filters.BookmarkFilter { Name = name }, CancellationToken.None)).ToList();
+        var instanceId = bookmarks.Count == 1 ? bookmarks[0].WorkflowInstanceId : string.Empty;
+
+        await DocumentDecisionResumeEndpoint.Resume(
+            new DocumentDecisionResumeEndpoint.ResumeRequest(
+                SessionId: session, TenantId: Tenant.ToString(), DecisionJson: decisionJson,
+                Feedback: null, DeciderId: "orchestrator", DeciderDisplay: null,
+                Channel: "orchestrator", RulesReference: "system-default@1"),
+            bookmarkStore, runtime, loggerFactory, CancellationToken.None);
+
+        if (string.IsNullOrEmpty(instanceId)) return new Dictionary<string, object>();
+        var client = await runtime.CreateClientAsync(instanceId);
+        var state = await client.ExportStateAsync();
+        return state.Output ?? new Dictionary<string, object>();
+    }
+
+    private static Dictionary<string, object> LifecycleInput() => new()
+    {
+        ["producerRole"] = "senior_developer",
+        ["producerAction"] = "decompose-issue",
+        ["producerVariablesJson"] = "{\"workItemJson\":\"x\"}",
+        ["documentType"] = Type,
+        ["issueId"] = Issue,
+        ["correlationId"] = "corr-42",
+        ["acceptanceRulesJson"] = "",
+        ["tenantId"] = Tenant.ToString(),
+    };
+
+    private static string? Status(IDictionary<string, object> output)
+        => output.TryGetValue("status", out var s) ? s?.ToString() : null;
+
+    private static List<string?> CapturedTypes(CapturingHandler capture) =>
+        capture.Bodies
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .Select(e => e.GetProperty("eventType").GetString())
+            .ToList();
+
+    private static ServiceProvider BuildProvider(
+        CapturingHandler capture, IDocumentInstanceRepository docs, IEventRepository events)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var publisher = new CapturingPublisher();
+        services.AddSingleton(publisher);
+        services.AddSingleton<IAcceptanceRequestPublisher>(publisher);
+
+        // The REAL re-entry service over faked 39-11 repos + a fixed ambient tenant.
+        services.AddSingleton(docs);
+        services.AddSingleton(events);
+        services.AddSingleton<ITenantContext>(new FixedTenantContext(Tenant));
+        services.AddSingleton<ILifecycleReEntryService, LifecycleReEntryService>();
+
+        services.AddElsa(elsa =>
+        {
+            elsa.AddActivitiesFrom<EmitDocumentEventActivity>();
+            elsa.AddWorkflow<DocumentLifecycleWorkflow>();
+            elsa.AddWorkflow<StubLlmCallWorkflow>();
+            elsa.AddWorkflow<StubDocumentReviewWorkflow>();
+            elsa.UseWorkflows(w => w.UseTammaEventPersistence());
+        });
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = "http://tamma.test",
+                ["Engine:CallbackUrl"] = "http://engine.test",
+            })
+            .Build();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddSingleton(_ => new Tamma.Activities.LlmCall.TammaApiClient(
+            new HttpClient(capture) { BaseAddress = null },
+            NullLogger<Tamma.Activities.LlmCall.TammaApiClient>.Instance,
+            config));
+
+        return services.BuildServiceProvider();
+    }
+
+    // ── seed fixtures ──────────────────────────────────────────────────
+
+    private static DomainEvent Ev(string type, long seq, Guid documentId, int round)
+    {
+        var tags = new Dictionary<string, object?>
+        {
+            ["issueId"] = Issue,
+            ["documentType"] = Type,
+            ["documentId"] = documentId.ToString(),
+            ["round"] = round,
+        };
+        return new DomainEvent
+        {
+            Id = Guid.NewGuid(), Type = type, TenantId = Tenant,
+            Tags = JsonSerializer.Serialize(tags),
+            CreatedAt = new DateTime(2026, 7, 23, 0, 0, (int)seq, DateTimeKind.Utc),
+            SequenceNumber = seq,
+        };
+    }
+
+    private static DocumentInstance ValidatedRow() => Row("validated");
+    private static DocumentInstance AcceptedRow() => Row("accepted");
+
+    private static DocumentInstance Row(string status) => new()
+    {
+        Id = ExistingDoc, DocumentType = Type, IssueId = Issue, Revision = 1, Status = status,
+        ProducedByRole = "senior_developer", ProducedByAction = "decompose-issue",
+        ProducedByWorkflow = "llm-call", SchemaVersion = 1, CorrelationId = "corr-42",
+        BodyJson = ValidDecomposition(), TenantId = Tenant,
+        CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
+    };
+
+    private static string Accept() => "{\"kind\":\"accept\"}";
+
+    private static string ValidDecomposition() =>
+        "{\"summary\":\"Split rate limiting into middleware then config.\",\"subtasks\":[" +
+        "{\"id\":\"ST-1\",\"title\":\"Middleware\",\"description\":\"limiter\",\"estimateHours\":6,\"complexity\":\"medium\",\"dependsOn\":[]}]}";
+
+    private static string ApproveReview() =>
+        "{\"subject\":{\"kind\":\"document\",\"documentId\":\"0192a8b0-1111-7abc-8def-000000000001\",\"documentType\":\"decomposition\"}," +
+        "\"decision\":\"approve\",\"summary\":\"looks good\",\"issues\":[]}";
+
+    // ── stubs + fakes ──────────────────────────────────────────────────
+
+    public class StubLlmCallWorkflow : WorkflowBase
+    {
+        protected override void Build(IWorkflowBuilder builder)
+        {
+            builder.DefinitionId = "llm-call";
+            builder.Root = new Sequence
+            {
+                Activities =
+                {
+                    new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) },
+                    new SetOutput { Id = "OutResponse", OutputName = new("llmResponse"),
+                        OutputValue = new(_ => (object)(Llm.TryDequeue(out var v) ? v : "{}")) },
+                },
+            };
+        }
+    }
+
+    public class StubDocumentReviewWorkflow : WorkflowBase
+    {
+        protected override void Build(IWorkflowBuilder builder)
+        {
+            builder.DefinitionId = "document-review";
+            builder.Root = new Sequence
+            {
+                Activities =
+                {
+                    new SetOutput { Id = "OutSuccess", OutputName = new("success"), OutputValue = new(_ => (object)true) },
+                    new SetOutput { Id = "OutReview", OutputName = new("reviewJson"),
+                        OutputValue = new(_ => (object)(Reviews.TryDequeue(out var v) ? v : "{}")) },
+                },
+            };
+        }
+    }
+
+    private sealed class CapturingPublisher : IAcceptanceRequestPublisher
+    {
+        private readonly ConcurrentQueue<AcceptanceRequest> _requests = new();
+        public AcceptanceRequest? Last => _requests.LastOrDefault();
+        public Task PublishAsync(AcceptanceRequest request, CancellationToken ct)
+        {
+            _requests.Enqueue(request);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public List<string> Bodies { get; } = new();
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            if (request.Content is not null)
+                Bodies.Add(await request.Content.ReadAsStringAsync(ct));
+            return new HttpResponseMessage(HttpStatusCode.Created)
+            {
+                Content = new StringContent("{\"ok\":true,\"persisted\":1}"),
+            };
+        }
+    }
+
+    private sealed class FixedTenantContext : ITenantContext
+    {
+        private Guid? _tenant;
+        public FixedTenantContext(Guid tenant) => _tenant = tenant;
+        public Guid? TenantId => _tenant;
+        public void SetTenantId(Guid tenantId) => _tenant = tenantId;
+        public void ClearTenantId() => _tenant = null;
+    }
+
+    private sealed class FakeDocuments : IDocumentInstanceRepository
+    {
+        private readonly IReadOnlyList<DocumentInstance> _latestAccepted;
+        private readonly Dictionary<Guid, DocumentInstance> _byId;
+        public FakeDocuments(IReadOnlyList<DocumentInstance> latestAccepted, Dictionary<Guid, DocumentInstance> byId)
+        {
+            _latestAccepted = latestAccepted;
+            _byId = byId;
+        }
+        public Task<IReadOnlyList<DocumentInstance>> GetLatestAcceptedAsync(Guid tenantId, string issueId, CancellationToken ct)
+            => Task.FromResult(_latestAccepted);
+        public Task<DocumentInstance?> GetByIdAsync(Guid tenantId, Guid documentId, CancellationToken ct)
+            => Task.FromResult(_byId.TryGetValue(documentId, out var d) ? d : null);
+        public Task<IReadOnlyList<DocumentInstance>> ListByIssueAsync(Guid tenantId, string issueId, CancellationToken ct)
+            => Task.FromResult<IReadOnlyList<DocumentInstance>>(_byId.Values.ToList());
+        public Task<DocumentInstance> InsertAsync(Guid tenantId, DocumentEnvelope envelope, Guid? correlatingEventId, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task<DocumentInstance> SetStatusAsync(Guid tenantId, Guid documentId, DocumentInstanceStatus status, Guid? correlatingEventId, CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+
+    private sealed class FakeEvents : IEventRepository
+    {
+        private readonly IReadOnlyList<DomainEvent> _document;
+        private readonly IReadOnlyList<DomainEvent> _approval;
+        public FakeEvents(IReadOnlyList<DomainEvent> document, IReadOnlyList<DomainEvent> approval)
+        {
+            _document = document;
+            _approval = approval;
+        }
+        public Task<(IReadOnlyList<DomainEvent> Events, int? Total)> QueryEventsAsync(
+            Guid tenantId, string? type, bool typeIsPrefix, string? correlationId, string? actor,
+            DateTimeOffset? from, DateTimeOffset? to, long? cursor, int limit, bool includeTotal = false)
+        {
+            var events = type == "APPROVAL." ? _approval : _document;
+            return Task.FromResult<(IReadOnlyList<DomainEvent>, int?)>((events, events.Count));
+        }
+        public Task<DomainEvent> AppendAsync(DomainEvent evt) => throw new NotSupportedException();
+        public Task<DomainEvent?> GetByIdAsync(Guid id) => throw new NotSupportedException();
+        public Task<List<DomainEvent>> QueryAsync(Guid? tenantId, string? type, int? issueNumber, int limit)
+            => throw new NotSupportedException();
+        public Task<DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type) => throw new NotSupportedException();
+        public Task ClearAsync(Guid tenantId) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset) => throw new NotSupportedException();
+        public Task<(IReadOnlyList<DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset) => throw new NotSupportedException();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryReadBackTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/LifecycleReEntryReadBackTests.cs
@@ -1,0 +1,132 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-10 (AC4 matrix clause, D10) — the re-entry read-back must be tolerant of a
+/// SERIALIZING runtime (the #15/#437 lesson), mirroring
+/// <c>ClarifyResumeReadBackTests</c>: the position payload arrives as a boxed
+/// <see cref="string"/> OR a <see cref="JsonElement"/>, and every boolean flag arrives
+/// as a boxed bool / <c>"true"</c>/<c>"True"</c> / <see cref="JsonElement"/>, truthy AND
+/// falsy. A missing payload fail-closes to a fresh Produce.
+/// </summary>
+[TestFixture]
+public class LifecycleReEntryReadBackTests
+{
+    private const string Type = "decomposition";
+    private static readonly Guid Doc = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001");
+
+    private static string PositionJson(LifecycleResumeStage stage) =>
+        JsonSerializer.Serialize(new LifecycleResumePosition
+        {
+            DocumentTypeKey = Type,
+            ResumeAt = stage,
+            ExistingDocumentId = Doc,
+            ExistingRevision = 0,
+            Basis = "test",
+        }, DocumentJson.Options);
+
+    private static JsonElement JsonBool(bool value) => JsonDocument.Parse(value ? "true" : "false").RootElement;
+
+    private static IDictionary<string, object> Input(params (string Key, object Value)[] entries)
+    {
+        var d = new Dictionary<string, object>();
+        foreach (var (k, v) in entries) d[k] = v;
+        return d;
+    }
+
+    // ── position payload as string AND JsonElement ─────────────────────
+
+    [Test]
+    public void ReadPosition_StringPayload_Parses()
+    {
+        var result = DocumentLifecycleHelper.ReadReEntryPosition(
+            Input(("PositionJson", PositionJson(LifecycleResumeStage.Review))));
+        result.Position.Should().NotBeNull();
+        result.Stage.Should().Be(LifecycleResumeStage.Review);
+        result.SkipProduce.Should().BeTrue();
+        result.SkipReview.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadPosition_JsonElementPayload_Parses()
+    {
+        var element = (object)JsonDocument.Parse(PositionJson(LifecycleResumeStage.Complete)).RootElement;
+        var result = DocumentLifecycleHelper.ReadReEntryPosition(Input(("PositionJson", element)));
+        result.Position.Should().NotBeNull();
+        result.Stage.Should().Be(LifecycleResumeStage.Complete);
+        result.ShortCircuitAccepted.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadPosition_JsonElementStringPayload_Parses()
+    {
+        // A serializing runtime may hand the JSON back as a JSON *string* element.
+        var asJsonString = (object)JsonDocument
+            .Parse(JsonSerializer.Serialize(PositionJson(LifecycleResumeStage.Accept))).RootElement;
+        var result = DocumentLifecycleHelper.ReadReEntryPosition(Input(("PositionJson", asJsonString)));
+        result.Position.Should().NotBeNull();
+        result.Stage.Should().Be(LifecycleResumeStage.Accept);
+    }
+
+    [Test]
+    public void ReadPosition_MissingPayload_FailsClosedToFreshProduce()
+    {
+        var result = DocumentLifecycleHelper.ReadReEntryPosition(Input(("Other", "x")));
+        result.Position.Should().BeNull();
+        result.Stage.Should().Be(LifecycleResumeStage.Produce);
+        result.SkipProduce.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadPosition_GarbagePayload_FailsClosedToFreshProduce()
+    {
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("PositionJson", "not json")))
+            .Stage.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    // ── boolean flags coerced tolerant (no PositionJson → explicit flags) ──
+
+    [Test]
+    public void ReadFlags_BoxedBoolTrue_Coerces()
+    {
+        var r = DocumentLifecycleHelper.ReadReEntryPosition(
+            Input(("SkipProduce", true), ("SkipReview", true), ("ShortCircuit", true)));
+        r.SkipProduce.Should().BeTrue();
+        r.SkipReview.Should().BeTrue();
+        r.ShortCircuitAccepted.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadFlags_StringTrue_Coerces()
+    {
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", "true"))).SkipProduce.Should().BeTrue();
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", "True"))).SkipProduce.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadFlags_JsonElementTrue_Coerces()
+    {
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", JsonBool(true))))
+            .SkipProduce.Should().BeTrue();
+    }
+
+    [Test]
+    public void ReadFlags_FalseRepresentations_Coerce()
+    {
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", false))).SkipProduce.Should().BeFalse();
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", "false"))).SkipProduce.Should().BeFalse();
+        DocumentLifecycleHelper.ReadReEntryPosition(Input(("SkipProduce", JsonBool(false)))).SkipProduce.Should().BeFalse();
+    }
+
+    [Test]
+    public void ReadPosition_NullInput_IsFresh()
+    {
+        DocumentLifecycleHelper.ReadReEntryPosition(null).Stage.Should().Be(LifecycleResumeStage.Produce);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumableStandardStructuralTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumableStandardStructuralTests.cs
@@ -1,0 +1,322 @@
+using System.Reflection;
+using Elsa.Workflows;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Core.Documents.Resume;
+using Tamma.ElsaServer.Workflows;
+
+namespace Tamma.Activities.Tests.Workflows;
+
+/// <summary>
+/// Story 39-10 (AC2/AC3, Design Decision D5) — the RESUMABLE-BY-DESIGN build gate.
+/// Enumerates every concrete <see cref="WorkflowBase"/> subclass in the
+/// <c>Tamma.ElsaServer</c> assembly (the <c>TaxonomyDriftBuildTests</c> discovery
+/// anchor) and fails — NAMING the workflow — unless it declares its resume behaviour
+/// or is on the justified, ratchet-style <see cref="LegacyResumeAllowlist"/>.
+///
+/// <para>Clauses: (a) <c>[ResumeBehavior]</c> XOR an allowlist entry (stale entries
+/// fail); (b) a <c>BookmarkSuspend</c>/<c>Both</c> workflow's built graph contains a
+/// node whose type is in BOTH its declaration's <c>SuspendActivities</c> AND
+/// <see cref="LifecycleBookmarks.CanonicalSuspendActivities"/> — and, inversely, a
+/// canonical suspend node in an undeclared workflow fails (declaration honesty);
+/// (c) a <c>LatestStateReEntry</c>/<c>Both</c> workflow's graph contains a
+/// <see cref="ComputeReEntryPositionActivity"/> node (the descriptor wiring, not
+/// hand-rolled guards). <see cref="DocumentLifecycleWorkflow"/> declares <c>Both</c>
+/// from day one and is NEVER allowlisted — so AC2 is proven on a real workflow.</para>
+///
+/// <para>The allowlist is seeded with every current legacy workflow + a one-line
+/// justification + the migration story that burns it down (39-12..39-15). Entries may
+/// only be REMOVED — the day a workflow starts declaring, its stale entry fails the
+/// build (the <c>KnownContractViolations</c> ratchet discipline).</para>
+/// </summary>
+[TestFixture]
+public class ResumableStandardStructuralTests
+{
+    /// <summary>
+    /// Every legacy workflow not yet migrated onto the resumable-by-design standard,
+    /// with a justification + the burn-down story. RATCHET: entries may only be
+    /// removed; a workflow that starts declaring <c>[ResumeBehavior]</c> makes its
+    /// entry stale and fails the build until the entry is deleted.
+    /// <see cref="DocumentLifecycleWorkflow"/> is deliberately ABSENT (it declares Both).
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> LegacyResumeAllowlist =
+        new Dictionary<string, string>
+        {
+            ["AdlOrchestratorWorkflow"] = "ADL orchestration composite; delegates to sub-workflows, no own lifecycle suspend/re-entry (burn-down: 39-13+).",
+            ["AmbiguityScoringWorkflow"] = "leaf llm-call producer, runs to completion (burn-down: 39-12+ once on the lifecycle).",
+            ["AssessmentWorkflow"] = "assessment intake producer, no suspend gate yet (burn-down: 39-14+).",
+            ["BlockerDiagnosisWorkflow"] = "diagnosis leaf, runs to completion (burn-down: 39-14+).",
+            ["BranchCreationWorkflow"] = "git side-effect leaf, no suspend/re-entry (burn-down: 39-15+).",
+            ["CiWithDebugRetryWorkflow"] = "CI retry loop, no human suspend gate (burn-down: 39-15+).",
+            ["ClarifyingQuestionsWorkflow"] = "legacy Clarify bookmark-suspend gate (not yet on the canonical builder; retired by a 39-13+ migration).",
+            ["CleanUpFailedTenantWorkflow"] = "platform tenant-cleanup saga, no document lifecycle (burn-down: n/a — platform, revisit 39-15+).",
+            ["CodeReviewWorkflow"] = "code-review leaf, runs to completion (burn-down: 39-14+).",
+            ["ContextGatheringWorkflow"] = "context-scan producer, no suspend gate (burn-down: 39-12+).",
+            ["CreateTenantWorkflow"] = "platform provisioning saga, no document lifecycle (burn-down: n/a — platform).",
+            ["DebuggingWorkflow"] = "debug leaf, runs to completion (burn-down: 39-15+).",
+            ["DeleteTenantWorkflow"] = "platform deprovisioning saga, no document lifecycle (burn-down: n/a — platform).",
+            ["DeploymentPipelineWorkflow"] = "deploy pipeline, no document-decision suspend (burn-down: 39-15+).",
+            ["DesignProposalWorkflow"] = "legacy Design bookmark-suspend gate (not yet on the canonical builder; retired by a 39-13+ migration).",
+            ["DocumentReviewWorkflow"] = "39-7 review producer sub-workflow, runs to completion (burn-down: 39-12+).",
+            ["HourlyAnalyticsRollupWorkflow"] = "scheduled analytics rollup, no document lifecycle (burn-down: n/a — platform).",
+            ["IssueDecompositionWorkflow"] = "the 39-12 pilot migration target — declares onto the lifecycle in 39-12 (burn-down: 39-12).",
+            ["IssueTriageWorkflow"] = "triage orchestration composite, delegates to sub-workflows (burn-down: 39-14+).",
+            ["LlmCallWorkflow"] = "the mediated llm-call leaf, runs to completion, holds no suspend gate (burn-down: n/a — infra leaf).",
+            ["MentorshipWorkflow"] = "mentoring leaf, runs to completion (burn-down: 39-14+).",
+            ["MergeApprovalWorkflow"] = "legacy merge-approval bookmark-suspend gate (not yet on the canonical builder; retired by a 39-13+ migration).",
+            ["MergeWorkflow"] = "merge side-effect workflow, no document lifecycle (burn-down: 39-15+).",
+            ["PanelReviewWorkflow"] = "39-7 panel-review router, delegates to reviewer sub-workflows (burn-down: 39-12+).",
+            ["PlanGenerationWorkflow"] = "plan producer leaf, runs to completion (burn-down: 39-13+).",
+            ["PlanReviewWorkflow"] = "plan-review panel, runs to completion (burn-down: 39-13+).",
+            ["PullRequestWorkflow"] = "PR side-effect workflow, no suspend gate (burn-down: 39-15+).",
+            ["ResearchWorkflow"] = "research producer leaf, runs to completion (burn-down: 39-12+).",
+            ["ReviewFixWorkflow"] = "review-fix loop, no human suspend gate (burn-down: 39-14+).",
+            ["RotateSecretWorkflow"] = "platform secret-rotation saga, no document lifecycle (burn-down: n/a — platform).",
+            ["SingleIssueCycleWorkflow"] = "issue-cycle orchestration composite, delegates to sub-workflows (burn-down: 39-14+).",
+            ["SingleReviewerWorkflow"] = "39-7 single-reviewer producer, runs to completion (burn-down: 39-12+).",
+            ["TaskCreationWorkflow"] = "task producer leaf, runs to completion (burn-down: 39-13+).",
+            ["TaskReviewWorkflow"] = "task-review panel, runs to completion (burn-down: 39-13+).",
+            ["TddWithDebugRetryWorkflow"] = "TDD retry loop, no human suspend gate (burn-down: 39-15+).",
+            ["TddWorkflow"] = "TDD cycle composite, delegates to sub-workflows (burn-down: 39-15+).",
+            ["TestCaseCreationWorkflow"] = "test producer leaf, runs to completion (burn-down: 39-13+).",
+            ["TestingWorkflow"] = "testing composite, delegates to sub-workflows (burn-down: 39-15+).",
+            ["TriageContextGatheringWorkflow"] = "triage context-scan producer, no suspend gate (burn-down: 39-14+).",
+            ["TriageItemCycleWorkflow"] = "triage item-cycle composite, delegates to sub-workflows (burn-down: 39-14+).",
+            ["TriagePODecisionWorkflow"] = "triage PO-decision leaf, runs to completion (burn-down: 39-14+).",
+            ["TriagePanelReviewWorkflow"] = "triage-review panel, runs to completion (burn-down: 39-14+).",
+            ["UpdateIssueStatusWorkflow"] = "issue-status side-effect leaf, no suspend/re-entry (burn-down: 39-15+).",
+        };
+
+    private static IReadOnlyList<Type> ConcreteWorkflows() =>
+        typeof(LlmCallWorkflow).Assembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(WorkflowBase).IsAssignableFrom(t))
+            .OrderBy(t => t.Name)
+            .ToList();
+
+    private static ResumeBehaviorAttribute? Declaration(Type workflow)
+        => workflow.GetCustomAttribute<ResumeBehaviorAttribute>(inherit: false);
+
+    // ── (a) declare-or-allowlist, ratchet ──────────────────────────────
+
+    [Test]
+    public void EveryWorkflow_DeclaresResumeBehavior_XorIsAllowlisted()
+    {
+        var violations = new List<string>();
+
+        foreach (var type in ConcreteWorkflows())
+        {
+            var declares = Declaration(type) is not null;
+            var allowlisted = LegacyResumeAllowlist.ContainsKey(type.Name);
+
+            if (declares && allowlisted)
+                violations.Add(
+                    $"  {type.Name}: declares [ResumeBehavior] AND is in LegacyResumeAllowlist — " +
+                    "delete its allowlist entry (the ratchet only turns one way).");
+            else if (!declares && !allowlisted)
+                violations.Add(
+                    $"  {type.Name}: neither declares [ResumeBehavior] nor is in LegacyResumeAllowlist — " +
+                    "add a [ResumeBehavior(...)] declaration (the resumable-by-design standard) or " +
+                    "allowlist it with a justification + burn-down story.");
+        }
+
+        violations.Should().BeEmpty(
+            "every concrete workflow must EITHER declare [ResumeBehavior] or be justified-and-allowlisted " +
+            "(exactly one):" + Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    [Test]
+    public void LegacyResumeAllowlist_HasNoStaleEntries()
+    {
+        var concreteNames = ConcreteWorkflows().Select(t => t.Name).ToHashSet();
+
+        var orphaned = LegacyResumeAllowlist.Keys
+            .Where(name => !concreteNames.Contains(name))
+            .Select(name => $"  {name}: allowlisted but no such concrete workflow — delete the entry.")
+            .ToList();
+
+        var nowDeclares = ConcreteWorkflows()
+            .Where(t => Declaration(t) is not null && LegacyResumeAllowlist.ContainsKey(t.Name))
+            .Select(t => $"  {t.Name}: now declares [ResumeBehavior] — delete its stale allowlist entry.")
+            .ToList();
+
+        orphaned.Concat(nowDeclares).ToList().Should().BeEmpty(
+            "LegacyResumeAllowlist entries may only be REMOVED; stale entries fail the build:" +
+            Environment.NewLine + string.Join(Environment.NewLine, orphaned.Concat(nowDeclares)));
+
+        foreach (var (_, reason) in LegacyResumeAllowlist)
+            reason.Should().NotBeNullOrWhiteSpace("every allowlist entry must carry a justification");
+    }
+
+    // ── (b) BookmarkSuspend/Both ⇒ canonical suspend node present ───────
+
+    [Test]
+    public void EveryBookmarkSuspendWorkflow_HasACanonicalSuspendNode()
+    {
+        var violations = new List<string>();
+
+        foreach (var type in ConcreteWorkflows())
+        {
+            var decl = Declaration(type);
+            if (decl is null || decl.Mode is not (ResumeMode.BookmarkSuspend or ResumeMode.Both))
+                continue;
+
+            if (decl.SuspendActivities.Length == 0)
+            {
+                violations.Add(
+                    $"  {type.Name}: declares {decl.Mode} but names NO SuspendActivities — a bookmark-suspend " +
+                    "workflow must declare the canonical gate type(s) it registers.");
+                continue;
+            }
+
+            var canonical = decl.SuspendActivities
+                .Where(t => LifecycleBookmarks.CanonicalSuspendActivities.ContainsKey(t))
+                .ToHashSet();
+            if (canonical.Count == 0)
+            {
+                violations.Add(
+                    $"  {type.Name}: its declared SuspendActivities are none of them in " +
+                    "LifecycleBookmarks.CanonicalSuspendActivities (a non-canonical bookmark builder).");
+                continue;
+            }
+
+            var nodeTypes = BuiltGraphNodeTypes(type);
+            if (!nodeTypes.Any(canonical.Contains))
+                violations.Add(
+                    $"  {type.Name}: declares a canonical suspend but its built graph contains no node of " +
+                    $"type {{{string.Join(", ", canonical.Select(t => t.Name))}}}.");
+        }
+
+        violations.Should().BeEmpty(
+            "every BookmarkSuspend/Both workflow must actually register a canonical suspend activity:" +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    // ── (b-inverse) declaration honesty ────────────────────────────────
+
+    [Test]
+    public void CanonicalSuspendNode_AppearsOnlyInDeclaredWorkflows()
+    {
+        var violations = new List<string>();
+
+        foreach (var type in ConcreteWorkflows())
+        {
+            var canonicalNodes = BuiltGraphNodeTypes(type)
+                .Where(LifecycleBookmarks.CanonicalSuspendActivities.ContainsKey)
+                .ToHashSet();
+            if (canonicalNodes.Count == 0)
+                continue;
+
+            var decl = Declaration(type);
+            if (decl is null || decl.Mode is not (ResumeMode.BookmarkSuspend or ResumeMode.Both))
+            {
+                violations.Add(
+                    $"  {type.Name}: its graph contains canonical suspend node(s) " +
+                    $"{{{string.Join(", ", canonicalNodes.Select(t => t.Name))}}} but it does not declare " +
+                    "BookmarkSuspend/Both — declaration honesty violated.");
+                continue;
+            }
+
+            var undeclared = canonicalNodes.Where(t => !decl.SuspendActivities.Contains(t)).ToList();
+            if (undeclared.Count > 0)
+                violations.Add(
+                    $"  {type.Name}: registers canonical suspend node(s) " +
+                    $"{{{string.Join(", ", undeclared.Select(t => t.Name))}}} not listed in its declaration's " +
+                    "SuspendActivities.");
+        }
+
+        violations.Should().BeEmpty(
+            "a canonical suspend activity may appear only in a workflow that DECLARES it (honesty):" +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    // ── (c) LatestStateReEntry/Both ⇒ ComputeReEntryPositionActivity node ──
+
+    [Test]
+    public void EveryReEntryWorkflow_HasAComputeReEntryNode()
+    {
+        var violations = new List<string>();
+
+        foreach (var type in ConcreteWorkflows())
+        {
+            var decl = Declaration(type);
+            if (decl is null || decl.Mode is not (ResumeMode.LatestStateReEntry or ResumeMode.Both))
+                continue;
+
+            var nodeTypes = BuiltGraphNodeTypes(type);
+            if (!nodeTypes.Contains(typeof(ComputeReEntryPositionActivity)))
+                violations.Add(
+                    $"  {type.Name}: declares {decl.Mode} (crash re-entry) but its built graph contains no " +
+                    "ComputeReEntryPositionActivity node (the generic re-entry wiring, D6).");
+        }
+
+        violations.Should().BeEmpty(
+            "every LatestStateReEntry/Both workflow must wire the generic ComputeReEntryPositionActivity:" +
+            Environment.NewLine + string.Join(Environment.NewLine, violations));
+    }
+
+    // ── AC2 proven on a real workflow ──────────────────────────────────
+
+    [Test]
+    public void DocumentLifecycleWorkflow_DeclaresBoth_AndIsNotAllowlisted()
+    {
+        LegacyResumeAllowlist.Should().NotContainKey(nameof(DocumentLifecycleWorkflow),
+            "the lifecycle declares its resume behaviour from day one — it is never allowlisted");
+
+        var decl = Declaration(typeof(DocumentLifecycleWorkflow));
+        decl.Should().NotBeNull("DocumentLifecycleWorkflow must carry a [ResumeBehavior] declaration (AC2)");
+        decl!.Mode.Should().Be(ResumeMode.Both,
+            "the lifecycle both suspends on the accept-gate bookmark AND re-enters after a crash");
+        decl.SuspendActivities.Should().Contain(typeof(WaitForDocumentDecisionActivity),
+            "its bookmark-suspend gate is the canonical WaitForDocumentDecisionActivity");
+    }
+
+    // ── graph walk (shared with DocumentLifecycleWorkflowStructureTests style) ──
+
+    private static HashSet<Type> BuiltGraphNodeTypes(Type workflowType)
+    {
+        var instance = (WorkflowBase)Activator.CreateInstance(workflowType)!;
+        var builder = WorkflowTestHelper.BuildWorkflow(instance);
+        var root = builder.Object.Root;
+
+        var seen = new HashSet<object>(ReferenceEqualityComparer.Instance);
+        var types = new HashSet<Type>();
+        var stack = new Stack<IActivity>();
+        if (root is not null) stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var a = stack.Pop();
+            if (a is null || !seen.Add(a)) continue;
+            types.Add(a.GetType());
+            foreach (var child in Children(a)) stack.Push(child);
+        }
+        return types;
+    }
+
+    private static IEnumerable<IActivity> Children(IActivity activity)
+    {
+        var type = activity.GetType();
+        var members = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Cast<MemberInfo>()
+            .Concat(type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+        foreach (var member in members)
+        {
+            object? value;
+            try
+            {
+                value = member switch
+                {
+                    PropertyInfo p when p.CanRead && p.GetIndexParameters().Length == 0 => p.GetValue(activity),
+                    FieldInfo f => f.GetValue(activity),
+                    _ => null,
+                };
+            }
+            catch { continue; }
+
+            if (value is IActivity child) yield return child;
+            else if (value is System.Collections.IEnumerable en and not string)
+                foreach (var item in en) if (item is IActivity nested) yield return nested;
+        }
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Resume/LifecycleResumeCalculatorTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/Resume/LifecycleResumeCalculatorTests.cs
@@ -1,0 +1,190 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core;
+using Tamma.Core.Documents.Resume;
+
+namespace Tamma.Core.Tests.Documents.Resume;
+
+/// <summary>
+/// Story 39-10 (AC5) — the pure re-entry position matrix for
+/// <see cref="LifecycleResumeCalculator"/>. Proves the fold reconstructs the coarse
+/// stage from durable truth deterministically, and that store/stream disagreement is
+/// a fail-loud <c>DOCUMENT.REENTRY.INCONSISTENT_STATE</c> (it never guesses).
+/// </summary>
+[TestFixture]
+public class LifecycleResumeCalculatorTests
+{
+    private const string Type = "decomposition";
+    private static readonly Guid Doc = Guid.Parse("0192a8b0-1111-7abc-8def-000000000001");
+    private static readonly Guid Session = Guid.Parse("0192a8b0-2222-7abc-8def-000000000002");
+
+    private static ResumeEventRow Row(string type, int seq, Guid? docId = null, int? revision = null, Guid? session = null, string? typeKey = Type)
+        => new(type, new DateTime(2026, 7, 23, 0, 0, seq, DateTimeKind.Utc), docId, typeKey, session, revision);
+
+    // ── Produce (no usable prior work) ─────────────────────────────────
+
+    [Test]
+    public void NoRowsNoEvents_YieldsProduce()
+    {
+        var p = LifecycleResumeCalculator.Reconstruct(Type, null, Array.Empty<ResumeEventRow>());
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+        p.ExistingDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public void ProducedButValidationFailed_YieldsProduce()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.FAILED", 2, Doc, 0),
+        };
+        LifecycleResumeCalculator.Reconstruct(Type, null, events).ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    [Test]
+    public void RevisionInFlight_RevisionStartedLast_YieldsProduce()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+            Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+            Row("DOCUMENT.REVISION_STARTED", 4, Doc, 1),
+        };
+        LifecycleResumeCalculator.Reconstruct(Type, null, events).ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    // ── Review (produced + validated, unreviewed) ──────────────────────
+
+    [Test]
+    public void ProducedAndValidated_Unreviewed_YieldsReviewAtThatRevision()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+        };
+        var p = LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Review);
+        p.ExistingDocumentId.Should().Be(Doc);
+        p.ExistingRevision.Should().Be(0);
+    }
+
+    [Test]
+    public void ReviseThenValidated_Unreviewed_YieldsReviewAtNewRevision()
+    {
+        var rev = Guid.Parse("0192a8b0-3333-7abc-8def-000000000003");
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+            Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+            Row("DOCUMENT.REVISION_STARTED", 4, rev, 1),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 5, rev, 1),
+        };
+        var p = LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Review);
+        p.ExistingDocumentId.Should().Be(rev);
+        p.ExistingRevision.Should().Be(1);
+    }
+
+    // ── Accept (unanswered approval) ───────────────────────────────────
+
+    [Test]
+    public void ApprovalRequested_Unanswered_YieldsAcceptWithSession()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+            Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+            Row("APPROVAL.REQUESTED", 4, Doc, 0, Session),
+        };
+        var p = LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Accept);
+        p.PendingDecisionSessionId.Should().Be(Session);
+    }
+
+    [Test]
+    public void ApprovalProvided_ClearsPending_NotAccept()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+            Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+            Row("APPROVAL.REQUESTED", 4, Doc, 0, Session),
+            Row("APPROVAL.PROVIDED", 5, Doc, 0, Session),
+        };
+        LifecycleResumeCalculator.Reconstruct(Type, null, events).ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    // ── Complete (accepted) ────────────────────────────────────────────
+
+    [Test]
+    public void Accepted_StoreAndStreamAgree_YieldsComplete()
+    {
+        var accepted = new AcceptedDocumentRef(Doc, Type, 1);
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+            Row("DOCUMENT.REVIEWED", 3, Doc, 0),
+            Row("APPROVAL.REQUESTED", 4, Doc, 0, Session),
+            Row("APPROVAL.PROVIDED", 5, Doc, 0, Session),
+            Row("DOCUMENT.ACCEPTED", 6, Doc, 0),
+        };
+        var p = LifecycleResumeCalculator.Reconstruct(Type, accepted, events);
+        p.ResumeAt.Should().Be(LifecycleResumeStage.Complete);
+        p.ExistingDocumentId.Should().Be(Doc);
+        p.ExistingRevision.Should().Be(1);
+    }
+
+    // ── Inconsistency (fail-loud, never guesses) ───────────────────────
+
+    [Test]
+    public void AcceptedRow_NoAcceptedEvent_ThrowsInconsistentState()
+    {
+        var accepted = new AcceptedDocumentRef(Doc, Type, 1);
+        var events = new[] { Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0) };
+
+        var act = () => LifecycleResumeCalculator.Reconstruct(Type, accepted, events);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.REENTRY.INCONSISTENT_STATE");
+    }
+
+    [Test]
+    public void AcceptedEvent_NoAcceptedRow_ThrowsInconsistentState()
+    {
+        var events = new[] { Row("DOCUMENT.ACCEPTED", 1, Doc, 0) };
+
+        var act = () => LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        act.Should().Throw<TammaError>().Which.Code.Should().Be("DOCUMENT.REENTRY.INCONSISTENT_STATE");
+    }
+
+    // ── Type isolation + determinism ───────────────────────────────────
+
+    [Test]
+    public void ForeignTypeEvents_AreIgnored()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0, typeKey: "plan"),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0, typeKey: "plan"),
+        };
+        LifecycleResumeCalculator.Reconstruct(Type, null, events).ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    [Test]
+    public void Reconstruct_IsDeterministic()
+    {
+        var events = new[]
+        {
+            Row("DOCUMENT.PRODUCED.SUCCESS", 1, Doc, 0),
+            Row("DOCUMENT.VALIDATED.SUCCESS", 2, Doc, 0),
+        };
+        var a = LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        var b = LifecycleResumeCalculator.Reconstruct(Type, null, events);
+        a.Should().Be(b);
+    }
+}

--- a/docs/stories/epic-39/README.md
+++ b/docs/stories/epic-39/README.md
@@ -52,7 +52,8 @@ lifecycle, and makes every workflow resumable by design.
    bookmark awaiting input (the generalized Design-Proposal pattern) or, after a
    crash/restart, **re-enters from the latest accepted state** reconstructed from
    the document store + DCB events — never from scratch. This becomes an
-   authoring standard with a structural test, not a per-workflow favor.
+   authoring standard with a structural test, not a per-workflow favor. See the
+   [Resumable-Workflow Authoring Standard](./resumable-workflow-standard.md) (Story 39-10).
 
 ## Design principles (settled)
 

--- a/docs/stories/epic-39/resumable-workflow-standard.md
+++ b/docs/stories/epic-39/resumable-workflow-standard.md
@@ -1,0 +1,158 @@
+# Resumable-Workflow Authoring Standard (Story 39-10)
+
+**Status:** enforced by a build gate (`ResumableStandardStructuralTests`).
+Pillar 3 of Epic 39 ("Resumable by design"). This document is the source of the
+_rules_; the structural test is the source of the _enforcement_.
+
+> **"Is this workflow resumable?" is answered by a build gate, not by reading its
+> source.** Every concrete `WorkflowBase` in `Tamma.ElsaServer` must either declare
+> `[ResumeBehavior(...)]` or sit on a justified, ratchet-style allowlist that
+> 39-12..39-15 burn down.
+
+---
+
+## 1. The two resume modes
+
+A lifecycle workflow is resumable in one (or both) of two ways, declared statically via
+`[ResumeBehavior(ResumeMode, SuspendActivities = …)]`
+(`apps/tamma-elsa/src/Tamma.Core/Documents/Resume/ResumeBehavior.cs`):
+
+| Mode | When it applies | Mechanism |
+|---|---|---|
+| `BookmarkSuspend` | The workflow must WAIT for external input (a human/orchestrator decision, an answer, an approval). | Suspends on a deterministic, tenant-folded bookmark; a later resume recomputes the same name and continues. |
+| `LatestStateReEntry` | The workflow can lose its Elsa instance (crash, pod eviction, deploy, definition-version bump) and must resume from durable truth. | A fresh instance for the same issue reconstructs its position from the document store + DCB events and skips work already accepted. |
+| `Both` | Both of the above (the `DocumentLifecycleWorkflow` posture). | The accept gate suspends on a bookmark AND Init consults the re-entry reconstructor. |
+
+**Elsa instance state is an optimization, not the truth.** If Elsa's persisted instance
+resumes cleanly, good — but correctness must hold even when the instance is gone.
+Document lineage + events are the durable truth (the same DCB principle as Story 37-1's
+"projection is rebuildable").
+
+---
+
+## 2. The ONE canonical bookmark builder
+
+All lifecycle suspend points build names through `LifecycleBookmarks`
+(`apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs`), never by hand.
+
+- **Core:** `Compose(gate, tenantId?, params segments)` — `{gate}-{norm(tenant)}-{norm(seg)}…`,
+  every segment (the tenant included) run through
+  `WaitForMergeApprovalActivity.NormalizeSegment`
+  (`apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs:136`). The
+  tenant fold is the IDOR guard: a resume caller scoped to tenant A computes a name keyed
+  by tenant A and can never resolve tenant B's bookmark (a cross-tenant attempt 404s).
+- **Two sanctioned key shapes:**
+  - `ForStageGate(tenantId, issueId, documentTypeKey, gate)` — the domain-keyed shape
+    (AC4), recomputable from durable domain coordinates alone. Use for stage gates.
+  - `ForDecisionSession(tenantId, sessionId)` — the 39-8 accept-gate shape where the
+    128-bit session id carries unguessability. Byte-identical to
+    `WaitForDocumentDecisionActivity.DecisionBookmarkName`
+    (`…/Documents/WaitForDocumentDecisionActivity.cs:127`), which now delegates here (pinned
+    by `LifecycleBookmarksTests.ForDecisionSession_IsByteIdenticalTo_DecisionBookmarkName`).
+    Determinism still holds: the session id is persisted in `LifecycleState` and on
+    `APPROVAL.REQUESTED`, so a post-deploy resume recomputes the same name.
+- **Canonical-gate registry:** `LifecycleBookmarks.CanonicalSuspendActivities`
+  (`Type → gate prefix`) is production data the structural test walks. A canonical suspend
+  node in an undeclared workflow fails the build (declaration honesty). Legacy
+  Clarify/Design/Merge waits are deliberately OUT — their workflows are allowlisted and
+  39-13+ migrations retire them.
+
+**Selection rule:** domain-keyed (`ForStageGate`) for a stage gate that must be
+recomputable from `(tenantId, issueId, documentType, gate)`; session-keyed
+(`ForDecisionSession`) where unguessability is load-bearing (the accept gate / escalation
+sink).
+
+---
+
+## 3. Serialization tolerance is not optional (the #15/#437 lesson)
+
+Every resume/re-entry read-back MUST be tolerant of a serializing runtime. The in-process
+runtime hands a value back as a boxed CLR type; a distributed dispatcher round-trips it to
+a `string` or `JsonElement`. A bare `is true` pattern silently takes the WRONG branch under
+serialization while still returning HTTP 200 — a silent mis-branch.
+
+- Coerce booleans via `ResumeInput.AsBool`
+  (`apps/tamma-elsa/src/Tamma.Activities/ResumeInput.cs`), NEVER `is true`.
+- Read the position payload tolerant of `string` AND `JsonElement`.
+- Every new read-back inherits the matrix from
+  `apps/tamma-elsa/tests/Tamma.Activities.Tests/Clarify/ClarifyResumeReadBackTests.cs`
+  (boxed bool / `"true"`/`"True"` / `JsonElement`, truthy AND falsy rows, missing key
+  fail-closed). 39-10's is
+  `…/Workflows/LifecycleReEntryReadBackTests.cs` over
+  `DocumentLifecycleHelper.ReadReEntryPosition`.
+
+---
+
+## 4. Idempotent step guards (no double-produce / double-review / double-accept)
+
+Guards live ONCE in the generic lifecycle (39-6), not per migrated workflow — migrations
+inherit them. `DocumentLifecycleHelper`
+(`apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/DocumentLifecycleHelper.cs`) carries
+`ShouldSkipProduce` / `ShouldSkipReview` / `ShouldShortCircuitAccepted` / `ApplyReEntry`;
+`DocumentLifecycleWorkflow`'s Init wires ONE `ComputeReEntryPositionActivity` node whose
+typed position routes `FlowDecision` guards:
+
+- `Complete` → short-circuit to the accepted terminal — no produce, no review, and NO second
+  `DOCUMENT.ACCEPTED`; it emits `DOCUMENT.REENTERED` instead.
+- `Review` → skip produce/validate, review the existing revision (body threaded from the
+  store).
+- `Accept` → re-suspend on the SAME recovered decision-session bookmark.
+- `Produce` → run fresh.
+
+An already-accepted document is a no-op for produce AND review (no duplicate LLM spend, no
+duplicate acceptance events). Proven by `LifecycleReEntryGuardTests` (twice over the same
+accepted lineage) and the integration suite's exactly-one-acceptance assertion.
+
+---
+
+## 5. The re-entry read sequence
+
+Re-entry is a **read model, not a replay-everything**. `LifecycleReEntryService`
+(`apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleReEntryService.cs`) reads, in order:
+
+1. **39-11 latest-accepted** — `IDocumentInstanceRepository.GetLatestAcceptedAsync(tenantId,
+   issueId, ct)` (in-process, never HTTP): the single indexed read that answers most of the
+   position question ("what is already accepted?").
+2. **4-7 event query** — `IEventRepository.QueryEventsAsync` over the issue's `DOCUMENT.*` /
+   `APPROVAL.*` slice, mapped to the neutral `ResumeEventRow` DTO, to fill in sub-stages
+   (produced-but-unreviewed, unanswered approval + recovered session id).
+3. **Typed position** — the pure `LifecycleResumeCalculator.Reconstruct(...)`
+   (`apps/tamma-elsa/src/Tamma.Core/Documents/Resume/LifecycleResumeCalculator.cs`) folds
+   both into a `LifecycleResumePosition` in the `ReplayReconstructor` left-fold style.
+
+The full `ReplayReconstructor`
+(`apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayReconstructor.cs`) stays the
+**forensic fallback** for edge/audit cases — NOT the hot path.
+
+**It never guesses.** Store/stream disagreement (an accepted row with no `DOCUMENT.ACCEPTED`
+event, or the converse) throws `DOCUMENT.REENTRY.INCONSISTENT_STATE` and points at the 4-8
+replay surface. Skipping a produce that was not accepted is worse than not skipping.
+
+---
+
+## 6. The declaration attribute + structural test contract
+
+- **Declaration:** `[ResumeBehavior(ResumeMode.X, SuspendActivities = new[] { typeof(Y) })]`
+  on the workflow class. `SuspendActivities` is REQUIRED non-empty for
+  `BookmarkSuspend`/`Both` (the "which builder" clause — each canonical gate type owns one
+  bookmark builder). It is reflection-enumerable data, not a doc comment.
+- **Gate** (`…/Workflows/ResumableStandardStructuralTests.cs`) — enumerates every concrete
+  `WorkflowBase` and asserts:
+  - (a) `[ResumeBehavior]` XOR a `LegacyResumeAllowlist` entry (stale entries fail);
+  - (b) `BookmarkSuspend`/`Both` ⇒ the built graph has a node whose type is in BOTH the
+    declaration's `SuspendActivities` AND `LifecycleBookmarks.CanonicalSuspendActivities`
+    (and the inverse honesty check);
+  - (c) `LatestStateReEntry`/`Both` ⇒ the graph has a `ComputeReEntryPositionActivity` node.
+  `DocumentLifecycleWorkflow` declares `Both` and is NEVER allowlisted.
+
+---
+
+## 7. Allowlist burn-down (39-12..39-15)
+
+`LegacyResumeAllowlist` is seeded with every current legacy workflow + a one-line
+justification + the migration story that retires it. **Ratchet discipline** (the
+`KnownContractViolations` pattern): entries may only be REMOVED; the day a workflow starts
+declaring `[ResumeBehavior]`, its stale entry fails the build. 39-12's pilot migration
+(IssueDecomposition) must pass the gate WITHOUT an allowlist entry — so the gate bites on the
+very first migration. Each subsequent migration (39-13..39-15) shrinks the list until it is
+empty and every workflow is resumable by construction.


### PR DESCRIPTION
## Story 39-10 — Resumable-by-Design Standard (Epic 39, Wave 4, critical path)

Makes **"resumable" an enforced authoring standard**, not a per-workflow favor. Next on the critical path (`39-6→39-10→39-12→39-13→39-15`); the pilot migration (39-12) depends on the gate this ships.

### What's in it
- **`resumable-workflow-standard.md`** (linked from the epic README, pillar 3) — the two resume modes, the canonical bookmark builder + both key shapes, the serialization-tolerance requirement, the idempotent-guard rule, the re-entry read sequence, and the declare-or-comply build gate.
- **`LifecycleBookmarks`** — the ONE canonical tenant-folded bookmark builder (`Compose` / `ForStageGate` / `ForDecisionSession` + a `CanonicalSuspendActivities` registry). 39-8's `WaitForDocumentDecisionActivity.DecisionBookmarkName` now **delegates** to `ForDecisionSession` (byte-identical, pinned by test).
- **`[ResumeBehavior]` attribute** + `ResumeMode {BookmarkSuspend, LatestStateReEntry, Both}` — a reflectable declaration every lifecycle workflow carries.
- **`LifecycleResumeCalculator`** (pure left-fold in `Tamma.Core`, `ReplayReconstructor` style) reconstructs a fresh instance's resume position from 39-11's latest-accepted read + DCB events — **never from Elsa instance internals**; store/stream disagreement throws `DOCUMENT.REENTRY.INCONSISTENT_STATE`, it never guesses. The **real** `LifecycleReEntryService` (over 39-11's `IDocumentInstanceRepository` + the 4-7 event surface) is wired as the default in both hosts (39-11 landed); `NullLifecycleReEntryService` is the `Documents:ReEntryDisabled` fallback.
- **Idempotent re-entry guards** in `DocumentLifecycleWorkflow` — a `ComputeReEntryPositionActivity` at Init routes guard `FlowDecision`s so re-entry cannot double-produce, double-review, or double-emit acceptance: `Complete` short-circuits to a finalize node emitting `DOCUMENT.REENTERED` (never a second `DOCUMENT.ACCEPTED`); `Review` skips produce/validate; `Accept` re-suspends on the recovered decision-session bookmark; `Produce` is a fresh run. The workflow declares `[ResumeBehavior(Both)]`.
- **`ResumableStandardStructuralTests`** — a build gate enumerating every concrete `WorkflowBase`; each must declare `[ResumeBehavior]` **or** sit in a ratcheted `LegacyResumeAllowlist` (seeded with all 43 legacy workflows + justification + burn-down story; stale entries fail the build). 39-12..39-15 burn it down.

### Data / events
`DOCUMENT.REENTERED` added to the `DocumentEvents` catalogue (exact-constants pin bumped 13→14). **No migration**; `has-pending-model-changes` clean on both contexts.

### Verification (independently re-run)
- Builds: all 8 projects green.
- `Tamma.Core.Tests`: **436 passed** (12 new `LifecycleResumeCalculator`). `Tamma.Activities.Tests` (filtered): **2497 passed**. The **structural gate** (`ResumableStandardStructuralTests` + `DocumentLifecycleWorkflowStructureTests`) and the bookmark-parity / guard / read-back suites all pass locally. Migration clean on both contexts.
- The crash/restart **integration suite** (`LifecycleReEntryIntegrationTests`) is `[Explicit]`/CI-gated — it uses the same in-process Elsa-runtime harness as 39-6's execution suite, which fails locally with `WorkflowGraphNotFoundException` at instantiation (a documented harness limitation, verified identical on the pre-existing 39-6 tests — **not** a regression) and runs in CI's .NET Tests job. The re-entry **logic** is covered by the pure calculator/guard/read-back unit tests + the structural gate, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_