### PR TITLE
docs(epic-40): Resumable Coding Execution — runner contract, durable agent-run waits, per-task re-entry

### DIFF
--- a/docs/stories/epic-40/EXECUTION-PLAN.md
+++ b/docs/stories/epic-40/EXECUTION-PLAN.md
@@ -1,0 +1,114 @@
+# Epic 40 — Parallel Execution Plan
+
+Derived from the 7 story implementation plans (their *Dependencies & Sequencing*,
+*Data & Migrations*, and *Effort Breakdown* sections). It answers: **what can run at once**,
+**what is forced serial**, and **where the schedule floor is** — and, crucially, **what Epic 39
+must land first**.
+
+## Headline numbers
+
+| Metric | Value |
+|---|---|
+| Total effort (sum of all stories) | **37.25 person-days** |
+| Critical path (Epic-40 internal, 39-10 assumed landed) | **20.5 days** — `40-2 → 40-4 → 40-6 → 40-7` |
+| Wave-parallel wall-clock (sum of wave poles) | **~22.75 days** |
+| Speedup vs. fully serial | **≈ 1.8×** |
+| Hard external gate | **Epic 39-10 must land before 40-2 starts** |
+| Hard serialization constraint | one **`TenantDbContext` migration** (40-3 `agent_run_waits`) — joins Epic 39's tenant-migration chain |
+
+The critical path is the resumability spine: **durable suspend → per-task re-entry → event feed →
+integration proof**. 40-1 (the runner) is a large but fully **independent** parallel branch — it
+ships on the existing dispatch/collect stack and gates nothing on the spine except the final
+integration proof (40-7).
+
+## The external gate: Epic 39-10 must land first
+
+Epic 40 **consumes** 39-10's `LifecycleBookmarks` (tenant-folded bookmark builder),
+`ResumeBehaviorAttribute`/`ResumeMode`, `CanonicalSuspendActivities`, `LegacyResumeAllowlist`,
+and `ResumableStandardStructuralTests`. 40-2's durable bookmark uses the builder; 40-5's
+declaration + allowlist burn-down is meaningless without the gate. **39-10 is Epic 39 wave 4** in
+that epic's execution plan (needs 39-6 + 39-8). So Epic 40's spine (40-2 onward) cannot start
+before Epic 39 reaches 39-10.
+
+**What can start before 39-10:** **40-1** (the `tamma-agent.yml` runner + scaffolding + local
+CLI) has **no Epic-39 dependency** — it can run on day 0, entirely in parallel with Epic 39. Given
+40-1 is the largest single story (8d) and closes the most visible product gap (the runner does not
+exist), **start 40-1 immediately** and let the spine follow 39-10.
+
+## Waves (Epic-40 internal; wave 1 gated on 39-10 for the spine)
+
+Each wave = stories whose hard prerequisites are all in strictly earlier waves (or already
+merged). `pole` = the longest single story = the wave's wall-clock if run fully parallel.
+
+| Wave | Stories (effort) | Pole | Notes |
+|---|---|---|---|
+| **0 (background)** | 40-1 (8) | 8 | **No Epic-39 dep — start day 0**, parallel with all of Epic 39. Ships the runner on the existing dispatch/collect stack. Lands whenever green; only 40-7 consumes it. |
+| **1** | 40-2 (6) | 6 | **Gated on 39-10.** The durable-bookmark suspend — the spine root. Adds `WaitForAgentRunActivity` + registers it in `CanonicalSuspendActivities`. |
+| **2** | 40-3 (6.75), 40-4 (6.5) | 6.75 | Both hard-need 40-2. 40-3 emits the one `TenantDbContext` migration (`agent_run_waits`) → serialize with Epic 39's tenant chain. 40-3 edits 40-2's `Execute` (row write) — coordinate. |
+| **3** | 40-5 (2), 40-6 (3.25) | 3.25 | 40-5 needs 40-2+40-4 (the gate's clauses b/c); 40-6 needs 40-2/3/4 (its emission sites). Both off the longest path. |
+| **4** | 40-7 (4.75) | 4.75 | **Solo tail.** Composition proof — hard-needs 40-1..40-6. |
+
+### Wave dependency at a glance
+```
+(Epic 39 … → 39-10)          40-1  ── background, no 39 dep, land when green ──┐
+                    │                                                          │
+W1                 40-2  (needs 39-10)                                         │
+                  ┌──┴──┐                                                      │
+W2              40-3   40-4                                                    │
+                  │   ┌─┴────┐                                                 │
+W3              40-6 40-5  (40-6 needs 40-2/3/4; 40-5 needs 40-2/4)            │
+                  └───┬──────────────────────────────────────────────────────┘
+W4                  40-7   (needs 40-1..40-6 — composition proof)
+```
+
+## The one hard serial constraint: the `agent_run_waits` migration
+
+**40-3** generates one EF migration against **`TenantDbContext`** (`agent_run_waits`). EF snapshots
+the whole tenant model on each `migrations add`, so it **cannot be generated concurrently** with
+Epic 39's tenant-context migrations (39-5 `acceptance_rules_overrides`, 39-11 `document_instances`,
+39-18 `channel_outbox`, 39-17 configs, 39-21 KB). **Take the single migration-author token**: land
+40-3's migration after whatever Epic-39 tenant migration precedes it at merge time, and rebase its
+snapshot. Everything else in Epic 40 is additive-append-mergeable (DI registrations, activity
+registrations, event constants, the allowlist edit) — standard merge, no ordering constraint.
+
+## Cross-story shared edits (sequence within a wave)
+
+- **`LifecycleBookmarks.cs`** — 40-2 adds `ForAgentRun` + the `CanonicalSuspendActivities` entry.
+  If 39-10 has not merged, 40-2 lands a shim and rebases onto `LifecycleBookmarks` at merge.
+- **`WaitForAgentRunActivity.Execute`** — created by 40-2; 40-3 adds the `agent_run_waits` row
+  write; 40-6 adds the `AGENT_RUN.*` emissions. Accretes across waves 1→2→3 (additive) — those
+  stories rebase in order on it.
+- **`SingleIssueCycleWorkflow.cs`** — 40-2 swaps the loop node; 40-4 inserts the re-entry node;
+  40-5 adds the `[ResumeBehavior]` attribute. Additive; sequence 40-2 → 40-4 → 40-5.
+- **Placeholder event constants** — 40-2/40-3/40-4 pin local placeholders; 40-6 consolidates them
+  into `AgentRunEventTypes`. Agree the exact strings up front; 40-6's migration is a rename.
+
+## Suggested PR grouping
+
+One PR per story is cleanest (each maps to a plan + its tests). Group only the tightest lockstep:
+
+- **PR-1** 40-1 (independent; merge whenever green — do not hold it to the spine)
+- **PR-2** 40-2 (spine root; gated on 39-10)
+- **PR-3** 40-3 · **PR-4** 40-4 (parallel; 40-3 coordinates the `Execute` row-write with 40-2's merge)
+- **PR-5** 40-5 · **PR-6** 40-6 (parallel; 40-6 consolidates the placeholder constants)
+- **PR-7** 40-7 (composition proof — do not fan out until 40-1..40-6 are green)
+
+## Levers to compress
+
+1. **Start 40-1 on day 0.** It is the biggest story, has no Epic-39 dependency, and gates only
+   40-7 — pure background parallelism against all of Epic 39. If 40-1 is done before 39-10 lands,
+   the spine is the only remaining work.
+2. **Protect 40-2's start = the day 39-10 merges.** 40-2 is the spine root; every wave-2/3/4 story
+   waits on it. Any slip in 39-10 slips all of Epic 40's spine.
+3. **Land 40-5 async, not at a wave boundary.** It is a 2-day declaration/gate flip off the longest
+   path; merge it the moment 40-4 is green rather than batching with 40-6.
+4. **40-7 is an unavoidable solo tail** (hard-needs the whole epic). Keep its review fast; land its
+   scenarios incrementally as each prerequisite merges rather than in one block.
+
+## Method note
+
+Generated from the 7 plans, not hand-guessed: each story's hard-vs-soft deps, `MODIFY` file paths,
+and migration target were extracted; waves, critical path, the collision matrix, and the migration
+order were synthesized. Re-run if the plans change materially. The 39-10 external gate is the single
+most important scheduling fact — Epic 40's spine is a downstream continuation of Epic 39's
+resumability wave.

--- a/docs/stories/epic-40/README.md
+++ b/docs/stories/epic-40/README.md
@@ -1,0 +1,164 @@
+# Epic 40: Resumable Coding Execution — the tamma-agent runner contract, durable agent-run waits, and per-task re-entry
+
+## Overview
+
+The coding/TDD implement step is the one place in `SingleIssueCycleWorkflow` where
+Tamma hands a task to an autonomous coding agent, waits ~30 minutes for it, and folds
+the result back into the cycle. It is also the **least durable** step in the platform and
+the one whose **runner side was specified but never built**. Two truths, established by
+the research below, motivate this epic:
+
+1. **The CI-side runner (`tamma-agent.yml`) does not exist.** Story 19-1 authored a
+   complete *contract* — inputs, steps, result-artifact schema, security posture — and
+   left it `ready-for-dev`. No workflow file, no runner scripts, and no scaffolding that
+   installs it into a user repo was ever created. The entire C# dispatch→monitor→collect
+   stack (`Tamma.Activities/AgentDispatch/*` + `Tamma.Api` mediation) is built and
+   **expects that file to already be present in the user's repo**; when it is absent the
+   mediation fails loud with *"Add the Tamma agent workflow template to
+   .github/workflows/"* — a dead end for every SaaS tenant. The single-user `LocalExecutor`
+   path is symmetrically incomplete: it shells out to a `packages/cli execute-agent`
+   command that is not implemented.
+
+2. **The wait is not durable.** `ExecuteAgentActivity` runs the whole
+   dispatch→monitor→collect cycle inline with `await`. The workflow instance stays
+   **Running** (not suspended on a bookmark) for the full ~35-minute monitor loop; a
+   deploy, pod eviction, or crash during that window loses the in-flight monitor and — with
+   no task-level re-entry — restarts the entire `SingleIssueCycleWorkflow` from scratch,
+   re-running context/plan/task/branch/PR generation and re-implementing tasks that already
+   landed on the branch. The webhook signal plane (`WebhookSignalRegistry`) is an
+   **in-memory, single-process** `ConcurrentDictionary<TaskCompletionSource>`: a
+   `workflow_run.completed` webhook that lands on a different pod than the waiting monitor
+   never matches, silently degrading to poll (Auto) or failing (Webhook).
+
+Epic 40 closes both gaps. It **ships the runner contract** (the missing CI-side flow, both
+SaaS and single-user), and it **makes the coding step resumable by design** to the Epic 39
+standard — replacing the inline monitor with a durable bookmark suspend, replacing the
+in-memory signal plane with a persisted signal that survives restart and crosses pods, and
+giving the per-task loop a git-and-events-based re-entry so a crash resumes at the right
+task instead of re-implementing.
+
+**Epic 39 relationship — Code is NOT a document type.** Epic 39's README is explicit:
+*"Code's store is git, its validator is the build/test/gate stack, and its review is a
+`Review` whose subject is a diff. No schema needed."* So the coding step does **not** move
+onto `DocumentLifecycleWorkflow`; it needs its **own** resumable pattern. That pattern is
+built on 39-10's mechanism — `LifecycleBookmarks` (tenant-folded deterministic bookmark
+names), the `[ResumeBehavior]` declaration + `ResumableStandardStructuralTests` build gate,
+`CanonicalSuspendActivities`, and the `LegacyResumeAllowlist` burn-down — but its re-entry
+read model is **git + DCB events**, not the 39-11 document store.
+
+## The problem, traced through the code
+
+The coding step's call chain (all under `apps/tamma-elsa/src/`):
+
+```
+SingleIssueCycleWorkflow.cs  (per-task TDD loop)
+  initTaskLoop → hasMoreTasks (CurrentTaskIndex < TotalTasks)
+    → extractCurrentTask (tasksJson[CurrentTaskIndex])
+    → tddForTask : ExecuteAgentActivity   ◄── INLINE await, ~35 min, instance stays Running
+        AgentExecutorFactory.Create(mode)
+          ├─ GitHubActionsExecutor  (SaaS)
+          │    IAgentDispatchService.DispatchAsync   → Tamma.Api mediation → workflow_dispatch on tamma-agent.yml  ◄── FILE DOES NOT EXIST
+          │    IAgentMonitorService.MonitorAsync      → Poll | Webhook | Auto
+          │         WebhookSignalRegistry (in-memory TCS)  ◄── single-process, no cross-pod, no bookmark
+          │    IAgentResultCollectorService.CollectAsync → ActionsResultAggregator (reads `tamma-result`/result.json)
+          └─ LocalExecutor  (single-user)
+               shells node packages/cli execute-agent  ◄── CLI command NOT implemented
+    → Completed → incrementTask → loop
+    → Failed    → dispatchTddRetry (tdd-with-debug-retry) → advance | fail-cycle
+  hasMoreTasks False → ciGate (ci-with-debug-retry) → merge gate → …
+```
+
+Contrast the durable primitive already used elsewhere in the same workflow family:
+`WaitForCIResultsActivity` (`Tamma.Activities/Testing/`) **suspends on an Elsa bookmark +
+`context.DelayFor(...)` durable timeout** with `Received`/`Timeout` edges, holding no thread
+for the wait. The coding step must adopt exactly this shape.
+
+## Research findings (honest gap analysis)
+
+| Question | Finding |
+|---|---|
+| **Does `tamma-agent.yml` exist anywhere?** | **No.** Not in Tamma's own `.github/workflows/` (which has `tamma-worker.yml` but no `tamma-agent.yml`), not in any `templates/` dir (only `.dev/templates` exists, unrelated), no `run-claude-code.sh`/`collect-results.sh`. Story 19-1 defined the contract; the file was never authored. No scaffolding/generator installs it into a user repo — `AgentDispatchMediationService.CheckWorkflowFileAsync` only *checks presence* and fails with a "add the template" message. It is **assumed user-provided and undocumented** today. |
+| **What is the runner contracted to do?** | Reconstructable from the dispatch inputs (`AgentDispatchService.BuildDispatchInputs`: `issue_number, task, plan_json, branch_name, tamma_session_id, agent_provider, agent_config_json`) and the result contract (`AgentResultArtifactParser` + `ActionsResultAggregator`): **checkout `branch_name` → install the agent CLI (claude-code default) → materialize the plan slice → run the coding agent + TDD with repo-secret API keys → push commits to the branch → emit `.tamma/result.json` (the `AgentResultArtifact` schema) → upload it as an artifact named `tamma-result` → post an issue comment.** Idempotent, 30-min timeout. In the SingleIssueCycle context the PR is created by a *separate* `pull-request` step **before** the TDD loop, so the per-task runner pushes commits to an existing branch and does not itself open the PR. All of this is *specified* (19-1) but *unimplemented*. |
+| **Result-artifact schema (drift-pinned)** | Artifact **name** `tamma-result` (`ActionsResultAggregator.ResultArtifactName`); entry a file ending `result.json` (`ResultArtifactFileName`); JSON fields consumed by `AgentResultArtifactParser.ParseResultJson`: `success, task, issue_number, branch_name, tamma_session_id, files_changed[], pr_number, commit_sha, error_message, agent_log_summary, tokens_used, duration_seconds, agent_provider, agent_version`. Caps enforced server-side (4 MB result.json, 2000 files, 32 KB log summary). |
+| **How is completion observed?** | `AgentMonitorService` in three modes — **Poll** (mediated `GET runs/{id}` loop, ~35 min deadline), **Webhook** (park on `WebhookSignalRegistry`), **Auto** (webhook then poll fallback). The webhook is published by `Tamma.Api` `InstallationRouterService.HandleWorkflowRunEvent` on `workflow_run.completed` → `IWebhookSignalRegistry.PublishSignal`. **Gaps:** inline `await` (instance never suspends), in-memory single-instance registry (no cross-pod), no Elsa bookmark, no DelayFor durable timeout at the activity, no task-level re-entry. |
+| **LocalExecutor (single-user) path** | Writes `.tamma/exec-request-{session}.json`, spawns `node packages/cli/dist/index.js execute-agent --request … --output …`, reads back an `AgentResultArtifact`-shaped file. The `execute-agent` CLI command **is not implemented** (the code itself says so). Single-user coding execution is therefore as unshipped as the SaaS runner. |
+| **Epic 39 hooks consumed** | 39-10: `LifecycleBookmarks` (tenant-folded builder), `ResumeBehaviorAttribute`/`ResumeMode`, `CanonicalSuspendActivities`, `LegacyResumeAllowlist`, `ResumableStandardStructuralTests`, the `ComputeReEntryPositionActivity` pattern. 39-8: `DocumentDecisionResumeEndpoint` as the tenant-folded resume-endpoint precedent; `NormalizeSegment`. **NOT consumed:** 39-11 document store (code is not a document — re-entry reads git + DCB events, mirroring 39-10's 4-7/4-8 read path). |
+
+## Design principles (settled)
+
+- **The runner is a versioned contract, shipped and installed, not assumed.** `tamma-agent.yml`
+  carries a `tamma-runner-version`; Tamma scaffolds it into a user repo through the GitHub App
+  and detects drift. The result-artifact schema is pinned to `AgentResultArtifactParser` by a
+  drift test, exactly as prompt contracts are pinned to their parsers.
+- **The wait suspends, it never spins.** The coding step dispatches, then **suspends on a
+  durable Elsa bookmark** with a `DelayFor` timeout — the `WaitForCIResultsActivity` shape —
+  so the workflow holds no thread and survives any restart. `Received`/`Timeout` are
+  deterministic edges; a lost webhook times out to a loud escalation, never a hang.
+- **The signal is durable and the bookmark store is the backplane.** Once the step suspends on
+  a real DB-persisted Elsa bookmark, **any pod** can resume it through Elsa's bookmark store —
+  that is the cross-pod delivery the in-memory TCS never had. The persisted signal row only
+  carries the `sessionId`/bookmark-name that the `workflow_run.completed` webhook lacks.
+- **Code's re-entry read is git + events, not a document store.** "Which task already landed"
+  is reconstructed from commits on the branch and `AGENT_RUN.*`/`CODE.*` DCB events keyed by the
+  deterministic per-task session id (`adl-{issue}-task-{index}`) — never from Elsa instance
+  internals. This is 39-10's latest-state re-entry, with git as the store.
+- **One resumable standard, enforced by the same build gate.** `SingleIssueCycleWorkflow`
+  declares `[ResumeBehavior]`, registers `WaitForAgentRunActivity` as a canonical suspend
+  activity, and **burns down its `LegacyResumeAllowlist` entry** — the first Epic-40 consumer
+  of the 39-10 gate.
+- **Per-mode scoping, drawn twice.** SaaS: the runner executes in the *tenant's* GitHub Actions
+  with the *tenant's* repo secrets; Tamma never sees the agent API keys; bookmarks and signals
+  are tenant-folded. Single-user: the runner is the local CLI on the sole user's host with the
+  user's own keys. Every feature answers both ownership questions (CLAUDE.md two-scoping rule).
+
+## Stories
+
+| Story | Title | Priority | Status | Est. Effort |
+|-------|-------|----------|--------|-------------|
+| 40-1 | The `tamma-agent.yml` Runner Contract & Repo Scaffolding (+ single-user CLI parity) | P0 | drafted | 6-8 days |
+| 40-2 | `WaitForAgentRunActivity` — durable bookmark suspend + `DelayFor` timeout | P0 | drafted | 5-7 days |
+| 40-3 | Durable agent-run signal plane + resume endpoint (cross-pod, restart-safe) | P0 | drafted | 5-7 days |
+| 40-4 | Per-task re-entry — reconstruct landed tasks from git + DCB events | P0 | drafted | 5-7 days |
+| 40-5 | `[ResumeBehavior]` on `SingleIssueCycleWorkflow` + allowlist burn-down | P0 | drafted | 2-3 days |
+| 40-6 | Agent-run lifecycle event family + re-entry feed | P1 | drafted | 3-4 days |
+| 40-7 | End-to-end crash/restart + mode-matrix integration proof | P0 | drafted | 4-5 days |
+
+## Supersedes / absorbs
+
+- **Story 19-1 (tamma-agent workflow template)** — formally *completed* by 40-1: 19-1
+  authored the contract but never shipped the file/scripts/scaffolding; 40-1 delivers them
+  and pins the artifact schema to `AgentResultArtifactParser`.
+- **The inline monitor inside `ExecuteAgentActivity`** — its dispatch/collect halves are
+  retained (reused by `WaitForAgentRunActivity`), but the inline ~35-min `await` on
+  `IAgentMonitorService.MonitorAsync` is replaced by the durable bookmark suspend (40-2).
+  `ExecuteAgentActivity` remains for non-resumable callers/tests; the SingleIssueCycle TDD
+  loop switches to `WaitForAgentRunActivity`.
+- **`WebhookSignalRegistry` (in-memory)** — superseded by the durable signal + Elsa bookmark
+  store (40-3). The in-memory registry may remain as a same-process fast-path optimization,
+  but correctness no longer depends on it.
+- **NOT superseded:** `AgentDispatchService`/`AgentMonitorService` (poll) /
+  `AgentResultCollectorService` / `ActionsResultAggregator` / `AgentResultArtifactParser`
+  stay the dispatch/collect substrate; the `AGENT_DISPATCH.RUN_*` mediation event family
+  (Tamma.Api) stays; 40-6 adds the engine-side *wait/re-entry* events beside it.
+
+## Dependencies
+
+- **Epic 39-10 (Resumable-by-Design Standard) — HARD, must land first.** Epic 40 consumes
+  `LifecycleBookmarks`, `ResumeBehaviorAttribute`/`ResumeMode`, `CanonicalSuspendActivities`,
+  `LegacyResumeAllowlist`, and `ResumableStandardStructuralTests`. 40-2's bookmark uses the
+  builder; 40-5's declaration + allowlist burn-down is meaningless without the gate.
+- **Epic 39-8 (Escalation & Approval Surface) — SOFT.** `DocumentDecisionResumeEndpoint` is
+  the tenant-folded resume-endpoint precedent 40-3 mirrors (404/409 posture, `NormalizeSegment`
+  reuse). 40-3 can develop against the pattern without waiting on 39-8's document specifics.
+- **Story 4-7 (event query API) + 4-8 (`ReplayReconstructor`)** — the DCB read path 40-4's
+  re-entry uses (identical to how 39-10 reads latest state), plus the git compare/PR reads
+  already in `ActionsResultAggregator`.
+- **Existing substrate (in place, verified):** the full `Tamma.Activities/AgentDispatch/*`
+  dispatch/monitor/collect stack, `AgentResultArtifactParser`, `ActionsResultAggregator`,
+  `WaitForCIResultsActivity` (the durable-wait precedent), the GitHub App installation +
+  `InstallationRouterService` webhook receiver, Elsa 3 bookmarks + EF persistence.
+- **NOT a dependency:** 39-11 document store / `DocumentLifecycleWorkflow` — code is not a
+  document type; re-entry reads git + events instead. Called out so the coupling is not
+  mistakenly introduced.
+- **Operating-mode detection (single-user vs SaaS)** — 40-1's runner install path and every
+  bookmark/signal scoping decision is per-mode (CLAUDE.md universal rule).

--- a/docs/stories/epic-40/sprint-status.yaml
+++ b/docs/stories/epic-40/sprint-status.yaml
@@ -1,0 +1,52 @@
+# generated: 2026-07-23
+# project: Tamma
+# project_key: Tamma
+# tracking_system: file-system
+# story_location: "{project-root}/docs/stories"
+#
+# Epic 40 — Resumable Coding Execution: the tamma-agent runner contract,
+# durable agent-run waits, and per-task re-entry.
+#
+# STATUS DEFINITIONS (same as docs/sprint-status.yaml):
+#   Epic:  backlog | contexted
+#   Story: backlog | drafted | ready-for-dev | in-progress | review | done | superseded
+#
+# NOTE: Epic 40's spine (40-2..40-7) is HARD-GATED on Epic 39-10
+#       (LifecycleBookmarks, ResumeBehavior, CanonicalSuspendActivities,
+#       LegacyResumeAllowlist, ResumableStandardStructuralTests). 40-1 has NO
+#       Epic-39 dependency and can start immediately.
+
+generated: 2026-07-23
+project: Tamma
+project_key: Tamma
+tracking_system: file-system
+story_location: "{project-root}/docs/stories"
+
+development_status:
+  epic-40: contexted   # README + EXECUTION-PLAN + 7 stories drafted (docs-only authoring pass).
+
+  # ── Wave 0 (background — no Epic-39 dependency, start day 0) ──
+  40-1-tamma-agent-runner-contract-and-scaffolding: drafted   # NET-NEW: tamma-agent.yml + scripts + result schema pin + GitHub-App scaffold + single-user in-process runner. 19-1 was contract-only, never built. Effort 6-8d. Prereq: none.
+
+  # ── Wave 1 (spine root — gated on 39-10) ──
+  40-2-wait-for-agent-run-activity-durable-bookmark: drafted  # Durable bookmark suspend + DelayFor timeout replacing the inline monitor. Effort 5-7d. Prereq: 39-10 (HARD).
+
+  # ── Wave 2 (need 40-2) ──
+  40-3-durable-agent-run-signal-and-resume-endpoint: drafted  # Persisted agent_run_waits row + webhook resume (cross-pod, restart-safe) + resume endpoint; demotes in-memory WebhookSignalRegistry. Effort 5-7d. Prereq: 40-2 (HARD), 39-8 (SOFT). MIGRATION: TenantDbContext (agent_run_waits) — single-author token.
+  40-4-per-task-re-entry-from-git-and-events: drafted         # Reconstruct landed tasks from git + DCB events keyed by adl-{issue}-task-{index}; resume loop at the right CurrentTaskIndex. Effort 5-7d. Prereq: 40-2 (HARD), 39-10 pattern (SOFT).
+
+  # ── Wave 3 (need 40-2/40-4) ──
+  40-5-resume-behavior-declaration-and-allowlist-burndown: drafted  # [ResumeBehavior(Both)] on SingleIssueCycleWorkflow + remove its LegacyResumeAllowlist entry; pass ResumableStandardStructuralTests with no allowlist. Effort 2-3d. Prereq: 39-10 + 40-2 + 40-4 (ALL HARD).
+  40-6-agent-run-lifecycle-event-family: drafted             # AgentRunEventTypes (WAIT_SUSPENDED/RECEIVED/TIMED_OUT/RESUME_UNRESOLVED/TASK_REENTERED) consolidating 40-2/3/4 placeholder pins; feeds re-entry. Effort 3-4d. Prereq: 40-2/40-3/40-4 (HARD).
+
+  # ── Wave 4 (composition proof — needs the whole epic) ──
+  40-7-crash-restart-mode-matrix-integration-proof: drafted  # Testcontainers: durable suspend/resume, cross-pod, crash re-entry (exactly-once/task), timeout, inconsistency-fails-loud, SaaS+local mode matrix, 40-1 runner self-check. Effort 4-5d. Prereq: 40-1..40-6 (HARD).
+
+  epic-40-retrospective: optional
+
+# ── Effort / schedule summary (see EXECUTION-PLAN.md) ──
+# total_effort_person_days: 37.25
+# critical_path_days: 20.5            # 40-2 -> 40-4 -> 40-6 -> 40-7 (39-10 assumed landed)
+# wave_parallel_wall_clock_days: 22.75
+# external_gate: "Epic 39-10 must land before the 40-2 spine can start"
+# tenant_migration: "40-3 agent_run_waits — joins Epic 39 tenant-context migration chain (single-author token)"

--- a/docs/stories/epic-40/story-40-1/40-1-tamma-agent-runner-contract-and-scaffolding.md
+++ b/docs/stories/epic-40/story-40-1/40-1-tamma-agent-runner-contract-and-scaffolding.md
@@ -1,0 +1,177 @@
+# Story 40-1: The `tamma-agent.yml` Runner Contract & Repo Scaffolding (+ single-user CLI parity)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **user who installed the Tamma GitHub App** (SaaS) — and as the **sole user of a
+self-hosted Tamma** (single-user),
+I want the CI-side coding-agent runner that Tamma dispatches to **actually exist, be
+installed into my repo (or runnable locally), and produce exactly the result artifact
+Tamma's collector expects**,
+So that the coding/TDD implement step can run end-to-end instead of failing with *"Add the
+Tamma agent workflow template to .github/workflows/"* — the dead end every tenant hits
+today.
+
+## Priority
+
+P0 — Without a shipped runner the entire dispatch→monitor→collect stack has nothing to
+dispatch to. Every other Epic-40 story (durable wait, signal plane, re-entry) makes the
+*wait* correct; this story makes there be something to wait **for**.
+
+## Architectural Context (READ FIRST)
+
+**This is net-new, not a refactor.** Story 19-1 (`docs/stories/epic-19/story-19-1/`)
+authored the runner *contract* — inputs, step outline, result-artifact schema, security
+posture — and left it `ready-for-dev`. **The file was never created.** Confirmed by
+research: no `tamma-agent.yml` anywhere on disk, no `templates/` runner dir (only
+`.dev/templates`, unrelated), no `run-claude-code.sh`/`collect-results.sh`, and no
+scaffolding that installs it into a user repo. Tamma's own `.github/workflows/` has
+`tamma-worker.yml` but no `tamma-agent.yml`.
+
+The C# side is fully built and pins the runner's output contract:
+
+- **Dispatch inputs** — `AgentDispatchService.BuildDispatchInputs`
+  (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentDispatchService.cs:91`) sends
+  exactly seven `workflow_dispatch` string inputs: `issue_number, task, plan_json,
+  branch_name, tamma_session_id, agent_provider, agent_config_json`.
+- **Workflow file name** — defaulted to `tamma-agent.yml` in three places
+  (`AgentDispatchService.cs:49`, `ExecuteAgentActivity.cs:187`,
+  `AgentDispatchMediationService.cs:41`); the mediation `CheckWorkflowFileAsync`
+  (`AgentDispatchMediationService.cs:101`) fails loud with `WorkflowNotFound` /
+  *"Add the Tamma agent workflow template to .github/workflows/"* when it is absent.
+- **Result artifact** — `ActionsResultAggregator`
+  (`apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/ActionsResultAggregator.cs:39`)
+  downloads the artifact named **`tamma-result`**, opens the entry ending **`result.json`**,
+  and `AgentResultArtifactParser.ParseResultJson`
+  (`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentResultArtifactParser.cs:38`)
+  decodes the `AgentResultArtifact` fields
+  (`Models/AgentExecutionModels.cs:151`): `success, task, issue_number, branch_name,
+  tamma_session_id, files_changed[], pr_number, commit_sha, error_message,
+  agent_log_summary, tokens_used, duration_seconds, agent_provider, agent_version`.
+  Caps: `MaxResultJsonBytes=4MB`, `MaxFilesChangedCount=2000`, `MaxAgentLogSummaryChars=32K`.
+
+**Single-user parity is symmetrically unshipped.** `LocalExecutor`
+(`Tamma.Activities/AgentDispatch/LocalExecutor.cs`) spawns
+`node packages/cli/dist/index.js execute-agent --request … --output …` and reads back an
+`AgentResultArtifact`-shaped file — but the `execute-agent` CLI command is **not
+implemented** (the executor's own XML doc and its "did not produce a result file
+(packages/cli execute-agent command may not be implemented yet)" error path say so).
+
+**In the SingleIssueCycle context the runner does NOT open the PR.** The `pull-request`
+sub-workflow creates the draft PR *before* the TDD loop
+(`SingleIssueCycleWorkflow.cs` `createPR` precedes `initTaskLoop`), and `task="implement"`
+with `plan_json` = a single-task slice. So the per-task runner **pushes commits to the
+existing branch**; `pr_number` in the artifact may be null and the collector derives PR/commit
+state from git (`ActionsResultAggregator` steps 2-4). The runner contract must therefore be
+correct for the "implement one task on an existing branch" call, not only the "one-shot whole
+issue" call.
+
+## Acceptance Criteria
+
+1. **Canonical, versioned runner workflow shipped in-repo.** A real
+   `apps/tamma-elsa/runner/github-actions/tamma-agent.yml` (path may differ; a `runner/`
+   home under the app, not `.github/workflows/` of Tamma itself) triggers **only** on
+   `workflow_dispatch` with exactly the seven inputs
+   `AgentDispatchService.BuildDispatchInputs` sends (names/types byte-matched). It carries a
+   `tamma-runner-version` marker (comment + an env/echo the run logs) so drift/upgrade can be
+   detected.
+
+2. **Runner steps implement the contract.** checkout `branch_name` → set up the agent
+   environment → write the plan slice (`plan_json`) and a `.tamma/INSTRUCTIONS.md` (plan +
+   branch/issue context + repo conventions read from `CLAUDE.md` if present) → run the coding
+   agent (`agent_provider`, default `claude-code`) in headless mode using **repo-secret API
+   keys** (`ANTHROPIC_API_KEY`, …) → run the repo's tests (TDD) → commit and **push to
+   `branch_name`** → always emit `.tamma/result.json` → upload it as an artifact named
+   **`tamma-result`** → post an issue status comment. Configurable `runs-on` and a
+   `timeout-minutes` (default 30).
+
+3. **Result artifact matches the parser exactly (drift-pinned).** The emitted `result.json`
+   uses the exact snake_case keys `AgentResultArtifactParser` reads, with correct JSON types.
+   A **drift test** (C#, `Tamma.Activities.Tests` or `Tamma.Api.Tests`) parses a golden
+   `result.json` fixture that the runner's collect script also validates against, and asserts
+   round-trip against `AgentResultArtifact` — so a schema change on either side fails the
+   build (the prompt-contract-pin precedent).
+
+4. **Agent keys never reach Tamma.** The workflow reads agent API keys from GitHub Actions
+   secrets only; no key is echoed, logged, or written into the artifact. The artifact carries
+   metadata only (no source content). Retention ≤ 1 day (`actions/upload-artifact@v4`).
+
+5. **Idempotent and fail-safe.** Re-running with the same `tamma_session_id`/`branch_name`
+   does not duplicate commits or PRs (guard by checking existing branch state); on agent
+   failure or timeout the workflow **still uploads** a `result.json` with `success:false` and
+   an `error_message`; the collect step runs even under GitHub's cancellation signal.
+
+6. **Multi-agent dispatch seam.** The `agent_provider` input routes to a per-agent runner
+   script (`claude-code` shipped; a documented `case` dispatch for adding `aider`/others),
+   each with install → run → collect phases producing the same `result.json`.
+
+7. **SaaS scaffolding path — install/update into a user repo via the GitHub App.** A Tamma
+   service (e.g. `RunnerScaffoldService` in `Tamma.Api`) can, through the tenant's GitHub App
+   installation, **commit `tamma-agent.yml` (and its scripts) into `.github/workflows/` of a
+   target repo** and **detect version drift** against the shipped canonical copy. Endpoint(s)
+   under the tenant-scoped admin surface: check status, install/upgrade. Tenant↔repo
+   authorization reuses the existing `IGitRepoAuthorizer` guard; the install commit uses the
+   installation token minted inside `Tamma.Api` (never in the engine). The `CheckWorkflowFileAsync`
+   "not found" path's error message points at this install action.
+
+8. **Single-user CLI parity — implement `execute-agent`.** The local coding path is made real:
+   either (a) implement the `packages/cli execute-agent` command to the `LocalExecutor`
+   request/result JSON protocol, OR (b) replace the shell-out with an in-process local runner —
+   whichever the implementation plan justifies — so a self-hosted single-user Tamma can run the
+   coding step and produce the same `AgentResultArtifact`. The single-user runner uses the sole
+   user's own agent keys from local config, never a tenant secret.
+
+9. **Documentation.** A user-facing setup doc (secrets to add, how the App installs the
+   workflow, self-hosted runner labels) and inline YAML comments per step. The
+   `docs/stories/epic-19/story-19-1` contract doc is cross-linked as the historical origin and
+   marked delivered-by-40-1.
+
+10. **Per-mode ownership is explicit.** The story/plan states, for both modes, who owns the
+    runner, whose keys it uses, and where the result lands — and the scaffolding path is a
+    no-op in single-user mode (no GitHub App), where the local runner (AC8) is used instead.
+
+## Technical Notes
+
+- **The 19-1 YAML skeleton is a starting point, not a spec to copy blindly** — reconcile every
+  input name and every `result.json` key against the *current* C# parser/aggregator (drift may
+  have occurred since 19-1 was written), and let AC3's drift test be the arbiter.
+- **PR creation belongs to the cycle, not the per-task runner** (see Architectural Context) —
+  the runner must behave correctly when `pr_number` is null and only commits are pushed.
+- Keep the workflow's `permissions` minimal (`contents: write`, `pull-requests: write`,
+  `issues: write`) — least privilege, 19-1 AC.
+- The scaffolding commit must be reviewable/diffable and must not clobber a user's customized
+  copy without an explicit upgrade action (drift *detected*, upgrade *opted into*).
+
+## Dependencies
+
+- **Existing (verified):** `AgentDispatchService`/`AgentResultArtifactParser`/
+  `ActionsResultAggregator`/`AgentDispatchMediationService`, `IGitHubActionsClient` +
+  `OctokitGitHubActionsClient` (installation-token commit path), `IGitRepoAuthorizer`, the
+  GitHub App installation flow, `LocalExecutor` + `IProcessRunner`.
+- **Story 19-1** — the contract this story delivers (was never implemented).
+- **Independent of** 40-2..40-7 — ships the runner regardless of the durable-wait work; those
+  stories change *how Tamma waits*, not *what the runner does*.
+
+## Estimated Effort
+
+6-8 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-1/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-1/implementation-plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan — Story 40-1: The `tamma-agent.yml` Runner Contract & Repo Scaffolding
+
+## Scope & Deliverable
+
+When this story is done, the coding-agent runner that Tamma dispatches to **exists, is
+version-marked, and produces exactly the artifact the collector parses** — closing the gap
+where 19-1 specified but never shipped it. Concretely: a canonical `tamma-agent.yml` +
+per-agent runner scripts live in-repo under `apps/tamma-elsa/runner/github-actions/`; a
+drift test pins the emitted `result.json` to `AgentResultArtifactParser`; a
+`RunnerScaffoldService` in `Tamma.Api` installs/upgrades the workflow into a tenant's repo
+through the GitHub App and reports drift; and the single-user `LocalExecutor` path is made
+real (the `execute-agent` seam implemented). A tenant that runs the SingleIssueCycle now gets
+a real agent run instead of a `WorkflowNotFound` dead end.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-1/40-1-tamma-agent-runner-contract-and-scaffolding.md` — this story (ACs are source of truth)
+- `docs/stories/epic-19/story-19-1/19-1-tamma-agent-workflow-template.md` — the historical contract (skeleton YAML, schema, security) — **reconcile, do not copy blindly**
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentDispatchService.cs:91` — `BuildDispatchInputs` (the seven inputs the runner MUST accept, exact names)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/Models/AgentExecutionModels.cs:151` — `AgentResultArtifact` (the result schema)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentResultArtifactParser.cs` — the parser + caps the runner output must satisfy
+- `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/ActionsResultAggregator.cs:39` — artifact name `tamma-result`, entry `result.json`, PR/compare/checks derivation
+- `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchMediationService.cs:100` — `CheckWorkflowFileAsync` / `WorkflowNotFound` (the dead end this story removes; its message points at the scaffold action)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/IGitHubActionsClient.cs` + `apps/tamma-elsa/src/Tamma.Api/Services/GitHub/OctokitGitHubActionsClient.cs` — installation-token client (the commit path scaffolding uses)
+- `apps/tamma-elsa/src/Tamma.Api/Services/Git/IGitRepoAuthorizer.cs` (via `AgentDispatchMediationService` usage) — tenant↔repo guard reused by the scaffold endpoint
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/LocalExecutor.cs` — the single-user request/result JSON protocol + the unimplemented `execute-agent` seam
+- `apps/tamma-elsa/tests/Tamma.Activities.Tests/AgentDispatch/AgentDispatchServiceTests.cs` — input-composition test shape to extend with the pin
+- `.github/workflows/tamma-worker.yml` — an existing Tamma-authored workflow for house YAML conventions
+
+## Design Decisions
+
+- **D1 — The runner lives in-repo under `apps/tamma-elsa/runner/github-actions/`, NOT in Tamma's `.github/workflows/`.** It is a *template Tamma ships to users*, not a workflow that runs on Tamma's own repo. Keeping it in `.github/workflows/` would make GitHub try to run it on the Tamma repo (wrong) and would hide it from the drift test. `runner/` is the canonical source; the scaffold service embeds it (build-time `EmbeddedResource`) so `Tamma.Api` can commit its exact bytes into a tenant repo. Tamma's own dogfooding install (Tamma developing Tamma) is just another scaffold target.
+- **D2 — Result schema is the single source of truth; the runner conforms to it, pinned by a golden fixture.** Rather than hand-syncing YAML to C#, ship `apps/tamma-elsa/runner/github-actions/result.schema.json` (JSON Schema) + a golden `result.example.json`; the collect script validates the runner's output against the schema in-run (fail the run on mismatch), and a C# drift test (`RunnerResultContractTests`) deserializes the same golden fixture through `AgentResultArtifactParser` and asserts every field maps. One fixture, checked both sides — schema drift fails CI on whichever side moved (mirrors `ContractBindingTests`/prompt-contract pinning).
+- **D3 — Per-agent runner scripts behind a provider `case`, `claude-code` shipped.** `run-claude-code.sh` (install `@anthropic-ai/claude-code`, run headless with `.tamma/INSTRUCTIONS.md` + plan, capture tokens/duration) + `collect-results.sh` (assemble `result.json` from git state + agent exit + logs, validate against the schema). The dispatch `case "${{ inputs.agent_provider }}"` is the extension seam (19-1 AC); adding `aider` later is a new script + case, no workflow surgery.
+- **D4 — The runner NEVER opens the PR in the per-task call.** Since the cycle creates the PR before the TDD loop (`SingleIssueCycleWorkflow` `createPR` precedes `initTaskLoop`), the runner's job for `task=implement` is: implement the plan slice, run tests, **push commits to `branch_name`**, emit the artifact with `pr_number` possibly null. The collector already derives PR/commit/files from git when the artifact omits them (`ActionsResultAggregator` steps 2-4). The runner supports an optional "open PR if none exists" only for the standalone (non-cycle) call, gated by an input default that the cycle leaves off.
+- **D5 — Scaffolding is install + drift-detect + opt-in upgrade, never silent clobber.** `RunnerScaffoldService.GetStatusAsync(tenant, repo)` reads the repo's `.github/workflows/tamma-agent.yml`, parses its `tamma-runner-version`, and returns `{ absent | current | drifted(userVersion, shippedVersion) | customized }`. `InstallAsync` commits the canonical bytes only when absent (or on explicit `upgrade=true`); a user-customized copy (version marker removed/edited) reports `customized` and refuses to overwrite without `force`. Commit via `IGitHubActionsClient` extension (`CreateOrUpdateFileAsync` on the installation token) — the token stays inside `Tamma.Api`. Endpoints on the existing tenant-admin surface: `GET /api/repos/{repo}/runner`, `POST /api/repos/{repo}/runner/install`.
+- **D6 — Single-user parity implements `execute-agent` in-process, retiring the Node shell-out (recommended path b).** Rather than resurrect `packages/cli` (legacy TS, per CLAUDE.md largely superseded), ship a C# `InProcessLocalRunner` that `LocalExecutor` invokes directly when configured, running the same claude-code CLI as a child process on the host with the sole user's keys and emitting the `AgentResultArtifact` JSON. `LocalExecutor`'s file-protocol shape is preserved for back-compat/tests; the default local path no longer depends on an unimplemented `packages/cli` command. (If the reviewer prefers path (a), the request/result JSON contract in `LocalExecutor`'s XML doc is the exact spec to implement — either way AC8 is satisfied by producing the same artifact.)
+- **D7 — Fail-loud on missing secrets, fail-safe on agent error.** No agent key ⇒ the runner writes `result.json {success:false, error_message:"ANTHROPIC_API_KEY secret not set"}` and exits non-zero (loud, but still uploads the artifact so the collector reports it, not a phantom timeout). Agent crash/timeout ⇒ same fail-safe artifact via a `always()` collect step (AC5). The workflow never completes green with no artifact.
+
+## Implementation Steps
+
+1. **CREATE `apps/tamma-elsa/runner/github-actions/tamma-agent.yml`** — the canonical workflow (D1): `workflow_dispatch` with the seven inputs pinned to `BuildDispatchInputs` (names/types), `permissions` least-privilege, `timeout-minutes` from a `timeout` derivation (default 30), configurable `runs-on`, a `tamma-runner-version` env + echo, and the step sequence of AC2 with an `always()` collect+upload. Inline per-step YAML comments (AC9).
+
+2. **CREATE `apps/tamma-elsa/runner/github-actions/scripts/run-claude-code.sh` + `collect-results.sh`** (D3) — install/run/collect for claude-code; `collect-results.sh` assembles `result.json` from git (`git diff --name-only`, HEAD sha), agent exit code, token/duration capture, and validates against `result.schema.json` before upload.
+
+3. **CREATE `apps/tamma-elsa/runner/github-actions/result.schema.json` + `result.example.json`** (D2) — the drift-pinned schema + golden fixture, snake_case keys matching `AgentResultArtifactParser`.
+
+4. **CREATE the multi-agent dispatch seam** — the `case "${{ inputs.agent_provider }}"` block in `tamma-agent.yml` (AC6), `claude-code` wired, an `aider`/`*` documented-but-unshipped branch that exits with a clear "unsupported provider" artifact.
+
+5. **CREATE `apps/tamma-elsa/src/Tamma.Api/Services/GitHub/RunnerScaffoldService.cs` + `IRunnerScaffoldService.cs`** (D5, AC7) — `GetStatusAsync`/`InstallAsync` over an `IGitHubActionsClient` file-commit extension; embed the runner files as `EmbeddedResource` (csproj `<EmbeddedResource Include="..\..\runner\**" />` or a copied build asset) so the shipped bytes are the committed bytes. Reuse `IGitRepoAuthorizer` for the tenant↔repo guard.
+
+6. **ADD the scaffold endpoints** to the tenant-admin API surface (`Tamma.Api` endpoint module) — `GET /api/repos/{repo}/runner`, `POST /api/repos/{repo}/runner/install` (body `{ upgrade?, force? }`), `PlatformOwner`/`tenant_admin` policy per mode; single-user mode → the endpoints are present but report `mode: single-user, use local runner` (no GitHub App).
+
+7. **MODIFY `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchMediationService.cs`** — the `WorkflowNotFound` failure message points at the scaffold action (`POST /api/repos/{repo}/runner/install`) rather than a bare "add the template" string. No behavior change beyond the message.
+
+8. **IMPLEMENT single-user parity (D6)** — CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/InProcessLocalRunner.cs`; **MODIFY `LocalExecutor.cs`** to invoke it when `Agent:Local:InProcess=true` (default for single-user), preserving the file-protocol path behind the flag; run claude-code as a child process via `IProcessRunner` with the user's local keys, emit the `AgentResultArtifact` JSON.
+
+9. **CREATE the drift + scaffold tests** (see Test Plan) — `RunnerResultContractTests`, `RunnerScaffoldServiceTests`, extend `AgentDispatchServiceTests` with the input-name pin, `InProcessLocalRunnerTests`.
+
+10. **CREATE `docs/guides/github-actions-runner-setup.md`** (AC9) — secrets, App-driven install, self-hosted runner labels, single-user local mode; cross-link 19-1 as delivered-by-40-1. Finish with full `dotnet test` + a YAML lint of the runner workflow.
+
+## Data & Migrations
+
+None. Runner status is read live from the target repo (no persisted state); no EF entities.
+`dotnet ef migrations has-pending-model-changes` stays clean.
+
+## Events
+
+- **Reuses (no new engine events):** dispatch/collect emit the existing
+  `AGENT_DISPATCH.RUN_TRIGGERED.*` / `RESULTS_COLLECTED.*` family (`AgentDispatchEventTypes`)
+  unchanged. The 40-6 wait/re-entry events are out of scope here.
+- **New (scaffold audit):** `RUNNER.SCAFFOLD.INSTALLED` / `RUNNER.SCAFFOLD.UPGRADED` /
+  `RUNNER.SCAFFOLD.SKIPPED` emitted by `RunnerScaffoldService` on the DCB stream (tags
+  `tenantId`, `repo`, `runnerVersion`) so an install into a user repo is auditable. One
+  constant block in a `RunnerScaffoldEventTypes.cs`.
+
+## Test Plan
+
+All NUnit + FluentAssertions (+ Moq). YAML/script validated by CI lint, not C# unit tests.
+
+- **`RunnerResultContractTests`** (unit, drift gate) — deserialize `result.example.json`
+  through `AgentResultArtifactParser.ParseResultJson`; assert every field populated and typed;
+  assert the JSON-Schema `required` set equals the parser's read set (fail if either side adds/
+  drops a field). **Covers AC3.**
+- **`AgentDispatchServiceTests` (extend)** — pin: the runner YAML's declared input names equal
+  `BuildDispatchInputs`' keys (read the YAML from the runner path, assert set-equality). **Covers AC1.**
+- **`RunnerScaffoldServiceTests`** (unit, Moq'd `IGitHubActionsClient` + `IGitRepoAuthorizer`) —
+  status matrix (absent/current/drifted/customized); install commits only when absent or
+  `upgrade`; customized refuses without `force`; guard-denied → no commit + typed 403; emits
+  `RUNNER.SCAFFOLD.*`. **Covers AC7.**
+- **`InProcessLocalRunnerTests`** (unit, fake `IProcessRunner`) — happy path produces a valid
+  `AgentResultArtifact`; agent non-zero exit → `success:false` artifact with error; timeout →
+  fail-safe artifact; uses local keys, never a tenant secret. **Covers AC8, AC5 (local half).**
+- **Runner self-test (CI job, optional integration)** — dispatch the shipped workflow on a
+  throwaway test repo with a mock agent (`agent_provider=mock`), assert a `tamma-result`
+  artifact with a schema-valid `result.json` and an issue comment. **Covers AC2, AC4, AC5, AC6.**
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — versioned workflow, seven inputs pinned | 1 | `AgentDispatchServiceTests` input-name pin |
+| 2 — steps implement the contract | 1, 2, 4 | Runner self-test CI job |
+| 3 — artifact matches parser (drift-pinned) | 2, 3 | `RunnerResultContractTests` |
+| 4 — keys never reach Tamma; metadata-only artifact | 1, 2 | Reviewer check + self-test (no secret in logs/artifact) |
+| 5 — idempotent, fail-safe artifact | 1, 2 | Runner self-test failure variant; `InProcessLocalRunnerTests` |
+| 6 — multi-agent dispatch seam | 4 | Self-test with `agent_provider=mock` |
+| 7 — SaaS scaffold install/upgrade/drift | 5, 6, 7 | `RunnerScaffoldServiceTests` |
+| 8 — single-user CLI parity | 8 | `InProcessLocalRunnerTests` |
+| 9 — documentation | 10 | Reviewer check: guide exists, YAML commented, 19-1 cross-linked |
+| 10 — per-mode ownership explicit | 5, 6, 8 | Reviewer check: scaffold no-op in single-user, local runner used |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisites:** none — this story ships on the *existing* dispatch/collect stack.
+- **In place, verified:** `AgentResultArtifactParser`, `ActionsResultAggregator`,
+  `IGitHubActionsClient`/`OctokitGitHubActionsClient` (needs a `CreateOrUpdateFile` extension —
+  add if absent), `IGitRepoAuthorizer`, `LocalExecutor`/`IProcessRunner`, the GitHub App flow.
+- **Feeds:** 40-7 (the mode-matrix integration proof dispatches this real runner); 40-2/40-3
+  wait *for* this runner's `workflow_run` but do not depend on its internals.
+- **Independent of** 39-x — no Epic-39 hook is consumed here.
+- **Sequencing within the story:** 1-4 (runner) → 5-7 (scaffold) ∥ 8 (local) → 9 → 10.
+
+## Risks & Mitigations
+
+- **Schema drift between YAML and C# recurs silently.** Mitigation: D2's single golden fixture
+  checked both sides + `RunnerResultContractTests` as a build gate — the whole point of AC3.
+- **claude-code headless flags change upstream.** Mitigation: pin the CLI version in the runner;
+  the `run-claude-code.sh` install step uses an exact version; a broken agent still yields a
+  fail-safe artifact (D7), never a hang.
+- **Scaffolding overwrites a user's customized workflow.** Mitigation: D5's `customized` status +
+  `force`-required overwrite; version marker is the drift signal; upgrade is opt-in.
+- **19-1's skeleton has drifted from the current parser.** Mitigation: reconcile against the
+  *code* (Pre-Reading paths), not the 19-1 doc; AC3's test arbitrates.
+- **`packages/cli` resurrection temptation.** Mitigation: D6 chooses the in-process C# runner so
+  no legacy-TS toolchain is revived; the file protocol stays only as a tested back-compat seam.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1, 2, 4 | `tamma-agent.yml` + claude-code/collect scripts + provider seam | 2.0 |
+| 3, 9 (contract) | result schema + golden fixture + `RunnerResultContractTests` | 0.75 |
+| 5, 6, 7 | `RunnerScaffoldService` + endpoints + mediation message | 1.75 |
+| 8 | single-user `InProcessLocalRunner` + `LocalExecutor` wiring | 1.5 |
+| 9 (rest) | scaffold/local unit tests + dispatch input pin | 1.0 |
+| 10 | runner self-test CI job + docs | 1.0 |
+| **Total** | | **8.0** (story estimate: 6-8 days) |

--- a/docs/stories/epic-40/story-40-2/40-2-wait-for-agent-run-activity-durable-bookmark.md
+++ b/docs/stories/epic-40/story-40-2/40-2-wait-for-agent-run-activity-durable-bookmark.md
@@ -1,0 +1,166 @@
+# Story 40-2: `WaitForAgentRunActivity` — Durable Bookmark Suspend + `DelayFor` Timeout
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **platform operator** (and the orchestrator running unattended),
+I want the coding/TDD step to **dispatch the agent run and then suspend on a durable
+bookmark** — resuming when the run completes or timing out on a durable deadline — instead of
+holding the workflow instance Running for ~35 minutes inside an inline `await`,
+So that a deploy, pod eviction, or crash during a coding run does not kill the in-flight
+monitor and force the whole issue cycle to restart from scratch.
+
+## Priority
+
+P0 — This is the core "resumable by design" change for the coding step. Without it, the
+signal plane (40-3) and re-entry (40-4) have no suspend point to resume, and 40-5's
+`[ResumeBehavior]` declaration would be a lie (the workflow declares `BookmarkSuspend` but
+has no canonical suspend activity).
+
+## Architectural Context (READ FIRST)
+
+**Today the coding step is inline and non-durable.** In `SingleIssueCycleWorkflow.cs` the TDD
+loop node `tddForTask` is an `ExecuteAgentActivity`
+(`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ExecuteAgentActivity.cs`). Its
+`ExecuteAsync` calls `executor.ExecuteAsync(request, ct)` and **awaits inline**
+(`ExecuteAgentActivity.cs:199`). For the `GitHubActionsExecutor`
+(`GitHubActionsExecutor.cs:42`) that single `await` covers dispatch → **`MonitorAsync` (a
+~35-minute poll/webhook loop)** → collect. Throughout, the Elsa workflow instance stays
+**Running** (a live async task holds the wait); nothing is persisted as a suspended bookmark.
+A restart mid-wait loses the monitor task, and — with no task re-entry (40-4) — the
+orchestrator re-dispatches the cycle from the start.
+
+**The durable primitive already exists in the same activity family.**
+`WaitForCIResultsActivity` (`apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs`)
+is the pattern to copy exactly:
+
+- `context.CreateBookmark(payload, OnResumeAsync)` — a result bookmark resumed by an external
+  webhook → **`Received`** outcome (`WaitForCIResultsActivity.cs:87`).
+- `context.DelayFor(TimeSpan.FromMinutes(timeout), OnTimeoutAsync)` — a **durable** scheduled
+  delay bookmark the scheduler auto-resumes at the deadline → **`Timeout`** outcome
+  (`WaitForCIResultsActivity.cs:94`). No thread is held for the wait; Elsa burns the loser
+  bookmark on completion.
+- Resume read-back is **serialization-tolerant** (`ResumeInput.AsBool`, the #15/#437 lesson).
+- `[FlowNode("Received", "Timeout")]`, fail-closed sentinel on unparseable/timeout.
+
+**Epic 39-10 provides the bookmark builder.** `LifecycleBookmarks`
+(`apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs`, story 39-10) is the
+one canonical **tenant-folded, deterministic** bookmark-name builder (same inputs → same name
+on suspend and resume; tenant A ≠ tenant B). This story adds a `ForAgentRun` shape to it (or
+consumes it if 39-10 shipped one) and registers `WaitForAgentRunActivity` in
+`LifecycleBookmarks.CanonicalSuspendActivities` so 40-5's structural test recognizes it.
+
+**Dispatch and collect are retained, the inline monitor is replaced.** The dispatch half
+(`IAgentDispatchService.DispatchAsync`) runs in the activity's synchronous `Execute` *before*
+suspending; the collect half (`IAgentResultCollectorService.CollectAsync`) runs in
+`OnResumeAsync`/`OnTimeoutAsync` *after* the run completes. Only the ~35-minute
+`IAgentMonitorService.MonitorAsync` inline wait is removed — replaced by the bookmark suspend.
+
+## Acceptance Criteria
+
+1. **New `WaitForAgentRunActivity` with a suspend/resume shape.** A new Elsa activity in
+   `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/` mirrors `WaitForCIResultsActivity`:
+   in `Execute` it **dispatches the agent run** (via `IAgentDispatchService`), then **creates
+   a result bookmark + a `DelayFor` timeout bookmark** and returns (the instance suspends). It
+   declares `[FlowNode("Received", "Timeout", "Failed")]` — `Failed` for a dispatch that never
+   succeeds (no run to wait for).
+
+2. **Tenant-folded, deterministic bookmark name.** The result bookmark name is built through
+   `LifecycleBookmarks.ForAgentRun(tenantId, repository, branchName, sessionId)` (a new shape
+   delegating to `LifecycleBookmarks.Compose`, all segments via `NormalizeSegment`). Same
+   inputs → identical name on suspend and on the 40-3 resume; different tenants → disjoint
+   names. The name is recomputable by the resume side from durable inputs alone.
+
+3. **Durable timeout enforced.** A `context.DelayFor(TimeSpan.FromMinutes(TimeoutMinutes), …)`
+   arms a durable deadline (default `request.TimeoutMinutes + safety`, matching the current
+   `GitHubActionsExecutor` `TimeoutMinutes` computation). On deadline the activity emits a
+   fail-closed sentinel result and takes the **`Timeout`** edge — the workflow can never
+   suspend forever. No blocking `Task.Delay`; no thread held for the wait.
+
+4. **Resume collects the result.** `OnResumeAsync` reads the run-completion payload
+   (workflow_run id/conclusion/artifacts url — delivered by the 40-3 signal), runs
+   `IAgentResultCollectorService.CollectAsync` to produce the `AgentExecutionResult`, sets the
+   same outputs `ExecuteAgentActivity` sets, and takes the **`Received`** edge (success or
+   agent-reported failure both route here; the loop's existing `Completed`/`Failed` gate on the
+   result is preserved).
+
+5. **Serialization-tolerant read-back.** Every resumed-input read uses the coercion helpers
+   (`ResumeInput.AsBool`/tolerant string/JsonElement matrix), never a bare `is true` — the
+   #15/#437 silent-wrong-branch lesson. A read-back test applies the boxed-bool/`"true"`/
+   `JsonElement` truthy+falsy matrix.
+
+6. **Registered as a canonical suspend activity.** `WaitForAgentRunActivity`'s type is added to
+   `LifecycleBookmarks.CanonicalSuspendActivities` (39-10's registry) with its gate prefix, so
+   40-5's `ResumableStandardStructuralTests` recognizes it as a sanctioned suspend point.
+
+7. **The TDD loop uses it (SaaS/GHA path).** `SingleIssueCycleWorkflow`'s `tddForTask` node is
+   switched from `ExecuteAgentActivity` to `WaitForAgentRunActivity` (inputs mapped identically:
+   repository, branchName, issueNumber, `task="implement"`, `plan_json=currentTaskJson`, the
+   deterministic `adl-{issue}-task-{index}` session id, provider, timeout, tenantId). The
+   loop's existing `Completed`/`Failed` outcomes are wired to the activity's `Received`(→gate on
+   result)/`Timeout`/`Failed` edges preserving current routing (retry on failure, advance on
+   success). *(The `SetVariable`/re-entry wiring interplay lands with 40-4/40-5; this story
+   delivers the activity + the GHA-mode suspend.)*
+
+8. **Single-user (Local) parity retained.** For `LocalExecutor` (single-user), where there is
+   no external webhook, the activity still functions: it may run the local runner to completion
+   inside `Execute` and short-circuit to `Received` (no external suspend needed), OR suspend on
+   a locally-signaled bookmark — the plan chooses and justifies. Either way the same outputs and
+   edges are produced, so the workflow definition is mode-agnostic (the `ExecuteAgentActivity`
+   guarantee is preserved).
+
+9. **Fail-loud on missing dependencies.** No `IAgentDispatchService`/collector registered ⇒
+   `TammaError`-style loud failure to the `Failed` edge with a diagnostic, never a silent hang
+   (mirrors `ExecuteAgentActivity.cs:167` and `DispatchAgentWorkflowActivity` DI guards).
+
+## Technical Notes
+
+- **Dispatch runs before suspend, in `Execute`.** The activity must obtain the run's existence
+  (dispatch 204 + the discover window) *before* it can meaningfully wait; a failed dispatch
+  takes `Failed` immediately (no bookmark). Consider dispatching synchronously in `Execute`
+  then suspending — do not suspend before a run exists to be signaled.
+- **The 40-3 signal carries what the webhook lacks.** The `workflow_run.completed` webhook
+  knows repo/branch/run-id but not the Tamma session id; 40-3's persisted signal row bridges
+  that so the resume can address this exact bookmark. This story defines the bookmark *name
+  contract* (AC2) that 40-3's resume recomputes; keep them in lockstep.
+- **Do not delete `ExecuteAgentActivity`.** It stays for non-resumable/standalone callers and
+  tests; only the SingleIssueCycle TDD loop node migrates (AC7). This bounds blast radius.
+- **Timeout semantics ≠ agent failure.** `Timeout` (deadline, no completion) is a distinct edge
+  from `Received`-with-`success:false` (agent ran, failed). The cycle routes them differently
+  (timeout → escalate/needs-human; agent-failure → tdd-with-debug-retry) — keep them separate.
+
+## Dependencies
+
+- **Story 39-10 (Resumable Standard) — HARD.** `LifecycleBookmarks` (+ the `ForAgentRun` shape
+  this story adds), `CanonicalSuspendActivities`, `NormalizeSegment`, `ResumeInput`. Blocking:
+  AC2/AC5/AC6 consume it directly.
+- **Story 40-3** — the durable signal + resume endpoint that actually resumes this bookmark
+  from the webhook. Developed in lockstep against AC2's name contract; 40-2 is testable against
+  a direct bookmark resume before 40-3 lands.
+- **Existing (verified):** `WaitForCIResultsActivity` (the pattern), `IAgentDispatchService`/
+  `IAgentResultCollectorService`/`GitHubActionsExecutor`/`LocalExecutor`, Elsa 3 bookmarks +
+  `DelayFor` + EF persistence.
+
+## Estimated Effort
+
+5-7 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-2/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-2/implementation-plan.md
@@ -1,0 +1,208 @@
+# Implementation Plan — Story 40-2: `WaitForAgentRunActivity` — Durable Bookmark Suspend + `DelayFor` Timeout
+
+## Scope & Deliverable
+
+When this story is done, the coding/TDD step no longer holds a workflow instance Running for
+~35 minutes. A new `WaitForAgentRunActivity` dispatches the agent run in its synchronous
+`Execute`, then **suspends on a durable, tenant-folded Elsa bookmark plus a `DelayFor`
+timeout** — the `WaitForCIResultsActivity` shape — resuming to collect the result
+(`Received`) or timing out on a durable deadline (`Timeout`), with `Failed` for a dispatch that
+never produces a run. The activity is registered in 39-10's `CanonicalSuspendActivities`, and
+`SingleIssueCycleWorkflow`'s `tddForTask` node switches to it. The dispatch/collect halves of
+the old inline path are reused; only the inline monitor `await` is removed.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-2/40-2-wait-for-agent-run-activity-durable-bookmark.md` — this story (ACs are source of truth)
+- `apps/tamma-elsa/src/Tamma.Activities/Testing/WaitForCIResultsActivity.cs` — THE pattern: `CreateBookmark` + `DelayFor`, `[FlowNode("Received","Timeout")]`, fail-closed sentinel, `ResumeInput.AsBool` read-back
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ExecuteAgentActivity.cs` — the current inline activity (inputs/outputs to mirror, DI-guard shape, event emission via `TammaEventEmitter`)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/GitHubActionsExecutor.cs` — the dispatch→monitor→collect composition to split (dispatch pre-suspend, collect post-resume); `TimeoutMinutes` computation (`request.TimeoutMinutes + 5`)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentDispatchService.cs` + `IAgentDispatchServices.cs` — `DispatchAsync` (returns `AgentDispatchResult { Success, DispatchedAt, … }`) run in `Execute`
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentResultCollectorService.cs` + `CollectAgentResultsActivity.cs` — `CollectAsync(request, monitorResult, ct)` run in `OnResumeAsync`; `AgentMonitorResult` shape it needs
+- `apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs` — 39-10's builder (add `ForAgentRun`); `CanonicalSuspendActivities` registry; `WaitForMergeApprovalActivity.NormalizeSegment`
+- `apps/tamma-elsa/src/Tamma.Activities/ResumeInput.cs` — `ResumeInput.AsBool` coercion (#15/#437)
+- `apps/tamma-elsa/tests/Tamma.Activities.Tests/Clarify/ClarifyResumeReadBackTests.cs` — the read-back tolerance matrix shape
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs:571` — the `tddForTask` node + loop wiring (`Completed`/`Failed` → incrementTask / dispatchTddRetry)
+- `docs/stories/epic-39/story-39-10/implementation-plan.md` — `LifecycleBookmarks`/`CanonicalSuspendActivities`/`ResumeBehavior` contracts consumed here
+- **NOT FOUND (prerequisite):** `LifecycleBookmarks.cs`, `CanonicalSuspendActivities` (land with 39-10). See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — Dispatch in `Execute` (sync), suspend only once a run exists.** The activity's
+  `Execute` calls `IAgentDispatchService.DispatchAsync` (204 = queued) and arms the discover
+  window exactly as `GitHubActionsExecutor` does today, so a failed dispatch takes `Failed`
+  immediately with no bookmark (nothing to wait for). Only on a successful dispatch does it
+  `CreateBookmark` + `DelayFor` and return (suspend). This preserves the current "dispatch
+  failure is loud and immediate" behavior while making the *wait* durable.
+- **D2 — `ForAgentRun` bookmark shape keyed by (tenant, repo, branch, session).** Add
+  `LifecycleBookmarks.ForAgentRun(string? tenantId, string repository, string branchName, string sessionId) => Compose("agent-run", tenantId, repository, branchName, sessionId)`.
+  All four business coordinates are known at dispatch AND recomputable by 40-3's resume from the
+  webhook (repo, branch) + the persisted signal row (session, tenant) — so "same inputs → same
+  name" holds across the suspend/resume boundary with durable inputs (mirrors 39-10 D2's
+  session-shape determinism argument). Segments normalized via `NormalizeSegment`.
+- **D3 — Two bookmarks, mutual burn (the CI-wait invariant).** `CreateBookmark(resultPayload,
+  OnResumeAsync)` for the completion signal + `DelayFor(timeout, OnTimeoutAsync)` for the
+  deadline. Whichever resumes first completes the activity; Elsa burns the remaining bookmark
+  (`AutoBurn`, as `WaitForCIResultsActivity` relies on). The timeout uses the same
+  `request.TimeoutMinutes + safety` the executor computes, so wall-clock behavior is unchanged.
+- **D4 — Collect in the resume handlers, from the signal payload.** `OnResumeAsync` builds an
+  `AgentMonitorResult` from the resumed run-completion payload (run id, conclusion, artifacts
+  url — 40-3's signal shape) and calls `IAgentResultCollectorService.CollectAsync(request,
+  monitorResult, ct)` → `AgentExecutionResult`; sets the same outputs as `ExecuteAgentActivity`
+  (`SetOutputs`) and the `LastAgentExecutionResult` variable the loop reads; takes `Received`.
+  `OnTimeoutAsync` sets a fail-closed `AgentExecutionResult.Failed("agent run timed out …")` and
+  takes `Timeout`. Collect failures fail closed to `Received`-with-failure (never a green result
+  from an unreadable run), matching `GitHubActionsExecutor` step-3 semantics.
+- **D5 — Local mode runs to completion in `Execute`, short-circuits `Received` (no external
+  suspend).** For `LocalExecutor` there is no `workflow_run` webhook; suspending on an external
+  signal would hang. The factory-selected mode is known in `Execute`; when it is `local`, the
+  activity runs the local runner synchronously (as today) and completes `Received` without
+  creating the external result bookmark — it still arms `DelayFor` for a hard timeout. So the
+  workflow definition stays mode-agnostic (AC8) while only the GHA path uses the external
+  suspend. Decision recorded rather than forcing a fake local webhook.
+- **D6 — Reuse `ExecuteAgentActivity`'s input/output surface verbatim.** Same `Input<>`/`Output<>`
+  properties, same `AgentExecutionRequest` construction, same `BuildStartData`/`BuildEndData`
+  event data — so the `SingleIssueCycleWorkflow` node swap (AC7) is a near-mechanical
+  type change with identical mappings, and downstream consumers (`LastAgentExecutionResult`) are
+  unaffected. `ExecuteAgentActivity` is left intact for non-resumable callers.
+- **D7 — Register in `CanonicalSuspendActivities` with gate `"agent-run"`.** One entry
+  `{ typeof(WaitForAgentRunActivity), "agent-run" }` so 40-5's structural test sees a sanctioned
+  suspend node; the legacy `ExecuteAgentActivity` stays OUT (it is not a suspend point).
+- **D8 — Fail-loud DI guards + event emission parity.** Missing dispatch service/collector ⇒
+  loud `Failed` with a diagnostic (mirrors `ExecuteAgentActivity.cs:167`). Emit
+  `TammaEventEmitter.EmitStart` at dispatch; the wait-lifecycle events (`AGENT_RUN.WAIT_*`) are
+  40-6's — this story emits the existing `AGENT.EXECUTION.*` start/end via the same emitter so
+  no audit regression occurs before 40-6 lands.
+
+## Implementation Steps
+
+1. **MODIFY `apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs`** (39-10's
+   file) — add `ForAgentRun(...)` (D2) and the `{ typeof(WaitForAgentRunActivity), "agent-run" }`
+   entry to `CanonicalSuspendActivities` (D7). If 39-10 has not merged, land this in a small
+   shared shim the story owns and rebase onto `LifecycleBookmarks` when it does (coordinate the
+   registry pin).
+
+2. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WaitForAgentRunActivity.cs`**
+   (AC1) — `[Activity("Tamma.AgentDispatch","Wait For Agent Run",…)]`,
+   `[FlowNode("Received","Timeout","Failed")]`, `ITammaActivity`. Inputs/outputs copied from
+   `ExecuteAgentActivity` (D6). `Execute` (D1): DI guard (D8) → build `AgentExecutionRequest` →
+   resolve mode via `AgentExecutorFactory` → if `local` run-to-completion + `Received` (D5) →
+   else `IAgentDispatchService.DispatchAsync`; dispatch fail → `Failed`; dispatch ok →
+   `CreateBookmark(ForAgentRun payload, OnResumeAsync)` + `DelayFor(timeout, OnTimeoutAsync)`
+   (D3) and return.
+
+3. **IMPLEMENT `OnResumeAsync` / `OnTimeoutAsync`** (D4, AC4/AC3) — resume: read the completion
+   payload serialization-tolerantly (D—AC5, `ResumeInput`), build `AgentMonitorResult`, collect,
+   `SetOutputs` + `LastAgentExecutionResult`, `CompleteActivityWithOutcomesAsync("Received")`;
+   timeout: fail-closed `AgentExecutionResult.Failed`, `SetOutputs`, `"Timeout"`.
+
+4. **MODIFY `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs`**
+   (AC7) — replace the `tddForTask` `ExecuteAgentActivity` node with `WaitForAgentRunActivity`
+   (identical input mappings, `TenantId` threaded from the `tenantId` variable). Wire edges:
+   `Received` → the existing result gate (the loop's `Completed`/`Failed` on
+   `LastAgentExecutionResult.Success` — add a small `FlowDecision` if the current wiring relied on
+   the activity's own `Completed`/`Failed`; preserve routing to `incrementTask` vs
+   `dispatchTddRetry`); `Timeout` → the tdd-failed escalation sink (`notifyTddFailed` →
+   fail-cycle, distinct from agent-failure retry); `Failed` → same escalation. Keep this change
+   minimal; the `[ResumeBehavior]` + re-entry node wiring is 40-4/40-5.
+
+5. **DI registration** — register `WaitForAgentRunActivity` in the Elsa activity registration
+   (both `Tamma.ElsaServer` and `Tamma.Api` hosts, wherever `ExecuteAgentActivity` is
+   registered) so DI resolves its logger + factory + services.
+
+6. **CREATE tests** (see Test Plan) — `WaitForAgentRunActivityTests`,
+   `WaitForAgentRunReadBackTests`, `LifecycleBookmarksAgentRunTests`, and a Testcontainers
+   suspend/resume smoke (folded into 40-7's integration but a minimal in-process resume test
+   here). Finish with `dotnet ef migrations has-pending-model-changes` (clean) + `dotnet test`.
+
+## Data & Migrations
+
+None in this story — the durable *bookmark* persists via Elsa's existing EF bookmark store; the
+persisted *signal row* is 40-3's migration. `dotnet ef migrations has-pending-model-changes`
+stays clean.
+
+## Events
+
+- **Emits (via `TammaEventEmitter`, unchanged family):** `AGENT.EXECUTION.STARTED` at dispatch,
+  `AGENT.EXECUTION.SUCCESS`/`FAILED` at resume/timeout — parity with `ExecuteAgentActivity` so no
+  audit regression. The dedicated `AGENT_RUN.WAIT_SUSPENDED`/`RECEIVED`/`TIMED_OUT` family is
+  **40-6** (this story does not add event constants).
+- **Consumes:** the 40-3 resume payload (run id, conclusion, artifacts url).
+
+## Test Plan
+
+All NUnit + FluentAssertions (+ Moq).
+
+- **`LifecycleBookmarksAgentRunTests`** (unit) — `ForAgentRun` determinism (same inputs →
+  byte-identical), tenant folding (A ≠ B), null tenant → `none` segment, hostile-char
+  normalization; `CanonicalSuspendActivities` contains `WaitForAgentRunActivity` with gate
+  `"agent-run"`. **Covers AC2, AC6.**
+- **`WaitForAgentRunActivityTests`** (unit, in-process `IWorkflowRunner` or activity harness,
+  Moq'd dispatch/collect) — dispatch fail → `Failed`, no bookmark; dispatch ok → suspends with a
+  bookmark named `ForAgentRun(...)` + a `DelayFor` bookmark present; resume with a success
+  payload → collects → `Received` with outputs set; resume with agent-failure payload → `Received`
+  with `Success:false`; timeout resume → `Timeout` with fail-closed sentinel; local mode →
+  runs-to-completion + `Received` without an external bookmark (D5); DI missing → loud `Failed`.
+  **Covers AC1, AC3, AC4, AC8, AC9.**
+- **`WaitForAgentRunReadBackTests`** (unit, `ClarifyResumeReadBackTests` shape) — completion
+  payload read-back across boxed-bool/`"true"`/`"True"`/`JsonElement`, truthy+falsy;
+  missing/unparseable → fail-closed failure result, never a green pass. **Covers AC5.**
+
+*(Full crash/restart + cross-instance resume is proven in 40-7's Testcontainers suite.)*
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — suspend/resume activity, `Received`/`Timeout`/`Failed` | 2, 3 | `WaitForAgentRunActivityTests` |
+| 2 — tenant-folded deterministic bookmark | 1 | `LifecycleBookmarksAgentRunTests` |
+| 3 — durable `DelayFor` timeout, no thread held | 2, 3 | `WaitForAgentRunActivityTests` timeout case |
+| 4 — resume collects the result, same outputs | 3 | `WaitForAgentRunActivityTests` resume cases |
+| 5 — serialization-tolerant read-back | 3 | `WaitForAgentRunReadBackTests` |
+| 6 — registered canonical suspend activity | 1 | `LifecycleBookmarksAgentRunTests` |
+| 7 — TDD loop uses it (GHA) | 4 | `WaitForAgentRunActivityTests` + `SingleIssueCycle` structure test (40-5) |
+| 8 — local parity, mode-agnostic definition | 2, 3 | `WaitForAgentRunActivityTests` local case |
+| 9 — fail-loud DI guards | 2 | `WaitForAgentRunActivityTests` DI-missing case |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisite:** 39-10 (`LifecycleBookmarks`, `CanonicalSuspendActivities`,
+  `NormalizeSegment`, `ResumeInput`). Do not start step 1 before it compiles; a shared shim
+  bridges if 40-2 runs slightly ahead, rebased onto `LifecycleBookmarks` at merge.
+- **Lockstep:** 40-3 — the resume side that fires this bookmark from the webhook; agree the
+  `ForAgentRun` name contract (AC2) + the completion payload shape in both plans up front. 40-2
+  is unit-testable via direct bookmark resume before 40-3 lands.
+- **In place, verified:** `WaitForCIResultsActivity`, the dispatch/collect services,
+  `AgentExecutorFactory`, Elsa bookmarks + `DelayFor` + EF store.
+- **Feeds:** 40-4 (re-entry routes into this suspend point), 40-5 (declares the workflow
+  resumable citing this canonical activity), 40-6 (adds the wait event family), 40-7 (integration
+  proof).
+- **Sequencing within the story:** 1 → 2 → 3 → 4/5 → 6.
+
+## Risks & Mitigations
+
+- **Suspending before a run exists ⇒ a bookmark no webhook can match (permanent Timeout).**
+  Mitigation: D1 dispatches (and confirms 204 + discover-window arming) in `Execute` before any
+  bookmark; failed dispatch never suspends.
+- **Bookmark-name divergence from 40-3's resume ⇒ silent no-resume → always Timeout.**
+  Mitigation: single `ForAgentRun` builder used by both; a byte-parity pin test shared with 40-3;
+  the name is recomputable from durable inputs only.
+- **Local mode hangs waiting for a webhook that never comes.** Mitigation: D5 runs local
+  to-completion in `Execute`; local never creates the external result bookmark.
+- **Loop-routing regression when swapping the node (AC7).** Mitigation: preserve the exact
+  `Completed`/`Failed` gate on `LastAgentExecutionResult.Success`; keep `Timeout` a *distinct*
+  escalation edge from agent-failure-retry (Technical Note); covered by the structure test in 40-5.
+- **Double audit / missing audit during the split.** Mitigation: D8 keeps the existing
+  `AGENT.EXECUTION.*` emission until 40-6 formalizes the wait family — no gap, no double count.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1 | `ForAgentRun` + registry entry | 0.5 |
+| 2 | `WaitForAgentRunActivity` `Execute` (dispatch + suspend + local branch) | 1.5 |
+| 3 | resume/timeout handlers + collect + fail-closed | 1.25 |
+| 4 | `SingleIssueCycleWorkflow` node swap + edge rewiring | 1.0 |
+| 5 | DI registration (both hosts) | 0.25 |
+| 6 | unit tests (activity, read-back, bookmarks) | 1.5 |
+| **Total** | | **6.0** (story estimate: 5-7 days) |

--- a/docs/stories/epic-40/story-40-3/40-3-durable-agent-run-signal-and-resume-endpoint.md
+++ b/docs/stories/epic-40/story-40-3/40-3-durable-agent-run-signal-and-resume-endpoint.md
@@ -1,0 +1,148 @@
+# Story 40-3: Durable Agent-Run Signal Plane + Resume Endpoint (cross-pod, restart-safe)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **platform operator running Tamma on more than one pod** (and across deploys),
+I want the `workflow_run.completed` webhook that signals a finished coding run to **resume the
+suspended workflow reliably — even when the webhook lands on a different pod than the one that
+dispatched, and even after a restart**,
+So that agent-run completion delivery is not a single-process, in-memory race that silently
+degrades to polling (or fails) whenever the topology is not a single box.
+
+## Priority
+
+P0 — 40-2 makes the coding step suspend on a durable bookmark; this story is what *resumes* it
+from the real webhook. Without it, 40-2's suspend has no production wake-up path other than the
+poll fallback, and the multi-instance correctness gap the whole epic calls out stays open.
+
+## Architectural Context (READ FIRST)
+
+**Today the signal plane is in-memory and single-process.** `WebhookSignalRegistry`
+(`apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs`) is a
+`ConcurrentDictionary<string, TaskCompletionSource<AgentWebhookSignal>>`. The waiting
+`AgentMonitorService.WaitForWebhookAsync` (`AgentMonitorService.cs:97`) parks a TCS; the
+webhook handler `InstallationRouterService.HandleWorkflowRunEvent`
+(`apps/tamma-elsa/src/Tamma.Api/Services/GitHub/InstallationRouterService.cs:377`) calls
+`PublishSignal` on `workflow_run.completed`. The registry's own XML doc is explicit about the
+limit:
+
+> *Scope: single process. … For distributed deployments where the ElsaServer process runs the
+> activity, webhook mode falls back to poll (Auto) or fails (explicit Webhook).*
+
+So on multi-pod deployments (or after a restart) the waiter's TCS and the webhook's publish can
+live in **different processes** and never meet. The signal key is scoped by GitHub App
+installation id (`AgentWebhookSignalKey`, review-finding-5) to prevent cross-tenant wakeups, but
+it remains a process-local dictionary.
+
+**40-2 changes the substrate — and that is the fix.** Once the coding step suspends on a real
+**DB-persisted Elsa bookmark** (40-2) instead of an in-memory TCS, **any pod can resume it
+through Elsa's bookmark store** — Elsa's persistence *is* the cross-pod backplane. What the
+webhook still lacks is the Tamma **session id / bookmark name**: the `workflow_run.completed`
+payload carries repo, head branch, run id, and installation id, but not the Tamma session id
+that `LifecycleBookmarks.ForAgentRun(tenant, repo, branch, session)` needs. A small **persisted
+signal/dispatch row**, written at dispatch time and matched by the webhook, bridges that gap
+durably.
+
+**The resume-endpoint precedent is 39-8.** `DocumentDecisionResumeEndpoint` (39-8) /
+`DesignResumeEndpoint` / `ClarifyResumeEndpoint` are the tenant-folded resume endpoints to
+mirror: recompute the bookmark name from the request, resume via Elsa's bookmark runtime, 404 on
+no-bookmark, 409 on collision, tenant-fold so tenant A cannot resume tenant B.
+
+## Acceptance Criteria
+
+1. **Persisted agent-run signal row (durable, tenant-scoped).** A new table (e.g.
+   `agent_run_waits`) records, written at dispatch (40-2's `Execute`): `{ tenant_id, repository,
+   branch_name, session_id, installation_id, workflow_instance_id, bookmark_name, dispatched_at,
+   status }` where `status ∈ { pending, received, timed_out }`. It survives process restart. One
+   row per in-flight coding run; `(tenant_id, repository, branch_name, session_id)` unique.
+
+2. **Webhook resolves the row and resumes the bookmark.** `HandleWorkflowRunEvent` (or a service
+   it calls) matches an incoming `workflow_run.completed` by `(installation_id, repository,
+   head_branch)` to the pending row(s), reads the `bookmark_name` + `session_id`, and **resumes
+   the 40-2 bookmark through Elsa's persistent bookmark runtime** with the completion payload
+   (run id, conclusion, artifacts url). This works regardless of which pod is handling the
+   webhook vs. which pod dispatched. The row is marked `received`.
+
+3. **Resume endpoint (mirrors 39-8).** An HTTP `AgentRunResumeEndpoint`
+   (`apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/` or `Tamma.Api`) accepts a run-completion
+   callback (auth per the existing webhook/HMAC path), recomputes the bookmark name via
+   `LifecycleBookmarks.ForAgentRun`, resumes, and returns **404** when no matching bookmark/row
+   exists, **409** on an ambiguous/duplicate match, tenant-folded so cross-tenant resume is
+   impossible. It is the same resume the webhook path uses, exposed as an endpoint for
+   retries/manual reconciliation.
+
+4. **Poll fallback reconciled to be durable.** The existing poll path
+   (`AgentMonitorService.PollAsync`) is repurposed as a **durable reconciler**: a periodic
+   sweep (or the 40-2 `DelayFor` wake) reads `pending` rows past a threshold, polls
+   `GET runs/{id}` via the mediated API, and if terminal, resumes the bookmark the same way the
+   webhook does — so a missed webhook still completes without a live in-process poll loop. No
+   `pending` row is left dangling past the row's timeout.
+
+5. **Cross-pod delivery proven.** A test simulates the split: dispatch (suspend) on
+   "instance/pod A", deliver the webhook on "instance/pod B" (a *second* host/service over the
+   *same* store), and assert the workflow resumes correctly on B. The in-memory registry is NOT
+   consulted for correctness.
+
+6. **In-memory registry demoted, not required.** `WebhookSignalRegistry` may remain as a
+   same-process fast-path (resume immediately without a store round-trip when the waiter is
+   local), but correctness no longer depends on it: with the registry unwired, the durable path
+   still resumes. The `AgentMonitorService` webhook/Auto/Poll mode logic is updated so "Webhook
+   mode without the in-memory registry" is no longer a hard failure.
+
+7. **Tenant-folded and installation-scoped.** The row match and the bookmark name both fold the
+   tenant (and the installation id, preserving the review-finding-5 cross-tenant guard), so two
+   tenants sharing an `owner/repo` + branch cannot resume each other's runs.
+
+8. **Fail-loud, exactly-once resume.** A webhook matching an already-`received` row is a no-op
+   (idempotent redelivery — GitHub redelivers). A resume of an already-burned bookmark is a
+   logged no-op, not an error. A row with no resolvable bookmark after its timeout emits a loud
+   diagnostic event and marks `timed_out` (the 40-2 `Timeout` edge handles the workflow side).
+
+## Technical Notes
+
+- **Elsa's bookmark store is the backplane — do not build a message bus.** The cross-pod
+  delivery is achieved by resuming a persisted bookmark, which any pod can do against the shared
+  DB. The signal row only supplies the missing `session_id`/`bookmark_name`; it is not a queue.
+- **Keep the installation-id scoping.** `AgentWebhookSignalKey` already folds `installation_id`
+  (review-finding-5); the persisted row must carry it and the match must use it, or the
+  cross-tenant guard regresses.
+- **Redelivery is expected.** GitHub redelivers webhooks; the `received` status + burned-bookmark
+  no-op make resume idempotent (AC8).
+- **The reconciler replaces the live poll loop, not the discover phase.** Discovery of the run id
+  (dispatch returns 204 with no run URL) still happens; the *waiting* is durable now.
+
+## Dependencies
+
+- **Story 40-2 — HARD.** The durable bookmark this story resumes; the `ForAgentRun` name
+  contract and completion payload shape are shared (lockstep). Blocking.
+- **Story 39-10 (`LifecycleBookmarks`) — HARD (via 40-2).** The name builder recomputed on resume.
+- **Story 39-8 — SOFT.** `DocumentDecisionResumeEndpoint` is the tenant-folded resume-endpoint
+  pattern (404/409, tenant fold). Mirrored, not consumed.
+- **Existing (verified):** `InstallationRouterService.HandleWorkflowRunEvent` (webhook receiver),
+  `AgentMonitorService` (poll loop → reconciler), `AgentDispatchMediationService` (mediated
+  `GET runs/{id}`), Elsa 3 persistent bookmark runtime + EF store, `TenantDbContext`.
+
+## Estimated Effort
+
+5-7 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-3/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-3/implementation-plan.md
@@ -1,0 +1,204 @@
+# Implementation Plan — Story 40-3: Durable Agent-Run Signal Plane + Resume Endpoint
+
+## Scope & Deliverable
+
+When this story is done, a finished coding run resumes the suspended workflow **durably and
+across pods**. A persisted `agent_run_waits` row written at dispatch carries the
+`session_id`/`bookmark_name` the `workflow_run.completed` webhook lacks; the webhook (on any
+pod) matches the row and resumes the 40-2 bookmark through Elsa's persistent bookmark runtime;
+an `AgentRunResumeEndpoint` exposes the same resume (404/409, tenant-folded, mirroring 39-8); and
+the old in-process poll loop becomes a durable reconciler that catches missed webhooks. The
+in-memory `WebhookSignalRegistry` is demoted to an optional same-process fast path — correctness
+no longer depends on it.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-3/40-3-durable-agent-run-signal-and-resume-endpoint.md` — this story (ACs are source of truth)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WebhookSignalRegistry.cs` — the in-memory plane being demoted; `AgentWebhookSignalKey` (installation-id folding, review-finding-5), `AgentWebhookSignal` (payload shape)
+- `apps/tamma-elsa/src/Tamma.Api/Services/GitHub/InstallationRouterService.cs:377` — `HandleWorkflowRunEvent`: how repo/branch/run-id/installation-id/conclusion are extracted from the webhook, `PublishSignal` call site
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentMonitorService.cs` — `WaitForWebhookAsync` (registry wait), `PollAsync` (→ reconciler), mode logic (Webhook/Auto/Poll), installation-id resolution
+- `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchMediationService.cs` — mediated `GetRunAsync`/`DiscoverRunAsync` the reconciler polls through
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DesignResumeEndpoint.cs` + `ClarifyResumeEndpoint.cs` (and 39-8's `DocumentDecisionResumeEndpoint`) — the tenant-folded resume-endpoint pattern (bookmark-name recompute, 404/409 posture)
+- `apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs` — `ForAgentRun` (40-2) recomputed on resume
+- `docs/stories/epic-40/story-40-2/implementation-plan.md` — the `ForAgentRun` name contract + completion payload shape (lockstep)
+- `apps/tamma-elsa/src/Tamma.Data/` — `TenantDbContext`, `TammaModelConfiguration`, an existing entity + repository for the row pattern (e.g. how `domain_events`/other tenant tables are wired)
+- how a bookmark is resumed programmatically in-engine: the Elsa `IBookmarkQueue`/bookmark-resume API used by `DesignResumeEndpoint` (copy that call)
+- **NOT FOUND (prerequisite):** `WaitForAgentRunActivity` + `ForAgentRun` (40-2), `DocumentDecisionResumeEndpoint` (39-8). See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — The signal row is a correlation record, NOT a queue.** `agent_run_waits` exists solely
+  to give the webhook the `session_id`/`bookmark_name`/`workflow_instance_id` it cannot derive
+  from the `workflow_run` payload. Delivery itself rides Elsa's persistent bookmark store (any
+  pod resumes a DB bookmark). No RabbitMQ, no new bus — the epic's "bookmark store is the
+  backplane" principle. Written by 40-2's `Execute` at dispatch; read by the webhook/endpoint/
+  reconciler.
+- **D2 — Match key `(installation_id, repository, head_branch)`; disambiguate by session.** The
+  webhook knows those three. Normally one pending row matches; concurrent dispatches on the same
+  branch (rare — the TDD loop is sequential per branch) are disambiguated by resuming the row
+  whose `dispatched_at` is the latest before the run's `created_at`, and a genuinely ambiguous
+  match returns 409 on the endpoint / logs-and-skips on the webhook (never a wrong resume). The
+  installation id preserves the review-finding-5 cross-tenant guard (AC7).
+- **D3 — Resume through a shared `AgentRunResumer` service, called by webhook + endpoint +
+  reconciler.** One `IAgentRunResumer.ResumeAsync(matchKey, completionPayload, ct)` that (a)
+  loads the pending row, (b) recomputes `ForAgentRun(...)` and asserts byte-equality with the
+  stored `bookmark_name` (drift guard), (c) resumes the bookmark via Elsa's bookmark runtime with
+  the payload, (d) marks the row `received`. Idempotent: already-`received` row or already-burned
+  bookmark ⇒ logged no-op success (AC8, GitHub redelivery). All three entry points delegate here
+  so behavior is identical.
+- **D4 — `AgentRunResumeEndpoint` mirrors `DocumentDecisionResumeEndpoint` exactly.** Same auth
+  (the existing webhook HMAC / installation-scoped path), same recompute-name → resume → 404/409
+  shape, tenant-folded. It is the manual/retry surface; the webhook path is the automatic one.
+  Both call `IAgentRunResumer`.
+- **D5 — The poll loop becomes a durable reconciler, not a live wait.** Delete the in-request
+  ~35-min `PollAsync` loop from the wait path; keep its per-tick mediated `GetRunAsync` logic and
+  move it into `AgentRunReconciler` — a hosted sweep (or driven by 40-2's `DelayFor` wake) that
+  reads `pending` rows older than a short threshold, polls the run, and resumes via
+  `IAgentRunResumer` if terminal. So "webhook missed" self-heals durably; no thread parks for the
+  wait. `AgentMonitorService`'s discover phase (finding the run id post-204) is retained.
+- **D6 — Demote, don't delete, `WebhookSignalRegistry`.** Keep it as an optional same-process
+  fast-path: `IAgentRunResumer` may first try an in-memory waiter (sub-second local resume) then
+  fall through to the durable bookmark resume. With the registry unregistered, the durable path is
+  authoritative. Update `AgentMonitorService`'s "Webhook mode without registry → hard fail" branch
+  to "→ durable path" (AC6). This bounds churn and keeps the fast local case fast.
+- **D7 — The row is tenant-DB-scoped.** `agent_run_waits` lives in the tenant schema
+  (`TenantDbContext`) so per-tenant isolation is structural (matches the platform's schema-per-
+  tenant model); single-user mode uses the central schema like every other tenant. Migration
+  against `TenantDbContext` — subject to the single-migration-author token (see Dependencies).
+
+## Implementation Steps
+
+1. **CREATE the entity + migration** — `apps/tamma-elsa/src/Tamma.Data/Entities/AgentRunWait.cs`
+   (D1 fields), register in `TenantDbContext` + `TammaModelConfiguration` (unique
+   `(tenant_id, repository, branch_name, session_id)`, index on `(installation_id, repository,
+   branch_name, status)`), generate the `TenantDbContext` migration (D7 — hold the migration
+   token). CREATE `IAgentRunWaitRepository` + `AgentRunWaitRepository`
+   (`apps/tamma-elsa/src/Tamma.Data/Repositories/`).
+
+2. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/IAgentRunResumer.cs` +
+   `AgentRunResumer.cs`** (D3) — load row → recompute + assert `ForAgentRun` name → resume
+   bookmark (Elsa bookmark runtime, the `DesignResumeEndpoint` call shape) → mark `received`;
+   idempotent; optional in-memory fast-path (D6). Emits the loud diagnostic on unresolvable row
+   (AC8) — the constant is 40-6's; use a placeholder pinned to 40-6.
+
+3. **MODIFY 40-2's `WaitForAgentRunActivity.Execute`** — after a successful dispatch, **write the
+   `agent_run_waits` pending row** (tenant, repo, branch, session, installation id resolved via
+   the mediated `ResolveInstallationIdAsync`, `workflow_instance_id`, `bookmark_name =
+   ForAgentRun(...)`). This is the one cross-story edit (coordinate with 40-2). Local mode writes
+   no row (it never suspends externally).
+
+4. **MODIFY `apps/tamma-elsa/src/Tamma.Api/Services/GitHub/InstallationRouterService.cs`**
+   (`HandleWorkflowRunEvent`) — after (or instead of) `PublishSignal`, call
+   `IAgentRunResumer.ResumeAsync` with the `(installation_id, repo, head_branch)` match key +
+   the completion payload (D2/D3). Keep the `PublishSignal` fast-path call (D6). Non-matching
+   runs stay `Skipped`.
+
+5. **CREATE `AgentRunResumeEndpoint`** (`apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/`, or
+   Tamma.Api alongside the webhook) (D4, AC3) — recompute name → `IAgentRunResumer` → 404/409,
+   tenant-folded, existing auth.
+
+6. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentRunReconciler.cs`** (D5) —
+   hosted/periodic sweep over `pending` rows, mediated poll, resume-if-terminal, mark
+   `timed_out` past the row timeout. Register as a hosted service (guarded by a config flag like
+   the existing worker `RunOnStartup` pattern).
+
+7. **MODIFY `AgentMonitorService`** — relax the "Webhook-without-registry = hard fail" branch to
+   route through the durable path (D6, AC6); retain discovery. (The bulk of the live poll wait is
+   superseded by 40-2's suspend + this reconciler; keep the discover helper.)
+
+8. **DI registration** (both hosts) — `IAgentRunWaitRepository`, `IAgentRunResumer`,
+   `AgentRunReconciler`. **CREATE tests** (see Test Plan). Finish with
+   `dotnet ef migrations has-pending-model-changes` (clean after the intended migration) +
+   `dotnet test`.
+
+## Data & Migrations
+
+- **New table `agent_run_waits`** in `TenantDbContext` (D7): `id, tenant_id, repository,
+  branch_name, session_id, installation_id, workflow_instance_id, bookmark_name, dispatched_at,
+  status, updated_at`; unique `(tenant_id, repository, branch_name, session_id)`; index
+  `(installation_id, repository, branch_name, status)`. One EF migration against
+  `TenantDbContext` — **subject to the single-migration-author token** (coordinate with any
+  concurrent tenant-context migration). No data backfill (new in-flight state only).
+
+## Events
+
+- **Emits (40-6 constants, placeholder-pinned here):** `AGENT_RUN.RESUME_UNRESOLVED` (loud, on a
+  row with no resolvable bookmark past timeout) and reuses 40-6's `AGENT_RUN.RECEIVED`/`TIMED_OUT`
+  where the resumer marks the row. If 40-6 has not merged, define a local constant and migrate it
+  to 40-6's `AgentRunEventTypes` at merge (documented conscious pin).
+- **Consumes:** the `workflow_run.completed` webhook payload; the mediated `GET runs/{id}` status.
+
+## Test Plan
+
+All NUnit + FluentAssertions (+ Moq; Testcontainers for the cross-pod scenario, shared with 40-7).
+
+- **`AgentRunWaitRepositoryTests`** (unit/Testcontainers) — upsert pending, unique constraint,
+  match by `(installation_id, repo, branch, status=pending)`, mark received/timed_out. **Covers AC1.**
+- **`AgentRunResumerTests`** (unit, Moq'd repo + bookmark runtime) — resume marks received +
+  resumes the named bookmark; name-drift (stored ≠ recomputed) → loud fail, no resume; already-
+  received → idempotent no-op; already-burned bookmark → logged no-op; ambiguous match → 409/skip;
+  installation-scoping (tenant A payload never resumes tenant B row). **Covers AC2, AC7, AC8.**
+- **`AgentRunResumeEndpointTests`** (unit/API) — 404 no row, 409 ambiguous, 200 resume,
+  tenant-fold rejection, auth. **Covers AC3.**
+- **`AgentRunReconcilerTests`** (unit, Moq'd mediation) — pending-past-threshold + terminal run →
+  resume; still-running → leave pending; past row-timeout → `timed_out` + loud event. **Covers AC4, AC8.**
+- **`InstallationRouterWorkflowRunResumeTests`** (unit) — `workflow_run.completed` → resolver →
+  `IAgentRunResumer` called with the right key; non-Tamma run → Skipped. **Covers AC2.**
+- **Cross-pod integration** (Testcontainers, shared with 40-7 step) — dispatch+suspend on host A;
+  dispose A; deliver webhook via a fresh host B on the same store; assert resume on B, registry
+  unwired. **Covers AC5, AC6.**
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — durable tenant-scoped signal row | 1, 3 | `AgentRunWaitRepositoryTests` |
+| 2 — webhook resolves row + resumes bookmark | 2, 4 | `AgentRunResumerTests`, `InstallationRouterWorkflowRunResumeTests` |
+| 3 — resume endpoint (39-8 shape, 404/409) | 5 | `AgentRunResumeEndpointTests` |
+| 4 — durable poll reconciler | 6 | `AgentRunReconcilerTests` |
+| 5 — cross-pod delivery proven | 8 | Cross-pod integration (with 40-7) |
+| 6 — in-memory registry demoted, not required | 2, 7 | Cross-pod integration (registry unwired); `AgentMonitorService` mode test |
+| 7 — tenant + installation folded | 2, 5 | `AgentRunResumerTests` scoping cases |
+| 8 — fail-loud, exactly-once resume | 2, 6 | `AgentRunResumerTests`, `AgentRunReconcilerTests` idempotency/timeout cases |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisites:** 40-2 (`WaitForAgentRunActivity` + `ForAgentRun` — step 3 edits it;
+  the bookmark this story resumes) and, through it, 39-10 (`LifecycleBookmarks`). Blocking.
+- **Soft:** 39-8 (`DocumentDecisionResumeEndpoint` pattern for step 5) — mirrored, not consumed;
+  can proceed against `DesignResumeEndpoint` if 39-8 is not yet in.
+- **Migration ordering:** `agent_run_waits` is a `TenantDbContext` migration — take the single
+  migration-author token; rebase its snapshot onto whatever tenant migration precedes it at merge.
+- **In place, verified:** `InstallationRouterService` webhook receiver, `AgentMonitorService`
+  poll/discover, `AgentDispatchMediationService` mediated reads, Elsa persistent bookmark runtime,
+  `TenantDbContext`.
+- **Feeds:** 40-7 (cross-pod + crash integration), 40-6 (formalizes the event constants used here).
+- **Sequencing within the story:** 1 → 2 → 3/4 → 5/6 → 7 → 8.
+
+## Risks & Mitigations
+
+- **Ambiguous branch match resumes the wrong run.** Mitigation: D2's latest-before-created_at
+  disambiguation + 409/skip on genuine ambiguity + the stored-vs-recomputed name byte-guard (D3) —
+  a mismatched name never resumes.
+- **Webhook redelivery double-resumes.** Mitigation: `received` status + burned-bookmark no-op
+  (D3, AC8); resume is idempotent.
+- **Reconciler and webhook race to resume the same row.** Mitigation: the resumer's row-status CAS
+  (`pending → received`) + Elsa's single-burn bookmark make concurrent resumes converge to one
+  effect; the loser is a no-op.
+- **Migration-token contention with concurrent tenant migrations.** Mitigation: additive table,
+  standard rebase; coordinate the token per the epic execution plan.
+- **Cross-tenant regression if installation scoping is dropped.** Mitigation: AC7 carries
+  `installation_id` on the row + match; `AgentRunResumerTests` scoping cases guard it.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1 | entity + `TenantDbContext` migration + repository | 1.0 |
+| 2 | `AgentRunResumer` (resume + idempotency + name guard + fast-path) | 1.25 |
+| 3 | 40-2 `Execute` row write (cross-story) | 0.5 |
+| 4 | `InstallationRouterService` resolve+resume wiring | 0.75 |
+| 5 | `AgentRunResumeEndpoint` | 0.75 |
+| 6, 7 | reconciler + `AgentMonitorService` mode relax | 1.0 |
+| 8 | DI + unit tests (repo, resumer, endpoint, reconciler, router) | 1.5 |
+| **Total** | | **6.75** (story estimate: 5-7 days) |

--- a/docs/stories/epic-40/story-40-4/40-4-per-task-re-entry-from-git-and-events.md
+++ b/docs/stories/epic-40/story-40-4/40-4-per-task-re-entry-from-git-and-events.md
@@ -1,0 +1,155 @@
+# Story 40-4: Per-Task Re-Entry — Reconstruct Landed Tasks from Git + DCB Events
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **platform operator** (and the orchestrator running unattended),
+I want a crashed/restarted `SingleIssueCycleWorkflow` to **re-enter the per-task TDD loop at the
+task that was actually in flight** — reconstructed from the commits already on the branch and
+the DCB event trail — instead of restarting the cycle from scratch and re-implementing tasks
+that already landed,
+So that a deploy or eviction during a multi-task issue costs at most one task's rework, not the
+whole issue.
+
+## Priority
+
+P0 — This is the coding-side analogue of 39-10's latest-state re-entry. Without it, 40-2's
+durable suspend saves a single in-flight run but a *crash* (instance gone) still restarts the
+cycle at `CurrentTaskIndex = 0`, re-running context/plan/task/branch/PR and re-implementing
+completed tasks. It is what makes the whole coding step "resumable by design," not just
+"resumable while suspended."
+
+## Architectural Context (READ FIRST)
+
+**The loop advances a counter with no durable memory of progress.** In
+`SingleIssueCycleWorkflow.cs` the TDD loop is:
+
+```
+initTaskLoop  (TotalTasks = parse(tasksJson).length; CurrentTaskIndex = 0)   [line 517]
+hasMoreTasks  (CurrentTaskIndex < TotalTasks)                                 [line 530]
+  → extractCurrentTask (tasksJson[CurrentTaskIndex])                          [line 537]
+  → tddForTask  (WaitForAgentRunActivity after 40-2; session adl-{issue}-task-{index}) [line 571]
+  → Completed → incrementTask (CurrentTaskIndex++) → hasMoreTasks             [line 590]
+  → Failed    → dispatchTddRetry → advance | fail-cycle
+```
+
+`CurrentTaskIndex`/`TotalTasks` are Elsa workflow variables. If the instance survives, Elsa
+resumes them; **if the instance is gone (crash, definition-version bump, store loss), the
+orchestrator re-dispatches a fresh `SingleIssueCycleWorkflow` for the issue and the loop starts
+at index 0** — re-running every prior stage and re-implementing landed tasks. There is no read of
+"what already happened for this issue."
+
+**39-10 established the pattern; code needs its own read model.** 39-10's `LifecycleReEntryService`
+reconstructs a document workflow's position from the **39-11 document store + DCB events**. Epic
+39's README is explicit that **code is NOT a document type** — code's store is git. So the coding
+loop cannot reuse the document-store read; it reconstructs from:
+
+1. **Git** — the branch's commits (via the mediated compare/PR reads already in
+   `ActionsResultAggregator`): which tasks' expected changes are already committed.
+2. **DCB events** — per-task `AGENT_RUN.*` / `AGENT.EXECUTION.*` / `CODE.*` events keyed by the
+   deterministic session id `adl-{issue}-task-{index}` (queried via the Story 4-7 event API, the
+   same surface 39-10 uses).
+
+The deterministic per-task session id (`SingleIssueCycleWorkflow.cs:581`,
+`$"adl-{issueNumber}-task-{currentTaskIndex}"`) is the join key that makes this reconstruction
+possible — each task's events are addressable.
+
+## Acceptance Criteria
+
+1. **Task re-entry read model.** A component (e.g. `TaskLoopReEntryService` in
+   `Tamma.Activities/AgentDispatch/`) answers, for `(tenantId, issueNumber, branchName,
+   tasksJson)`: **the lowest task index not yet landed** — i.e. the `CurrentTaskIndex` a fresh
+   instance should resume at. It reconstructs from (a) per-task DCB events keyed by
+   `adl-{issue}-task-{index}` (a task with an `AGENT_RUN.RECEIVED`/success + `CODE.*` committed
+   event is landed) and (b) git branch state (the expected files/commits for the task are present),
+   never from Elsa instance internals. It returns a typed position with a human-readable basis.
+
+2. **Idempotent loop guard.** A re-entering cycle **skips the produce/dispatch for any already-
+   landed task** and resumes at the first unlanded index. Re-entering twice over the same landed
+   state yields zero new agent dispatches for landed tasks and zero duplicate `CODE.*`/agent
+   events (mirrors 39-10 AC6).
+
+3. **Wired into the loop.** `SingleIssueCycleWorkflow`'s `initTaskLoop` (or a new node before
+   `hasMoreTasks`) consults the re-entry service to set the initial `CurrentTaskIndex` to the
+   reconstructed resume index instead of hard-`0`, when re-entering for an issue that already has
+   landed tasks. A fresh issue with no history resolves to `0` (today's behavior, zero risk).
+
+4. **Disagreement fails loud, never guesses.** If git and events disagree (a task's events say
+   landed but its commits are absent, or vice-versa), the service throws a typed
+   `TammaError`-style inconsistency (pointing at the 4-8 replay surface) rather than silently
+   skipping or re-implementing — the 39-10 "mis-reconstruction is worse than no re-entry"
+   principle. The cycle routes the inconsistency to its loud fail/escalation sink.
+
+5. **Reuses git/event reads, no new fetch stack.** The git side reuses the mediated
+   compare/PR/commit reads already in `ActionsResultAggregator`/the mediation client; the event
+   side reuses `IEventRepository` (Story 4-7 query surface) — the same reads 39-10 uses. No new
+   GitHub client, no second event query path.
+
+6. **Null-seam default.** Until fully wired/validated, the service ships behind a
+   `NullTaskLoopReEntryService` that always returns index `0` (today's behavior), so re-entry
+   goes live by a DI swap without a workflow-code change (the 39-10 D7 pattern).
+
+7. **Emits a re-entry event.** When re-entry skips ≥1 task, the cycle emits
+   `AGENT_RUN.TASK_REENTERED` (40-6 family) with `{ issueNumber, resumeIndex, landedIndices,
+   basis }` so time-travel debugging shows the crash-recovery decision. A fresh (index-0) start
+   is not a re-entry and emits nothing.
+
+8. **Per-mode correct.** SaaS: git reads are the tenant's installation-scoped mediated reads;
+   events are tenant-folded. Single-user: local git + central-schema events. The reconstruction
+   logic is mode-agnostic; only the read sources differ (as they already do for dispatch/collect).
+
+## Technical Notes
+
+- **Git is the authority for "landed"; events are the corroborating trail.** A task is landed
+  when its expected changes are committed on the branch AND its `adl-{issue}-task-{index}` run
+  event says success. Requiring both avoids skipping a task whose events fired but whose push
+  failed (D4's inconsistency case), and avoids re-implementing a task whose events were lost but
+  whose commits are present (corroborate, then trust git).
+- **The session-id scheme is the join key — keep it deterministic.** `adl-{issue}-task-{index}`
+  must remain stable; any change to it breaks re-entry addressing. If a future story changes it,
+  re-entry must migrate in lockstep.
+- **This does not re-run earlier stages.** Re-entry here is scoped to the *TDD task loop* — the
+  cycle's earlier stages (context/plan/tasks/branch/PR) are re-run on a fresh dispatch as today
+  (they are cheap/idempotent relative to coding, and `tasksJson` must be regenerated to index
+  into). A future story may extend re-entry to skip those too; out of scope here. *(State this
+  boundary explicitly so the scope is honest.)*
+- **`tasksJson` determinism matters.** Re-entry indexes into `tasksJson[CurrentTaskIndex]`; if
+  task regeneration produces a different ordering, the index is meaningless. The plan must address
+  how `tasksJson` is stabilized/rehydrated for a re-entering issue (e.g. read the tasks from the
+  PR's committed plan `.md` files or a prior `TASK.CREATED` event rather than regenerating).
+
+## Dependencies
+
+- **Story 40-2 — HARD.** The loop node is `WaitForAgentRunActivity`; re-entry sets the index it
+  resumes at. 40-4's guard skips landed tasks before that suspend.
+- **Story 39-10 — SOFT (pattern), and the event-read path.** `LifecycleReEntryService`/
+  `LifecycleResumeCalculator` are the pure-calculator + I/O-service split to mirror; the 4-7/4-8
+  read path is shared. Not consumed directly (different store), but the shape is copied.
+- **Story 4-7 (event query API) + 4-8 (`ReplayReconstructor`)** — the DCB read + forensic
+  fallback. Existing.
+- **Existing (verified):** `ActionsResultAggregator` (git compare/PR reads), `IEventRepository`,
+  the `adl-{issue}-task-{index}` session scheme, `SingleIssueCycleWorkflow` loop.
+
+## Estimated Effort
+
+5-7 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-4/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-4/implementation-plan.md
@@ -1,0 +1,181 @@
+# Implementation Plan — Story 40-4: Per-Task Re-Entry from Git + DCB Events
+
+## Scope & Deliverable
+
+When this story is done, a fresh `SingleIssueCycleWorkflow` dispatched after a crash re-enters
+the TDD task loop at the first **unlanded** task instead of index 0. A `TaskLoopReEntryService`
+reconstructs the resume index from git (commits on the branch, via the mediated reads already in
+`ActionsResultAggregator`) corroborated by per-task DCB events keyed by `adl-{issue}-task-{index}`
+(via the Story 4-7 event query); the loop's init consults it; git/event disagreement fails loud;
+and the whole thing ships behind a `NullTaskLoopReEntryService` (returns 0) so it goes live by DI
+swap. Scope is the task loop only — earlier cycle stages re-run as today (boundary stated).
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-4/40-4-per-task-re-entry-from-git-and-events.md` — this story (ACs are source of truth)
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs:513-592` — the loop: `initTaskLoop`/`hasMoreTasks`/`extractCurrentTask`/`tddForTask`/`incrementTask`, the `CurrentTaskIndex`/`TotalTasks` vars, the `adl-{issue}-task-{index}` session id (line 581)
+- `docs/stories/epic-39/story-39-10/implementation-plan.md` — the calculator/service split (D1), `LifecycleResumeCalculator` pure-fold, `ILifecycleReEntryService`, `NullLifecycleReEntryService` seam (D7), `INCONSISTENT_STATE` fail-loud — the shape to mirror with git as the store
+- `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/ActionsResultAggregator.cs` — mediated compare/PR/commit reads (`TryCompareAsync`, `TryFindPullRequestAsync`) reused for "which files/commits are on the branch"
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` — Story 4-7 query surface (`QueryAsync(tenant, type, issueNumber, …)`, `ListByCorrelationIdAsync`) — per-task event read by session id
+- `apps/tamma-elsa/src/Tamma.Api/Services/Engine/Replay/ReplayReconstructor.cs` — the pure left-fold state-from-events style (forensic fallback)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentResultArtifactParser.cs` — `files_changed` shape used to compare expected-vs-committed
+- `docs/stories/epic-4/story-4-7/*` + `story-4-8/*` — event-query / replay contracts
+- **NOT FOUND (prerequisite):** `WaitForAgentRunActivity` (40-2), `AgentRunEventTypes` (40-6). See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — Pure calculator (`Tamma.Core`) + I/O service (`Tamma.Activities`), the 39-10 split, git
+  as the store.** `TaskLoopResumeCalculator` (pure) folds a per-task evidence list
+  `IReadOnlyList<TaskEvidence>` → the resume index; it has zero I/O and is exhaustively unit-
+  tested. `TaskLoopReEntryService` (I/O) gathers the evidence — git compare/PR reads +
+  `IEventRepository` per-task queries — maps to `TaskEvidence`, calls the calculator. Placement
+  mirrors 39-10 D1: the pure half in `Tamma.Core/AgentDispatch/Resume/` (reachable from the
+  engine), the I/O half in `Tamma.Activities/AgentDispatch/` DI-registered in both hosts.
+- **D2 — "Landed" = committed-on-branch AND a success run event, per task.** For task index `i`:
+  gather (a) the `adl-{issue}-task-{i}` events (`AGENT_RUN.RECEIVED` success / `AGENT.EXECUTION.SUCCESS`
+  / `CODE.COMMITTED`-style) and (b) whether the task's expected `files_changed` (from its
+  accepted plan slice) are present in the branch's committed diff. `TaskEvidence { Index,
+  HasSuccessEvent, HasCommittedChanges }`. `Landed ⇔ HasSuccessEvent && HasCommittedChanges`.
+  The resume index = the lowest `i` in `[0, TotalTasks)` that is not landed (tasks are sequential
+  by dependency order — the loop advances one at a time — so the first gap is the resume point).
+- **D3 — Disagreement is a typed inconsistency, never a guess (39-10 principle).** `HasSuccessEvent
+  && !HasCommittedChanges` (events say done, commits absent — a push that never landed) or
+  `!HasSuccessEvent && HasCommittedChanges` (commits present, events lost) at the *boundary* task
+  ⇒ the calculator throws `TammaError CODE.REENTRY.INCONSISTENT_STATE` with the offending index +
+  a pointer to the 4-8 replay surface. The service surfaces it; the cycle routes it to the loud
+  fail sink (`emitStepFailed`). Conservative default when only ONE signal is weakly present and
+  it's below the boundary: treat as landed only with both; ambiguity at/after the boundary fails
+  loud. (Rationale: re-implementing a landed task is wasteful but safe; SKIPPING an unlanded task
+  is a silent correctness hole — so bias to fail-loud, never to over-skip.)
+- **D4 — `tasksJson` is rehydrated, not regenerated, for a re-entering issue.** Re-entry indexes
+  into `tasksJson[i]`, so the ordering must match the original run. The service reads the tasks
+  from the durable source the cycle already commits — the plan/task `.md` files on the PR branch
+  (created by the `pull-request`/`task-creation` steps) or the prior `TASK.CREATED`/task-creation
+  event — and the loop uses that rehydrated `tasksJson` when re-entering, rather than a fresh
+  `task-creation` LLM run that could reorder. A fresh issue (no PR/branch) regenerates as today.
+  *(This is the subtlest correctness dependency — called out as its own AC-adjacent concern.)*
+- **D5 — `NullTaskLoopReEntryService` default (39-10 D7 seam).** Ships returning index 0 (today's
+  behavior). Real service behind a config flag; go-live is a DI swap, no workflow change. So the
+  loop wiring (D6) lands safely even before the read model is fully validated.
+- **D6 — One node before `hasMoreTasks`, sets `CurrentTaskIndex`.** `initTaskLoop` keeps computing
+  `TotalTasks`; a new `ComputeTaskResumeIndexActivity` (resolves `ITaskLoopReEntryService` via
+  `context.GetService<T>()`, the `EventPersistenceMiddleware` pattern) sets `CurrentTaskIndex` to
+  the reconstructed index and emits `AGENT_RUN.TASK_REENTERED` only when `resumeIndex > 0`. Inputs
+  read serialization-tolerantly (`ResumeInput`); the node is skipped/short-circuits to 0 when the
+  service is Null. This is the coding analogue of 39-10's `ComputeReEntryPositionActivity`.
+- **D7 — Scope boundary: the task loop only.** Earlier stages (context/plan/tasks/branch/PR)
+  re-run on a fresh dispatch. Stated in the story and here so no reader assumes whole-cycle
+  re-entry. Extending re-entry upstream is a future story; `tasksJson` rehydration (D4) is the
+  minimum needed to make task-loop re-entry correct.
+
+## Implementation Steps
+
+1. **CREATE `apps/tamma-elsa/src/Tamma.Core/AgentDispatch/Resume/TaskEvidence.cs` +
+   `TaskLoopResumePosition.cs` + `TaskLoopResumeCalculator.cs`** (D1/D2/D3) — pure fold over
+   ordered `TaskEvidence` → `TaskLoopResumePosition { ResumeIndex, LandedIndices[], Basis }`;
+   inconsistency → `TammaError CODE.REENTRY.INCONSISTENT_STATE`. Exhaustive matrix in tests.
+
+2. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ITaskLoopReEntryService.cs`,
+   `TaskLoopReEntryService.cs`, `NullTaskLoopReEntryService.cs`** (D1/D5) — the service gathers
+   git evidence (mediated compare/PR reads — reuse the `ActionsResultAggregator` client seam,
+   extracted behind an interface if needed) + per-task events (`IEventRepository` by
+   `adl-{issue}-task-{i}` correlation), maps to `TaskEvidence`, calls the calculator; exposes
+   `RehydrateTasksJsonAsync` (D4). Null seam returns index 0.
+
+3. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ComputeTaskResumeIndexActivity.cs`**
+   (D6) — inputs `IssueNumber`, `BranchName`, `TasksJson`, `TenantId`; outputs `ResumeIndex`,
+   `RehydratedTasksJson`; resolves `ITaskLoopReEntryService`; emits `AGENT_RUN.TASK_REENTERED`
+   (40-6 constant, placeholder-pinned) when `ResumeIndex > 0`; service missing → loud `TammaError`.
+
+4. **MODIFY `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs`** —
+   insert `computeTaskResumeIndex` between `initTaskLoop` and `hasMoreTasks`; set
+   `CurrentTaskIndex` from its output (default 0); use `RehydratedTasksJson` for the loop when
+   re-entering (D4). Route its inconsistency outcome to `emitStepFailed` (D3). Minimal edit; the
+   `[ResumeBehavior]` declaration is 40-5.
+
+5. **DI registration** (both hosts) — `NullTaskLoopReEntryService` as default, real service behind
+   the config flag (D5). Extract the git-read seam from `ActionsResultAggregator` if it is not
+   already interface-reachable from `Tamma.Activities`.
+
+6. **CREATE tests** (see Test Plan). Finish with `dotnet ef migrations has-pending-model-changes`
+   (clean — no schema) + `dotnet test`.
+
+## Data & Migrations
+
+None. Re-entry reads git (mediated) + the existing `domain_events` table (4-7 surface). No new
+table. `dotnet ef migrations has-pending-model-changes` stays clean.
+
+## Events
+
+- **Emits (40-6 family, placeholder-pinned):** `AGENT_RUN.TASK_REENTERED` (tags `issueNumber`,
+  `tenantId`, `branchName`; data `resumeIndex`, `landedIndices`, `basis`) — only when a task is
+  skipped. Migrate the constant to 40-6's `AgentRunEventTypes` at merge (conscious pin).
+- **Consumes (re-entry read):** per-task `AGENT_RUN.RECEIVED`/`AGENT.EXECUTION.SUCCESS`/`CODE.*`
+  events by `adl-{issue}-task-{i}` correlation; no other family.
+
+## Test Plan
+
+All NUnit + FluentAssertions (+ Moq; git/event reads faked).
+
+- **`TaskLoopResumeCalculatorTests`** (unit, pure) — the matrix: no evidence → 0; tasks 0..k
+  landed → k+1; gap at 0 → 0; all landed → `TotalTasks` (loop completes); boundary inconsistency
+  (event-without-commit / commit-without-event) → `INCONSISTENT_STATE`; below-boundary weak signal
+  → conservative; determinism. **Covers AC1, AC2, AC4.**
+- **`TaskLoopReEntryServiceTests`** (unit, Moq'd git-read seam + `IEventRepository`) — landed tasks
+  from combined git+events; per-task correlation query by `adl-{issue}-task-{i}`; `Null` service →
+  0; `RehydrateTasksJsonAsync` reads committed plan, not a fresh LLM run. **Covers AC1, AC5, AC6, D4.**
+- **`ComputeTaskResumeIndexActivityTests`** (unit, activity harness) — sets `CurrentTaskIndex`;
+  emits `TASK_REENTERED` only when `>0`; service-missing loud fail; read-back tolerance. **Covers AC3, AC7.**
+- **`SingleIssueCycleReEntryStructureTests`** (graph walk) — the compute node sits between
+  `initTaskLoop` and `hasMoreTasks`, inconsistency edge → `emitStepFailed`. **Covers AC3.**
+- *(Full crash → fresh-instance-skips-landed-task integration is in 40-7.)*
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — task re-entry read model | 1, 2 | `TaskLoopResumeCalculatorTests`, `TaskLoopReEntryServiceTests` |
+| 2 — idempotent guard, no double dispatch | 1, 4 | `TaskLoopResumeCalculatorTests`; 40-7 exactly-once |
+| 3 — wired into the loop | 3, 4 | `ComputeTaskResumeIndexActivityTests`, `SingleIssueCycleReEntryStructureTests` |
+| 4 — disagreement fails loud | 1, 4 | `TaskLoopResumeCalculatorTests` inconsistency cases |
+| 5 — reuses git/event reads | 2 | `TaskLoopReEntryServiceTests` |
+| 6 — null-seam default | 2, 5 | `TaskLoopReEntryServiceTests` Null case |
+| 7 — emits re-entry event | 3 | `ComputeTaskResumeIndexActivityTests` |
+| 8 — per-mode correct | 2, 5 | `TaskLoopReEntryServiceTests` (read-source seams) |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisite:** 40-2 (`WaitForAgentRunActivity` — the loop node the guard precedes).
+- **Soft:** 39-10 (calculator/service split + `NullX` seam pattern to mirror; the 4-7/4-8 read
+  path). 40-6 (event constant — placeholder-pin until it merges).
+- **In place, verified:** `ActionsResultAggregator` git reads, `IEventRepository` (4-7), the
+  `adl-{issue}-task-{index}` scheme, `ReplayReconstructor` (forensic fallback).
+- **Feeds:** 40-5 (the `[ResumeBehavior]` `LatestStateReEntry`/`Both` declaration cites this
+  compute node), 40-7 (crash integration proof).
+- **Sequencing within the story:** 1 → 2 → 3 → 4 → 5 → 6.
+
+## Risks & Mitigations
+
+- **Over-skipping an unlanded task = silent correctness hole (worse than no re-entry).**
+  Mitigation: D2/D3 require BOTH git commits and a success event to mark landed; boundary
+  disagreement fails loud; bias is always to re-implement (safe) over skip (unsafe).
+- **`tasksJson` reordering on re-entry makes indices meaningless.** Mitigation: D4 rehydrates
+  tasks from the committed plan / prior event, not a fresh LLM run; a dedicated service test.
+- **Session-id scheme change silently breaks addressing.** Mitigation: Technical Note pins the
+  scheme; a test asserts the loop's session id matches the re-entry query key format.
+- **Git-read seam not reachable from `Tamma.Activities`.** Mitigation: step 5 extracts the read
+  behind an interface (the mediation client already crosses this boundary for dispatch/collect).
+- **Scope creep into whole-cycle re-entry.** Mitigation: D7 boundary stated in story + plan;
+  earlier stages explicitly re-run.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1 | pure calculator + position types + inconsistency | 1.0 |
+| 2 | re-entry service (git + event gather, rehydrate) + null seam | 1.75 |
+| 3 | compute activity + event emit | 0.75 |
+| 4 | loop wiring + inconsistency routing | 1.0 |
+| 5 | DI + git-read seam extraction | 0.5 |
+| 6 | unit tests (calculator, service, activity, structure) | 1.5 |
+| **Total** | | **6.5** (story estimate: 5-7 days) |

--- a/docs/stories/epic-40/story-40-5/40-5-resume-behavior-declaration-and-allowlist-burndown.md
+++ b/docs/stories/epic-40/story-40-5/40-5-resume-behavior-declaration-and-allowlist-burndown.md
@@ -1,0 +1,111 @@
+# Story 40-5: `[ResumeBehavior]` on `SingleIssueCycleWorkflow` + Allowlist Burn-Down
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **platform maintainer relying on the build gate to answer "is this workflow resumable?"**,
+I want `SingleIssueCycleWorkflow` to **statically declare its resume behavior and pass 39-10's
+structural test without an allowlist entry**,
+So that the coding cycle's resumability is enforced by CI — not by trusting that 40-2/40-3/40-4
+were wired correctly — and the epic's central claim ("the coding step is resumable by design")
+is machine-checked.
+
+## Priority
+
+P0 — This is the acceptance gate that makes 40-2/40-3/40-4 real rather than aspirational. It is
+the first Epic-40 consumer of 39-10's `ResumableStandardStructuralTests` + `LegacyResumeAllowlist`
+burn-down, exactly as 39-12 is the first Epic-39 consumer.
+
+## Architectural Context (READ FIRST)
+
+**39-10 seeds `SingleIssueCycleWorkflow` in the legacy allowlist.** 39-10's D5 seeds
+`LegacyResumeAllowlist` with *"all ~30 current workflows, each with a one-line justification +
+the migration story that burns it down."* `SingleIssueCycleWorkflow` is one of them — allowlisted
+because, at 39-10's landing, it was the non-durable inline-monitor cycle. Its allowlist entry
+names **Epic 40 as the burn-down story**.
+
+**The gate has three clauses** (39-10 AC3 / D4 / D5), checked by
+`ResumableStandardStructuralTests` (`apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/`):
+
+- (a) every concrete `WorkflowBase` has a `[ResumeBehavior]` XOR a `LegacyResumeAllowlist` entry
+  (a stale entry — workflow now declares — fails the build);
+- (b) `BookmarkSuspend`/`Both` ⇒ the graph contains a node whose type is in BOTH the declaration's
+  `SuspendActivities` AND `LifecycleBookmarks.CanonicalSuspendActivities`;
+- (c) `LatestStateReEntry`/`Both` ⇒ the graph contains the re-entry compute node.
+
+By the time this story runs, 40-2 has registered `WaitForAgentRunActivity` in
+`CanonicalSuspendActivities` and switched the loop node to it; 40-4 has added
+`ComputeTaskResumeIndexActivity` to the graph. So the cycle now genuinely satisfies both (b) and
+(c) — this story flips the declaration and removes the allowlist entry, and the gate proves it.
+
+## Acceptance Criteria
+
+1. **`[ResumeBehavior(Both)]` declared.** `SingleIssueCycleWorkflow` carries
+   `[ResumeBehavior(ResumeMode.Both, SuspendActivities = [typeof(WaitForAgentRunActivity)])]`
+   (39-10's attribute). `Both` because the cycle both suspends on the durable agent-run bookmark
+   (40-2) and re-enters from latest git/event state (40-4).
+
+2. **Allowlist entry removed.** `SingleIssueCycleWorkflow`'s entry in `LegacyResumeAllowlist` is
+   deleted. Per 39-10's ratchet, a stale entry (workflow now declares) fails the build — so the
+   removal is mandatory, not optional.
+
+3. **Structural test passes with no allowlist entry.** `ResumableStandardStructuralTests`' clauses
+   (a)/(b)/(c) all pass for `SingleIssueCycleWorkflow`: it declares; its graph contains
+   `WaitForAgentRunActivity` (canonical suspend, registered by 40-2); its graph contains
+   `ComputeTaskResumeIndexActivity` (re-entry node, added by 40-4). This is the burn-down proof.
+
+4. **Canonical registry entry confirmed.** `WaitForAgentRunActivity` is in
+   `LifecycleBookmarks.CanonicalSuspendActivities` with gate `"agent-run"` (landed by 40-2;
+   asserted here so the dependency is explicit and a regression fails this story's test).
+
+5. **Declaration honesty holds.** The 39-10 inverse checks pass: the cycle does not declare
+   `BookmarkSuspend`-only while containing the re-entry node, nor `LatestStateReEntry`-only while
+   containing a canonical suspend node — `Both` is the truthful declaration and the test confirms
+   consistency.
+
+6. **No behavioral change.** This story adds an attribute and deletes an allowlist line; it changes
+   no runtime wiring (that is 40-2/40-3/40-4). The full workflow test suite stays green.
+
+## Technical Notes
+
+- **This story is deliberately thin and gated on 40-2 + 40-4.** It cannot pass until the loop node
+  is `WaitForAgentRunActivity` (40-2) AND the re-entry node is present (40-4). Attempting it
+  earlier fails clause (b) or (c) — which is the gate working as designed.
+- **`Both`, not `BookmarkSuspend`.** The cycle has *two* resumability properties (suspend +
+  crash re-entry); declaring only one would fail the honesty inverse (AC5) once the other node is
+  in the graph.
+- **If 39-10's attribute/enum names differ at merge**, adopt the exact 39-10 shipped names — this
+  story tracks 39-10's contract, it does not define it.
+
+## Dependencies
+
+- **Story 39-10 — HARD.** `ResumeBehaviorAttribute`/`ResumeMode`, `CanonicalSuspendActivities`,
+  `LegacyResumeAllowlist`, `ResumableStandardStructuralTests`. This story is a consumer.
+- **Story 40-2 — HARD.** `WaitForAgentRunActivity` + its `CanonicalSuspendActivities` registration
+  + the loop node swap (clause b).
+- **Story 40-4 — HARD.** `ComputeTaskResumeIndexActivity` in the graph (clause c).
+- **Existing:** the structural test enumerator (`TaxonomyDriftBuildTests` anchor), `WorkflowTestHelper`.
+
+## Estimated Effort
+
+2-3 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-5/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-5/implementation-plan.md
@@ -1,0 +1,123 @@
+# Implementation Plan — Story 40-5: `[ResumeBehavior]` on `SingleIssueCycleWorkflow` + Allowlist Burn-Down
+
+## Scope & Deliverable
+
+When this story is done, `SingleIssueCycleWorkflow` declares
+`[ResumeBehavior(ResumeMode.Both, SuspendActivities = [typeof(WaitForAgentRunActivity)])]`, its
+entry in 39-10's `LegacyResumeAllowlist` is removed, and `ResumableStandardStructuralTests`
+passes all three clauses for it with **no allowlist entry** — the first Epic-40 burn-down,
+machine-proving that the coding cycle is resumable by design. No runtime wiring changes here
+(that is 40-2/40-3/40-4); this is the declaration + gate flip.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-5/40-5-resume-behavior-declaration-and-allowlist-burndown.md` — this story (ACs are source of truth)
+- `docs/stories/epic-39/story-39-10/implementation-plan.md` — D3 (`ResumeBehaviorAttribute`/`ResumeMode`), D4 (`CanonicalSuspendActivities`), D5 (`LegacyResumeAllowlist` ratchet), step 8 (`ResumableStandardStructuralTests` clauses a/b/c + honesty inverse)
+- `apps/tamma-elsa/src/Tamma.Core/Documents/Resume/ResumeBehavior.cs` — the attribute + enum (39-10)
+- `apps/tamma-elsa/src/Tamma.Activities/Documents/LifecycleBookmarks.cs` — `CanonicalSuspendActivities` (40-2 adds `WaitForAgentRunActivity`)
+- `apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumableStandardStructuralTests.cs` — the gate + the `LegacyResumeAllowlist` seed (39-10) that names Epic 40 as burn-down for `SingleIssueCycleWorkflow`
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs` — the class to annotate; the loop now containing `WaitForAgentRunActivity` (40-2) + `ComputeTaskResumeIndexActivity` (40-4)
+- `apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/WorkflowTestHelper.cs` — `BuildWorkflow` graph-walk used by the gate
+- **NOT FOUND (prerequisite):** all of 39-10's resume infrastructure, 40-2's `WaitForAgentRunActivity`, 40-4's `ComputeTaskResumeIndexActivity`. See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — `Both`, `SuspendActivities = [typeof(WaitForAgentRunActivity)]`.** The cycle satisfies
+  both resume modes (durable suspend on the agent-run bookmark + crash re-entry from git/events),
+  so `Both` is the only honest declaration; `SuspendActivities` lists the single canonical suspend
+  type the graph contains. (The cycle also contains `WaitForCIResultsActivity` and
+  `WaitForPRMergedActivity` — legacy waits NOT in `CanonicalSuspendActivities`; they are not listed
+  because the resumable *standard* is about the lifecycle-canonical suspend points. If 39-10's
+  clause (b) requires *every* suspend node be canonical, that is a broader migration out of scope —
+  D2 addresses.)
+- **D2 — Scope check against 39-10 clause (b)'s exact wording.** 39-10 D4/step-8 phrase clause (b)
+  as "contains ≥1 node whose type is in BOTH the declaration's `SuspendActivities` AND
+  `CanonicalSuspendActivities`" — an existence check, not a for-all. So listing
+  `WaitForAgentRunActivity` suffices; the legacy `WaitForCIResults`/`WaitForPRMerged` waits do not
+  need to be canonical for this story to pass. This is confirmed against 39-10's plan; if 39-10
+  shipped a stricter for-all clause, this story escalates to also register those waits (a scope
+  bump recorded here, not silently absorbed).
+- **D3 — Removal is mandatory (ratchet), not cleanup.** 39-10's `KnownContractViolations`
+  discipline fails the build on a *stale* allowlist entry (workflow now declares). So deleting
+  `SingleIssueCycleWorkflow`'s line is forced by the gate the moment AC1 lands — the two edits are
+  one atomic change.
+- **D4 — Track 39-10's shipped names.** If the attribute/enum/registry names differ from the plan
+  at merge, adopt the shipped names verbatim. This story owns no contract; it consumes 39-10's.
+
+## Implementation Steps
+
+1. **MODIFY `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs`** — add
+   `[ResumeBehavior(ResumeMode.Both, SuspendActivities = [typeof(WaitForAgentRunActivity)])]` to
+   the class (D1). Add the `using` for the 39-10 attribute namespace.
+
+2. **MODIFY `apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/ResumableStandardStructuralTests.cs`
+   (or wherever `LegacyResumeAllowlist` is seeded)** — remove the `SingleIssueCycleWorkflow` entry
+   (D3).
+
+3. **VERIFY clause (b)/(c) preconditions** — confirm (assert in a small dedicated test if not
+   already covered) that `WaitForAgentRunActivity` is in `CanonicalSuspendActivities` (40-2) and
+   that the built `SingleIssueCycleWorkflow` graph contains both `WaitForAgentRunActivity` and
+   `ComputeTaskResumeIndexActivity` (40-4). If either is missing, this story is blocked on that
+   story (the gate working as designed).
+
+4. **RUN `ResumableStandardStructuralTests`** — all clauses green for `SingleIssueCycleWorkflow`
+   with no allowlist entry (AC3). Run the full workflow suite (AC6). Finish with `dotnet test`.
+
+## Data & Migrations
+
+None. `dotnet ef migrations has-pending-model-changes` stays clean.
+
+## Events
+
+None. No runtime path changes.
+
+## Test Plan
+
+All NUnit + FluentAssertions.
+
+- **`ResumableStandardStructuralTests` (existing, 39-10)** — now asserts `SingleIssueCycleWorkflow`
+  passes clauses (a)/(b)/(c) + honesty inverse with no allowlist entry; a stale entry (if not
+  removed) fails. **Covers AC2, AC3, AC5.**
+- **`SingleIssueCycleResumeDeclarationTests`** (new, small) — reflect the `[ResumeBehavior]` on
+  `SingleIssueCycleWorkflow`: `Mode == Both`, `SuspendActivities` contains
+  `WaitForAgentRunActivity`; assert `CanonicalSuspendActivities` contains `WaitForAgentRunActivity`
+  (gate `"agent-run"`). **Covers AC1, AC4.**
+- **Full workflow suite** — green, no behavioral regression. **Covers AC6.**
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — `[ResumeBehavior(Both)]` declared | 1 | `SingleIssueCycleResumeDeclarationTests` |
+| 2 — allowlist entry removed | 2 | `ResumableStandardStructuralTests` stale-entry check |
+| 3 — passes gate with no allowlist entry | 1, 2, 4 | `ResumableStandardStructuralTests` |
+| 4 — canonical registry entry confirmed | 3 | `SingleIssueCycleResumeDeclarationTests` |
+| 5 — declaration honesty holds | 1 | `ResumableStandardStructuralTests` honesty inverse |
+| 6 — no behavioral change | 4 | Full workflow suite green |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisites:** 39-10 (the attribute + gate + allowlist), 40-2 (`WaitForAgentRunActivity`
+  registered + loop node — clause b), 40-4 (`ComputeTaskResumeIndexActivity` in graph — clause c).
+  This story is the LAST of the four to land; it cannot pass earlier (the gate enforces order).
+- **In place, verified:** `ResumableStandardStructuralTests` enumerator, `WorkflowTestHelper`.
+- **Feeds:** nothing downstream — it is the epic's acceptance gate for resumability.
+- **Sequencing within the story:** 1/2 (atomic) → 3 → 4.
+
+## Risks & Mitigations
+
+- **Landed before 40-2/40-4 ⇒ clause (b)/(c) fail.** Mitigation: this is the gate working; sequence
+  40-5 last (execution plan wave). Step 3 verifies preconditions before flipping.
+- **39-10 shipped a stricter for-all clause (b) than planned.** Mitigation: D2 records the check
+  against 39-10's actual wording; a stricter clause escalates to a recorded scope bump (register
+  the legacy waits), not a silent workaround.
+- **Attribute/enum name drift from 39-10.** Mitigation: D4 tracks shipped names; mechanical rename.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1, 2 | attribute + allowlist removal | 0.5 |
+| 3 | precondition verification test | 0.5 |
+| 4 | run gate + full suite, fix any honesty-inverse surprise | 1.0 |
+| **Total** | | **2.0** (story estimate: 2-3 days) |

--- a/docs/stories/epic-40/story-40-6/40-6-agent-run-lifecycle-event-family.md
+++ b/docs/stories/epic-40/story-40-6/40-6-agent-run-lifecycle-event-family.md
@@ -1,0 +1,124 @@
+# Story 40-6: Agent-Run Lifecycle Event Family + Re-Entry Feed
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As an **operator debugging a coding run via time-travel** (and as 40-4's re-entry read model),
+I want the durable agent-run *wait* lifecycle — suspended, received, timed-out, re-entered — to
+be first-class `AGENT_RUN.*` events on the DCB stream, keyed for per-task re-entry,
+So that the audit trail shows when a run suspended, how it woke (webhook vs poll vs timeout), and
+which task a crash re-entered at — and so 40-4 has a durable, queryable trail to reconstruct from.
+
+## Priority
+
+P1 — The epic functions without a dedicated event family (40-2 keeps the existing
+`AGENT.EXECUTION.*` emission), but re-entry (40-4) reads events keyed by the per-task session id,
+and the wait lifecycle (suspend/received/timeout) is invisible to time-travel today. This story
+formalizes the family the other stories placeholder-pin against and makes the re-entry feed
+first-class.
+
+## Architectural Context (READ FIRST)
+
+**There are already several agent-adjacent event families — this story adds the missing *wait*
+layer beside them, it does not reinvent them:**
+
+- `AGENT.DISPATCH.STARTED/SUCCESS/FAILED` — engine-side `DispatchAgentWorkflowActivity` /
+  `ExecuteAgentActivity` via `TammaEventEmitter` (`EventType="AGENT.DISPATCH"`/`"AGENT.EXECUTION"`).
+- `AGENT.RESULTS.*` — `CollectAgentResultsActivity`.
+- `AGENT_DISPATCH.RUN_TRIGGERED/RUN_POLLED/RESULTS_COLLECTED.SUCCESS/FAILED` — the **Tamma.Api**
+  mediation audit (`AgentDispatchEventTypes`,
+  `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchEventTypes.cs`), one terminal
+  event per mediated call.
+
+What is **missing** is the *durable wait* lifecycle that 40-2 introduces: the moment the workflow
+**suspends** on the agent-run bookmark, the moment it is **received** (and by which path), the
+**timeout**, and the crash **re-entry** decision (40-4). 40-2 and 40-3 and 40-4 currently
+placeholder-pin these constants; this story defines them in one place and wires the emissions.
+
+**Events are keyed for re-entry.** 40-4 reconstructs the resume index from per-task events keyed
+by `adl-{issue}-task-{index}`. This story guarantees the wait-lifecycle events carry that
+correlation id + `issueNumber` + `tenantId` so the 4-7 query surface can retrieve them per task.
+
+## Acceptance Criteria
+
+1. **`AgentRunEventTypes` constant catalogue.** A single source of truth (e.g.
+   `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentRunEventTypes.cs`) defines the wait
+   lifecycle family: `AGENT_RUN.WAIT_SUSPENDED`, `AGENT_RUN.RECEIVED`, `AGENT_RUN.TIMED_OUT`,
+   `AGENT_RUN.RESUME_UNRESOLVED`, `AGENT_RUN.TASK_REENTERED` (names may refine in the plan; the
+   set covers suspend / wake / timeout / unresolved-signal / crash-reentry). Each has a stable
+   `AGGREGATE.ACTION.STATUS`-style constant.
+
+2. **Emission wired at the real transitions.** `WaitForAgentRunActivity` (40-2) emits
+   `WAIT_SUSPENDED` on suspend, `RECEIVED` on resume (with the wake path: `webhook`|`poll`|`local`),
+   `TIMED_OUT` on the DelayFor edge; `AgentRunResumer`/reconciler (40-3) emits `RESUME_UNRESOLVED`
+   on an unresolvable/timed-out row; `ComputeTaskResumeIndexActivity` (40-4) emits
+   `TASK_REENTERED`. The placeholder pins in 40-2/40-3/40-4 are replaced by these constants.
+
+3. **Correlation + tags for re-entry.** Every event carries `correlationId = adl-{issue}-task-{index}`
+   (the per-task session id), `issueNumber`, `tenantId`, `repository`, `branchName`, and the
+   wake-path/basis in `data`. This is the trail 40-4's re-entry read consumes; a test asserts the
+   4-7 query by `(tenantId, AGENT_RUN.RECEIVED, issueNumber)` returns the per-task rows.
+
+4. **Tenant-folded, per-mode.** Events are tenant-scoped (SaaS) / central (single-user) exactly
+   like the existing families; no cross-tenant leakage. The `TenantId` tag is resolved from the
+   workflow context the same way `DispatchAgentWorkflowActivity.ReadTenantIdFromContext` does.
+
+5. **Relationship to existing families documented, no duplication.** The plan states how
+   `AGENT_RUN.*` (engine wait lifecycle) relates to `AGENT_DISPATCH.RUN_*` (Tamma.Api mediation
+   audit) and `AGENT.EXECUTION.*` (activity start/end) — the wait family is *additive*, the others
+   are unchanged. No event is emitted twice for the same transition.
+
+6. **Feeds re-entry, verified end-to-end.** A test drives a per-task suspend→received sequence,
+   then runs 40-4's `TaskLoopReEntryService` against the emitted stream and asserts it reconstructs
+   the landed task from these events (corroborated by git) — proving the family is a usable re-entry
+   feed, not just audit decoration.
+
+7. **Analytics/dashboards unbroken.** The existing `PlatformAnalyticsService` `AGENT.DISPATCH.`
+   prefix handling is not disturbed; if `AGENT_RUN.*` should surface in any dashboard, it is added
+   deliberately (not required, but the plan notes the touchpoint).
+
+## Technical Notes
+
+- **One catalogue, not scattered string literals.** The whole point is a single
+  `AgentRunEventTypes` the other stories reference — avoid the `"AGENT.RESULTS.PARTIAL"`-style
+  inline literals (`CollectAgentResultsActivity.cs:209`) proliferating.
+- **`RECEIVED` records the wake path.** `webhook` (40-3 durable resume), `poll` (reconciler),
+  `local` (single-user in-process) — so time-travel and metrics can tell how completion was
+  actually observed (the current in-memory registry made this invisible).
+- **This is P1 and can land slightly after 40-2/40-3/40-4** — those ship with placeholder
+  constants; this story consolidates them. Keep the placeholder→catalogue migration mechanical.
+- Follow the DCB event conventions in CLAUDE.md (`AGGREGATE.ACTION.STATUS`, JSONB tags, UUID v7,
+  `metadata.eventSource`).
+
+## Dependencies
+
+- **Stories 40-2, 40-3, 40-4 — HARD (consumers of the constants).** This story replaces their
+  placeholder pins; it can be developed against their emission sites in lockstep or land just
+  after, migrating the placeholders.
+- **Story 4-7 (event query API)** — the retrieval surface AC3/AC6 assert against. Existing.
+- **Existing (verified):** `TammaEventEmitter`, `IEventRepository`/`IAlertEventEmitter`,
+  `AgentDispatchEventTypes` (the sibling mediation family), the DCB conventions.
+
+## Estimated Effort
+
+3-4 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-6/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-6/implementation-plan.md
@@ -1,0 +1,158 @@
+# Implementation Plan — Story 40-6: Agent-Run Lifecycle Event Family + Re-Entry Feed
+
+## Scope & Deliverable
+
+When this story is done, the durable agent-run *wait* lifecycle is a first-class `AGENT_RUN.*`
+DCB family in one catalogue (`AgentRunEventTypes`): suspend, received (with wake path), timed-out,
+resume-unresolved, task-reentered. 40-2/40-3/40-4's placeholder-pinned constants are replaced by
+it; every event carries the per-task `adl-{issue}-task-{index}` correlation + `issueNumber`/
+`tenantId` so 40-4's re-entry read consumes it via the 4-7 query. The family is additive beside
+the existing `AGENT_DISPATCH.RUN_*` (mediation) and `AGENT.EXECUTION.*` (activity) families — no
+transition double-emitted.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-6/40-6-agent-run-lifecycle-event-family.md` — this story (ACs are source of truth)
+- `apps/tamma-elsa/src/Tamma.Api/Services/AgentDispatch/AgentDispatchEventTypes.cs` — the sibling mediation family (naming style `AGENT_DISPATCH.RUN_TRIGGERED.SUCCESS`) to align with
+- `apps/tamma-elsa/src/Tamma.Activities/Core/` — `TammaEventEmitter` (engine drain emission) + `ITammaActivity` `BuildStartData`/`BuildEndData` conventions
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/DispatchAgentWorkflowActivity.cs:274` — `ReadTenantIdFromContext` (the tenant-resolution pattern events reuse)
+- `apps/tamma-elsa/src/Tamma.Data/Repositories/IEventRepository.cs` — the 4-7 query surface AC3/AC6 assert against
+- `apps/tamma-elsa/src/Tamma.Api/Services/Analytics/PlatformAnalyticsService.cs:55` — the `AGENT.DISPATCH.` prefix handling to not disturb (AC7)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/CollectAgentResultsActivity.cs:209` — an inline `"AGENT.RESULTS.PARTIAL"` literal (the anti-pattern to avoid)
+- CLAUDE.md — DCB event conventions (`AGGREGATE.ACTION.STATUS`, JSONB tags, `metadata.eventSource`)
+- `docs/stories/epic-40/story-40-2/implementation-plan.md`, `-40-3`, `-40-4` — the placeholder pins this story replaces (emission sites)
+- **NOT FOUND (prerequisite):** `WaitForAgentRunActivity` (40-2), `AgentRunResumer` (40-3), `ComputeTaskResumeIndexActivity` (40-4). See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — One `AgentRunEventTypes` catalogue in `Tamma.Activities/AgentDispatch/`.** Constants:
+  `WaitSuspended = "AGENT_RUN.WAIT_SUSPENDED"`, `Received = "AGENT_RUN.RECEIVED"`,
+  `TimedOut = "AGENT_RUN.TIMED_OUT"`, `ResumeUnresolved = "AGENT_RUN.RESUME_UNRESOLVED"`,
+  `TaskReentered = "AGENT_RUN.TASK_REENTERED"`. Placed in `Tamma.Activities` (not `Tamma.Api`)
+  because the emitters are engine-side activities/services; `AgentDispatchEventTypes` (mediation)
+  stays in `Tamma.Api` for its side. Two catalogues, two layers, clearly labelled.
+- **D2 — Additive, never double-emitting.** The mediation family already records dispatch/poll/
+  collect on the *wire* side; `AGENT.EXECUTION.*` records the activity start/end. `AGENT_RUN.*`
+  records the *durable wait* transitions that neither captures (suspend/wake-path/timeout/
+  reentry). Mapping table in the plan (below) pins who emits what so no transition is covered
+  twice. 40-2's interim `AGENT.EXECUTION.*` start/end is retained (it is the activity lifecycle);
+  `AGENT_RUN.*` adds the wait lifecycle on top.
+- **D3 — `RECEIVED` carries `wakePath ∈ {webhook, poll, local}`.** The resumer/activity knows how
+  the wake happened; recording it makes "how was completion observed" queryable — the visibility
+  the in-memory registry never gave. Metrics can histogram wake path.
+- **D4 — Correlation id is the per-task session id.** Every `AGENT_RUN.*` event sets
+  `correlationId = adl-{issue}-task-{index}` and tags `issueNumber`/`tenantId`/`repository`/
+  `branchName`. This is the exact key 40-4 queries; the family is designed as the re-entry feed,
+  not just audit (AC3/AC6). Emitted via `TammaEventEmitter` (engine drain) with the tenant resolved
+  by the `ReadTenantIdFromContext` pattern.
+- **D5 — Mechanical placeholder→catalogue migration.** 40-2/40-3/40-4 each define a local
+  placeholder constant with the same string value; this story deletes those and points the
+  emissions at `AgentRunEventTypes`. Because the string values are agreed up front, the migration
+  is a rename, not a behavior change — landable just after those stories with zero risk.
+
+## Implementation Steps
+
+1. **CREATE `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/AgentRunEventTypes.cs`** (D1) —
+   the constant catalogue + a `StatusForEvent`/tag-builder helper mirroring `AgentDispatchEventTypes`.
+
+2. **MODIFY `WaitForAgentRunActivity`** (40-2) — emit `WAIT_SUSPENDED` at suspend (after the
+   bookmark is created), `RECEIVED` (with `wakePath`) in `OnResumeAsync`, `TIMED_OUT` in
+   `OnTimeoutAsync`; carry the D4 correlation/tags. Replace 40-2's placeholder pins.
+
+3. **MODIFY `AgentRunResumer` + `AgentRunReconciler`** (40-3) — emit `RESUME_UNRESOLVED` on an
+   unresolvable/timed-out row; set `wakePath=webhook` (resumer) / `poll` (reconciler) into the
+   `RECEIVED` path data. Replace 40-3's placeholder pin.
+
+4. **MODIFY `ComputeTaskResumeIndexActivity`** (40-4) — emit `TASK_REENTERED` from
+   `AgentRunEventTypes.TaskReentered`. Replace 40-4's placeholder pin.
+
+5. **DOCUMENT the family relationship** — a short section in this plan + a comment block in
+   `AgentRunEventTypes.cs` mapping `AGENT_RUN.*` vs `AGENT_DISPATCH.RUN_*` vs `AGENT.EXECUTION.*`
+   (D2 table). Note the `PlatformAnalyticsService` touchpoint (AC7) — no change unless a dashboard
+   is explicitly extended.
+
+6. **CREATE tests** (see Test Plan). Finish with `dotnet ef migrations has-pending-model-changes`
+   (clean) + `dotnet test`.
+
+### Emission map (D2 — no double emit)
+
+| Transition | Family / constant | Emitter |
+|---|---|---|
+| Mediated dispatch/poll/collect (wire) | `AGENT_DISPATCH.RUN_*` (existing) | `AgentDispatchMediationService` |
+| Activity start/end | `AGENT.EXECUTION.*` (existing) | `WaitForAgentRunActivity` (via `TammaEventEmitter`) |
+| Durable wait suspended | `AGENT_RUN.WAIT_SUSPENDED` (new) | `WaitForAgentRunActivity` |
+| Wait received (+ wakePath) | `AGENT_RUN.RECEIVED` (new) | `WaitForAgentRunActivity` / `AgentRunResumer` |
+| Wait timed out | `AGENT_RUN.TIMED_OUT` (new) | `WaitForAgentRunActivity` |
+| Signal row unresolvable | `AGENT_RUN.RESUME_UNRESOLVED` (new) | `AgentRunReconciler` |
+| Crash re-entry skipped a task | `AGENT_RUN.TASK_REENTERED` (new) | `ComputeTaskResumeIndexActivity` |
+
+## Data & Migrations
+
+None. Events ride the existing `domain_events` drain → `EventRepository`. No schema change.
+`dotnet ef migrations has-pending-model-changes` stays clean.
+
+## Events
+
+- **Emits (new catalogue):** `AGENT_RUN.WAIT_SUSPENDED`, `AGENT_RUN.RECEIVED`,
+  `AGENT_RUN.TIMED_OUT`, `AGENT_RUN.RESUME_UNRESOLVED`, `AGENT_RUN.TASK_REENTERED` — tags
+  `issueNumber`, `tenantId`, `repository`, `branchName`, `correlationId=adl-{issue}-task-{index}`;
+  data includes `wakePath`/`basis`/`resumeIndex` per event.
+- **Unchanged:** `AGENT_DISPATCH.RUN_*`, `AGENT.EXECUTION.*`, `AGENT.RESULTS.*`.
+
+## Test Plan
+
+All NUnit + FluentAssertions (+ Moq; Testcontainers for the 4-7 query round-trip, shareable with 40-7).
+
+- **`AgentRunEventTypesTests`** (unit) — constants stable, `AGGREGATE.ACTION.STATUS` shape,
+  distinct from the mediation family. **Covers AC1.**
+- **`WaitForAgentRunActivityEventTests`** (unit, capturing event client) — suspend emits
+  `WAIT_SUSPENDED`; resume emits `RECEIVED` with the right `wakePath`; timeout emits `TIMED_OUT`;
+  all carry the per-task correlation + tenant. **Covers AC2, AC3, AC4.**
+- **`AgentRunResumerEventTests` / `ComputeTaskResumeIndexActivityEventTests`** (unit) —
+  `RESUME_UNRESOLVED` / `TASK_REENTERED` emitted with correct tags. **Covers AC2.**
+- **`AgentRunEventFeedTests`** (Testcontainers or in-memory `IEventRepository`) — emit a per-task
+  suspend→received sequence, query 4-7 by `(tenant, AGENT_RUN.RECEIVED, issue)`, feed 40-4's
+  `TaskLoopReEntryService`, assert it reconstructs the landed task. **Covers AC3, AC6.**
+- **Regression:** `PlatformAnalyticsService` `AGENT.DISPATCH.` handling unaffected. **Covers AC7.**
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — `AgentRunEventTypes` catalogue | 1 | `AgentRunEventTypesTests` |
+| 2 — emission wired at real transitions | 2, 3, 4 | activity/resumer/compute event tests |
+| 3 — correlation + tags for re-entry | 2, 3, 4 | `WaitForAgentRunActivityEventTests`, `AgentRunEventFeedTests` |
+| 4 — tenant-folded, per-mode | 2 | `WaitForAgentRunActivityEventTests` tenant cases |
+| 5 — relationship documented, no duplication | 5 | Reviewer check (emission map) |
+| 6 — feeds re-entry end-to-end | — | `AgentRunEventFeedTests` |
+| 7 — analytics unbroken | 5 | `PlatformAnalyticsService` regression |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisites (consumers of the constants):** 40-2, 40-3, 40-4 — this story replaces
+  their placeholder pins; land it just after, or develop in lockstep with agreed string values.
+- **In place, verified:** `TammaEventEmitter`, `IEventRepository` (4-7), `AgentDispatchEventTypes`
+  (sibling family), the DCB conventions.
+- **Feeds:** 40-4's re-entry read (the feed), 40-7's integration (asserts the stream shape).
+- **Sequencing within the story:** 1 → 2/3/4 → 5 → 6.
+
+## Risks & Mitigations
+
+- **Double-emitting a transition already covered by the mediation/activity families.** Mitigation:
+  D2's emission map pins one emitter per transition; a test asserts no `AGENT_RUN.*` duplicates an
+  `AGENT_DISPATCH.RUN_*` semantic.
+- **Placeholder/catalogue string drift.** Mitigation: agree the exact strings in 40-2/40-3/40-4
+  plans up front (they already pin these values); D5 migration is a rename.
+- **Event-store bloat from per-poll emission.** Mitigation: `RECEIVED`/`TIMED_OUT` are terminal
+  (one per run), not per-poll — mirrors the mediation family's AC7 terminal-only discipline.
+- **Landing before its consumers destabilizes their placeholder builds.** Mitigation: P1, sequenced
+  after them; the placeholders keep 40-2/40-3/40-4 green until this consolidates.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1, 5 | catalogue + relationship doc/comment | 0.75 |
+| 2, 3, 4 | wire emissions, replace placeholders | 1.25 |
+| 6 | unit + feed tests | 1.25 |
+| **Total** | | **3.25** (story estimate: 3-4 days) |

--- a/docs/stories/epic-40/story-40-7/40-7-crash-restart-mode-matrix-integration-proof.md
+++ b/docs/stories/epic-40/story-40-7/40-7-crash-restart-mode-matrix-integration-proof.md
@@ -1,0 +1,134 @@
+# Story 40-7: End-to-End Crash/Restart + Mode-Matrix Integration Proof
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then, before writing any code, check the knowledge base:
+
+- `.dev/spikes/` — existing research
+- `.dev/bugs/` — known bugs
+- `.dev/findings/` — pitfalls and best practices
+- `.dev/decisions/` — architecture decisions
+
+## User Story
+
+As a **platform maintainer**,
+I want an integration suite that proves the coding step **survives a crash mid-run, resumes
+across pods, re-enters at the right task without re-implementing landed work, and behaves
+identically in SaaS (GHA) and single-user (local) modes**,
+So that "the coding step is resumable by design" and "the runner works end-to-end" are proven
+against a real Postgres + Elsa persistence, not just asserted by unit tests.
+
+## Priority
+
+P0 — Unit tests prove each piece (40-2 suspend, 40-3 resume, 40-4 re-entry); only an integration
+suite proves they compose into the resumability guarantee the epic exists to deliver. This is the
+epic's end-to-end acceptance proof (the 39-10 `LifecycleReEntryIntegrationTests` analogue for
+code).
+
+## Architectural Context (READ FIRST)
+
+**The precedent is 39-10's crash/restart integration.** 39-10 AC7/AC8 (its D8) run a lifecycle
+workflow to a mid-point on **Testcontainers Postgres with Elsa EF persistence**, **kill the
+instance without a graceful suspend** (dispose the host/provider), build a **fresh provider on the
+same database**, dispatch a **fresh instance for the same issue**, and assert correct re-entry +
+no duplicate work + exactly-one acceptance. This story does the same for the coding step, with git
++ DCB events (not the document store) as the re-entry truth.
+
+**Two modes to prove** (CLAUDE.md universal rule):
+
+- **SaaS / GitHub Actions** — dispatch via the real `tamma-agent.yml` runner (40-1) on a test
+  repo (or a mocked `IGitHubActionsClient` when a live runner is impractical in CI); resume via the
+  durable webhook path (40-3); re-enter from git + events (40-4).
+- **Single-user / local** — the in-process local runner (40-1 AC8); no external webhook; the wait
+  completes in-process; re-entry from local git + central-schema events.
+
+**The composition under test:**
+
+```
+dispatch → WaitForAgentRunActivity suspends (durable bookmark)   [40-2]
+         → workflow_run.completed on pod B resumes it            [40-3]
+         → collect → loop advances
+   ── crash mid-loop (instance disposed) ──
+   fresh SingleIssueCycle for the same issue
+         → ComputeTaskResumeIndexActivity reconstructs index     [40-4]
+         → skips landed tasks, resumes at the in-flight task
+         → completes; exactly one agent dispatch per task
+```
+
+## Acceptance Criteria
+
+1. **Durable suspend/resume proven (Testcontainers).** A test runs the TDD loop to a mid-task
+   suspend on the durable bookmark (Elsa EF persistence on Postgres), delivers the completion
+   signal, and asserts the workflow resumes and advances. No thread was parked for the wait
+   (the instance was genuinely suspended, verified via the bookmark store).
+
+2. **Cross-pod delivery proven.** Suspend on host A; **dispose host A** (no graceful resume);
+   deliver the `workflow_run.completed` signal via a **fresh host B on the same store**; assert
+   resume on B — with the in-memory `WebhookSignalRegistry` unwired, so only the durable path
+   (40-3) can be responsible. (Shared with 40-3 AC5.)
+
+3. **Crash re-entry skips landed tasks.** Run a multi-task cycle so tasks 0..k land (commits on
+   the branch + `AGENT_RUN.*` events), **kill the instance** (dispose, no suspend), dispatch a
+   **fresh** `SingleIssueCycleWorkflow` for the same issue; assert it re-enters at task k+1
+   (`ComputeTaskResumeIndexActivity` output), does **not** re-dispatch an agent run for tasks 0..k,
+   and completes. (Shared with 40-4 AC2.)
+
+4. **Exactly-once per task.** Across the crash + re-entry, the final DCB stream contains exactly
+   one successful agent run (`AGENT_RUN.RECEIVED` success) per landed task — no duplicate
+   implementation, no duplicate events (the 39-10 "exactly one acceptance" analogue).
+
+5. **Timeout path proven.** A run whose completion signal never arrives hits the durable
+   `DelayFor` deadline, takes the `Timeout` edge, and the cycle escalates (needs-human), never
+   hangs.
+
+6. **Inconsistency fails loud.** A crafted git/event disagreement (event-landed but commits
+   absent) makes re-entry throw `CODE.REENTRY.INCONSISTENT_STATE` and the cycle route to its loud
+   fail sink — never silently skipping the task (40-4 AC4).
+
+7. **Mode matrix.** The core scenarios (suspend/resume, crash re-entry, exactly-once) run in
+   **both** SaaS (GHA path, real runner or mocked Actions client) and single-user (local runner)
+   modes, asserting identical workflow behavior — the `ExecuteAgentActivity`→`WaitForAgentRunActivity`
+   mode-agnosticism guarantee.
+
+8. **Runner contract self-check (from 40-1).** The 40-1 runner self-test (dispatch the real
+   `tamma-agent.yml` with a mock agent → `tamma-result` artifact → schema-valid `result.json`) is
+   included in or referenced by this suite so the CI-side contract is exercised end-to-end, not
+   just the C# wait side.
+
+## Technical Notes
+
+- **Reuse the 39-10 / 39-6 Testcontainers fixture shape.** Container-per-fixture Postgres, Elsa EF
+  persistence incl. the bookmark + `agent_run_waits` tables, stub sub-workflows for the non-coding
+  cycle stages, a capturing event client. Do not invent a new harness.
+- **"Crash" = dispose without graceful suspend + fresh provider on the same DB** (39-10 D8). The
+  old instance is dead weight; the new one must not depend on it — that is the honest crash shape.
+- **Mock the agent, not the plumbing.** Use `agent_provider=mock` / a fake `IGitHubActionsClient`
+  so the suite is deterministic and fast; the point is the suspend/resume/re-entry plumbing, not
+  the LLM. The 40-1 self-test covers the real runner separately.
+- **Keep scenarios to the AC list** — integration suites rot when they sprawl; each AC is one
+  scenario.
+
+## Dependencies
+
+- **Stories 40-1..40-6 — HARD.** This is the composition proof; every piece must be in.
+  40-1 (runner + local), 40-2 (suspend), 40-3 (durable resume + cross-pod), 40-4 (re-entry),
+  40-5 (declaration — the structural gate is a separate build check but the wiring it guards is
+  exercised here), 40-6 (the event family the assertions read).
+- **Existing (verified):** the 39-10/39-6 Testcontainers fixtures, Elsa EF persistence, the
+  dispatch/collect/mediation stack, `IEventRepository`.
+
+## Estimated Effort
+
+4-5 days
+
+## Change Log
+
+| Date       | Version | Changes                | Author |
+| ---------- | ------- | ---------------------- | ------ |
+| 2026-07-23 | 1.0.0   | Initial story creation | Claude |

--- a/docs/stories/epic-40/story-40-7/implementation-plan.md
+++ b/docs/stories/epic-40/story-40-7/implementation-plan.md
@@ -1,0 +1,146 @@
+# Implementation Plan — Story 40-7: End-to-End Crash/Restart + Mode-Matrix Integration Proof
+
+## Scope & Deliverable
+
+When this story is done, a Testcontainers integration suite proves the composed resumability
+guarantee: the coding step suspends durably (40-2), resumes across a disposed host on the same
+store (40-3), re-enters at the right task after a crash without re-implementing landed work
+(40-4), emits exactly one successful run per task (40-6 events), times out to escalation rather
+than hanging, fails loud on git/event inconsistency, and behaves identically in SaaS (GHA) and
+single-user (local) modes. The 40-1 runner self-check is wired in so the CI-side contract is also
+exercised end-to-end. No production code changes here — this is the epic's acceptance proof.
+
+## Pre-Reading
+
+- `docs/stories/epic-40/story-40-7/40-7-crash-restart-mode-matrix-integration-proof.md` — this story (ACs are source of truth)
+- `docs/stories/epic-39/story-39-10/implementation-plan.md` step 10 (`LifecycleReEntryIntegrationTests`, D8 crash shape) — THE precedent to mirror for code
+- `docs/stories/epic-39/story-39-6/implementation-plan.md` step 10 — the shared Testcontainers fixture (Elsa EF persistence, stub sub-workflows, capturing event client)
+- `apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/TriageItemCycleApplyFaultExecutionTests.cs` — real-`IWorkflowRunner` execution harness with capturing event client
+- `apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs` — the workflow under test (loop + re-entry node + suspend node after 40-2/40-4)
+- `apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/WaitForAgentRunActivity.cs` (40-2), `AgentRunResumer.cs` (40-3), `ComputeTaskResumeIndexActivity.cs` (40-4), `AgentRunEventTypes.cs` (40-6)
+- `apps/tamma-elsa/src/Tamma.Data/Entities/AgentRunWait.cs` (40-3) — the signal row asserted in cross-pod resume
+- `apps/tamma-elsa/runner/github-actions/tamma-agent.yml` (40-1) — the runner the self-check dispatches
+- **NOT FOUND (prerequisite):** all of the above land in 40-1..40-6. See Dependencies & Sequencing.
+
+## Design Decisions
+
+- **D1 — Extend the 39-6/39-10 Testcontainers fixture, do not build a new one.** Reuse the
+  container-per-fixture Postgres + Elsa EF persistence + capturing event client, adding the
+  `agent_run_waits` table (40-3) and stub sub-workflows for the non-coding cycle stages
+  (`context-gathering`/`plan-generation`/…/`pull-request` return canned success so the run reaches
+  the TDD loop fast). The agent is a fake (`IGitHubActionsClient` mock / `agent_provider=mock`) so
+  scenarios are deterministic (Technical Note).
+- **D2 — "Crash" = dispose host/provider without graceful suspend, fresh provider on the same DB
+  (39-10 D8).** The old instance is abandoned mid-loop; a new `SingleIssueCycleWorkflow` is
+  dispatched for the same issue against the same Postgres. Re-entry must succeed from git + events
+  alone (the point of 40-4). This is the honest crash, not a graceful checkpoint.
+- **D3 — Git is faked via the mediation seam, deterministically.** "Commits on the branch" is
+  modeled by the fake `IGitHubActionsClient` compare/PR reads returning the landed tasks' files;
+  `AGENT_RUN.*` events are real (emitted by the real activities). So re-entry reads a real event
+  stream corroborated by a controllable git fake — exactly the 40-4 evidence model.
+- **D4 — Cross-pod = two `WorkflowRuntime`/host instances over one Postgres.** Host A dispatches
+  and suspends; host A is disposed; host B (a fresh runtime on the same connection string) receives
+  the `workflow_run.completed` (via `AgentRunResumer`) and resumes the DB bookmark. The in-memory
+  `WebhookSignalRegistry` is left unregistered on both so only the durable path can resume (AC2/
+  40-3 AC5). This shares the 40-3 cross-pod test — one implementation, referenced from both plans.
+- **D5 — Mode matrix via the executor factory override.** SaaS scenarios force `github_actions`
+  mode (fake Actions client + durable webhook resume); single-user scenarios force `local` mode
+  (fake `InProcessLocalRunner`, in-`Execute` completion). The same workflow definition runs both;
+  assertions are identical. Proves the mode-agnosticism (AC7).
+- **D6 — The 40-1 runner self-check is a referenced CI job, not a C# Testcontainers scenario.**
+  Dispatching a real GitHub Actions workflow needs a live repo/runner, which is a CI-workflow
+  concern, not an in-process test. So AC8 is satisfied by *including/referencing* the 40-1 runner
+  self-test job in this suite's CI stage (a gate that runs the shipped `tamma-agent.yml` with a
+  mock agent), keeping the C# suite hermetic. Recorded so AC8 is honestly scoped.
+
+## Implementation Steps
+
+1. **CREATE `apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/CodingStepResumeIntegrationTests.cs`**
+   — the fixture extension (D1): Postgres + Elsa EF + `agent_run_waits` + stub cycle sub-workflows
+   + fake agent/Actions client + capturing event client.
+
+2. **Scenario: durable suspend/resume** (AC1) — run to a mid-task suspend; assert a bookmark row
+   exists + no thread parked; deliver the signal; assert resume + advance.
+
+3. **Scenario: cross-pod** (AC2, shared with 40-3) — D4: dispose host A, resume on host B, registry
+   unwired; assert resume on B + the `agent_run_waits` row marked received.
+
+4. **Scenario: crash re-entry skips landed tasks** (AC3, AC4) — D2/D3: land tasks 0..k, crash,
+   fresh dispatch; assert `ComputeTaskResumeIndexActivity` → k+1, no agent dispatch for 0..k,
+   completion, and exactly one `AGENT_RUN.RECEIVED` success per landed task in the final stream.
+
+5. **Scenario: timeout** (AC5) — never deliver the signal; assert the `DelayFor` deadline → `Timeout`
+   edge → needs-human escalation, no hang (bounded test time).
+
+6. **Scenario: inconsistency fails loud** (AC6) — craft event-landed-but-commits-absent for the
+   boundary task; assert `CODE.REENTRY.INCONSISTENT_STATE` → `emitStepFailed`.
+
+7. **Mode matrix** (AC7) — parameterize scenarios 2/4/… across `github_actions` and `local` modes
+   (D5); assert identical behavior.
+
+8. **Wire the 40-1 runner self-check** (AC8, D6) — reference/include the runner CI job in this
+   suite's CI stage. Finish with `dotnet test` (the C# suite) + the runner job green.
+
+## Data & Migrations
+
+None (tests only). Consumes 40-3's `agent_run_waits` migration + the existing Elsa/`domain_events`
+tables. `dotnet ef migrations has-pending-model-changes` stays clean.
+
+## Events
+
+- **Asserts (does not emit):** `AGENT_RUN.WAIT_SUSPENDED`/`RECEIVED`/`TIMED_OUT`/`TASK_REENTERED`
+  (40-6) in the captured stream — exactly-once-per-task (AC4), wake-path correctness, re-entry
+  event on skip.
+
+## Test Plan
+
+This story *is* the test plan; the suite is `CodingStepResumeIntegrationTests` (NUnit +
+FluentAssertions + Testcontainers). Scenarios map 1:1 to ACs (steps 2-7); the mode matrix (step 7)
+runs the core three under both modes; the runner self-check (step 8) is the referenced CI job.
+
+## Definition of Done
+
+| AC | Satisfied by step(s) | Verified by |
+|---|---|---|
+| 1 — durable suspend/resume | 2 | `CodingStepResumeIntegrationTests` suspend/resume scenario |
+| 2 — cross-pod delivery | 3 | cross-pod scenario (registry unwired) |
+| 3 — crash re-entry skips landed tasks | 4 | crash re-entry scenario |
+| 4 — exactly-once per task | 4 | stream assertion (one `AGENT_RUN.RECEIVED` success/task) |
+| 5 — timeout escalates, no hang | 5 | timeout scenario |
+| 6 — inconsistency fails loud | 6 | inconsistency scenario |
+| 7 — mode matrix identical | 7 | parameterized SaaS/local runs |
+| 8 — runner contract self-check | 8 | referenced 40-1 runner CI job green |
+
+## Dependencies & Sequencing
+
+- **Hard prerequisites:** 40-1..40-6 — the entire epic; this is the composition proof and lands
+  last. 40-5's build gate is a separate CI check but exercises the same wiring proven here.
+- **In place, verified:** 39-6/39-10 Testcontainers fixtures, Elsa EF persistence, the
+  dispatch/collect/mediation stack, `IEventRepository`, `TriageItemCycleApplyFaultExecutionTests`
+  harness.
+- **Feeds:** nothing downstream — it is the epic's end-to-end acceptance.
+- **Sequencing within the story:** 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8.
+
+## Risks & Mitigations
+
+- **Integration flakiness (host dispose/rebuild on shared Postgres).** Mitigation: reuse the proven
+  39-6/39-10 container-per-fixture pattern; keep scenarios to the AC list; deterministic fake agent.
+- **Cross-pod scenario is subtle to simulate in one process.** Mitigation: D4's two-runtime-one-DB
+  shape is the 39-10 AC8 precedent; share the single implementation with 40-3.
+- **Live-runner dispatch is not hermetic.** Mitigation: D6 keeps the C# suite mocked; the real
+  runner is a separate referenced CI job (AC8), honestly scoped.
+- **Suite rot / sprawl.** Mitigation: one scenario per AC; no speculative scenarios.
+- **Prerequisite stack incomplete when this starts.** Mitigation: sequence last (execution plan
+  wave 5); each scenario can land incrementally as its prerequisite story merges.
+
+## Effort Breakdown
+
+| Step(s) | Work | Days |
+|---|---|---|
+| 1 | fixture extension (agent_run_waits, stubs, fakes) | 1.0 |
+| 2, 3 | suspend/resume + cross-pod scenarios | 1.0 |
+| 4 | crash re-entry + exactly-once | 1.0 |
+| 5, 6 | timeout + inconsistency scenarios | 0.75 |
+| 7 | mode matrix parameterization | 0.75 |
+| 8 | runner self-check CI wiring | 0.25 |
+| **Total** | | **4.75** (story estimate: 4-5 days) |


### PR DESCRIPTION
## Epic 40 — Resumable Coding Execution (planning docs)

Planning-only (README + EXECUTION-PLAN + sprint-status + 7 stories, each with a story spec + implementation plan), matching the Epic 39 house style. **No code.**

### Why — two gaps the research established
1. **The CI-side coding-agent runner `tamma-agent.yml` does not exist.** Story 19-1 authored the full *contract* (7 dispatch inputs, step outline, `tamma-result` artifact schema with 14 fields, repo-secret security posture) and left it `ready-for-dev` — but **no workflow file, no scripts, and no scaffolding** to install it into a user repo were ever built. The whole C# `dispatch→monitor→collect` stack expects it present and **fails loud when absent** (*"Add the Tamma agent workflow template to .github/workflows/"*), a dead end for every SaaS tenant. The single-user `LocalExecutor` path is symmetrically incomplete (an unimplemented `packages/cli execute-agent`).
2. **The wait is not durable.** `ExecuteAgentActivity` runs the ~35-min `dispatch→monitor→collect` inline (the instance stays **Running**, not bookmark-suspended); `WebhookSignalRegistry` is an **in-memory single-process** `ConcurrentDictionary<TaskCompletionSource>` (a `workflow_run.completed` webhook on a different pod than the waiter never matches); and there is **no task-level re-entry**, so a crash restarts the whole `SingleIssueCycleWorkflow` and re-implements tasks that already landed on the branch.

### Stories
| # | Story |
|---|---|
| 40-1 | Ship the `tamma-agent.yml` runner contract + result-schema pin + GitHub-App repo scaffolding + single-user in-process CLI parity *(independent — starts day 0)* |
| 40-2 | `WaitForAgentRunActivity` — durable bookmark suspend + `DelayFor` timeout, replacing the inline monitor |
| 40-3 | Durable agent-run signal plane (persisted row) + resume endpoint — cross-pod & restart-safe; demotes the in-memory registry |
| 40-4 | Per-task re-entry — reconstruct landed tasks from **git commits + DCB events**, resume the loop at the right `CurrentTaskIndex` |
| 40-5 | Declare `[ResumeBehavior]` on `SingleIssueCycleWorkflow` + burn down its 39-10 allowlist entry |
| 40-6 | `AGENT_RUN.*` lifecycle event family feeding re-entry |
| 40-7 | Testcontainers crash/restart + cross-pod + SaaS/local mode-matrix proof |

### Key design decisions
- **Durable fix is substrate, not a new bus:** once 40-2 suspends on a DB-persisted Elsa bookmark, *any* pod resumes it through the bookmark store (that's the cross-pod backplane); a small persisted `agent_run_waits` row only supplies the `session_id`/`bookmark_name` the webhook lacks; the in-memory registry is demoted to an optional same-process fast path.
- **Re-entry authority is git** ("landed" = commits on the branch), **corroborated by `AGENT_RUN.*` events**; git/event disagreement fails loud (`CODE.REENTRY.INCONSISTENT_STATE`), never silently skips.
- **Code is NOT a document type** (Epic 39 rule) — so this reuses 39-10's `LifecycleBookmarks`/`[ResumeBehavior]` mechanism but does **not** touch the 39-11 document store; re-entry reads git + events.

### Dependencies
Epic 40's spine consumes **39-10** (`LifecycleBookmarks`, `[ResumeBehavior]`, `CanonicalSuspendActivities`, `LegacyResumeAllowlist`, the structural gate — now merged). **40-1 has no Epic-39 dependency.** 40-3 adds a `TenantDbContext` migration that must join the single-author tenant-migration chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_