### PR TITLE
docs(epic-41): full-team workflow coverage — remaining SDLC activities as lifecycle workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,8 +249,28 @@ jobs:
           if [ $rc -ne 0 ]; then
             echo "FAILED PROJECTS:$failed"
             for n in $failed; do
-              echo "---- OUTPUT OF FAILED PROJECT $n (tail 400) ----"
-              tail -400 "/tmp/test-logs/$n.log"
+              # Failed test names live in the .trx, not the console: each test
+              # spins a WebApplicationFactory whose startup logs flood stdout,
+              # pushing the "Failed <test>" line far above any tail window, and
+              # the .trx is only reachable as a token-gated artifact. Split the
+              # newest .trx on '<' so every start-tag lands on its own line,
+              # then pull the failed UnitTestResult names (attribute-order
+              # independent, no extra tooling) so intermittent failures are
+              # diagnosable straight from the CI log.
+              echo "---- FAILED TESTS IN $n (from .trx) ----"
+              trx=$(ls -t "tests/$n/TestResults"/*.trx 2>/dev/null | head -1)
+              if [ -n "$trx" ]; then
+                tr '<' '\n' < "$trx" \
+                  | grep 'UnitTestResult ' \
+                  | grep 'outcome="Failed"' \
+                  | grep -oE 'testName="[^"]*"' \
+                  | sed 's/^/  FAILED: /' \
+                  || echo "  (no Failed results in .trx — likely a host/hang exit)"
+              else
+                echo "  (no .trx found)"
+              fi
+              echo "---- OUTPUT OF FAILED PROJECT $n (tail 200) ----"
+              tail -200 "/tmp/test-logs/$n.log"
             done
           else
             echo "ALL PROJECTS PASSED"

--- a/docs/stories/epic-41/README.md
+++ b/docs/stories/epic-41/README.md
@@ -1,0 +1,247 @@
+# Epic 41: Full-Team Workflow Coverage — the remaining recurring SDLC activities as lifecycle workflows
+
+## Overview
+
+Epic 39 gave Tamma a **spine**: typed work documents, one produce→validate→review→revise→accept
+lifecycle, an orchestrator that routes acceptance by the 70–100 autonomy dial, resumable-by-design
+workflows, and a Task View where a suspended decision lands in a tenant role's inbox. Epic 40 made the
+coding step durable on that spine.
+
+But the platform only *runs* that spine for a narrow slice of what a software team does day to day: the
+**issue → decompose → plan → tasks → TDD → PR → review → merge → deploy** happy path, plus intake
+(triage/clarify/research/ambiguity) and mentorship. Tamma's stated intent is broader — *automate the
+entire software-development process*: every recurring activity an **engineer, UX, designer, product
+owner, project manager, scrum master, architect, or tester** performs should eventually be a Tamma
+workflow.
+
+This epic closes that gap. It takes the activities that today exist only as a **prompt cell** (an
+`(role, action)` template dispatchable through `llm-call`, but with no owning workflow that saves
+documents, rides the lifecycle, or routes acceptance) — or don't exist at all (the UX/designer/PM/scrum
+role families) — and turns each into a **first-class lifecycle workflow** on the Epic 39 substrate.
+
+**Every workflow in this epic follows the same five rules (no new architecture):**
+
+1. **Thin binding over `document-lifecycle`.** Each producing workflow declares `consumes: [...]` /
+   `produces: <DocumentType>`, binds one `(role, action)` produce cell, and contributes no bespoke
+   parse/branch/terminal logic — exactly the 39-12/39-13/39-14 migration pattern. Where the output is
+   prose (ADR, postmortem, release notes, changelog, runbook, docs, stakeholder update), it rides the
+   lifecycle as a **prose document with an audience tag** (Epic 39: *"prose stays prose"*).
+2. **DCB events.** Every transition emits the generic `DOCUMENT.*` family plus a domain-specific family
+   (`ADR.*`, `SPRINT.*`, `THREATMODEL.*`, …) so existing dashboards and new ones both see a loud,
+   tagged, `issueId`/`repository`-lineaged trail.
+3. **Orchestrator-routed acceptance, autonomy-gated.** The accept gate **always** publishes an
+   `AcceptanceRequest` on the workflow↔orchestrator channel and suspends (39-8). The orchestrator reads
+   the acceptance rules + the autonomy level (70–100, per-document-type overridable) and decides WHO
+   decides — itself (more, the higher the dial) or a **tenant role** whose holders see the decision in
+   their Task View. Never an if-else that skips the decision; never an embedded accept `llm-call`.
+4. **Human-or-agent execution.** The produce/review step is written so **either** fulfils it: at lower
+   autonomy it is assigned to a human holder of the appropriate tenant role (lands in their Task View,
+   scoped by 39-20 access); at higher autonomy the appropriate `AgentRole` performs the `llm-call`. The
+   workflow binds a `(role, action)` cell either way — the assignment target (agent process vs. human
+   role) is the orchestrator's routing decision, not the workflow's shape.
+5. **Resumable by design.** Interactive workflows declare `[ResumeBehavior(Both)]` (accept gate suspends
+   on a canonical tenant-folded bookmark via `LifecycleBookmarks`; Init reconstructs from the document
+   store + DCB events); run-to-completion producers declare `[ResumeBehavior(LatestStateReEntry)]`;
+   scheduled workflows use the `HourlyAnalyticsRollupScheduler` cron pattern. All pass the 39-10
+   structural test without an allowlist entry.
+
+**Vocabulary is reused, not reinvented.** Where an activity's output fits an existing Epic 39 type
+(`Findings`, `Review`, `Design`, `Plan`, `Diagnosis`, `TriageDecision`, `TestSpec`, prose) this epic uses
+it. Only a handful of genuinely new types are proposed (Story 41-1) and each is justified against an
+existing type it could NOT reuse.
+
+## New roles & the two role families that don't exist yet
+
+The taxonomy (`Tamma.Core/Agents`) models **8 roles**: developer, senior_developer, tester, security,
+devops, architect, product_owner, tech_writer. The user's target set names **four the platform has no
+role for** — they currently fall back to `product_owner` via `LegacyRoleAliases` (`scrum_master`,
+`analyst`) or aren't modelled at all (UX, designer, project_manager). Story **41-1** adds
+`scrum_master`, `project_manager`, and `ux_designer` (covering both UX and visual-design work) as first
+-class `AgentRole`s with their action cells, plus the new document types the epic needs. **Every other
+story in the epic can still ship and run human-assigned before 41-1 lands** (rule 4 — a lower-autonomy
+step routes to a human role regardless of whether an agent exists); 41-1 is what unlocks *agent*
+execution of those steps at higher autonomy, so it is P0 but not a hard blocker for the human path.
+
+## Coverage matrix
+
+Legend — **✅ covered** (a named workflow owns it) · **◑ partial** (touched inside a larger workflow /
+only as a panel lens / prose-in-PR, no first-class workflow) · **✗ missing** (prompt cell only, or no
+cell at all). "New story" names the Epic 41 story that closes a ◑/✗.
+
+### Engineer (developer + senior_developer)
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Implement feature/fix (TDD) | ✅ | `tdd-cycle`, `tdd-with-debug-retry`, `single-issue-cycle` |
+| Write tests | ✅ | `test-case-creation`, `testing-pipeline` |
+| Debug | ✅ | `debugging` |
+| Address review comments | ✅ | `review-fix` |
+| Issue decomposition / task creation | ✅ | `issue-decomposition`, `task-creation` |
+| Implementation planning | ✅ | `plan-generation` |
+| Blocker resolution / mentorship | ✅ | `blocker-diagnosis`, `mentorship` |
+| **Standalone code review (not mentorship-bound)** | ◑ | **41-17** (only inside `code-review`/panel today) |
+| **PR triage / review-queue** | ✗ | **41-17** |
+| **Refactor planning** | ✗ | **41-18** (cell `plan-refactor`, no workflow) |
+
+### Architect
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Design proposal | ✅ | `design-proposal` |
+| Plan review (architecture lens) | ✅ | `plan-review`, `review-panel` |
+| **ADR authoring** | ✗ | **41-9** (cell `write-adr`) |
+| **System design doc (API contract / data model / integration)** | ✗ | **41-10** (cells exist, no workflow) |
+| **Tech-debt & technical-risk triage** | ✗ | **41-11** (cell `assess-technical-risk`; no tech-debt cell) |
+| **Dependency & upgrade planning** | ✗ | **41-12** (cell `plan-migration-strategy` + security `audit-dependencies`) |
+
+### Product Owner
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Intake / triage | ✅ | `issue-triage`, `triage-*` |
+| Clarify requirements | ✅ | `clarifying-questions` |
+| Research | ✅ | `research` |
+| Ambiguity scoring | ✅ | `ambiguity-scoring` |
+| Skill assessment | ✅ | `assessment` |
+| **Acceptance-criteria authoring** | ✗ | **41-2** (cell `define-acceptance-criteria`) |
+| **Backlog prioritization / grooming** | ✗ | **41-3** (cell `prioritize-backlog`) |
+| **Roadmap shaping** | ✗ | **41-4** (cell `plan-roadmap`) |
+| **Stakeholder / status update** | ✗ | **41-5** (cell `summarize-stakeholder`) |
+
+### Project Manager & Scrum Master (no role today → 41-1)
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| **Sprint planning** | ✗ | **41-6** |
+| **Standup synthesis** | ✗ | **41-7** (event-sourced digest) |
+| **Retrospective facilitation** | ✗ | **41-8** |
+| Impediment tracking | ◑ | `blocker-diagnosis` (dev-blocker only; team-level in 41-7/41-8) |
+| Status reporting | ✗ | **41-5** (shared with PO) |
+
+### Tester
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Test-case authoring (TDD red) | ✅ | `test-case-creation` |
+| Test execution / quality gate | ✅ | `testing-pipeline` |
+| Defect triage (panel lens) | ◑ | `triage-panel-review` |
+| Testability review (panel lens) | ◑ | `review-panel` |
+| **Test-plan / strategy authoring** | ✗ | **41-13** (cell `plan-test-strategy`) |
+| **Exploratory test charter** | ✗ | **41-14** (cell `exploratory-test`) |
+| **Acceptance verification** | ✗ | **41-15** (cell `verify-acceptance`) |
+| **Regression & flaky-test management** | ✗ | **41-16** (cell `write-regression-test`) |
+
+### Security
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Vulnerability / security review (panel & triage lens) | ◑ | `triage-panel-review`, `review-panel` |
+| Secret rotation | ◑ | `rotate-secret` (ops saga, not a review) |
+| **Threat modeling** | ✗ | **41-19** (cell `threat-model`) |
+| **Scheduled dependency / secret / compliance audit** | ✗ | **41-20** (cells `audit-dependencies`/`audit-secrets`/`review-compliance`) |
+| **Security incident analysis** | ✗ | **41-21** (cell `analyze-security-incident`) |
+
+### DevOps
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| Deploy / promotion pipeline | ✅ | `deployment-pipeline` |
+| CI configuration | ◑ | `ci-with-debug-retry` (runs CI; doesn't author config) |
+| Incident diagnosis (panel lens) | ◑ | `triage-panel-review` |
+| **Incident response & postmortem** | ✗ | **41-22** (cells `plan-incident-response`/`write-postmortem`) |
+| **Capacity & health review** | ✗ | **41-23** (cells `assess-capacity`/`monitor-health`) |
+| Rollback | ✗ | folded into **41-22** (cell `rollback`) |
+
+### Tech Writer
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| PR description | ◑ | `pull-request` (inline, not a doc) |
+| **Release notes & changelog** | ✗ | **41-24** (cells `write-release-notes`/`update-changelog`) |
+| **User & API documentation** | ✗ | **41-25** (cells `write-user-docs`/`write-api-docs`) |
+| **Runbook & ops-docs** | ✗ | **41-26** (cell `write-runbook`) |
+| Doc review | ◑ | folded into 41-24/41-25/41-26 review stage (cell `review-docs`) |
+
+### UX / Designer (no role today → 41-1)
+
+| Activity | Status | Workflow / story |
+|---|---|---|
+| **User-flow drafting** | ✗ | **41-27** |
+| **Wireframe / UI spec authoring** | ✗ | **41-27** |
+| **Design review & accessibility audit** | ✗ | **41-28** |
+
+## New document types (Story 41-1)
+
+Reuse first; a new type is proposed only when no existing Epic 39 type carries the domain rules.
+
+| New type | Why not an existing type | Domain rules beyond schema |
+|---|---|---|
+| `AcceptanceCriteria` | Not a `Clarification` (that resolves ambiguity) nor a `Plan` (that maps files); it is the testable definition-of-done consumed by 41-15 and the merge gate | each criterion independently verifiable; Given/When/Then or checklist form; bound to an `issueId`; no criterion references unimplemented scope |
+| `BacklogOrdering` | A `TriageDecision` classifies one item; this **ranks a set** with rationale | total order over the referenced item set; every item has a rationale + value/effort estimate; no ties |
+| `SprintPlan` | A `Plan` maps tasks-to-files for one issue; a sprint commits a **capacity-bounded set of issues** to a time-box | committed set ≤ stated capacity; every committed item has an owner-role + estimate; carry-over flagged |
+| `TestPlan` | A `TestSpec` is executable cases bound to task IDs; a test plan is the **strategy** (scope, risk-based coverage, environments, entry/exit) above them | risk areas ranked; each strategy line maps to a coverage target; entry/exit criteria stated |
+| `ThreatModel` | `Findings` cite evidence but carry no attack structure; threat modelling needs assets/threats/mitigations | STRIDE (or configured) categorisation; each threat has asset + mitigation + residual-risk; unmitigated high-risk ⇒ escalation |
+| `UxSpec` | A `Design` weighs technical alternatives; a UX spec captures **flows/states/acceptance** for an interface | every flow has entry + success + error states; each screen/step lists a11y requirements; maps to acceptance criteria |
+
+Everything else reuses: **`Findings`** (standup digest, retro, capacity/health review, exploratory
+charter, security audit, technical-risk), **`Review`** (standalone code review, acceptance verification,
+design/a11y review, doc review), **`Diagnosis`** (incident/security-incident analysis), **`Plan`**
+(refactor plan, dependency-upgrade plan, roadmap, incident-response plan), **`TriageDecision`** (PR
+triage, tech-debt triage, regression/flaky triage), and **prose-with-audience-tag** (ADR, postmortem,
+release notes, changelog, runbook, user/API docs, stakeholder update).
+
+## Sequencing (highest-leverage first)
+
+**Wave 0 — enabler.** 41-1 (roles + doc types). Human path for every other story can start in parallel;
+41-1 gates only the agent path.
+
+**Wave 1 — highest leverage (closes the biggest holes on the critical path).**
+- **41-2 Acceptance-Criteria Authoring** — feeds `verify-acceptance` (41-15) *and* the merge gate; today
+  "done" is undefined outside a plan. Highest single-story leverage.
+- **41-15 Acceptance Verification** — closes the loop 41-2 opens; turns "tests pass" into "requirement
+  met" at the accept gate.
+- **41-17 Standalone Code Review & PR Triage** — code review only exists mentorship-bound; every repo
+  needs review-of-a-diff and a routed PR queue as a stand-alone.
+- **41-9 ADR Authoring** — cheap, high-value, pure prose-on-lifecycle; proves the prose path for the
+  whole tech-writer/devops family behind it.
+
+**Wave 2 — recurring, event-sourced, scheduled (compounding value).**
+- **41-7 Standup Synthesis**, **41-16 Regression & Flaky-Test Management**, **41-11 Tech-Debt & Risk
+  Triage**, **41-20 Scheduled Security Audit**, **41-23 Capacity & Health Review** — all read the DCB
+  stream / CI history on a cron and produce a `Findings`/`TriageDecision`; each replaces a standing human
+  chore. 41-24 Release Notes & 41-25 User/API Docs are release/merge-triggered siblings.
+
+**Wave 3 — planning & design depth.**
+- 41-3 Backlog Prioritization, 41-6 Sprint Planning, 41-4 Roadmap, 41-8 Retro, 41-5 Stakeholder Update,
+  41-10 System Design Doc, 41-18 Refactor Planning, 41-19 Threat Modeling, 41-21 Security Incident,
+  41-22 Incident & Postmortem, 41-12 Dependency & Upgrade, 41-13 Test-Plan, 41-14 Exploratory Charter,
+  41-26 Runbook.
+
+**Wave 4 — new surface (UX/design; depends on 41-1's `ux_designer` role + `UxSpec` type).**
+- 41-27 User-Flow & Wireframe Drafting, 41-28 Design Review & Accessibility Audit.
+
+## Deliberately out of scope (not automated as a workflow)
+
+- **Live human ceremonies as real-time events** (the actual standup/retro *meeting*, sprint *review demo*
+  to stakeholders). Tamma automates the **artifact** (digest, retro report, plan) and routes it, not the
+  synchronous human conversation. — *A meeting is a human-coordination act; the value Tamma adds is the
+  durable, event-sourced artifact around it.*
+- **Pixel-level visual design production** (actual mockup rendering in a design tool). 41-27 produces a
+  structured `UxSpec` + flow/state description; rendering pixels is a design-tool integration, not a
+  document-lifecycle workflow. — *Out until a design-tool provider abstraction exists, parallel to the
+  Git/AI provider abstractions.*
+- **Hiring, budgeting, vendor/contract management, people-management 1:1s.** — *Team-operations, not
+  software-development activities; outside Tamma's SDLC charter.*
+- **Final production-deploy authorization for regulated/breaking changes.** Stays a human decision by
+  acceptance-rules policy (always-escalate class), not a new workflow. — *Epic 39 already models this as
+  policy, not code.*
+
+## Dependencies
+
+- **Epic 39** (all of it): document core/types/registry, `DocumentLifecycleWorkflow`, review producers,
+  acceptance rules + orchestrator routing, escalation surface, resume standard + structural test,
+  document store & lineage API, teams/roles/repo-access & task routing, orchestrator chat + Task View.
+- **Epic 40** for any workflow whose accept leads into a coding execution (41-18 refactor plan → coding
+  step reuses the durable runner).
+- `HourlyAnalyticsRollupScheduler` cron pattern for the scheduled workflows (41-7/41-11/41-16/41-20/41-23).
+- `Tamma.Core/Agents` taxonomy extension (41-1) for the agent path of 41-6/41-7/41-8/41-27/41-28.

--- a/docs/stories/epic-41/story-41-1/41-1-team-role-and-document-type-extensions.md
+++ b/docs/stories/epic-41/story-41-1/41-1-team-role-and-document-type-extensions.md
@@ -1,0 +1,54 @@
+# Story 41-1: Team-Role & Document-Type Extensions
+
+Status: drafted
+
+## User Story
+
+As the **Epic 41 program**, I want the agent taxonomy and the Epic 39 document registry extended with the
+roles and typed documents the remaining team activities need, so that every Epic 41 workflow can bind a
+real `(role, action)` cell and produce a registered typed document — enabling the *agent* execution path
+(rule 4) at higher autonomy, while the human-assigned path already works.
+
+## Priority
+
+P0 — enabler. Gates the agent path of the role-family stories (41-6/41-7/41-8/41-27/41-28) and the typed
+outputs of 41-2/41-3/41-6/41-13/41-19/41-27. Not a hard blocker for the human path of any story.
+
+## Scope
+
+1. **New `AgentRole`s** in `Tamma.Core/Agents/AgentRole.cs`: `scrum_master`, `project_manager`,
+   `ux_designer`. Remove the `scrum_master → product_owner` entry from `LegacyRoleAliases` (it becomes a
+   real role); keep `analyst` aliased. Add each role's `_system.md` identity preamble and its action
+   cells under `Prompts/{role}/`.
+2. **New `AgentAction` tokens** + `RolePhaseMap` eligibility entries for the activities that lack a cell:
+   `plan-sprint`, `synthesize-standup`, `facilitate-retro`, `track-impediments` (scrum_master);
+   `report-status`, `coordinate-release` (project_manager); `draft-user-flow`, `author-ui-spec`,
+   `review-design`, `audit-accessibility` (ux_designer); `triage-tech-debt` (architect),
+   `triage-pr` (senior_developer), `manage-regression` (tester). Existing cells (`write-adr`,
+   `prioritize-backlog`, `verify-acceptance`, `threat-model`, …) are reused unchanged.
+3. **New document types** registered in the 39-2 registry with schema + domain rules + prompt-contract
+   renderer + examples + drift test: `AcceptanceCriteria`, `BacklogOrdering`, `SprintPlan`, `TestPlan`,
+   `ThreatModel`, `UxSpec` (rules per the README table). Each declares which producers `produce` it.
+4. **Prose-document audience tags** extended for the new prose outputs (ADR, postmortem, release-notes,
+   changelog, runbook, user/API docs, stakeholder-update, retro, roadmap).
+
+## Acceptance Criteria
+
+1. The three new roles round-trip through `EnumWire`/`RolePhaseMap`; `ValidRoles` = 11; every new
+   `(role, action)` pair passes `IsRoleEligibleForPhase`; the taxonomy drift test is green.
+2. `PromptFileLoader` starts fail-loud: every new taxonomy cell has a file and no file sits outside the
+   taxonomy (the existing one-cell-one-file invariant holds for the enlarged grid).
+3. The six new document types are registered, carry executable domain rules with unit tests, and each has
+   a generated prompt contract (39-16 mechanism) bound to its producer cell.
+4. `ContractBindingTests` extends to the new cells with no build-gate regression.
+5. No existing role/action/document behaviour changes (byte-stable for the 8 current roles).
+
+## Dependencies
+
+- **Blocking:** Epic 39 (39-2 registry, 39-3/39-4 type pattern, 39-16 contract generation), 27-15/27-18
+  taxonomy machinery.
+- **Unblocks:** the agent path of every Epic 41 role-family story.
+
+## Estimated Effort
+
+5–7 days

--- a/docs/stories/epic-41/story-41-10/41-10-system-design-document.md
+++ b/docs/stories/epic-41/story-41-10/41-10-system-design-document.md
@@ -1,0 +1,57 @@
+# Story 41-10: System Design Document Workflow
+
+Status: drafted
+
+## User Story
+
+As an **architect** (or eligible role-holder), I want a workflow that produces a typed `Design` document
+for a larger feature — covering API contract, data model, and integration points with weighed
+alternatives — on the standard lifecycle, so that non-trivial designs are proposed, reviewed, and accepted
+before implementation planning, instead of being improvised in the plan step.
+
+## Priority
+
+P2 / Wave 3 — the depth counterpart to `design-proposal` for multi-surface features.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [issue, Findings, AcceptanceCriteria?, context-scan]` /
+`produces: Design`. Produce cell `(architect, plan-system-design)`, drawing on the
+`design-api-contract` / `design-data-model` / `design-integration` cells as sub-lenses folded into the one
+`Design` document (rather than three separate workflows).
+
+## Produced document
+
+`Design` (39-4): ≥1 alternative with trade-offs; recommendation references an alternative; the API/data
+/integration facets are sections of the one document. `issueId` lineage. Reviewed via panel (architect +
+senior-dev + security + relevant lenses).
+
+## Events
+
+`SYSTEM_DESIGN.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; a design touching a public contract or cross-service boundary can be an
+always-escalate class. Accepted `Design` is consumed by `plan-generation` and can seed 41-9 ADRs.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; architect accepts.
+- **85–100:** agent drafts and self-accepts; contract/boundary-affecting designs always escalate per policy.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Design` validated (alternatives + trade-offs + recommendation).
+2. API/data/integration facets present as sections; no separate bespoke workflows.
+3. Accepted `Design` consumable by `plan-generation` and 41-9 via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Design`, lifecycle, review-panel, store).
+- **Related:** feeds `plan-generation`, 41-9.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-11/41-11-tech-debt-and-technical-risk-triage.md
+++ b/docs/stories/epic-41/story-41-11/41-11-tech-debt-and-technical-risk-triage.md
@@ -1,0 +1,57 @@
+# Story 41-11: Tech-Debt & Technical-Risk Triage Workflow
+
+Status: drafted
+
+## User Story
+
+As an **architect** (or eligible role-holder), I want a scheduled workflow that scans the codebase + DCB
+history for accumulating technical debt and standing risks, triages each into a typed `TriageDecision`,
+and (for the top items) a `Findings` risk assessment, so that debt is surfaced and prioritised on a cadence
+instead of only when it causes an incident.
+
+## Priority
+
+P2 / Wave 2 — recurring, compounding; keeps the architecture honest between features.
+
+## Scope
+
+Scheduled sweep → thin binding over `document-lifecycle`. `consumes: [codebase scan (context-scan),
+DCB events, dependency/build signals]` / `produces: TriageDecision` per debt/risk item, plus a ranked
+`Findings` for the top-N. Produce cells `(architect, triage-tech-debt)` (41-1) and
+`(architect, assess-technical-risk)`.
+
+## Produced documents
+
+`TriageDecision` (severity/category/effort/urgency, reasoning required) and `Findings` (evidence-cited,
+ranked technical-risk assessment).
+
+## Events
+
+`TECH_DEBT.SWEEP.STARTED`/`.ITEM`/`.COMPLETED` alongside `DOCUMENT.*`, tagged `repository`/`tenantId`.
+
+## Orchestrator / user interaction
+
+Accepted items route to the backlog via the orchestrator (can seed 41-3 backlog ordering / 41-6 sprint
+planning); high-risk items assigned to the architect/senior-dev role's Task View.
+
+## Autonomy behavior
+
+- **70–84:** agent surfaces candidates; architect confirms which become backlog items.
+- **85–100:** agent triages and self-accepts; backlog seeding automatic; a risk above a configured
+  threshold always escalates.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent; fail-closed per item.
+2. Closed-enum classification with required reasoning; risk `Findings` cite concrete evidence.
+3. Output consumable by 41-3/41-6 as backlog candidates.
+4. `[ResumeBehavior(LatestStateReEntry)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`triage-tech-debt` cell), Epic 39 (`TriageDecision`, `Findings`, lifecycle, store),
+  scheduler pattern, `context-gathering`.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-12/41-12-dependency-and-upgrade-planning.md
+++ b/docs/stories/epic-41/story-41-12/41-12-dependency-and-upgrade-planning.md
@@ -1,0 +1,54 @@
+# Story 41-12: Dependency & Upgrade Planning Workflow
+
+Status: drafted
+
+## User Story
+
+As an **architect** (with a **security** lens), I want a workflow that turns dependency/upgrade pressure
+(from the 41-20 audit or a schedule) into a typed migration `Plan` on the lifecycle, so that upgrades are
+sequenced, risk-assessed, and accepted before work starts — instead of a risky big-bang bump.
+
+## Priority
+
+P3 / Wave 3 — recurring maintenance; consumes 41-20 findings.
+
+## Scope
+
+Triggered by 41-20 findings or scheduled → thin binding over `document-lifecycle`. `consumes: [dependency
+Findings (41-20), manifest, breaking-change advisories]` / `produces: Plan`. Produce cell
+`(architect, plan-migration-strategy)` with a `(security, audit-dependencies)` review lens.
+
+## Produced document
+
+`Plan` (39-4): per-upgrade task with file map, ordering (dependencies resolvable), testing stated per
+task, rollback note. `repository` lineage. Reviewed via panel (architect + security + relevant).
+
+## Events
+
+`DEP_UPGRADE.PLAN.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; an accepted plan hands off to the coding step (Epic 40) task-by-task. A
+major-version upgrade of a load-bearing dependency can be an always-escalate class.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; architect accepts before work.
+- **85–100:** agent drafts and self-accepts minor/patch upgrade plans; majors always escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Plan` validated (dependency ordering, per-task testing).
+2. Consumes 41-20 dependency findings when present.
+3. Accepted plan consumable by the coding step via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Plan`, lifecycle, review-panel, store); Epic 40 for execution.
+- **Related:** consumes 41-20.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-13/41-13-test-plan-authoring.md
+++ b/docs/stories/epic-41/story-41-13/41-13-test-plan-authoring.md
@@ -1,0 +1,53 @@
+# Story 41-13: Test-Plan / Strategy Authoring Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tester** (or eligible role-holder), I want a workflow that authors a risk-based **TestPlan** for an
+issue or release — scope, coverage targets, environments, entry/exit criteria — on the standard lifecycle,
+so that testing strategy is explicit and accepted above the executable cases, instead of implicit in
+`test-case-creation`.
+
+## Priority
+
+P3 / Wave 3 — the strategy layer above `TestSpec`; consumes 41-2.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [issue, AcceptanceCriteria (41-2), Plan, Findings]` /
+`produces: TestPlan`. Produce cell `(tester, plan-test-strategy)`.
+
+## Produced document
+
+`TestPlan` (41-1): risk areas ranked; each strategy line maps to a coverage target; entry/exit criteria
+stated. `issueId` lineage. Reviewed via `(tester, review-testability)` / architect lens.
+
+## Events
+
+`TEST_PLAN.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; accepted `TestPlan` drives `test-case-creation` (which produces the bound
+`TestSpec` cases) and 41-14 charter scoping.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; tester accepts.
+- **85–100:** agent drafts and self-accepts; a plan for a safety-critical area can be always-escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `TestPlan` validated (risk ranking, coverage mapping, entry/exit).
+2. Consumes `AcceptanceCriteria` when present; strategy lines trace to criteria.
+3. Consumable by `test-case-creation` / 41-14 via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`TestPlan` type), Epic 39 (lifecycle, review, store); 41-2.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-14/41-14-exploratory-test-charter.md
+++ b/docs/stories/epic-41/story-41-14/41-14-exploratory-test-charter.md
@@ -1,0 +1,53 @@
+# Story 41-14: Exploratory Test Charter Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tester** (or eligible role-holder), I want a workflow that produces an exploratory-testing charter
+and captures the session's observations as a typed `Findings` document on the lifecycle, so that
+unscripted testing yields tracked, evidence-cited findings instead of ephemeral notes.
+
+## Priority
+
+P3 / Wave 3 — complements scripted testing; consumes 41-13.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [TestPlan (41-13)?, feature under test, AcceptanceCriteria?]`
+/ `produces: Findings` (charter mission + session observations). Produce cell `(tester, exploratory-test)`.
+
+## Produced document
+
+`Findings`: each observation cites what was exercised as evidence; severity + reproduction where a defect
+is found; ranked. `issueId` lineage.
+
+## Events
+
+`EXPLORATORY.CHARTER.STARTED` → `.SESSION` → `.FINDINGS` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; defect findings can seed `triage-defect`/41-17; the charter is
+human-or-agent (a human tester runs the session at low autonomy, an agent explores at high autonomy).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts the charter; a human runs the session and records findings.
+- **85–100:** agent charters, explores (tool-enabled), and self-accepts; confirmed defects always route to
+  triage.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Findings` cite concrete evidence; empty session ⇒ valid empty findings.
+2. Defect findings integrate with triage/PR-triage.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Findings`, lifecycle, store, routing).
+- **Related:** consumes 41-13; feeds 41-17/triage.
+
+## Estimated Effort
+
+3 days

--- a/docs/stories/epic-41/story-41-15/41-15-acceptance-verification.md
+++ b/docs/stories/epic-41/story-41-15/41-15-acceptance-verification.md
@@ -1,0 +1,57 @@
+# Story 41-15: Acceptance Verification Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tester** (or eligible role-holder), I want a workflow that verifies an implemented change against
+its accepted `AcceptanceCriteria` and emits a typed `Review` verdict on the lifecycle, so that the cycle
+answers *"does this meet the requirement?"* — not just *"do the tests pass?"* — before merge/close.
+
+## Priority
+
+P0 / Wave 1 — closes the loop 41-2 opens. Without it, acceptance criteria are authored but never checked.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [AcceptanceCriteria, diff/PR, TestSpec?, CI results]`
+/ `produces: Review` (subject = the change; each criterion mapped pass/fail with evidence). Produce cell
+`(tester, verify-acceptance)`.
+
+## Produced document
+
+Unified `Review` whose issues carry the failing criterion id + evidence; a blocking failure ⇒ not
+approvable (39-4 invariant). Decision enum drives merge routing.
+
+## Events
+
+`ACCEPTANCE.VERIFY.STARTED` → `.VERDICT` (approved/changes/undecidable) alongside `DOCUMENT.*`, tagged
+`issueId`/`prId`/`repository`.
+
+## Orchestrator / user interaction
+
+Accept gate routes the verdict per autonomy. A "changes-requested" verdict escalates with lineage
+(criteria + failing evidence) so the orchestrator can loop back to `review-fix`/coding or assign a human.
+
+## Autonomy behavior
+
+- **70–84:** a human tester verifies; verdict acceptance is human.
+- **85–94:** agent verifies; a human confirms an "approved" verdict on the merge path.
+- **95–100:** agent verifies and self-accepts an unambiguous pass; any failing criterion always escalates.
+
+## Acceptance Criteria
+
+1. Reads the latest accepted `AcceptanceCriteria` (41-2) via 39-11; hard-fails loud if none exists (never
+   silently "passes" an issue with no criteria).
+2. Produces a validated unified `Review`; blocking failures cannot be laundered into approval.
+3. Verdict integrates with `single-issue-cycle`/`merge-approval` as a gate input.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-2, Epic 39 (`Review`, lifecycle, store), Epic 40 (change under test).
+- **Unblocks:** requirement-complete merge gating.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-16/41-16-regression-and-flaky-test-management.md
+++ b/docs/stories/epic-41/story-41-16/41-16-regression-and-flaky-test-management.md
@@ -1,0 +1,59 @@
+# Story 41-16: Regression & Flaky-Test Management Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tester** (or eligible role-holder), I want a scheduled workflow that mines CI history + the DCB
+stream for repeated failures and non-deterministic tests, triages them, and drafts a regression `TestSpec`
+for genuine regressions, so that flaky tests are quarantined and regressions are captured instead of
+silently eroding the gate.
+
+## Priority
+
+P1 / Wave 2 — protects the quality gate that everything else leans on; recurring and event-sourced.
+
+## Scope
+
+Scheduled sweep → thin binding over `document-lifecycle`. `consumes: [CI run history, GATE.*/TEST.* DCB
+events]` / `produces: TriageDecision` (per suspect test: regression | flaky | environmental) and, for a
+confirmed regression, a follow-on `produces: TestSpec` (a bound regression case). Produce cells
+`(tester, manage-regression)` (41-1) and `(tester, write-regression-test)`.
+
+## Produced documents
+
+`TriageDecision` (closed-enum classification + reasoning per suspect test) and, when regression is
+confirmed, a `TestSpec` case bound to the affected task/behavior.
+
+## Events
+
+`REGRESSION.SWEEP.STARTED`/`.ITEM`/`.COMPLETED`; `FLAKY.QUARANTINE.PROPOSED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Each triage decision routes through the accept gate; a "flaky ⇒ quarantine" or "regression ⇒ add test"
+action is assigned to a tester/dev role or self-decided at high autonomy. The regression `TestSpec` can
+hand off to the coding step (Epic 40) to land the test.
+
+## Autonomy behavior
+
+- **70–84:** agent triages; a human tester approves quarantine/regression-test actions.
+- **85–100:** agent triages and self-accepts classification; quarantine + regression-test creation auto
+  -assigned within the eligible set; destructive quarantine of a load-bearing test can be an always
+  -escalate class.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent per window; fail-closed per suspect (recorded, not dropped).
+2. Classification uses closed enums with required reasoning; no false "flaky" that hides a real regression.
+3. Confirmed regression yields a validated `TestSpec` bound to a task/behavior id.
+4. `[ResumeBehavior(LatestStateReEntry)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`manage-regression` cell), Epic 39 (`TriageDecision`, `TestSpec`, lifecycle, store),
+  scheduler pattern; Epic 40 for landing the regression test.
+
+## Estimated Effort
+
+5–6 days

--- a/docs/stories/epic-41/story-41-17/41-17-standalone-code-review-and-pr-triage.md
+++ b/docs/stories/epic-41/story-41-17/41-17-standalone-code-review-and-pr-triage.md
@@ -1,0 +1,64 @@
+# Story 41-17: Standalone Code Review & PR Triage Workflow
+
+Status: drafted
+
+## User Story
+
+As an **engineer / senior developer**, I want first-class code review of an arbitrary diff and a routed
+PR-triage queue — independent of the mentorship engine — so that any PR (human- or agent-authored,
+inside or outside the autonomous loop) gets a typed `Review` and open PRs are prioritised and assigned,
+instead of code review only existing bolted into `code-review`/`mentorship`.
+
+## Priority
+
+P0 / Wave 1 — code review is the most universal team activity and today has no stand-alone lifecycle
+workflow.
+
+## Scope
+
+Two thin bindings sharing this story:
+- **Code review:** `document-lifecycle`, `consumes: [diff/PR, Plan?, AcceptanceCriteria?]` /
+  `produces: Review`. Produce cell `(senior_developer, code-review)` (developer/security/tester lenses
+  available via panel policy). Subject is a diff — *code is not a document type* (Epic 39), so the review
+  subject is a git reference, not a stored code doc.
+- **PR triage:** scheduled (`HourlyAnalyticsRollupScheduler` pattern) sweep of open PRs →
+  `document-lifecycle`, `produces: TriageDecision` per PR (priority, staleness, needs-review/needs-author,
+  suggested reviewer role). Produce cell `(senior_developer, triage-pr)` (41-1).
+
+## Produced documents
+
+`Review` (per diff) and `TriageDecision` (per open PR, with closed-enum classification + reasoning).
+
+## Events
+
+`CODE_REVIEW.STARTED`/`.VERDICT`; `PR_TRIAGE.SWEEP.STARTED`/`.ITEM`/`.COMPLETED` alongside `DOCUMENT.*`,
+tagged `prId`/`repository`.
+
+## Orchestrator / user interaction
+
+Review verdict + each PR-triage decision route through the accept gate; the orchestrator assigns a
+reviewer/author-follow-up to the appropriate tenant role's Task View, or self-decides at high autonomy.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts the review/triage; a human reviewer signs off.
+- **85–94:** agent review accepted for non-blocking verdicts; blocking issues escalate.
+- **95–100:** agent review self-accepted; PR-triage assignments made automatically within the eligible set.
+
+## Acceptance Criteria
+
+1. Code-review binding produces a validated unified `Review` over a diff subject; blocking issues ⇒ not
+   approvable; no launder-to-concerns path (the `PlanReviewWorkflow.ExtractReview` anti-pattern stays dead).
+2. PR-triage sweep is idempotent, fail-closed per item (a failed item is recorded, not dropped), and
+   tenant-scoped.
+3. Both declare resume behavior (review `Both`; sweep `LatestStateReEntry`) and pass 39-10 without allowlist.
+4. Reviewer-role selection comes from acceptance/review rules, not hardcoded.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Review`, `TriageDecision`, lifecycle, review producers, task routing).
+- **Related:** reuses 39-7 panel; complements `review-fix`.
+
+## Estimated Effort
+
+5–6 days

--- a/docs/stories/epic-41/story-41-18/41-18-refactor-planning.md
+++ b/docs/stories/epic-41/story-41-18/41-18-refactor-planning.md
@@ -1,0 +1,55 @@
+# Story 41-18: Refactor Planning Workflow
+
+Status: drafted
+
+## User Story
+
+As a **senior developer** (or eligible role-holder), I want a workflow that turns a refactor need (from
+41-11 tech-debt triage or a review concern) into a typed `Plan` on the lifecycle, so that refactors are
+scoped, sequenced, and accepted with a behavior-preservation strategy before the coding step runs —
+instead of an unbounded ad-hoc rewrite.
+
+## Priority
+
+P3 / Wave 3 — turns tech-debt findings into safe, planned work.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [tech-debt TriageDecision (41-11), context-scan, Review
+concerns]` / `produces: Plan`. Produce cell `(senior_developer, plan-refactor)`.
+
+## Produced document
+
+`Plan` (39-4): per-step file map, dependency ordering, behavior-preservation/testing stated per step (the
+`refactor` action's characterization-test requirement expressed as plan content). `repository`/`issueId`
+lineage. Reviewed via panel.
+
+## Events
+
+`REFACTOR.PLAN.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; accepted plan hands off to the coding step (Epic 40) step-by-step. A
+refactor touching a public API can be an always-escalate class.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; senior dev accepts before work.
+- **85–100:** agent drafts and self-accepts contained refactors; API-affecting refactors always escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Plan` validated (ordering, per-step testing/behavior preservation).
+2. Consumes 41-11 tech-debt output when present.
+3. Accepted plan consumable by the coding step via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Plan`, lifecycle, review-panel, store); Epic 40 for execution.
+- **Related:** consumes 41-11.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-19/41-19-threat-modeling.md
+++ b/docs/stories/epic-41/story-41-19/41-19-threat-modeling.md
@@ -1,0 +1,53 @@
+# Story 41-19: Threat Modeling Workflow
+
+Status: drafted
+
+## User Story
+
+As a **security** engineer (or eligible role-holder), I want a workflow that produces a typed `ThreatModel`
+for a feature or system surface on the lifecycle — assets, threats, mitigations, residual risk — so that
+security design is explicit, reviewed, and accepted before implementation, instead of an afterthought.
+
+## Priority
+
+P3 / Wave 3 — proactive security; naturally paired with 41-10 system design.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [Design (41-10)?, issue, context-scan, data-flow]` /
+`produces: ThreatModel`. Produce cell `(security, threat-model)`.
+
+## Produced document
+
+`ThreatModel` (41-1): STRIDE (or configured) categorisation; each threat has asset + mitigation +
+residual-risk; unmitigated high-risk ⇒ escalation. `issueId` lineage. Reviewed via security/architect lens.
+
+## Events
+
+`THREATMODEL.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; unmitigated high-risk threats always escalate regardless of dial and can
+seed security tasks. Accepted model informs `plan-generation` and 41-15 verification.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; security accepts.
+- **85–100:** agent drafts and self-accepts a fully-mitigated model; any unmitigated high-risk escalates.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `ThreatModel` validated (categorisation, mitigation+residual per threat).
+2. Unmitigated high-risk cannot be accepted silently — it is a typed escalation.
+3. Consumable by `plan-generation`/41-15 via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`ThreatModel` type), Epic 39 (lifecycle, review, store).
+- **Related:** consumes 41-10.
+
+## Estimated Effort
+
+4 days

--- a/docs/stories/epic-41/story-41-2/41-2-acceptance-criteria-authoring.md
+++ b/docs/stories/epic-41/story-41-2/41-2-acceptance-criteria-authoring.md
@@ -1,0 +1,61 @@
+# Story 41-2: Acceptance-Criteria Authoring Workflow
+
+Status: drafted
+
+## User Story
+
+As a **product owner** (or an eligible role-holder at lower autonomy), I want a workflow that turns an
+issue + its clarified requirements into a typed, testable **AcceptanceCriteria** document on the standard
+lifecycle, so that "done" is defined once, reviewed, accepted, and then consumed by acceptance
+verification (41-15) and the merge gate — instead of being implicit in a plan or a reviewer's head.
+
+## Priority
+
+P0 / Wave 1 — highest single-story leverage. It is the upstream anchor for 41-15 and gives the merge/accept
+gates an explicit definition-of-done to check against.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [issue, Clarification?, Findings?]` /
+`produces: AcceptanceCriteria`. Produce cell `(product_owner, define-acceptance-criteria)`.
+
+## Produced document
+
+`AcceptanceCriteria` (41-1): independently verifiable criteria in Given/When/Then or checklist form,
+bound to `issueId`, no criterion referencing out-of-scope work. Reviewed via the unified `Review`
+(single reviewer default: a second PO or tester lens; panel by policy).
+
+## Events
+
+`ACCEPTANCE_CRITERIA.STARTED` → `.DRAFTED` → `.ACCEPTED` / typed-escalation, alongside generic
+`DOCUMENT.*`. All tagged `issueId`/`repository`/`tenantId`.
+
+## Orchestrator / user interaction
+
+Accept gate publishes `AcceptanceRequest`; orchestrator routes per rules + autonomy. A holder of the PO
+role (or the initiator) can accept in the Task View or by asking the orchestrator in chat.
+
+## Autonomy behavior
+
+- **70–84:** produce is assigned to a human PO; accept is a human decision.
+- **85–94:** agent drafts, human accepts.
+- **95–100:** agent drafts and self-accepts unless an always-escalate class (e.g. contract-affecting
+  criteria) is configured.
+
+## Acceptance Criteria
+
+1. Rebuilt as a thin lifecycle binding; no bespoke parse/terminal.
+2. Output validated by the `AcceptanceCriteria` type; validation failure flows the repair/review/escalation
+   rings, never a dead end.
+3. Accepted document persisted with lineage: Issue → Clarification? → AcceptanceCriteria → Reviews.
+4. 41-15 can read the latest accepted `AcceptanceCriteria` for an issue via the 39-11 store.
+5. `[ResumeBehavior(Both)]`; passes the 39-10 structural test with no allowlist entry.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`AcceptanceCriteria` type), Epic 39 lifecycle/store/accept.
+- **Unblocks:** 41-15, merge-gate consumption.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-20/41-20-scheduled-security-audit.md
+++ b/docs/stories/epic-41/story-41-20/41-20-scheduled-security-audit.md
@@ -1,0 +1,57 @@
+# Story 41-20: Scheduled Security Audit Workflow
+
+Status: drafted
+
+## User Story
+
+As a **security** engineer (or eligible role-holder), I want a scheduled workflow that audits dependencies,
+scans for exposed secrets, and checks compliance posture, producing a typed `Findings` report, so that
+security drift is caught on a cadence and routed — not discovered during an incident.
+
+## Priority
+
+P1 / Wave 2 — recurring, high-consequence; complements the reactive 41-21.
+
+## Scope
+
+Scheduled sweep → thin binding over `document-lifecycle`. `consumes: [dependency manifest + advisories,
+secret-scan surface, compliance checklist]` / `produces: Findings`. Produce cells
+`(security, audit-dependencies)`, `(security, audit-secrets)`, `(security, review-compliance)` — run as
+parallel lenses whose findings aggregate into one ranked `Findings` document.
+
+## Produced document
+
+`Findings`: each finding cites the vulnerable package/secret/control as evidence, with
+severity + remediation; ranked; high-severity unmitigated ⇒ escalation.
+
+## Events
+
+`SECURITY_AUDIT.STARTED`/`.LENS`/`.REPORT` alongside `DOCUMENT.*`, tagged `repository`/`tenantId`.
+
+## Orchestrator / user interaction
+
+Accepted report routes per autonomy; each actionable finding is assigned to the owning role (dev for a
+dep bump — can seed 41-12; security for a control gap); an exposed live secret is an always-escalate class
+that also triggers `rotate-secret`.
+
+## Autonomy behavior
+
+- **70–84:** agent audits; security reviews before findings are actioned.
+- **85–100:** agent audits and self-accepts; low-risk dep bumps auto-assigned; exposed-secret / high-CVSS
+  always escalates regardless of dial.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent; each lens fail-closed (a lens failure is recorded, not dropped).
+2. Findings cite concrete evidence with severity + remediation; empty ⇒ valid empty report.
+3. Exposed-secret path always escalates and integrates with `rotate-secret`.
+4. `[ResumeBehavior(LatestStateReEntry)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Findings`, lifecycle, store, task routing), scheduler pattern; `rotate-secret`.
+- **Related:** feeds 41-12 dependency-upgrade planning.
+
+## Estimated Effort
+
+5–6 days

--- a/docs/stories/epic-41/story-41-21/41-21-security-incident-analysis.md
+++ b/docs/stories/epic-41/story-41-21/41-21-security-incident-analysis.md
@@ -1,0 +1,54 @@
+# Story 41-21: Security Incident Analysis Workflow
+
+Status: drafted
+
+## User Story
+
+As a **security** engineer (or eligible role-holder), I want a workflow that analyzes a security incident
+into a typed `Diagnosis` on the lifecycle — ranked hypotheses, blast radius, affected assets, remediation
+— so that security incidents get a rigorous, evidence-cited root-cause and tracked follow-ups, not an
+ad-hoc scramble.
+
+## Priority
+
+P3 / Wave 3 — reactive security; sibling to devops 41-22.
+
+## Scope
+
+Reactive trigger (security alert / event) → thin binding over `document-lifecycle`. `consumes: [alert +
+DCB events, audit Findings (41-20)?, affected surface context]` / `produces: Diagnosis`. Produce cell
+`(security, analyze-security-incident)`.
+
+## Produced document
+
+`Diagnosis` (39-4): hypotheses ranked by confidence; fix/remediation references affected files/assets;
+blast radius stated. `repository` lineage. Reviewed via security lens.
+
+## Events
+
+`SECURITY_INCIDENT.STARTED` → `.DIAGNOSED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; a confirmed active incident is an always-escalate class that pages the
+security role and can trigger `rotate-secret` / a remediation plan; follow-ups route to owning roles.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts the diagnosis; security accepts and directs response.
+- **85–100:** agent diagnoses and self-accepts low-severity findings; active/high-severity always escalates.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Diagnosis` validated (ranked hypotheses, remediation references).
+2. Active-incident path always escalates and can dispatch `rotate-secret`/remediation.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Diagnosis`, lifecycle, store, escalation); `rotate-secret`.
+- **Related:** consumes 41-20; feeds 41-22 postmortem when cross-cutting.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-22/41-22-incident-response-and-postmortem.md
+++ b/docs/stories/epic-41/story-41-22/41-22-incident-response-and-postmortem.md
@@ -1,0 +1,62 @@
+# Story 41-22: Incident Response & Postmortem Workflow
+
+Status: drafted
+
+## User Story
+
+As a **devops** engineer (or eligible role-holder), I want a workflow that runs an operational incident
+from diagnosis through response to a written postmortem on the lifecycle, so that incidents produce a
+tracked root-cause `Diagnosis`, coordinated response, and a blameless postmortem with action items —
+instead of an untracked firefight.
+
+## Priority
+
+P3 / Wave 3 — high-consequence reactive ops; seeds 41-26 runbooks.
+
+## Scope
+
+Reactive trigger (alert / health-review escalation) → thin binding(s) over `document-lifecycle`, run as a
+short sequence:
+1. `produces: Diagnosis` — cell `(devops, diagnose-incident)`.
+2. `produces: Plan` (response/rollback) — cells `(devops, plan-incident-response)` / `(devops, rollback)`.
+3. `produces: prose (postmortem, audience=engineering)` — cell `(devops, write-postmortem)`.
+`consumes: [alert, DCB deployment/health events, affected service context]`.
+
+## Produced documents
+
+`Diagnosis` (ranked hypotheses, affected files), `Plan` (response/rollback steps), and an audience-tagged
+prose postmortem (timeline / root cause / impact / action items). `repository`/incident lineage.
+
+## Events
+
+`INCIDENT.STARTED` → `.DIAGNOSED` → `.RESPONSE_ACCEPTED` → `.RESOLVED` → `POSTMORTEM.ACCEPTED` alongside
+`DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Active incident is an always-escalate class that pages the devops role; the response plan's accept gate is
+time-sensitive (bounded human window, then orchestrator-decides per policy). Postmortem action items route
+to owning roles and can dispatch 41-26.
+
+## Autonomy behavior
+
+- **70–84:** agent diagnoses + drafts response; a human approves before executing rollback/response.
+- **85–100:** agent may execute a pre-approved low-risk response class; destructive/prod rollback always
+  escalates; postmortem drafted and human-accepted by default.
+
+## Acceptance Criteria
+
+1. Each stage is a thin lifecycle binding producing its typed/prose document; no bespoke terminals.
+2. Active-incident always-escalate; destructive response always requires the configured decision.
+3. Postmortem action items produce role-scoped Task View entries; can dispatch 41-26.
+4. `[ResumeBehavior(Both)]` across the sequence; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Diagnosis`, `Plan`, prose, lifecycle, store, escalation), Epic 40 for any
+  code/infra response step.
+- **Related:** consumes 41-23 escalations; feeds 41-26; sibling to 41-21.
+
+## Estimated Effort
+
+5–6 days

--- a/docs/stories/epic-41/story-41-23/41-23-capacity-and-health-review.md
+++ b/docs/stories/epic-41/story-41-23/41-23-capacity-and-health-review.md
@@ -1,0 +1,54 @@
+# Story 41-23: Capacity & Health Review Workflow
+
+Status: drafted
+
+## User Story
+
+As a **devops** engineer (or eligible role-holder), I want a scheduled workflow that reviews system health
+signals and capacity trends and produces a typed `Findings` report, so that saturation and degradation are
+flagged proactively and routed, instead of surfacing only as an incident.
+
+## Priority
+
+P2 / Wave 2 — recurring, ops-hygiene; pairs with the reactive 41-22.
+
+## Scope
+
+Scheduled sweep → thin binding over `document-lifecycle`. `consumes: [health/metric signals, deployment +
+analytics events]` / `produces: Findings`. Produce cells `(devops, monitor-health)` and
+`(devops, assess-capacity)` as lenses aggregating into one report.
+
+## Produced document
+
+`Findings`: each finding cites a metric/trend as evidence, with severity + recommended action; ranked;
+projected-breach items flagged.
+
+## Events
+
+`HEALTH_REVIEW.STARTED`/`.REPORT` alongside `DOCUMENT.*`, tagged `repository`/`tenantId`/window.
+
+## Orchestrator / user interaction
+
+Accepted report routes per autonomy; a projected-capacity breach or degraded-health finding is assigned to
+the devops role's Task View or self-actioned at high autonomy (can seed a scaling/infra task).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; devops reviews before actioning.
+- **85–100:** agent drafts and self-accepts; routine scaling recommendations auto-assigned; a breach above
+  a configured threshold always escalates.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent per window; each lens fail-closed.
+2. Findings cite concrete metric evidence; empty ⇒ valid empty report.
+3. `[ResumeBehavior(LatestStateReEntry)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (`Findings`, lifecycle, store), scheduler pattern, analytics/health signals
+  (28-10 rollup, 4-7 query API).
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-24/41-24-release-notes-and-changelog.md
+++ b/docs/stories/epic-41/story-41-24/41-24-release-notes-and-changelog.md
@@ -1,0 +1,55 @@
+# Story 41-24: Release Notes & Changelog Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tech writer** (or eligible role-holder), I want a release-triggered workflow that composes release
+notes (audience: users) and updates the changelog (audience: developers) from the merged changes in a
+release window, as prose documents on the lifecycle, so that every release ships accurate, reviewed notes
+without hand-assembly.
+
+## Priority
+
+P1 / Wave 2 — release-triggered, recurring, user-facing; a clear prose-on-lifecycle win.
+
+## Scope
+
+Triggered by a release/tag event → thin binding over `document-lifecycle`. `consumes: [merged PRs +
+Decompositions/Plans in the release window, DCB MERGE.* events]` / `produces: prose (release-notes,
+audience=user)` and `prose (changelog, audience=developer)`. Produce cells `(tech_writer,
+write-release-notes)` and `(tech_writer, update-changelog)`; review via `(tech_writer, review-docs)`.
+
+## Produced documents
+
+Two audience-tagged prose documents, `repository`/release-lineaged. *Prose stays prose* — markdown, no
+forced schema; review stage is a `Review` over the text.
+
+## Events
+
+`RELEASE_NOTES.STARTED`/`.DRAFTED`/`.ACCEPTED`; `CHANGELOG.UPDATED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accepted notes route per autonomy; publishing to the release/GitHub surface is the post-accept action. A
+customer-facing release can be a configured always-escalate class (human sign-off before publish).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; tech writer/PO accepts before publish.
+- **85–100:** agent drafts and self-accepts internal changelog; customer-facing notes publish per policy
+  (always-escalate optional).
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; both outputs ride the lifecycle as audience-tagged prose reviewed by a `Review`.
+2. Window derivation is deterministic (the release just cut); re-run is idempotent.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose handling, lifecycle, review, store), 4-7 query API for the window.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-25/41-25-user-and-api-documentation.md
+++ b/docs/stories/epic-41/story-41-25/41-25-user-and-api-documentation.md
@@ -1,0 +1,54 @@
+# Story 41-25: User & API Documentation Workflow
+
+Status: drafted
+
+## User Story
+
+As a **tech writer** (or eligible role-holder), I want a merge-triggered workflow that drafts or updates
+user-facing docs and API reference for a shipped feature, as audience-tagged prose on the lifecycle, so
+that documentation tracks the code instead of lagging it.
+
+## Priority
+
+P2 / Wave 2 — merge-triggered, recurring; keeps docs in sync with delivery.
+
+## Scope
+
+Triggered when a feature merges (or on demand) → thin binding over `document-lifecycle`. `consumes:
+[merged diff, Plan, AcceptanceCriteria?, existing docs]` / `produces: prose (user-docs, audience=user)`
+and/or `prose (api-docs, audience=developer)`. Produce cells `(tech_writer, write-user-docs)` and
+`(tech_writer, write-api-docs)`; review via `(tech_writer, review-docs)`.
+
+## Produced documents
+
+Audience-tagged prose docs, `issueId`/`repository`-lineaged. Review stage is a `Review` over the text
+(accuracy-against-diff is the key check).
+
+## Events
+
+`USER_DOCS.STARTED`/`.DRAFTED`/`.ACCEPTED`; `API_DOCS.UPDATED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accepted docs route per autonomy; publishing to the docs surface (e.g. wiki.tamma.dev) is the post-accept
+action. Missing/contradicting existing docs surface as review concerns, not silent overwrites.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; tech writer accepts.
+- **85–100:** agent drafts and self-accepts; contract-affecting API-doc changes can be always-escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; prose reviewed by a `Review` that checks accuracy against the merged diff.
+2. Idempotent per feature; updates existing docs rather than duplicating.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose handling, lifecycle, review, store).
+- **Related:** consumes 41-2 AcceptanceCriteria when present.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-26/41-26-runbook-and-ops-docs-authoring.md
+++ b/docs/stories/epic-41/story-41-26/41-26-runbook-and-ops-docs-authoring.md
@@ -1,0 +1,55 @@
+# Story 41-26: Runbook & Ops-Docs Authoring Workflow
+
+Status: drafted
+
+## User Story
+
+As a **devops** engineer / tech writer (or eligible role-holder), I want a workflow that authors an
+operational runbook for a service or a recurring operational task, as audience-tagged prose on the
+lifecycle, so that on-call procedures are captured, reviewed, and kept current instead of tribal knowledge.
+
+## Priority
+
+P3 / Wave 3 — proactive ops hygiene; naturally seeded by 41-22 postmortems.
+
+## Scope
+
+Triggered on demand or by a postmortem action item → thin binding over `document-lifecycle`. `consumes:
+[service/infra context (context-scan), incident Diagnosis/postmortem?, deployment config]` / `produces:
+prose (runbook, audience=ops)`. Produce cell `(devops, write-runbook)`; review via `(tech_writer,
+review-docs)` or an ops peer.
+
+## Produced document
+
+Audience-tagged prose runbook (symptoms → checks → remediation → escalation), `repository`-lineaged.
+Review stage is a `Review` over the text.
+
+## Events
+
+`RUNBOOK.STARTED`/`.DRAFTED`/`.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accepted runbook routes per autonomy and is published to the ops docs surface; a 41-22 postmortem
+"add/update runbook" action item can dispatch this workflow directly.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; devops accepts.
+- **85–100:** agent drafts and self-accepts; a runbook covering a regulated/critical path can be
+  always-escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; prose reviewed by a `Review`.
+2. Can be dispatched as a postmortem follow-up with the incident `Diagnosis` as input.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose handling, lifecycle, review, store), `context-gathering`.
+- **Related:** dispatched by 41-22.
+
+## Estimated Effort
+
+2–3 days

--- a/docs/stories/epic-41/story-41-27/41-27-user-flow-and-wireframe-drafting.md
+++ b/docs/stories/epic-41/story-41-27/41-27-user-flow-and-wireframe-drafting.md
@@ -1,0 +1,58 @@
+# Story 41-27: User-Flow & Wireframe/UI-Spec Drafting Workflow
+
+Status: drafted
+
+## User Story
+
+As a **UX / designer** (or eligible role-holder), I want a workflow that drafts the user flows and a
+structured UI spec for a feature as a typed `UxSpec` on the lifecycle — screens, states, transitions,
+accessibility requirements — so that interface design is proposed, reviewed, and accepted before
+implementation, instead of being invented in code.
+
+## Priority
+
+P3 / Wave 4 — opens the entirely-missing UX/design surface. Depends on 41-1's `ux_designer` role +
+`UxSpec` type.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [issue, AcceptanceCriteria (41-2)?, Findings]` /
+`produces: UxSpec`. Produce cells `(ux_designer, draft-user-flow)` and `(ux_designer, author-ui-spec)`
+(41-1), folded into one `UxSpec` document.
+
+## Produced document
+
+`UxSpec` (41-1): every flow has entry + success + error states; each screen/step lists a11y requirements;
+maps to acceptance criteria. `issueId` lineage. Reviewed via 41-28 / product-owner lens.
+
+## Events
+
+`UX_SPEC.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; accepted `UxSpec` feeds `plan-generation` and 41-2/41-15 (its a11y +
+state requirements become acceptance criteria). Pixel-level mockup rendering is out of scope (README) —
+this produces the structured spec, not rendered artwork.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts flows/spec; a human designer/PO accepts.
+- **85–100:** agent drafts and self-accepts within policy; brand/UX-guideline-affecting specs can be
+  always-escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `UxSpec` validated (flow states, a11y per screen, criteria mapping).
+2. Consumes `AcceptanceCriteria` when present; spec traces to criteria.
+3. Consumable by `plan-generation`/41-28 via 39-11.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`ux_designer` role, `UxSpec` type), Epic 39 (lifecycle, review, store).
+- **Related:** feeds 41-28; consumed by `plan-generation`.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-28/41-28-design-review-and-accessibility-audit.md
+++ b/docs/stories/epic-41/story-41-28/41-28-design-review-and-accessibility-audit.md
@@ -1,0 +1,55 @@
+# Story 41-28: Design Review & Accessibility Audit Workflow
+
+Status: drafted
+
+## User Story
+
+As a **UX / designer** (or eligible role-holder), I want a workflow that reviews a `UxSpec` or a shipped UI
+against usability heuristics and accessibility standards, producing a typed `Review` on the lifecycle, so
+that design and a11y quality are checked and routed — not left to chance.
+
+## Priority
+
+P3 / Wave 4 — the review counterpart to 41-27. Depends on 41-1's `ux_designer` role.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [UxSpec (41-27) or shipped UI diff, AcceptanceCriteria?]`
+/ `produces: Review` (subject = the spec or UI; issues carry a11y standard + severity + fix). Produce cells
+`(ux_designer, review-design)` and `(ux_designer, audit-accessibility)` (41-1) as lenses aggregating into
+one `Review`.
+
+## Produced document
+
+Unified `Review`: each issue carries category (usability | a11y) + severity + WCAG (or configured)
+reference + fix; blocking a11y issues ⇒ not approvable (39-4 invariant). `issueId` lineage.
+
+## Events
+
+`DESIGN_REVIEW.STARTED` → `.VERDICT` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Verdict routes through the accept gate; a blocking a11y failure escalates with lineage and can loop back to
+41-27 or the coding step. Legal/compliance-relevant a11y failures can be an always-escalate class.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts the review; a human designer signs off.
+- **85–100:** agent review self-accepted for non-blocking verdicts; blocking a11y issues always escalate.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; validated unified `Review`; blocking a11y issues cannot be laundered into approval.
+2. a11y lens references a configured standard (WCAG default) per issue.
+3. Verdict integrates as a gate input for UI-affecting merges.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`ux_designer` role), Epic 39 (`Review`, lifecycle, review producers, store).
+- **Related:** reviews 41-27 output.
+
+## Estimated Effort
+
+4 days

--- a/docs/stories/epic-41/story-41-3/41-3-backlog-prioritization-and-grooming.md
+++ b/docs/stories/epic-41/story-41-3/41-3-backlog-prioritization-and-grooming.md
@@ -1,0 +1,54 @@
+# Story 41-3: Backlog Prioritization & Grooming Workflow
+
+Status: drafted
+
+## User Story
+
+As a **product owner** (or eligible role-holder), I want a workflow that ranks a set of backlog items into
+a typed `BacklogOrdering` on the lifecycle — with value/effort rationale per item — so that prioritisation
+is explicit, reviewed, accepted, and consumable by sprint planning, instead of an ad-hoc reorder.
+
+## Priority
+
+P2 / Wave 3 — feeds 41-6 sprint planning and 41-4 roadmap.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [backlog items (issues), TriageDecisions from
+41-11/41-16/41-17, Findings]` / `produces: BacklogOrdering`. Produce cell
+`(product_owner, prioritize-backlog)`.
+
+## Produced document
+
+`BacklogOrdering` (41-1): total order over the referenced item set; every item has a rationale +
+value/effort estimate; no ties. `tenantId`/`repository` lineage.
+
+## Events
+
+`BACKLOG.GROOMING.STARTED` → `.ORDERED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; accepted ordering is the input 41-6 reads. Large reprioritisations
+affecting committed work can be an always-escalate class.
+
+## Autonomy behavior
+
+- **70–84:** agent proposes an ordering; PO accepts.
+- **85–100:** agent orders and self-accepts within policy; reordering above a churn threshold escalates.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `BacklogOrdering` validated (total order, rationale per item, no ties).
+2. Consumes upstream `TriageDecision`/`Findings` as ranking evidence.
+3. Consumable by 41-6 via the 39-11 store.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`BacklogOrdering` type), Epic 39 (lifecycle, store, accept).
+- **Unblocks:** 41-6.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-4/41-4-roadmap-shaping.md
+++ b/docs/stories/epic-41/story-41-4/41-4-roadmap-shaping.md
@@ -1,0 +1,51 @@
+# Story 41-4: Roadmap Shaping Workflow
+
+Status: drafted
+
+## User Story
+
+As a **product owner** (or eligible role-holder), I want a workflow that shapes a themed, time-horizon
+roadmap from the backlog and strategic inputs, as an audience-tagged prose document on the lifecycle, so
+that direction is captured, reviewed, and accepted with lineage instead of living in a slide deck.
+
+## Priority
+
+P3 / Wave 3 — strategic altitude; lower cadence than sprint/backlog work.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [BacklogOrdering (41-3), Findings, stakeholder inputs]`
+/ `produces: prose (roadmap, audience=stakeholder)`. Produce cell `(product_owner, plan-roadmap)`.
+
+## Produced document
+
+Audience-tagged prose roadmap (themes × horizons with rationale). *Prose stays prose*; review stage is a
+`Review` over the text. `tenantId` lineage.
+
+## Events
+
+`ROADMAP.STARTED`/`.DRAFTED`/`.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; a roadmap is typically a human-accepted artifact even at high autonomy
+(strategic) — expressed as an always-escalate policy class, not hardcoded.
+
+## Autonomy behavior
+
+- **70–94:** agent drafts; PO accepts.
+- **95–100:** agent drafts; acceptance still routed to a human by default policy for strategic scope.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; prose reviewed by a `Review`.
+2. Consumes `BacklogOrdering`/`Findings` as inputs.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose handling, lifecycle, review, store); 41-3.
+
+## Estimated Effort
+
+3 days

--- a/docs/stories/epic-41/story-41-5/41-5-stakeholder-and-status-reporting.md
+++ b/docs/stories/epic-41/story-41-5/41-5-stakeholder-and-status-reporting.md
@@ -1,0 +1,53 @@
+# Story 41-5: Stakeholder & Status Reporting Workflow
+
+Status: drafted
+
+## User Story
+
+As a **product owner / project manager** (or eligible role-holder), I want a scheduled workflow that
+synthesizes progress against commitments from the DCB stream into an audience-tagged status update, so that
+stakeholders get an accurate, evidence-backed report on a cadence without manual assembly.
+
+## Priority
+
+P2 / Wave 3 — recurring, cross-role; reuses the 41-7 event-read pattern at a stakeholder altitude.
+
+## Scope
+
+Scheduled trigger → thin binding over `document-lifecycle`. `consumes: [SprintPlan (41-6), DCB events for
+the period, blocker/escalation events]` / `produces: prose (status-update, audience=stakeholder)`. Produce
+cell `(product_owner, summarize-stakeholder)` (PM variant `(project_manager, report-status)` via 41-1).
+
+## Produced document
+
+Audience-tagged prose status update (accomplished / in-flight / at-risk / next), each claim traceable to
+DCB evidence. `tenantId`/period lineage. Review stage is a `Review` over the text.
+
+## Events
+
+`STATUS_REPORT.STARTED`/`.DRAFTED`/`.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accepted report delivered via the orchestrator to the stakeholder audience; sensitive/external reporting
+can be an always-escalate class (human sign-off before send).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; PO/PM accepts before send.
+- **85–100:** agent drafts and self-accepts internal reports; external stakeholder reports per policy.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent per period; every claim cites DCB evidence.
+2. Thin lifecycle binding; prose reviewed by a `Review`.
+3. `[ResumeBehavior(Both)]` (scheduled + accept-gate); 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose handling, lifecycle, review, store, 4-7 query API), scheduler pattern.
+- **Related:** consumes 41-6 SprintPlan.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-6/41-6-sprint-planning.md
+++ b/docs/stories/epic-41/story-41-6/41-6-sprint-planning.md
@@ -1,0 +1,55 @@
+# Story 41-6: Sprint Planning Workflow
+
+Status: drafted
+
+## User Story
+
+As a **scrum master / project manager** (or eligible role-holder), I want a workflow that commits a
+capacity-bounded set of prioritised items to a time-box as a typed `SprintPlan` on the lifecycle, so that
+sprint commitment is explicit, reviewed, and accepted — with owners and estimates — instead of decided in
+an untracked meeting.
+
+## Priority
+
+P2 / Wave 3 — the agile-cadence anchor; consumes 41-3, feeds 41-7/41-8.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [BacklogOrdering (41-3), team capacity, prior SprintPlan
+carry-over]` / `produces: SprintPlan`. Produce cell `(scrum_master, plan-sprint)` (41-1).
+
+## Produced document
+
+`SprintPlan` (41-1): committed set ≤ stated capacity; every committed item has an owner-role + estimate;
+carry-over flagged. `tenantId`/`repository`/sprint lineage.
+
+## Events
+
+`SPRINT.PLANNING.STARTED` → `.PLANNED` → `.ACCEPTED` / `.CLOSED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; the accepted plan seeds Task View assignments per committed item's
+owner-role. Over-commit beyond capacity is a validator rejection, not an accept-time surprise.
+
+## Autonomy behavior
+
+- **70–84:** agent proposes; scrum master/PM accepts the commitment.
+- **85–100:** agent plans and self-accepts within capacity; commitment beyond a configured capacity band
+  always escalates.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `SprintPlan` validated (capacity bound, owner+estimate per item, carry-over).
+2. Consumes accepted `BacklogOrdering`; hard-fails loud if none exists.
+3. Committed items produce role-scoped Task View entries via 39-20.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`scrum_master` role, `SprintPlan` type), 41-3, Epic 39 (lifecycle, store, routing).
+- **Related:** 41-7, 41-8.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-7/41-7-standup-synthesis.md
+++ b/docs/stories/epic-41/story-41-7/41-7-standup-synthesis.md
@@ -1,0 +1,59 @@
+# Story 41-7: Standup Synthesis Workflow
+
+Status: drafted
+
+## User Story
+
+As a **scrum master** (or eligible role-holder), I want a scheduled workflow that reads the DCB event
+stream for a team/repo over the last day and synthesizes a **standup digest** (what moved, what's blocked,
+what's at risk) as a typed `Findings` document, so that the daily status picture is assembled from the
+audit trail automatically instead of collected by hand.
+
+## Priority
+
+P1 / Wave 2 — recurring, event-sourced, compounding. Replaces a standing daily chore and showcases the
+"read the stream on a cron" pattern for 41-11/41-16/41-20/41-23.
+
+## Scope
+
+Scheduled trigger (the `HourlyAnalyticsRollupScheduler` cron pattern, daily per configured team-window) →
+thin binding over `document-lifecycle`. `consumes: [DCB events window, open Decompositions/Plans/PRs,
+blocker events]` / `produces: Findings`. Produce cell `(scrum_master, synthesize-standup)` (41-1).
+
+## Produced document
+
+`Findings`: each item cites its source event(s) as evidence; ranked by risk; blocked/at-risk items flagged
+with the owning role. `issueId`/`repository` lineage on every finding.
+
+## Events
+
+`STANDUP.SYNTHESIS.STARTED` → `.DIGEST` alongside `DOCUMENT.*`, tagged `repository`/`tenantId`/window.
+
+## Orchestrator / user interaction
+
+The accepted digest is delivered to the team via the orchestrator (chat post + Task View items for each
+flagged blocker, routed to the owning role). Low-value/empty windows produce an empty-but-valid `Findings`
+(no false noise).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts; scrum master reviews before the digest is broadcast.
+- **85–100:** agent synthesizes and self-accepts; each flagged blocker still routes to its owning role's
+  Task View as an assigned follow-up.
+
+## Acceptance Criteria
+
+1. Scheduled, tenant-scoped, idempotent per window (re-running the same window is a no-op re-read).
+2. Every finding cites concrete DCB evidence; confidence/relevance ∈ [0,1]; empty window ⇒ valid empty digest.
+3. `[ResumeBehavior(LatestStateReEntry)]`; 39-10 structural test green without allowlist.
+4. Blocker follow-ups land in the correct role's Task View via the 39-20 audience resolver.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`scrum_master` role), Epic 39 (`Findings`, lifecycle, store, task routing, 4-7 query
+  API), scheduler pattern.
+- **Related:** feeds 41-8 retro input.
+
+## Estimated Effort
+
+4–5 days

--- a/docs/stories/epic-41/story-41-8/41-8-retrospective-facilitation.md
+++ b/docs/stories/epic-41/story-41-8/41-8-retrospective-facilitation.md
@@ -1,0 +1,56 @@
+# Story 41-8: Retrospective Facilitation Workflow
+
+Status: drafted
+
+## User Story
+
+As a **scrum master** (or eligible role-holder), I want a workflow that assembles a retrospective from a
+sprint's DCB history — what went well, what didn't, action items — as a `Findings` document (with prose
+narrative) on the lifecycle, so that retros produce durable, tracked action items instead of evaporating
+after the meeting.
+
+## Priority
+
+P3 / Wave 3 — per-sprint cadence; consumes 41-6/41-7 outputs.
+
+## Scope
+
+Triggered at sprint close (or scheduled) → thin binding over `document-lifecycle`. `consumes: [SprintPlan
+(41-6), standup digests (41-7), DCB events for the sprint, blocker/escalation events]` / `produces:
+Findings` (retro items with evidence) plus a prose narrative summary. Produce cell
+`(scrum_master, facilitate-retro)` (41-1).
+
+## Produced document
+
+`Findings`: each retro item cites sprint evidence; action items ranked and role-owned. Accompanying prose
+narrative is audience-tagged (team). `tenantId`/sprint lineage.
+
+## Events
+
+`RETRO.STARTED` → `.SYNTHESIZED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accepted action items route to owning roles' Task Views (and can seed 41-3/41-11 backlog candidates). The
+retro is deliberately an **artifact around** the human conversation, not a replacement for it (README
+out-of-scope note).
+
+## Autonomy behavior
+
+- **70–84:** agent drafts the retro; scrum master reviews/accepts before broadcast.
+- **85–100:** agent synthesizes and self-accepts; action items auto-assigned within the eligible set.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; `Findings` items cite concrete sprint evidence.
+2. Action items produce role-scoped Task View entries via 39-20.
+3. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** 41-1 (`scrum_master` role), Epic 39 (`Findings`, lifecycle, store, routing, 4-7 query API).
+- **Related:** 41-6, 41-7.
+
+## Estimated Effort
+
+3–4 days

--- a/docs/stories/epic-41/story-41-9/41-9-adr-authoring.md
+++ b/docs/stories/epic-41/story-41-9/41-9-adr-authoring.md
@@ -1,0 +1,57 @@
+# Story 41-9: ADR Authoring Workflow
+
+Status: drafted
+
+## User Story
+
+As an **architect** (or eligible role-holder), I want a workflow that captures a significant technical
+decision as an **Architecture Decision Record** — a prose document with an audience tag — on the standard
+lifecycle, so that decisions are drafted, reviewed, accepted, and stored with issue lineage instead of
+living only in chat or a reviewer's memory.
+
+## Priority
+
+P1 / Wave 1 — cheap, high-value, and the reference implementation of the **prose-on-lifecycle** path that
+the whole tech-writer / devops / PM prose family (41-4, 41-5, 41-22, 41-24, 41-25, 41-26, 41-8) reuses.
+
+## Scope
+
+Thin binding over `document-lifecycle`. `consumes: [issue, Design?, Findings?]` / `produces: prose (ADR,
+audience=engineering)`. Produce cell `(architect, write-adr)`. *Prose stays prose* (Epic 39): markdown +
+audience tag, no forced schema; the review stage is a `Review` over the prose.
+
+## Produced document
+
+Prose ADR (context / decision / consequences / alternatives-considered, but structure is convention, not
+validated schema), audience-tagged, `issueId`-lineaged.
+
+## Events
+
+`ADR.STARTED` → `.DRAFTED` → `.ACCEPTED` alongside `DOCUMENT.*`.
+
+## Orchestrator / user interaction
+
+Accept gate routes per autonomy; a decision affecting a public contract can be a configured always-escalate
+class. Accepted ADRs are queryable per issue and per repo.
+
+## Autonomy behavior
+
+- **70–84:** agent drafts, architect accepts.
+- **85–100:** agent drafts and self-accepts unless the decision touches an always-escalate class.
+
+## Acceptance Criteria
+
+1. Thin lifecycle binding; prose rides the lifecycle with an audience tag; review stage produces a `Review`
+   over the ADR text.
+2. No bespoke parse/terminal; non-success exits are typed escalations with lineage.
+3. Accepted ADR persisted with lineage and retrievable via the 39-11 store.
+4. `[ResumeBehavior(Both)]`; 39-10 structural test green without allowlist.
+
+## Dependencies
+
+- **Blocking:** Epic 39 (prose-document handling, lifecycle, review, store).
+- **Related:** consumes 41-10 System Design output when present.
+
+## Estimated Effort
+
+2–3 days


### PR DESCRIPTION
## Epic 41 — Full-Team Workflow Coverage

A gap analysis + a new epic that extends Tamma's stated intent (**automate the entire software-development process**) to the recurring activities the platform doesn't yet own as workflows. Today the Epic 39 spine only *runs* for the `issue → decompose → plan → tasks → TDD → PR → review → merge → deploy` happy path plus intake and mentorship; many role activities exist only as a **prompt cell** (dispatchable, but with no owning workflow that saves documents, rides the lifecycle, or routes acceptance) — and the UX/designer/PM/scrum role families don't exist at all.

### How it was built
Inventoried the **45** existing Elsa workflows, the **8-role × 79-action** taxonomy (`Tamma.Core/Agents`), and the **79** prompt cells; built a role × activity coverage matrix (✅/◑/✗); authored **28 stories** for the gaps. No new architecture — every workflow reuses the Epic 39 substrate.

### The five rules every Epic 41 workflow follows
1. **Thin binding over `document-lifecycle`** (the 39-12/13/14 migration pattern); prose outputs ride the lifecycle as prose documents with an audience tag.
2. **DCB events** — generic `DOCUMENT.*` + a domain family (`ADR.*`, `SPRINT.*`, `THREATMODEL.*`, …), `issueId`/`repository`-lineaged.
3. **Orchestrator-routed acceptance, autonomy-gated** — the gate always publishes an `AcceptanceRequest` and suspends (39-8); the orchestrator decides who decides per the 70–100 dial.
4. **Human-or-agent execution** — lower autonomy assigns the step to a human holder of the tenant role (Task View, 39-20 scoped); higher autonomy runs the appropriate `AgentRole`. Same `(role, action)` binding either way.
5. **Resumable by design** — `[ResumeBehavior(Both|LatestStateReEntry)]`, scheduled ones use the cron scheduler pattern; all pass the 39-10 structural test with no allowlist entry.

Vocabulary is reused from Epic 39 wherever it fits (`Findings`/`Review`/`Design`/`Plan`/`Diagnosis`/`TriageDecision`/`TestSpec`/prose); only **six** genuinely new document types are proposed (Story 41-1), each justified against the existing type it could not reuse.

### Key structural finding
The taxonomy models 8 roles but the target set names **four with no role**: `scrum_master`/`analyst` alias to `product_owner`; UX/designer/`project_manager` aren't modelled at all. **Story 41-1** adds `scrum_master`, `project_manager`, and `ux_designer` as first-class roles + the new document types. Every other story can still ship and run **human-assigned** before 41-1 lands (rule 4) — 41-1 is what unlocks *agent* execution at higher autonomy.

### The 28 stories
41-1 role & doc-type extensions · 41-2 acceptance-criteria · 41-3 backlog prioritization · 41-4 roadmap · 41-5 stakeholder/status reporting · 41-6 sprint planning · 41-7 standup synthesis · 41-8 retro · 41-9 ADR · 41-10 system design · 41-11 tech-debt/risk triage · 41-12 dependency/upgrade planning · 41-13 test-plan · 41-14 exploratory charter · 41-15 acceptance verification · 41-16 regression/flaky management · 41-17 standalone code review + PR triage · 41-18 refactor planning · 41-19 threat modeling · 41-20 scheduled security audit · 41-21 security incident analysis · 41-22 incident response & postmortem · 41-23 capacity/health review · 41-24 release notes/changelog · 41-25 user/API docs · 41-26 runbook · 41-27 UX flow/wireframe · 41-28 design review & a11y audit.

### Recommended sequencing (highest-leverage first)
1. **41-1** (enabler). 2. **Wave 1:** 41-2 acceptance-criteria, 41-15 verification, 41-17 code review/PR triage, 41-9 ADR. 3. **Wave 2 (scheduled/event-sourced):** 41-7, 41-16, 41-11, 41-20, 41-23, 41-24, 41-25. 4. **Wave 3:** planning/design depth. 5. **Wave 4:** the UX/design surface (41-27/28), gated on 41-1.

### Out of scope (in README)
Live human ceremonies as synchronous meetings (Tamma automates the artifact, not the meeting); pixel-level mockup rendering (needs a design-tool provider abstraction); hiring/budget/vendor/people-management; final prod-deploy authorization for regulated/breaking changes (already Epic 39 acceptance-rules policy).

Docs-only — no code, no migrations.


---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_