### PR TITLE
fix(39-6): wire document persistence into DocumentLifecycleWorkflow

### DIFF
--- a/.dev/findings/document-lifecycle-persist-not-wired.md
+++ b/.dev/findings/document-lifecycle-persist-not-wired.md
@@ -73,5 +73,26 @@ lineage" promise of Epic 39 is not met end-to-end at runtime.
 
 ---
 
-**Status**: 🔍 Needs Review
+## ✅ Resolution (2026-07-23)
+
+Wired `PersistDocumentInstanceActivity` into `DocumentLifecycleWorkflow`. Because the store is
+insert-only (PK = `envelope.Id`), each distinct envelope is persisted **exactly once**: at
+revise-start (before it is superseded) and at the terminal transition (accepted/rejected/escalated,
+the escalate persist gated for the no-draft case). A pre-minted `UuidV7` workflow variable
+(`TransitionEventId`) links each transition's `DOCUMENT.*` emit and its adjacent persist via
+`CorrelatingEventId` (the AC7 seam), resume-deterministic across suspend/resume, and inherits the
+39-10 re-entry gating (no double-persist on crash/re-entry). Fail-loud preserved. No schema change.
+Structure test pins the persist node set + mint→emit→persist adjacency.
+
+**Residual (deliberately not gold-plated):** the store projects terminal state + the superseded
+revision chain, NOT a row per intermediate produced→validated→reviewed state — consistent with the
+store's "read-optimized product layer, stream wins" doctrine. Per-transition status rows, if ever
+wanted, are a clean follow-up via a `SetDocumentInstanceStatus` activity over the existing
+`/api/engine/documents/{id}/status` endpoint. The `[Explicit]` execution-test harness still seeds the
+store (its `CapturingHandler` stub records the persist POST but doesn't feed the read fake) — a
+harness-only follow-up; the wiring itself is proven by the structure-test pins.
+
+---
+
+**Status**: ✅ Resolved
 **Last Updated**: 2026-07-23

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
@@ -89,6 +89,16 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         var acceptRequestedAtUtc = builder.WithVariable<string>("AcceptRequestedAtUtc", "");
         var acceptanceRequestJson = builder.WithVariable<string>("AcceptanceRequestJson", "");
 
+        // ── Story 39-11 (D6 / AC7) persist↔emit linkage ────────────────
+        // The pre-minted DOCUMENT.* transition event id, minted ONCE per
+        // persisting transition into this durable workflow variable (Elsa
+        // replays it across suspend/resume — never a bare Guid.NewGuid() at
+        // two sites). It is threaded to BOTH the emit
+        // (EmitDocumentEventActivity.EventId) and the adjacent persist
+        // (PersistDocumentInstanceActivity.CorrelatingEventId) so the
+        // domain_events row and the document_instances row share one id.
+        var transitionEventId = builder.WithVariable<string>("TransitionEventId", "");
+
         // ── Dispatch result containers ─────────────────────────────────
         var produceResult = builder.WithVariable<IDictionary<string, object>?>();
         var repairResult = builder.WithVariable<IDictionary<string, object>?>();
@@ -494,6 +504,9 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             "EmitRevisionStarted", "Emit Revision Started", DocumentEvents.RevisionStarted,
             currentDocId, documentType, currentRound, issueId, correlationId, sessionId, tenantId,
             "Revision started");
+        // AC7 — thread the pre-minted transition id so the emitted event and the
+        // adjacent PersistRevised row (the about-to-be-superseded draft) share it.
+        emitRevisionStarted.EventId = new(ctx => transitionEventId.Get(ctx));
 
         var prepareRevision = new SetVariable
         {
@@ -680,6 +693,12 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             currentDocId, documentType, currentRound, issueId, correlationId, sessionId, tenantId, escalateOutcome, "Document rejected (human decision)");
         var emitEscalated = TerminalEmit("EmitEscalated", "Emit Escalated", DocumentEvents.Escalated,
             currentDocId, documentType, currentRound, issueId, correlationId, sessionId, tenantId, escalateOutcome, "Document escalated");
+        // AC7 — each terminal emit shares its pre-minted id with the adjacent
+        // Persist{Accepted|Rejected|Escalated} row (persisted AFTER the finalize
+        // that stamps the terminal DocumentState onto the envelope).
+        emitAccepted.EventId = new(ctx => transitionEventId.Get(ctx));
+        emitRejected.EventId = new(ctx => transitionEventId.Get(ctx));
+        emitEscalated.EventId = new(ctx => transitionEventId.Get(ctx));
 
         var finalizeAccepted = Finalize("FinalizeAccepted", "Finalize Accepted",
             stateJson, DocumentState.Accepted, outStatus, outOutcome, outDocId, outLifecycleResult, outDocJson,
@@ -690,6 +709,46 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         var finalizeEscalated = Finalize("FinalizeEscalated", "Finalize Escalated",
             stateJson, DocumentState.Escalated, outStatus, outOutcome, outDocId, outLifecycleResult, outDocJson,
             currentDocId, currentDocJson, currentRound, TerminalKind.Escalated, escalateOutcome);
+
+        // ================================================================
+        // Story 39-11 (D6) — document_instances persist wiring
+        // ================================================================
+        // The store is an INSERT-ONLY read model keyed on the envelope id, where a
+        // superseding revise inserts a new row AND flips its predecessor to
+        // 'superseded' (DocumentInstanceRepository, D4). So each distinct envelope
+        // is persisted EXACTLY ONCE — re-inserting the same id would violate the
+        // primary key. Two write points cover every distinct draft with no
+        // double-insert:
+        //   • PersistRevised — persists the CURRENT draft at REVISION_STARTED, just
+        //     BEFORE it is superseded, so the supersession chain has its ancestor.
+        //   • Persist{Accepted|Rejected|Escalated} — persists the FINAL draft AFTER
+        //     its terminal Finalize stamps Accepted/Rejected/Escalated, so
+        //     GetLatestAcceptedAsync returns the accepted body and the terminal
+        //     row's supersedes-lookup resolves the ancestor written above.
+        // A draft is superseded XOR terminal, never both, so no id is written twice.
+        // Each persist is fail-loud: a store failure FAULTS the run (the document is
+        // the product, not telemetry).
+        var mintRevisionEventId = MintEventId("MintRevisionEventId", "Mint Revision Event Id", transitionEventId);
+        var mintAcceptedEventId = MintEventId("MintAcceptedEventId", "Mint Accepted Event Id", transitionEventId);
+        var mintRejectedEventId = MintEventId("MintRejectedEventId", "Mint Rejected Event Id", transitionEventId);
+        var mintEscalatedEventId = MintEventId("MintEscalatedEventId", "Mint Escalated Event Id", transitionEventId);
+
+        var persistRevised = PersistDoc("PersistRevised", "Persist Revised",
+            currentDocJson, transitionEventId, tenantId);
+        var persistAccepted = PersistDoc("PersistAccepted", "Persist Accepted",
+            currentDocJson, transitionEventId, tenantId);
+        var persistRejected = PersistDoc("PersistRejected", "Persist Rejected",
+            currentDocJson, transitionEventId, tenantId);
+        var persistEscalated = PersistDoc("PersistEscalated", "Persist Escalated",
+            currentDocJson, transitionEventId, tenantId);
+
+        // An escalation can be reached with NO draft ever produced (a producer that
+        // never returned a parseable payload → validation exhausted). Nothing to
+        // persist there; gate the escalate persist on a present envelope so the
+        // fail-loud "non-empty EnvelopeJson" guard is not tripped on empty state.
+        var escalateHasDocumentGate = new FlowDecision(ctx => !string.IsNullOrWhiteSpace(currentDocJson.Get(ctx)))
+        { Id = "EscalateHasDocumentGate", Name = "Escalated Document To Persist?" };
+        escalateHasDocumentGate.SetDisplayText("Escalated Document To Persist?");
 
         // 39-10 (D6) — Complete short-circuit terminal: the document of this type is ALREADY
         // accepted. Emits NO second DOCUMENT.ACCEPTED (DOCUMENT.REENTERED was emitted by
@@ -756,8 +815,11 @@ public class DocumentLifecycleWorkflow : WorkflowBase
                 buildAcceptanceRequest, hasDeliveryGate, dispatchDelivery, publishRequest, waitForDecision, applyGuardrails,
                 acceptGate, rejectGate, reviseGate,
                 seedValidationExhausted, seedAmbiguity, seedRounds, seedUndecidable,
+                mintRevisionEventId, mintAcceptedEventId, mintRejectedEventId, mintEscalatedEventId,
                 emitAccepted, emitRejected, emitEscalated,
                 finalizeAccepted, finalizeRejected, finalizeEscalated,
+                persistRevised, persistAccepted, persistRejected, persistEscalated,
+                escalateHasDocumentGate,
                 setOutputs, finish,
             },
             Connections =
@@ -800,12 +862,17 @@ public class DocumentLifecycleWorkflow : WorkflowBase
 
                 ConnectOutcome(routeAccept, "True", buildAcceptanceRequest),
                 ConnectOutcome(routeAccept, "False", routeRevise),
-                ConnectOutcome(routeRevise, "True", emitRevisionStarted),
+                ConnectOutcome(routeRevise, "True", mintRevisionEventId),
                 ConnectOutcome(routeRevise, "False", routeRounds),
                 ConnectOutcome(routeRounds, "True", seedRounds),
                 ConnectOutcome(routeRounds, "False", seedUndecidable),
 
-                Connect(emitRevisionStarted, prepareRevision),
+                // REVISE — mint the transition id, emit REVISION_STARTED, then
+                // persist the current (about-to-be-superseded) draft BEFORE the new
+                // revision is minted, so the supersession chain has its ancestor.
+                Connect(mintRevisionEventId, emitRevisionStarted),
+                Connect(emitRevisionStarted, persistRevised),
+                Connect(persistRevised, prepareRevision),
                 Connect(prepareRevision, dispatchRevise),
                 Connect(dispatchRevise, ingestRevise),
                 Connect(ingestRevise, validateDraft),
@@ -821,26 +888,39 @@ public class DocumentLifecycleWorkflow : WorkflowBase
                 ConnectOutcome(waitForDecision, "Reject", applyGuardrails),
                 ConnectOutcome(waitForDecision, "Escalate", applyGuardrails),
                 Connect(applyGuardrails, acceptGate),
-                ConnectOutcome(acceptGate, "True", emitAccepted),
+                ConnectOutcome(acceptGate, "True", mintAcceptedEventId),
                 ConnectOutcome(acceptGate, "False", rejectGate),
-                ConnectOutcome(rejectGate, "True", emitRejected),
+                ConnectOutcome(rejectGate, "True", mintRejectedEventId),
                 ConnectOutcome(rejectGate, "False", reviseGate),
-                ConnectOutcome(reviseGate, "True", emitRevisionStarted),
-                ConnectOutcome(reviseGate, "False", emitEscalated),
+                ConnectOutcome(reviseGate, "True", mintRevisionEventId),
+                ConnectOutcome(reviseGate, "False", mintEscalatedEventId),
 
-                // Escalate seeds → shared escalated terminal
-                Connect(seedValidationExhausted, emitEscalated),
-                Connect(seedAmbiguity, emitEscalated),
-                Connect(seedRounds, emitEscalated),
-                Connect(seedUndecidable, emitEscalated),
+                // Escalate seeds → mint the escalate transition id → shared escalated terminal
+                Connect(seedValidationExhausted, mintEscalatedEventId),
+                Connect(seedAmbiguity, mintEscalatedEventId),
+                Connect(seedRounds, mintEscalatedEventId),
+                Connect(seedUndecidable, mintEscalatedEventId),
 
-                // Terminals
+                // Terminals — mint id → emit → finalize (stamps the terminal
+                // DocumentState) → persist the final envelope → outputs. The persist
+                // sits AFTER finalize so the store row carries the accepted / rejected
+                // / escalated status (not the pre-terminal reviewed state).
+                Connect(mintAcceptedEventId, emitAccepted),
                 Connect(emitAccepted, finalizeAccepted),
-                Connect(finalizeAccepted, setOutputs),
+                Connect(finalizeAccepted, persistAccepted),
+                Connect(persistAccepted, setOutputs),
+
+                Connect(mintRejectedEventId, emitRejected),
                 Connect(emitRejected, finalizeRejected),
-                Connect(finalizeRejected, setOutputs),
+                Connect(finalizeRejected, persistRejected),
+                Connect(persistRejected, setOutputs),
+
+                Connect(mintEscalatedEventId, emitEscalated),
                 Connect(emitEscalated, finalizeEscalated),
-                Connect(finalizeEscalated, setOutputs),
+                Connect(finalizeEscalated, escalateHasDocumentGate),
+                ConnectOutcome(escalateHasDocumentGate, "True", persistEscalated),
+                ConnectOutcome(escalateHasDocumentGate, "False", setOutputs),
+                Connect(persistEscalated, setOutputs),
 
                 Connect(setOutputs, finish),
             }
@@ -938,6 +1018,47 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         };
         sv.SetDisplayText(name);
         return sv;
+    }
+
+    /// <summary>
+    /// Story 39-11 (AC7) — mint a fresh transition event id into a durable workflow
+    /// variable, ONCE per persisting transition. A UUID v7 (time-sortable, the house
+    /// mint used at Init for the session id) written to a persisted variable so Elsa
+    /// replays the same value across suspend/resume — the emit and its adjacent
+    /// persist read it from the variable, never a second <c>Guid.NewGuid()</c>.
+    /// </summary>
+    private static SetVariable MintEventId(string id, string name, Variable<string> target)
+    {
+        var sv = new SetVariable
+        {
+            Id = id, Name = name,
+            Variable = target,
+            Value = new(_ => (object)UuidV7.NewGuid().ToString()),
+        };
+        sv.SetDisplayText(name);
+        return sv;
+    }
+
+    /// <summary>
+    /// Story 39-11 (D6) — a document_instances persist node. Serializes the current
+    /// envelope (<paramref name="envelopeJson"/> is the <c>DocumentJson.Serialize</c>
+    /// output already held in the lifecycle's <c>CurrentDocumentJson</c> variable) and
+    /// correlates the store row to the pre-minted transition event id (AC7). Fail-loud
+    /// by construction — a persist failure FAULTS the run.
+    /// </summary>
+    private static PersistDocumentInstanceActivity PersistDoc(
+        string id, string name,
+        Variable<string> envelopeJson, Variable<string> eventId, Variable<string> tenantId)
+    {
+        var p = new PersistDocumentInstanceActivity
+        {
+            Id = id, Name = name,
+            EnvelopeJson = new(ctx => envelopeJson.Get(ctx)),
+            CorrelatingEventId = new(ctx => eventId.Get(ctx)),
+            TenantId = new(ctx => tenantId.Get(ctx)),
+        };
+        p.SetDisplayText(name);
+        return p;
     }
 
     private enum TerminalKind { Accepted, Rejected, Escalated }

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AssessmentFamilyLifecycleExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AssessmentFamilyLifecycleExecutionTests.cs
@@ -313,7 +313,9 @@ public class AssessmentFamilyLifecycleExecutionTests
 
     private static List<string?> CapturedTypes(CapturingHandler capture) =>
         capture.Bodies
-            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.TryGetProperty("events", out var evs)
+                ? evs.EnumerateArray()
+                : System.Linq.Enumerable.Empty<JsonElement>())
             .Select(e => e.GetProperty("eventType").GetString())
             .ToList();
 

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/DocumentLifecycleWorkflowStructureTests.cs
@@ -244,6 +244,89 @@ public class DocumentLifecycleWorkflowStructureTests
                 "the lifecycle exposes the decider's notes as the additive 'decisionNotes' output (39-13 D6d)");
     }
 
+    // ── Story 39-11 (D6) — document_instances persist wiring ───────────
+
+    [Test]
+    public void Workflow_PersistsDocumentInstance_AtSupersedeAndEveryTerminal()
+    {
+        // The insert-only store (PK = envelope id) is written EXACTLY ONCE per
+        // distinct envelope: PersistRevised captures the about-to-be-superseded
+        // draft; Persist{Accepted|Rejected|Escalated} capture the final draft after
+        // its terminal Finalize. Re-persisting a produced/validated/reviewed draft
+        // that later reaches a terminal would double-insert the same id — so those
+        // in-place transitions are NOT persist sites.
+        var persistIds = AllActivities().OfType<PersistDocumentInstanceActivity>().Select(a => a.Id).ToHashSet();
+        persistIds.Should().BeEquivalentTo(new[]
+        {
+            "PersistRevised", "PersistAccepted", "PersistRejected", "PersistEscalated",
+        }, "the lifecycle persists each distinct envelope once — at supersede and at each terminal");
+    }
+
+    [Test]
+    public void Workflow_PairsEmitWithPersist_SharingThePreMintedTransitionId()
+    {
+        // AC7 — every persist is adjacent to its transition emit, and a mint node
+        // feeds the emit so the emitted DOCUMENT.* event and the document_instances
+        // row share the SAME pre-minted id (EmitDocumentEventActivity.EventId ==
+        // PersistDocumentInstanceActivity.CorrelatingEventId, both reading the
+        // TransitionEventId variable).
+        var fc = Flowchart();
+        bool Edge(string source, string target) =>
+            fc.Connections.Any(c => c.Source.Activity.Id == source && c.Target.Activity.Id == target);
+
+        // Mint → emit (the pre-minted id is established before the event is emitted).
+        Edge("MintRevisionEventId", "EmitRevisionStarted").Should().BeTrue();
+        Edge("MintAcceptedEventId", "EmitAccepted").Should().BeTrue();
+        Edge("MintRejectedEventId", "EmitRejected").Should().BeTrue();
+        Edge("MintEscalatedEventId", "EmitEscalated").Should().BeTrue();
+
+        // REVISE persists the current draft right after emitting REVISION_STARTED,
+        // BEFORE the superseding revision is prepared.
+        Edge("EmitRevisionStarted", "PersistRevised").Should().BeTrue("the revise persist captures the superseded ancestor");
+        Edge("PersistRevised", "PrepareRevision").Should().BeTrue();
+
+        // Terminals persist AFTER Finalize (so the row carries the terminal status).
+        Edge("FinalizeAccepted", "PersistAccepted").Should().BeTrue("the accepted row is written after the state is stamped Accepted");
+        Edge("FinalizeRejected", "PersistRejected").Should().BeTrue();
+
+        // The escalate persist is gated on a present envelope (a producer that never
+        // yielded a draft escalates with nothing to persist).
+        Edge("FinalizeEscalated", "EscalateHasDocumentGate").Should().BeTrue();
+        fc.Connections.Any(c => c.Source.Activity.Id == "EscalateHasDocumentGate" &&
+            c.Source.Port == "True" && c.Target.Activity.Id == "PersistEscalated")
+            .Should().BeTrue("a present escalated envelope is persisted");
+        fc.Connections.Any(c => c.Source.Activity.Id == "EscalateHasDocumentGate" &&
+            c.Source.Port == "False" && c.Target.Activity.Id == "SetOutputs")
+            .Should().BeTrue("an escalation with no draft skips the persist");
+    }
+
+    [Test]
+    public void Workflow_PersistingEmits_ThreadThePreMintedEventId()
+    {
+        // The four persisting transition emits carry a delegate-backed EventId (the
+        // pre-minted TransitionEventId), not the default null literal — proving the
+        // store↔stream id is threaded onto the emit half of the pair. DocumentId is
+        // ALWAYS delegate-backed on every emit, so its expression type is the
+        // reference shape for "variable-backed"; a literal default is a different type.
+        var emits = AllActivities().OfType<EmitDocumentEventActivity>()
+            .ToDictionary(e => e.Id, e => e);
+
+        foreach (var id in new[] { "EmitRevisionStarted", "EmitAccepted", "EmitRejected", "EmitEscalated" })
+        {
+            emits.Should().ContainKey(id);
+            emits[id].EventId.Expression?.Type.Should().Be("Delegate",
+                $"{id}.EventId is a variable-backed delegate (the pre-minted TransitionEventId)");
+        }
+
+        // Inversely, the non-persisting emits keep the auto-minted id: EventId stays
+        // its default literal (no pre-minted linkage).
+        foreach (var id in new[] { "EmitProduced", "EmitValidated", "EmitReviewRequested", "EmitReviewed" })
+        {
+            emits[id].EventId.Expression?.Type.Should().Be("Literal",
+                $"{id} leaves EventId at its default literal (auto-minted event id, no pre-minted linkage)");
+        }
+    }
+
     // ── AC5 — constant pins ────────────────────────────────────────────
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueDecompositionLifecycleExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/IssueDecompositionLifecycleExecutionTests.cs
@@ -50,14 +50,17 @@ namespace Tamma.Activities.Tests.Workflows;
 /// <see cref="DecompositionBindingHelperTests"/> + <see cref="DocumentLifecycleHelperTests"/>
 /// — this proves the WIRING.</para>
 ///
-/// <para><b>Known gap (filed against 39-11/39-6, not patched here per the plan).</b> The
-/// 39-11 <see cref="PersistDocumentInstanceActivity"/> ships the engine→store seam but is NOT
-/// yet wired into the lifecycle graph (its own scope note defers the per-transition
-/// persist+emit wiring). So a LIVE run persists no <c>document_instances</c> rows and AC5's
-/// "read the accepted instance back through <see cref="IDocumentInstanceRepository"/>" cannot
-/// be asserted from a fresh run. The crash re-entry scenarios (e)/(f) instead SEED the store
-/// with the state a crashed run left behind (the 39-10 harness pattern), which exercises the
-/// store-read path AC5 depends on.</para>
+/// <para><b>Store seeding (why it stays).</b> The lifecycle now WIRES
+/// <see cref="PersistDocumentInstanceActivity"/> at supersede + every terminal (39-11 D6), so
+/// a live run DOES project <c>document_instances</c> rows. But in THIS harness the persist
+/// hop goes through <c>TammaApiClient</c> → the <see cref="CapturingHandler"/> stub (which just
+/// records the POST body and 201s); it does NOT flow into the <see cref="IDocumentInstanceRepository"/>
+/// fake that the read path (<see cref="LifecycleReEntryService"/>) queries. Those two seams are
+/// intentionally decoupled in-process, so the crash re-entry scenarios (e)/(f) still SEED the
+/// read fake with the state a crashed run left behind (the 39-10 harness pattern) to exercise
+/// the store-read path AC5 depends on. Wiring the stub handler to feed the read fake is a
+/// harness-only follow-up; the persist WIRING itself is proved structurally by
+/// <c>DocumentLifecycleWorkflowStructureTests</c>.</para>
 /// </summary>
 [TestFixture]
 [Explicit("Full Elsa workflow-runtime integration — runs in the CI Postgres jobs, skipped in the fast local gate")]
@@ -316,7 +319,9 @@ public class IssueDecompositionLifecycleExecutionTests
 
     private static IEnumerable<JsonElement> CapturedEvents(CapturingHandler capture) =>
         capture.Bodies
-            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.TryGetProperty("events", out var evs)
+                ? evs.EnumerateArray()
+                : System.Linq.Enumerable.Empty<JsonElement>())
             .ToList();
 
     private static int? SubtaskCountOnCompleted(CapturingHandler capture)

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/PlanningFamilyLifecycleExecutionTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/PlanningFamilyLifecycleExecutionTests.cs
@@ -297,7 +297,9 @@ public class PlanningFamilyLifecycleExecutionTests
 
     private static List<string?> CapturedTypes(CapturingHandler capture) =>
         capture.Bodies
-            .SelectMany(b => JsonDocument.Parse(b).RootElement.GetProperty("events").EnumerateArray())
+            .SelectMany(b => JsonDocument.Parse(b).RootElement.TryGetProperty("events", out var evs)
+                ? evs.EnumerateArray()
+                : System.Linq.Enumerable.Empty<JsonElement>())
             .Select(e => e.GetProperty("eventType").GetString())
             .ToList();
 


### PR DESCRIPTION
## Close the persist-wiring gap (39-6 / 39-11)

`DocumentLifecycleWorkflow` drove produce→validate→review→revise→accept and emitted the `DOCUMENT.*` event family, but **never called `PersistDocumentInstanceActivity`** — so a live run persisted **no** `document_instances` rows, only the event stream. That blocked the store read-model (`GetLatestAcceptedAsync`, lineage) and the live-store assertions deferred across 39-12/39-13/39-14 (they had to seed the store in tests). Filed in `.dev/findings/document-lifecycle-persist-not-wired.md`, now **Resolved**.

### What changed
Wired persist into the lifecycle graph, honoring the **insert-only** store (PK = `envelope.Id`; a superseding revise inserts a new row and flips its predecessor to `superseded`). Persisting the same envelope Id at multiple transitions would PK-violate, so each **distinct envelope is persisted exactly once**, at two write points:

- **`PersistRevised`** — persists the current draft right after `EmitRevisionStarted`, *before* it is superseded, so the supersession chain keeps its ancestor row.
- **`PersistAccepted` / `PersistRejected` / `PersistEscalated`** — persists the final draft *after* `Finalize` stamps the terminal `DocumentState`, so `GetLatestAcceptedAsync` returns the accepted body and the terminal row's supersedes-lookup resolves the ancestor. The escalate persist is **gated** (`EscalateHasDocumentGate`) because an escalation can occur before any draft exists (the activity's fail-loud non-empty-envelope guard would otherwise trip).

A draft is superseded **XOR** terminal, never both → no id is inserted twice.

### AC7 emit↔persist linkage
One durable workflow variable `TransitionEventId`, minted once per persisting transition by a `Mint*EventId` `SetVariable` node using `UuidV7.NewGuid()` (the house mint, **not** a bare `Guid.NewGuid()` at two sites). The emit (`EmitDocumentEventActivity.EventId`) and the adjacent persist (`PersistDocumentInstanceActivity.CorrelatingEventId`) read the same variable, so the `domain_events` row and the `document_instances` row **share one id**.

### Resume determinism & re-entry idempotency
- Ids live in a persisted variable Elsa replays across the accept-gate suspend (the only suspend, and it never sits between a mint and its consuming persist).
- Persist inherits the existing 39-10 re-entry gating for free (it lives on the same paths as the emits): the `Complete` short-circuit persists nothing; a re-entry persists only at the terminal it newly reaches; a crashed-and-re-dispatched run never double-persists.
- **Fail-loud preserved** — `PersistDocumentInstanceActivity` is unchanged; persist faults propagate (the document is the product, not telemetry).

### Tests
- `DocumentLifecycleWorkflowStructureTests` — 3 new pins: the exact persist node set, the mint→emit→persist adjacency (incl. the escalate gate's True/False edges), and that the 4 persisting emits thread a `Delegate` `EventId` while the 4 non-persisting emits keep the `Literal` default. **19/19 pass.**
- The `[Explicit]` execution harnesses' event-body parser now skips the new persist POSTs.

### Verification
- `dotnet build`: **0 warnings, 0 errors**.
- `Tamma.Activities.Tests` (fast gate): **2516 passed, 0 failed**.
- `Tamma.Core.Tests`: **436 passed, 0 failed**.
- `Tamma.Api.Tests`: compiles.
- `dotnet ef migrations has-pending-model-changes`: **clean** for both contexts — **no schema change**.

### Residual (deliberately not gold-plated)
The store projects **terminal state + the superseded revision chain**, not a row per intermediate produced→validated→reviewed state — consistent with the store's "read-optimized product layer, stream wins" doctrine. Per-transition status rows, if ever wanted, are a clean follow-up via a `SetDocumentInstanceStatus` activity over the existing `/api/engine/documents/{id}/status` endpoint. The `[Explicit]` execution harness still seeds the store (its `CapturingHandler` stub records the persist POST but doesn't feed the read fake) — a harness-only follow-up; the wiring itself is proven by the structure-test pins.

### Data & migrations
None.


---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_