### PR TITLE
docs(epic-42): Agent Capability & Tool Layer epic

### DIFF
--- a/docs/stories/epic-42/README.md
+++ b/docs/stories/epic-42/README.md
@@ -1,0 +1,204 @@
+# Epic 42: Agent Capability & Tool Layer — a first-class, extensible, secured, autonomy-gated tool catalog
+
+## Overview
+
+Tamma's workflows produce typed **documents** (Epic 39) and dispatch them by kind (Epic 41), and an
+agent can *act* through the tool-execution framework in `Tamma.Activities/LlmCall/Tools/`. But that
+framework is **coding-only**. `Program.cs` registers exactly **six** `IToolExecutor`s —
+`FileReadTool`, `FileWriteTool`, `GitOperationsTool`, `RunTestsTool`, `SearchCodeTool`,
+`ShellExecuteTool`. So an agent can edit the repo, run git, run tests, and run a shell — but has **no
+first-class tool** to reach a cloud/VPS resource, flip a feature flag, drive a deploy, or call an
+external API. Worse, the catalog is closed:
+
+- **The registry is compile-time static.** `ToolExecutorRegistry` is populated once from
+  `IEnumerable<IToolExecutor>` injected by DI. Adding a tool means shipping a class and a DI line.
+  There is **no dynamic / per-deployment / per-tenant registration** and **no MCP path** — the catalog
+  cannot grow without a code change per tool.
+- **A tool declares no governance.** `IToolExecutor` exposes `ToolName`, `Description`, `InputSchema`,
+  `ExecuteAsync` — and nothing about **who may call it**, **at what autonomy level**, **what credential
+  it needs**, or **how destructive it is**. `ToolCallValidator` + `ActionGate` block dangerous *shell
+  strings*, but that is a per-command denylist, not a per-tool permission model.
+- **No credential binding.** No tool binds to a stored secret. `ShellExecuteTool` has been silently
+  standing in for a real capability layer — an agent that needs to deploy shells out, unbound and
+  ungoverned.
+- **No durable tool-use audit.** `ToolLoopEventEmitter` emits ephemeral `TOOL_LOOP.*` SSE progress
+  events to `IToolLoopEventSink`; nothing writes a **durable DCB `TOOL.*` row** the way documents get a
+  `DOCUMENT.*` trail.
+
+None of this is planned. There is no epic or story for a tool/capability layer.
+
+**This epic makes the tool layer first-class: extensible (native + dynamic + MCP), secured
+(secret-bound, redacted), and autonomy-gated (per-role, per-autonomy, per-mode) — the same governance
+documents already get.** It *extends* the real `IToolExecutor` / `IToolExecutorRegistry` /
+`ResolveToolsActivity` / `ParallelToolExecutor` / `ToolCallValidator` surface. It does **not** design a
+parallel framework, and it does **not** reinvent the accept gate (Epic 39) or the secret store
+(Epic 29) — it composes them.
+
+## The gap this epic fills — and how it underpins Epic 41
+
+Epic 41 turns every recurring SDLC activity into a lifecycle workflow, and **41-29** (the Task-Level
+Flow Router) dispatches each `PlanTask` to the workflow matching its `TaskKind`
+(`code`/`test`/`docs`/`infra`/`design`/`investigation`/`chore`). But the workflow it dispatches has an
+agent, and **that agent has no tool to do non-code work**:
+
+- A `docs` task routed to `41-24`/`41-25`/`41-26` needs a **publish** capability (push to the wiki /
+  docs host / issue tracker) — there is none.
+- An `infra` task routed to `deployment-pipeline` needs **deploy-control** and **cloud/VPS** tools —
+  there are none; today it can only shell out.
+- `41-22` (incident response & postmortem, incl. `rollback`) and `41-23` (capacity & health review)
+  need **cloud/VPS** ops and a **feature-flag kill-switch** — there are none.
+- `41-5` (stakeholder update) and `41-7` (standup digest) need an **authenticated HTTP** tool to post
+  the artifact to Slack/Jira/etc. — there is none.
+
+So Epic 42 is the **missing foundation under Epic 41**: 41-29 can *route* to a `docs`/`infra`/`design`
+workflow, but until this epic lands, that workflow's agent falls back to `ShellExecute` or to the
+human-assigned path (41 rule 4). This epic lights up the *agent* path of the non-code kinds by giving
+each the governed tool it needs — with **no change to the router** (41-29's `kind→workflow` map is
+untouched; this epic populates the tools those workflows resolve).
+
+## The tool contract (what a tool declares) — extending the real `IToolExecutor`
+
+Today `IToolExecutor` is `{ ToolName, Description, InputSchema, ExecuteAsync }` and *must never throw*
+(errors are `ToolExecutionResult { Success = false }`). Story **42-1** keeps all four members and the
+never-throw contract, and adds a governance descriptor. To avoid breaking the six built-ins and the
+never-throw guarantee, the new metadata is exposed as a **`ToolDescriptor`** the executor surfaces
+(via a `Descriptor` member with a **fail-safe default** — most-restrictive, never permissive — so an
+un-annotated tool is *denied by default*, not silently granted):
+
+| Field (new) | Type | Meaning | Fail-safe default |
+|---|---|---|---|
+| `Category` | `ToolCategory` = `Native` \| `Mcp` \| `ProviderAbstracted` | Where the tool comes from; drives which registration path owns it. | `Native` |
+| `PermissionClass` | `ToolPermissionClass` = `ReadOnly` \| `Mutating` \| `Command` \| `Destructive` | Governance tier. `ReadOnly` = no side effects (FileRead, SearchCode). `Mutating` = reversible write (FileWrite, GitOperations, RunTests). `Command` = arbitrary exec, already `ActionGate`-gated (ShellExecute). `Destructive` = irreversible / prod-impacting (delete a cloud resource, flip a prod flag, promote a deploy). | `Destructive` (deny-by-default) |
+| `AutonomyFloor` | `int` (70–100) | Minimum autonomy dial at which an `AgentRole` may invoke the tool **directly**; below it, the action is routed to the orchestrator/human via the accept-gate channel — never silently skipped. | `100` |
+| `RequiredSecret` | `SecretRequirement?` | Declares the credential this tool needs — `{ Purpose (Epic 29 `SecretPurpose`), logical Name, scope-shape }`. `null` for tools that touch nothing external. | `null` |
+| `Suspends` | `bool` | Tool may start a long external op and **suspend** the workflow (resumable-by-design, Epic 39), resuming on completion callback. | `false` |
+
+The four existing members are unchanged; the six built-ins each declare a real `ToolDescriptor` (e.g.
+`SearchCodeTool` → `ReadOnly`, floor 70, no secret; `ShellExecuteTool` → `Command`, floor 85, no
+secret — it stays `ActionGate`-gated). `IToolExecutorRegistry` gains a **dynamic registration** seam
+(`Register(IToolExecutor)` / `Unregister(name)` alongside today's DI-seeded set) so tools can be added
+per deployment/tenant and by MCP — the *vocabulary of governance is static; the catalog is dynamic*,
+mirroring Epic 39's "vocabulary static, composition dynamic".
+
+## Permission + autonomy + secret model (single-user **and** SaaS)
+
+Per CLAUDE.md's universal rule, every tenant-aware surface here answers ownership **twice**. The model
+mirrors the **Prompt Store** two-scoping pattern exactly (Story 42-2 owns the persistence, a
+`tool_bindings` table analogous to `prompt_overrides`; a `CHECK (user_id XOR tenant_id)` constraint):
+
+- **single-user mode** — the sole user owns tool enablement + the per-role/per-autonomy grant.
+  Bindings keyed by `user_id`. Resolution: user binding → system default descriptor.
+- **SaaS mode** — `tenant_owner` / `tenant_admin` owns the tenant's grants; `member` users get the
+  resolved grant with **no edit access** (403 on write, exactly like the Prompt Store). Bindings keyed
+  by `tenant_id`. **No per-user override layer.** Resolution: tenant binding → system default.
+
+**Enforcement is in `ResolveToolsActivity` (Story 42-3), not a new gate.** A workflow step declares the
+tools it needs (`ToolNamesInput`, already the activity's input); the resolver returns only the subset
+that is (a) enabled for the principal, (b) permitted for the agent's `AgentRole`, and (c)
+**autonomy-eligible** — `Descriptor.AutonomyFloor ≤ current dial`. A needed tool that is `Destructive`
+or above the floor is **not handed to the agent as callable**; instead the step routes that action to
+the orchestrator/human over the **existing** `AcceptanceRequest` channel (Epic 39: *"the acceptor is an
+actor, not a branch"*) — the same shape as the accept gate, so a destructive tool call is a *decision
+taken by someone*, never an unattended side effect. The autonomy dial is read live, never cached into a
+running workflow (Epic 39 rule).
+
+**Credentials (Story 42-4)** bind through Epic 29's `ISecretStore` — `SecretScope.Tenant` in SaaS
+(keyed by the tenant `Guid`), `SecretScope.Platform`/user-owned in single-user. Secrets are **never**
+in tool args logged, in `ToolExecutionResult.Output`, in DCB `TOOL.*` events, or in error messages
+(reuse `ErrorRedactor`). ⚠️ **Reconciliation with Epic 29:** `ISecretStore` **now exists** (Story 29-1
+landed — CLAUDE.md's "does not yet exist" note is stale), but by design it *never returns plaintext
+through a public signature* (plaintext only reaches a registered rotation handler via callback). A tool
+that authenticates to Hetzner/Slack needs the live secret at execution time — so 42-4 **files a hard
+dependency** on an authorized, audited *reveal-to-runtime-consumer* path (an Epic 29 extension building
+on the 29-3 reveal-once UX + `ISecretAccessAuditor`); until it lands, external-touching tools run only
+in the human-assigned path. This is the epic's single biggest external dependency (see Open Questions).
+
+## Tool families (the concrete capabilities the platform needs)
+
+| Family (story) | What it does | Permission class | Secret (Epic 29 `SecretPurpose`) | Epic 41 consumers |
+|---|---|---|---|---|
+| **Cloud / VPS resource ops** (42-7) — provider-abstracted (Hetzner / generic), like the Git & AI provider abstractions | list / create / resize / delete VPS & cloud resources | `ReadOnly` (list) · `Mutating` (create/resize) · `Destructive` (delete) | `ApiKey` (cloud-provider token) | `deployment-pipeline` (infra tasks via 41-29) · **41-22** incident/rollback · **41-23** capacity & health |
+| **Feature-flag / config toggle** (42-8) | read & flip feature flags / runtime config | `Mutating` (non-prod) · `Destructive` (prod flag / kill-switch) | `ApiKey` (flag provider) | `deployment-pipeline` promotion · **41-22** kill-switch · 41-29 `infra` kind |
+| **Deploy control** (42-8) | trigger / promote / rollback / gate a release | `Destructive` (prod) · `Mutating` (staging) | `ApiKey` or `SigningKey` (deploy platform) | `deployment-pipeline` · **41-22** rollback · **41-24** release notes trigger |
+| **Authenticated HTTP / external API** (42-9) — generic, host+method allowlisted, per-endpoint bound | one authenticated REST call to a bound endpoint | `Mutating` (default; `ReadOnly` for GET-only bindings) | `ApiKey` (per-endpoint) | **41-5** stakeholder update · **41-7** standup publish · **41-24/25/26** docs publish · any integration |
+| **MCP-exposed tools** (42-6) | whatever an external MCP server exposes | inherited/declared per tool (deny-by-default until classified) | per bound server | open-ended — any future kind |
+
+Each family declares its `PermissionClass`, `AutonomyFloor`, and `RequiredSecret`, so it is governed by
+42-1–42-5 with **zero bespoke security code** — a new tool is a descriptor + an executor, not a new
+gate.
+
+## Stories
+
+| Story | Title | Purpose (one line) |
+|---|---|---|
+| **42-1** | Tool Contract & Registry Evolution | Add `ToolDescriptor` (category / permission class / autonomy floor / secret requirement / suspends) to the `IToolExecutor` surface and a dynamic `Register`/`Unregister` seam to `IToolExecutorRegistry`; annotate the six built-ins. |
+| **42-2** | Tool Binding & Config Store (two-scoping) | Persist per-principal tool enablement + config as `tool_bindings` (user_id XOR tenant_id), mirroring `prompt_overrides`; define the single-user & SaaS resolution order. |
+| **42-3** | Per-Tool Permission & Autonomy Gating | Extend `ResolveToolsActivity` to return the permitted + autonomy-eligible subset for an agent+principal; route `Destructive`/above-floor tools to the orchestrator via the `AcceptanceRequest` channel. |
+| **42-4** | Tool Credential / Secret Binding | Bind external-touching tools to `ISecretStore` (per-tenant SaaS / per-user single-user); file the reveal-to-runtime-consumer dependency on Epic 29; guarantee no-secret-in-logs/events. |
+| **42-5** | Tool-Use DCB Audit | Emit durable `TOOL.INVOKED` / `TOOL.SUCCEEDED` / `TOOL.FAILED` / `TOOL.DENIED` / `TOOL.ESCALATED` DCB events (secret-redacted args, `issueId`/`tenantId` tags) at the `ParallelToolExecutor` hook, alongside the ephemeral `TOOL_LOOP.*` SSE stream. |
+| **42-6** | MCP Integration | Let external MCP servers expose tools into the registry via the 42-1 dynamic path, wrapped as `IToolExecutor` with the same permission/autonomy/secret/audit treatment as native tools. |
+| **42-7** | Cloud / VPS Resource Operations Tool | Provider-abstracted (Hetzner + generic) cloud/VPS list/create/resize/delete tool family. |
+| **42-8** | Feature-Flag & Deploy-Control Tools | Feature-flag / config-toggle and deploy trigger/promote/rollback tools — the release-control family. |
+| **42-9** | Authenticated HTTP / External-API Tool | Generic host+method-allowlisted authenticated REST tool covering publish/notify/integration needs. |
+
+## Sequencing
+
+**Wave 0 — the contract.** **42-1** (descriptor + dynamic registry). Everything depends on it.
+
+**Wave 1 — governance rails (parallel after 42-1).** **42-2** (binding store) → **42-3** (gating in
+`ResolveToolsActivity`); **42-4** (secret binding); **42-5** (DCB audit). Together these are the
+security envelope every family and MCP tool inherits — no family ships before them.
+
+**Wave 2 — the open catalog.** **42-6** (MCP) — the dynamic-tool path proving a non-native tool obeys
+42-1–42-5.
+
+**Wave 3 — the families (parallel).** **42-7** cloud/VPS, **42-8** flags & deploy, **42-9** HTTP —
+each a descriptor + executor on the Wave-1 rails. Order by Epic 41 demand: 42-9 (unblocks the most
+41 workflows: docs publish, stakeholder, standup) first, then 42-8, then 42-7.
+
+## Out of scope (deliberately not this epic)
+
+- **A general plugin/marketplace runtime for arbitrary code.** MCP (42-6) is the extensibility path;
+  loading untrusted in-process assemblies is not. — *MCP gives the open catalog with a process boundary
+  and the same governance; in-proc plugins reopen the trust surface this epic closes.*
+- **Rewriting the accept gate or the secret store.** This epic *composes* the Epic 39 `AcceptanceRequest`
+  channel and the Epic 29 `ISecretStore`; it adds neither a second acceptor nor a second cabinet.
+- **Building the flag / deploy / cloud *providers themselves*.** 42-7/42-8/42-9 define the
+  provider-abstracted tool + one reference driver each (Hetzner, a flag provider, the deploy platform);
+  exhaustive driver coverage per vendor is follow-on, exactly as the Git/AI provider abstractions grew.
+- **The reveal-to-runtime-consumer secret path.** Named and depended-on here (42-4), but it is an
+  **Epic 29 extension**, not built in Epic 42.
+
+## Dependencies
+
+- **Epic 29 (secrets):** `ISecretStore` / `SecretRef` / `SecretScope` / `SecretPurpose` **exist**
+  (Story 29-1). **Hard-blocked capability:** an authorized *reveal-to-runtime-consumer* path (29-3
+  reveal-once UX + `ISecretAccessAuditor` extension) — 42-4/42-7/42-8/42-9's agent path waits on it;
+  the human-assigned path (Epic 41 rule 4) does not.
+- **Epic 39:** the `AcceptanceRequest` workflow↔orchestrator channel + autonomy dial (42-3 routing),
+  the DCB emitter drain (`TammaEventEmitter` → `tamma:events` → `EventDrain`, used by 42-5),
+  resumable-by-design (42-1 `Suspends`).
+- **Epic 41 / 41-29:** the consumers. 41-29's `TaskKind`→workflow map is unchanged; this epic supplies
+  the tools those dispatched workflows resolve. `docs`/`infra`/`design` agent paths light up as
+  42-7/42-8/42-9 land.
+- **Existing surface (extended, not replaced):** `IToolExecutor`, `IToolExecutorRegistry` /
+  `ToolExecutorRegistry`, `ResolveToolsActivity`, `ParallelToolExecutor`, `ToolCallValidator` +
+  `ActionGate`, `IToolLoopEventSink` / `ToolLoopEventEmitter`.
+
+## Open design questions (worth a decision)
+
+1. **Secret reveal for runtime tool execution (biggest).** `ISecretStore` never returns plaintext
+   through its public signature. Do we (a) extend Epic 29 with an audited *reveal-to-consumer* API for
+   tool execution, or (b) an injection seam that hands the tool a short-lived credential it never
+   stores? 42-4 assumes (a) is filed as an Epic 29 story; confirm the direction.
+2. **Descriptor default: deny vs. read-only.** An un-annotated tool defaults to `Destructive` / floor
+   `100` (deny-by-default). Safe, but every dynamically-registered/MCP tool is inert until classified.
+   Accept the friction, or default MCP tools to `ReadOnly` and require explicit elevation to write?
+3. **Where does destructive-tool routing suspend?** 42-3 routes a destructive/above-floor tool call to
+   the orchestrator via `AcceptanceRequest`. Is a **tool invocation** an acceptance decision (reuse the
+   accept-gate machinery verbatim) or a distinct `ToolAuthorizationRequest` family on the same channel?
+   Affects whether tool authorizations show up in the existing Task View unchanged.
+4. **MCP server trust & tenancy.** In SaaS, may a `tenant_admin` register an arbitrary MCP server
+   (tenant-scoped), or is the MCP server allowlist platform-owned? Determines whether 42-6 needs a
+   per-tenant MCP registration surface or only a platform one.
+</content>

--- a/docs/stories/epic-42/story-42-1/42-1-tool-contract-registry-evolution.md
+++ b/docs/stories/epic-42/story-42-1/42-1-tool-contract-registry-evolution.md
@@ -1,0 +1,145 @@
+# Story 42-1: Tool Contract & Registry Evolution
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As the **platform**, I want every tool to **declare its governance** — category, permission class,
+autonomy floor, required secret, and whether it suspends — and I want the registry to accept **dynamic
+registration**, so that a tool carries the metadata needed to gate, secure, and audit it, and the
+catalog can grow per deployment/tenant and via MCP without a code change per tool.
+
+## Priority
+
+P0 / Wave 0 — **the contract every other Epic 42 story builds on.** No gating (42-3), secret binding
+(42-4), audit (42-5), MCP path (42-6), or tool family (42-7/8/9) can exist until a tool can *declare*
+what it is and the registry can hold tools added at runtime.
+
+## The gap (READ FIRST)
+
+`IToolExecutor` (`Tamma.Activities/LlmCall/Tools/IToolExecutor.cs`) is `{ ToolName, Description,
+InputSchema, ExecuteAsync }` and **must never throw** (all failure is `ToolExecutionResult
+{ Success = false }`). It carries **no governance metadata** — nothing says who may call the tool, at
+what autonomy, what credential it needs, or how destructive it is.
+
+`ToolExecutorRegistry` (`ToolExecutorRegistry.cs`) is populated **once** in its constructor from
+`IEnumerable<IToolExecutor>` injected by DI (the six built-ins wired in `Tamma.Api/Program.cs` ~L753–763
+via `AddSingleton<IToolExecutor, …>`). `IToolExecutorRegistry` exposes only read paths — `GetExecutor`,
+`IsAllowed`, `GetAll`, `GetAllowed`. There is **no** `Register`/`Unregister`: the catalog is frozen at
+startup.
+
+## Scope
+
+1. **`ToolDescriptor` on the executor surface.** Introduce a `ToolDescriptor` record and surface it from
+   `IToolExecutor` via a new `ToolDescriptor Descriptor { get; }` member (a C# **default interface
+   member** returning the fail-safe default, so the six built-ins and any existing external
+   implementation compile unchanged, then are annotated explicitly).
+
+   ```csharp
+   public enum ToolCategory { Native, Mcp, ProviderAbstracted }
+   public enum ToolPermissionClass { ReadOnly, Mutating, Command, Destructive }
+
+   public sealed record SecretRequirement(
+       SecretPurpose Purpose,   // Epic 29 taxonomy: ApiKey, SigningKey, …
+       string Name,             // logical secret name, resolved to a SecretRef per mode by 42-4
+       bool Required);          // hard-fail vs. best-effort
+
+   public sealed record ToolDescriptor(
+       ToolCategory Category,
+       ToolPermissionClass PermissionClass,
+       int AutonomyFloor,            // 70–100
+       SecretRequirement? RequiredSecret,
+       bool Suspends);
+   ```
+
+   The **fail-safe default** (returned by the default interface member) is
+   `new ToolDescriptor(Native, Destructive, 100, null, false)` — **deny-by-default**: an un-annotated
+   tool is treated as the most dangerous, never silently granted. `AutonomyFloor` is validated to
+   `[70,100]` at registration (a floor of 70 = allowed at the supervised baseline).
+
+2. **Annotate the six built-ins.** Each declares a real descriptor:
+
+   | Tool | PermissionClass | AutonomyFloor | RequiredSecret |
+   |---|---|---|---|
+   | `SearchCodeTool` | `ReadOnly` | 70 | none |
+   | `FileReadTool` | `ReadOnly` | 70 | none |
+   | `FileWriteTool` | `Mutating` | 70 | none |
+   | `GitOperationsTool` | `Mutating` | 75 | none (platform creds resolved elsewhere today) |
+   | `RunTestsTool` | `Mutating` | 70 | none |
+   | `ShellExecuteTool` | `Command` | 85 | none (stays `ActionGate`-gated) |
+
+   These floors are defaults, overridable per principal by the 42-2 binding store.
+
+3. **Dynamic registration seam.** Extend `IToolExecutorRegistry` with `Register(IToolExecutor)` /
+   `Unregister(string toolName)` and make `ToolExecutorRegistry`'s backing map thread-safe
+   (`ConcurrentDictionary`, case-insensitive as today). The DI-seeded set remains the base layer;
+   dynamic registrations (42-6 MCP, per-deployment/per-tenant) layer on top. Duplicate-name handling
+   keeps today's "keep first, warn" for the DI seed but a dynamic `Register` of an existing name is an
+   explicit **replace-or-reject** decision (default reject; MCP refresh uses `Unregister`+`Register`).
+   Registry read paths (`GetAll`/`GetAllowed`) see the merged set.
+
+4. **Descriptor reaches the LLM tool definition.** `ResolveToolsActivity` / `ResolvedTool` already
+   builds the tools array the LLM sees. Thread the descriptor through so downstream stories can read
+   `PermissionClass`/`AutonomyFloor` at resolve time (42-3) — this story only *plumbs* it; 42-3 acts on
+   it. No behavior change to the six built-ins' availability in this story.
+
+## Acceptance Criteria
+
+1. `IToolExecutor.Descriptor` exists as a default interface member returning the deny-by-default
+   descriptor; the interface still compiles with only the four original members implemented (a
+   regression test implements a bare `IToolExecutor` and asserts its resolved descriptor is
+   `Destructive`/floor `100`).
+2. All six built-ins declare explicit descriptors matching the table; a test asserts each tool's
+   `PermissionClass`/`AutonomyFloor`.
+3. `AutonomyFloor` outside `[70,100]` is rejected at registration with a loud error (not clamped).
+4. `IToolExecutorRegistry.Register`/`Unregister` exist; a test registers a tool at runtime, resolves it
+   via `GetExecutor`/`GetAll`, unregisters it, and asserts it is gone — with no restart.
+5. Concurrent `Register`/`GetAll` calls are race-free (the backing store is concurrent); a stress test
+   asserts no lost/duplicated entries.
+6. A dynamic `Register` of a name already present rejects by default (test) and succeeds via
+   `Unregister`+`Register` (test).
+7. `ResolvedTool` carries the descriptor through `ResolveToolsActivity`; a test asserts a resolved
+   built-in exposes its `PermissionClass`. **No change** to which of the six tools an unrestricted
+   caller sees (back-compat: an empty allowlist still yields all six).
+
+## Events
+
+None new in this story (the `TOOL.*` DCB family is 42-5). Registry `Register`/`Unregister` log at
+INFO with the tool name and category (never secrets).
+
+## Single-user vs SaaS
+
+No principal-scoped behavior here — the descriptor is a **static property of the tool**, identical in
+both modes. Per-principal *overrides* of a tool's floor/enablement are 42-2; per-mode *resolution* is
+42-3. This story is mode-agnostic by construction.
+
+## Dependencies
+
+- **Epic 29** `SecretPurpose` enum (for `SecretRequirement.Purpose`) — exists.
+- **Unblocks:** 42-2 (store keys off descriptor names), 42-3 (reads `PermissionClass`/`AutonomyFloor`),
+  42-4 (reads `RequiredSecret`), 42-5 (tags events with `PermissionClass`), 42-6 (registers via the new
+  seam), 42-7/8/9 (each declares a descriptor).
+
+## Risks
+
+- **Default interface member reaching the wire.** If the LLM tools array is built off `GetAll()` and a
+  tool forgets its descriptor, deny-by-default could make it silently un-callable. Mitigation: a
+  startup drift test asserts every DI-registered tool declares an explicit (non-default) descriptor —
+  fail-loud at boot, matching `PromptFileLoader`'s "refuse to start on a missing cell" posture.
+- **Registry mutability + Elsa engine lifetime.** `ToolExecutorRegistry` is a singleton; dynamic
+  registration must not leak across tenants. Scope tenant-specific registrations behind 42-6's
+  per-tenant view rather than mutating the global singleton (flagged for 42-6).
+
+## Estimated Effort
+
+Medium (contract + registry change touching the hottest path; heavy on tests, light on new surface).
+~3–4 days.
+</content>

--- a/docs/stories/epic-42/story-42-2/42-2-tool-binding-config-store.md
+++ b/docs/stories/epic-42/story-42-2/42-2-tool-binding-config-store.md
@@ -1,0 +1,130 @@
+# Story 42-2: Tool Binding & Config Store (two-scoping)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As a **user (single-user) or a tenant_admin (SaaS)**, I want to control **which tools are enabled** and
+override their **per-role grant and autonomy floor**, stored under the right principal for my operating
+mode, so that the tool catalog is governed by the same two-scoping ownership model as prompts — the
+sole user owns it in single-user, the tenant_admin owns it in SaaS, and members can't edit it.
+
+## Priority
+
+P0 / Wave 1 — the persistence + resolution order that 42-3's gating reads. Ships right after 42-1.
+
+## The gap (READ FIRST)
+
+42-1 gives each tool a **system-default descriptor** (permission class + autonomy floor). But CLAUDE.md's
+universal rule demands per-principal customization with **two** ownership models: in single-user the
+sole user owns it; in SaaS the tenant_admin owns it and members don't. The Prompt Store already solves
+exactly this shape — `prompt_overrides` keyed by `user_id` XOR `tenant_id`, per-mode resolution order,
+member-write 403 in SaaS. There is **no equivalent for tools**: a tool's floor/enablement is currently
+a hardcoded descriptor with no override layer.
+
+## Scope
+
+1. **`tool_bindings` table** — the tool analogue of `prompt_overrides`, same XOR-principal shape:
+
+   ```sql
+   CREATE TABLE tool_bindings (
+     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+     user_id UUID,                 -- set in single-user mode; NULL in SaaS
+     tenant_id UUID,               -- set in SaaS mode; NULL in single-user
+     tool_name TEXT NOT NULL,      -- matches IToolExecutor.ToolName
+     enabled BOOLEAN NOT NULL DEFAULT true,
+     autonomy_floor INTEGER,       -- override of descriptor floor (NULL = use system default)
+     allowed_roles TEXT[],         -- AgentRole wire names permitted (NULL = descriptor/system default)
+     secret_binding_name TEXT,     -- logical secret name → resolved to a SecretRef by 42-4 (NULL = tool default)
+     config JSONB,                 -- tool-specific config (e.g. flag-provider base URL, HTTP host allowlist)
+     created_at TIMESTAMPTZ DEFAULT now(),
+     updated_at TIMESTAMPTZ DEFAULT now(),
+     CONSTRAINT tool_principal_xor CHECK (
+       (user_id IS NOT NULL AND tenant_id IS NULL)
+       OR (user_id IS NULL AND tenant_id IS NOT NULL)),
+     UNIQUE NULLS NOT DISTINCT (user_id, tenant_id, tool_name)
+   );
+   ```
+
+2. **Resolution order (mirrors the Prompt Store exactly).**
+   - **single-user** `(userId, toolName)`: user binding → system-default descriptor (42-1).
+   - **SaaS** `(tenantId, toolName)`: tenant binding → system-default descriptor. **No per-user layer.**
+   A binding overrides only the fields it sets (`autonomy_floor`, `allowed_roles`, `enabled`,
+   `secret_binding_name`, `config`); unset fields fall through to the descriptor — never a full-record
+   replace (same "override only what's set" semantics as prompts).
+
+3. **RBAC (mirrors the Prompt Store).**
+   | Action | single-user | SaaS |
+   |---|---|---|
+   | GET resolved binding | any user | any tenant member |
+   | PUT/DELETE binding | any user | `tenant_owner`/`tenant_admin` only (member → 403) |
+   | GET system defaults (descriptors) | any user | any member |
+
+4. **API** (endpoint shape identical across modes; middleware picks the key by mode + caller, exactly
+   like `/api/prompts`):
+   ```
+   GET    /api/tools                     — list catalog, resolved for the current principal
+   GET    /api/tools/:toolName           — resolved binding + descriptor
+   PUT    /api/tools/:toolName           — upsert binding (owner/admin only in SaaS)
+   DELETE /api/tools/:toolName           — delete binding → fall back to descriptor (owner/admin only)
+   GET    /api/tools/defaults            — system-default descriptors
+   ```
+
+5. **A `IToolBindingResolver`** that 42-3 calls: given `(principal, mode, toolName)` returns the
+   effective `{ enabled, autonomyFloor, allowedRoles, secretBindingName, config }`. Reads the mode the
+   same way the process settles it (CLAUDE.md Operating Modes) — never both keys.
+
+## Acceptance Criteria
+
+1. `tool_bindings` exists with the XOR constraint and `UNIQUE NULLS NOT DISTINCT` key; a test asserts a
+   row with both `user_id` and `tenant_id` set (or both null) is rejected by the DB.
+2. `IToolBindingResolver` returns the descriptor default when no binding exists, and the
+   field-level-merged binding when one does (test: a binding overriding only `autonomy_floor` leaves
+   `allowed_roles` at the descriptor value).
+3. single-user resolution keys off `user_id`; SaaS off `tenant_id`; a test per mode asserts the other
+   column is never consulted.
+4. SaaS `member` role hits 403 on PUT/DELETE; `tenant_admin` succeeds (test). single-user any-user
+   succeeds.
+5. Deleting a binding falls back to the descriptor (test asserts resolved floor returns to the 42-1
+   default).
+6. `GET /api/tools` lists the merged catalog (DI-seeded + dynamically registered from 42-1) resolved for
+   the caller.
+
+## Events
+
+`TOOL.BINDING_UPDATED` / `TOOL.BINDING_DELETED` DCB events (config-change audit) tagged with the
+principal key and `toolName` — never the secret, never the `config` payload verbatim if it can carry a
+credential (redact `config` values whose keys match the secret-field denylist). Emitted via the standard
+`TammaEventEmitter` drain.
+
+## Single-user vs SaaS
+
+This story **is** the two-scoping model for tools — it is the whole point. It reuses the Prompt Store's
+proven shape (XOR principal, per-mode resolution, member-write 403, no per-user SaaS layer) rather than
+inventing a new one.
+
+## Dependencies
+
+- **42-1** (descriptors are the fall-through target; `tool_name`/floor semantics come from there).
+- **Prompt Store** as the reference implementation to mirror (`prompt_overrides`, resolution order,
+  RBAC middleware).
+- **Unblocks:** 42-3 (consumes `IToolBindingResolver`), 42-4 (`secret_binding_name`).
+
+## Risks
+
+- **Divergence from the Prompt Store pattern.** If this reimplements resolution/RBAC subtly differently,
+  the platform grows two inconsistent override models. Mitigation: extract or directly reuse the Prompt
+  Store's mode-key middleware; a test asserts identical member-403 behavior.
+
+## Estimated Effort
+
+Medium. ~3 days (table + resolver + CRUD endpoints + RBAC, largely paralleling existing prompt code).
+</content>

--- a/docs/stories/epic-42/story-42-3/42-3-permission-autonomy-gating.md
+++ b/docs/stories/epic-42/story-42-3/42-3-permission-autonomy-gating.md
@@ -1,0 +1,127 @@
+# Story 42-3: Per-Tool Permission & Autonomy Gating
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As the **orchestrator dispatching a workflow step**, I want `ResolveToolsActivity` to hand the agent
+**only the tools it is permitted to use, for its role, at the current autonomy level** — and to route
+any destructive or above-floor tool to me (or a human) via the acceptance channel instead of letting
+the agent fire it unattended — so that a tool call carries the same governance as accepting a document:
+low-risk reads run free at high autonomy, and flipping a prod flag or deleting a VPS is a decision taken
+by an actor, never an unattended side effect.
+
+## Priority
+
+P0 / Wave 1 — the **enforcement** story. 42-1 lets a tool declare its class/floor and 42-2 stores
+per-principal overrides; this story is where those become behavior. Every family (42-7/8/9) and MCP tool
+(42-6) is inert-but-safe until this gates them.
+
+## The gap (READ FIRST)
+
+`ResolveToolsActivity` (`Tamma.Activities/LlmCall/ResolveToolsActivity.cs`) resolves tool **definitions**
+from config + a built-in switch and returns `List<ResolvedTool>`. It has a `ToolNamesInput` (the tools a
+step wants) and a `ProviderName` — but it applies **no permission, role, or autonomy filter**. Whatever
+names a step requests are resolved and handed to the LLM. `ToolExecutorRegistry.GetAllowed(allowlist)`
+filters by *name only*. `ToolCallValidator` checks name/format/args/`ActionGate` at call time but knows
+nothing about who the agent is or the autonomy dial. So **there is no per-tool permission or autonomy
+gate anywhere** — the accept gate governs *documents*, not *tool calls*.
+
+## Scope
+
+1. **Gated resolution in `ResolveToolsActivity`.** Add inputs for the resolution context — the agent's
+   `AgentRole`, the principal (userId/tenantId + mode), and the current autonomy level (read live from
+   the acceptance-rules/autonomy config, never cached — Epic 39 rule). For each requested tool name,
+   resolve via 42-2's `IToolBindingResolver` to `{ enabled, autonomyFloor, allowedRoles }` (falling
+   through to the 42-1 descriptor), then keep the tool **only if**: `enabled` **and** the agent's role
+   ∈ `allowedRoles` **and** `autonomyFloor ≤ currentAutonomy` **and** `PermissionClass != Destructive`.
+   The returned `List<ResolvedTool>` is the **eligible callable set** the agent sees.
+
+2. **Route the ineligible-but-needed tools, don't silently drop them.** A requested tool that is
+   `Destructive`, or `autonomyFloor > currentAutonomy`, is **not** dropped from the plan — it is
+   surfaced as a **required-but-gated capability**. The step publishes an authorization request on the
+   **existing** workflow↔orchestrator channel (Epic 39's `AcceptanceRequest` machinery — see Open
+   Question 3 on whether it is the accept family verbatim or a sibling `ToolAuthorizationRequest`) and
+   **suspends** (resumable-by-design). The orchestrator, reading the autonomy dial + acceptance rules,
+   either authorizes (itself, at high autonomy for the allowed classes) or assigns the decision to a
+   holder of the appropriate tenant role — landing in their Task View (Epic 39 39-20 scoping). This is
+   the **"acceptor is an actor, not a branch"** model applied to capabilities: a destructive tool call
+   is authorized by someone, exactly like accepting a document. On authorization, the tool becomes
+   callable for that bounded invocation; on denial the step takes the loud handoff edge.
+
+3. **Workflow/cell declares the tools its step needs.** Keep `ToolNamesInput` as the declaration point
+   (a step/producer says "I need `deploy_control`, `feature_flag`"). This story makes that declaration
+   *resolve to the permitted+eligible subset* per agent+principal rather than a blind pass-through. A
+   step that needs a tool it may never get (role not permitted at all) fails at resolve with a loud,
+   typed "capability not granted" — never a silent empty tool list that makes the agent hallucinate the
+   action succeeded.
+
+4. **Call-time defense-in-depth.** `ToolCallValidator` already runs at invocation. Extend its allowlist
+   check to also assert the tool is in the *eligible* set for the run (not just name-format-valid) — so a
+   model that fabricates a tool-call for a gated tool is rejected with the same posture as an
+   off-allowlist call. Belt-and-suspenders with the resolve-time filter.
+
+## Acceptance Criteria
+
+1. `ResolveToolsActivity` returns only tools that are enabled, role-permitted, autonomy-eligible, and
+   non-`Destructive` for the run context (table-driven test across roles × autonomy levels × classes).
+2. Autonomy is read live: two runs of the same step at autonomy 72 vs 95 resolve different eligible sets
+   for a tool with floor 85 (test) — the value is not captured into the workflow state.
+3. A requested `Destructive` (or above-floor) tool triggers an authorization request on the acceptance
+   channel and the step suspends; a test drives the authorize path (tool becomes callable) and the deny
+   path (loud handoff), asserting no unattended execution occurs before authorization.
+4. A step requesting a tool the agent's role is **never** granted fails loud/typed at resolve — asserted
+   not to produce an empty-but-successful tool list.
+5. `ToolCallValidator` rejects a fabricated call to a gated/ineligible tool at invocation time (test),
+   independent of the resolve-time filter.
+6. single-user and SaaS both enforce correctly: single-user reads the user's bindings, SaaS the
+   tenant's; a SaaS `member`-run agent gets the tenant_admin's resolved grants (no per-user layer).
+
+## Events
+
+`TOOL.RESOLVED` (eligible set size + gated count, per run), `TOOL.DENIED` (role/autonomy denial),
+`TOOL.ESCALATED` (routed to orchestrator/human for authorization), `TOOL.AUTHORIZED` /
+`TOOL.AUTHORIZATION_DENIED` (the decision outcome). All tagged `issueId`/`tenantId`/`toolName`/
+`permissionClass`; emitted via the standard `TammaEventEmitter` drain. (The invocation-level
+`TOOL.INVOKED/SUCCEEDED/FAILED` are 42-5.)
+
+## Single-user vs SaaS
+
+- **single-user:** the sole user's `tool_bindings` (42-2) drive role/floor/enablement; authorization of
+  a gated tool routes to the single orchestrator/user.
+- **SaaS:** the tenant's bindings drive it; authorization routes to the tenant orchestrator or a holder
+  of the appropriate tenant role — hard-scoped to the tenant (tools, context, and the acceptance channel
+  never cross the tenant boundary, per Epic 39's orchestrator-per-tenant model).
+
+## Dependencies
+
+- **42-1** (`PermissionClass`/`AutonomyFloor` on the descriptor), **42-2** (`IToolBindingResolver`).
+- **Epic 39:** the `AcceptanceRequest` workflow↔orchestrator channel + autonomy dial + Task View (the
+  authorization routing rides these unchanged).
+- **`Tamma.Core/Agents` `AgentRole`** for the role check (and Epic 41-1's added roles once landed —
+  `ux_designer`/`scrum_master`/`project_manager` — extend the grantable set with no change here).
+- **Unblocks:** every tool family (42-7/8/9) and MCP (42-6) — they are governed the moment they declare
+  a descriptor.
+
+## Risks
+
+- **Reusing vs. forking the accept gate.** Routing a tool authorization through `AcceptanceRequest`
+  must not duplicate acceptance semantics. Mitigation: resolve Open Question 3 up front — prefer reusing
+  the accept-gate actor/suspend/Task-View machinery with a `ToolAuthorizationRequest` payload so tool
+  authorizations appear in the existing inbox with no new surface.
+- **Silent empty tool list.** The classic failure is handing the agent zero tools and letting it claim
+  success. AC4 pins this as a loud, typed failure.
+
+## Estimated Effort
+
+Large. ~5–6 days (touches the hot resolve path + a new suspend/authorize edge; heavy cross-mode +
+cross-autonomy test matrix).
+</content>

--- a/docs/stories/epic-42/story-42-4/42-4-tool-credential-secret-binding.md
+++ b/docs/stories/epic-42/story-42-4/42-4-tool-credential-secret-binding.md
@@ -1,0 +1,125 @@
+# Story 42-4: Tool Credential / Secret Binding
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As a **tool that touches an external system**, I want to **bind to a stored secret** resolved for my
+principal — per-tenant in SaaS, per-user in single-user — and receive the live credential at execution
+time **without it ever reaching a log, an event, or the tool's output**, so that a cloud/flag/deploy/HTTP
+tool authenticates safely and the platform's no-secret-in-logs promise holds for capabilities the same
+way it holds for documents.
+
+## Priority
+
+P0 / Wave 1 — the security envelope for every external-touching family. 42-7/8/9 cannot ship their agent
+path without it. **Carries the epic's biggest external dependency** (the reveal path — see below).
+
+## The gap (READ FIRST)
+
+No tool binds to a secret today; the six built-ins touch only the local repo/git/shell. Epic 29's
+**`ISecretStore` now exists** (Story 29-1 — CLAUDE.md's "does not yet exist" note is **stale**), with
+`SecretRef` (`scope`, `tenantId?`, `name`), `SecretScope` (`Platform`/`Tenant`), `SecretPurpose`
+(`ApiKey`/`SigningKey`/`DbCredential`/HMAC/…), envelope-encrypted Postgres backend, and an
+`ISecretAccessAuditor` on every access. **But by explicit design `ISecretStore` never returns plaintext
+through a public signature** — plaintext reaches only a registered *rotation handler* via callback
+(reveal to a human is the separate 29-3 reveal-once UX). A tool calling Hetzner/Slack needs the *live
+plaintext* at execution time. **That path does not exist** — this is the reconciliation this story must
+make.
+
+## Scope
+
+1. **Resolve a tool's `RequiredSecret` to a `SecretRef` per mode.** 42-1's descriptor declares
+   `SecretRequirement(Purpose, Name, Required)`; 42-2's binding may override the logical `Name`
+   (`secret_binding_name`). This story resolves that to a concrete `SecretRef`:
+   - **single-user:** the user's secret — `SecretRef.ForTenant`/a user-owned scope per the single-user
+     ownership model (the sole user owns their secrets).
+   - **SaaS:** `SecretRef.ForTenant(tenantId, name)` — tenant-scoped, so tenant A's Hetzner key is never
+     visible to tenant B (enforced by `ISecretStore`'s existing tenant-scoped authorization).
+   A `Required` secret that does not resolve is a **loud, typed** "capability unconfigured" failure at
+   resolve time (42-3 surfaces it) — never a tool that runs unauthenticated.
+
+2. **The reveal-to-runtime-consumer path (the hard dependency).** Because `ISecretStore` won't return
+   plaintext publicly, define an **`IToolSecretProvider`** seam that hands a tool a **short-lived,
+   scoped credential** for one invocation without the tool ever seeing or storing the cabinet value.
+   Two candidate backings (Open Question 1 in the epic README):
+   - **(a)** an audited *reveal-to-consumer* extension of `ISecretStore` (building on 29-3 +
+     `ISecretAccessAuditor`) that returns plaintext to a registered *tool* consumer under policy;
+     **or (b)** an injection seam where the store performs the authenticated call *on behalf of* the
+     tool (the tool never receives plaintext).
+   **This story assumes (a) is filed as an Epic 29 story and hard-depends on it.** Until it lands, an
+   external-touching tool resolves only in the human-assigned path (Epic 41 rule 4) — the agent path is
+   dark but never silently unauthenticated.
+
+3. **No secret in logs / events / output — enforced.** The credential is fetched immediately before the
+   external call, held only for the call, and never placed in `ToolExecutionResult.Output`, in any DCB
+   `TOOL.*` event args (42-5 redacts by the `RequiredSecret` field names + a value-match denylist),
+   or in error messages (reuse `ErrorRedactor` / `SecurityHelpers`). A tool that would echo a bound
+   secret field back is redacted before the result leaves `ExecuteAsync`.
+
+4. **Access is audited through Epic 29's `ISecretAccessAuditor`.** Every tool secret fetch emits an
+   Epic 29 access-audit row *and* a DCB `TOOL.SECRET_ACCESSED` event (ref storage key only, never the
+   value) so the tool-use trail and the secret-access trail reconcile on `issueId`/`tenantId`.
+
+## Acceptance Criteria
+
+1. A tool's `RequiredSecret` resolves to the correct `SecretRef` per mode (test: SaaS → tenant-scoped
+   ref for the run's tenant; single-user → the user's ref); a cross-tenant resolve is impossible (test
+   asserts tenant A's run cannot resolve tenant B's secret).
+2. `IToolSecretProvider` returns a short-lived credential for one invocation; a test asserts the
+   credential is not retained after `ExecuteAsync` returns and never appears in the result.
+3. A `Required` secret that is unconfigured fails loud/typed at resolve (test) — the tool is never
+   invoked unauthenticated.
+4. No bound secret value appears in `ToolExecutionResult.Output`, DCB event args, or error text across
+   the family tools (test injects a known secret value and greps every emitted artifact for it).
+5. Every tool secret fetch produces an `ISecretAccessAuditor` row + a `TOOL.SECRET_ACCESSED` DCB event
+   carrying only the ref storage key.
+6. With the reveal path **absent**, an external-touching tool's agent path is disabled and the step
+   routes human-assigned (test with the reveal seam stubbed unavailable) — never a crash, never a silent
+   unauthenticated call.
+
+## Events
+
+`TOOL.SECRET_ACCESSED` (ref storage key + purpose + tenant tag, **no value**). All other tool events are
+42-5; this story defines only the secret-access one and the redaction rules the rest inherit.
+
+## Single-user vs SaaS
+
+- **single-user:** the sole user owns their secrets; the tool resolves the user-scoped ref.
+- **SaaS:** secrets are tenant-scoped (`SecretRef.ForTenant`), owned by `tenant_admin`; a `member`-run
+  agent uses the tenant's bound secret without seeing it. Tenant isolation is enforced by `ISecretStore`'s
+  existing tenant-scoped authorization — this story adds no cross-tenant path.
+
+## Dependencies
+
+- **Epic 29 (hard):** `ISecretStore`/`SecretRef`/`SecretScope`/`SecretPurpose`/`ISecretAccessAuditor`
+  **exist**; the **reveal-to-runtime-consumer capability does NOT** — this story **files that as a
+  blocking Epic 29 story** (extension of 29-3). Recommend the user confirm direction (a) vs (b) before
+  build.
+- **42-1** (`SecretRequirement` on the descriptor), **42-2** (`secret_binding_name` override), **42-5**
+  (redaction rules applied to the event args).
+- **Unblocks:** 42-7/8/9 agent paths.
+
+## Risks
+
+- **The reveal path is the critical-path blocker.** If Epic 29 doesn't land it, the entire external-tool
+  *agent* value is deferred (human-assigned still works). Mitigation: ship the resolution + redaction +
+  human-assigned fallback in this story so that when the reveal seam lands, families flip on with no
+  further security work.
+- **Leak surface breadth.** Secrets can leak via output, events, errors, or a mis-typed `config` blob
+  (42-2). Mitigation: a single choke-point redactor at the `ExecuteAsync`/event-emit boundary + the
+  grep-for-value test (AC4) run against every family.
+
+## Estimated Effort
+
+Large (blocked-dependency + security-critical). ~4–5 days for the resolution/redaction/fallback in this
+epic; the reveal path itself is Epic 29 effort, out of scope here.
+</content>

--- a/docs/stories/epic-42/story-42-5/42-5-tool-use-dcb-audit.md
+++ b/docs/stories/epic-42/story-42-5/42-5-tool-use-dcb-audit.md
@@ -1,0 +1,115 @@
+# Story 42-5: Tool-Use DCB Audit
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As the **platform audit trail**, I want **every tool invocation** to emit a durable, secret-redacted DCB
+event — invoked, succeeded, failed — tagged with `issueId`/`tenantId`/`toolName`/`permissionClass`, so
+that a tool call carries the same 100%-audit, time-travel-debuggable trail as a document transition, and
+"the agent deleted a VPS at 14:03 under autonomy 95, authorized by the orchestrator" is a queryable row.
+
+## Priority
+
+P0 / Wave 1 — the audit half of the security envelope. A `Destructive` capability without a durable
+trail is unacceptable; this must precede any family shipping.
+
+## The gap (READ FIRST)
+
+Tool progress is emitted **ephemerally**: `ToolLoopEventEmitter` (`Tamma.Activities/ToolExecution/`)
+writes `TOOL_LOOP.TURN_STARTED` / `TOOL_LOOP.TOOL_EXECUTING` / `TOOL_LOOP.TOOL_COMPLETED` to
+`IToolLoopEventSink`, whose default is `NullToolLoopEventSink` (**discards everything**); the live sink
+is an SSE/bus stream for the dashboard. **None of it is durable** — nothing writes a tool call to the
+`domain_events` DCB store. Documents get a `DOCUMENT.*` trail via `TammaEventEmitter` → the workflow's
+`tamma:events` transient list → `EventPersistenceMiddleware`/`EventDrain` → durable `domain_events`
+(see `EmitTestingEventActivity` for the exact pattern — no `IEventRepository` is held inside the Elsa
+engine). Tools have **no equivalent durable family**.
+
+## Scope
+
+1. **A durable `TOOL.*` DCB family**, emitted at the `ParallelToolExecutor.ExecuteSingleToolAsync` hook
+   points (the same places `EmitToolExecuting`/`EmitToolCompleted` fire the ephemeral SSE events) via
+   the `TammaEventEmitter` → `tamma:events` drain — **not** a direct repository call (the engine holds
+   none, per the established pattern):
+
+   | Event | When | Key payload (redacted) |
+   |---|---|---|
+   | `TOOL.INVOKED` | before `ExecuteAsync` | toolName, permissionClass, autonomyAtCall, argsRedacted |
+   | `TOOL.SUCCEEDED` | `Success == true` | toolName, durationMs, outputSizeBytes |
+   | `TOOL.FAILED` | `Success == false` / timeout / exception | toolName, durationMs, failureReason (redacted) |
+
+   These sit **alongside** (not replacing) the ephemeral `TOOL_LOOP.*` SSE events — SSE is the live UI
+   feed; `TOOL.*` is the permanent record. (42-3 already defines the pre-invocation governance events
+   `TOOL.RESOLVED`/`DENIED`/`ESCALATED`/`AUTHORIZED`; 42-4 defines `TOOL.SECRET_ACCESSED`. This story
+   owns the **invocation** trio and the shared redaction rule.)
+
+2. **Redaction is mandatory and centralized.** Args are redacted before they enter any event: fields
+   named by the tool's `RequiredSecret` (42-1) plus a value-match denylist (any substring equal to a
+   resolved secret value) are replaced with `«redacted»` via `ErrorRedactor`/`SecurityHelpers`. A tool
+   with no `RequiredSecret` still passes args through the sanitizer path. Oversized args are truncated
+   (reuse `ToolOutputHelper.Truncate`).
+
+3. **Tagging for lineage.** Every `TOOL.*` event carries `issueId` (the anchor — Epic 39: documents
+   reference issues), `tenantId` (empty/platform-scope in single-user), `toolName`, `permissionClass`,
+   and the `workflowInstanceId`/`toolCallId` correlation already threaded through the emitter (Story
+   32-23). This makes the per-issue lineage `Issue → … → tool calls → outcome` queryable next to the
+   document lineage.
+
+4. **Reconcile the two sinks.** Document the invariant: `IToolLoopEventSink` = ephemeral live progress;
+   `TOOL.*` DCB = durable audit. The hook fires both at the same point so a replay reconstructs the tool
+   timeline from `domain_events` even when no SSE consumer was attached.
+
+## Acceptance Criteria
+
+1. A tool invocation emits `TOOL.INVOKED` then exactly one of `TOOL.SUCCEEDED`/`TOOL.FAILED` to the
+   durable DCB store (integration test asserts rows in `domain_events` with matching `toolCallId`).
+2. A failing/timing-out/throwing tool emits `TOOL.FAILED` (error-status), never a silent success — a
+   degraded terminal is a loud audit row (mirrors `EmitTestingEventActivity`'s error-status posture).
+3. Redaction: a tool call whose args contain a bound secret value emits `TOOL.INVOKED` with the value
+   replaced by `«redacted»` (test greps the emitted event for the known value and asserts absence).
+4. Every `TOOL.*` event carries `issueId`/`tenantId`/`toolName`/`permissionClass` tags; a replay test
+   reconstructs the tool timeline for an issue from `domain_events` alone.
+5. Durable emission happens **regardless of sink**: with `NullToolLoopEventSink` wired (no SSE), the
+   `TOOL.*` rows are still persisted (test).
+6. The ephemeral `TOOL_LOOP.*` SSE events are unchanged (no regression to 32-x dashboard behavior).
+
+## Events
+
+Defines `TOOL.INVOKED` / `TOOL.SUCCEEDED` / `TOOL.FAILED` and the shared redaction rule inherited by all
+other `TOOL.*` events in the epic. Uses the `AGGREGATE.ACTION.STATUS` convention (`TOOL` aggregate).
+
+## Single-user vs SaaS
+
+Identical emission both modes; `tenantId` tag is populated in SaaS (routing the event into the tenant
+schema's `domain_events`, per Epic 39 39-21 tenant-scoped stores) and empty/platform in single-user. No
+per-mode behavior beyond the tag.
+
+## Dependencies
+
+- **42-1** (`PermissionClass` for the tag, `RequiredSecret` for the redaction field set).
+- **Epic 39 / Story 32-23** the `TammaEventEmitter` → `EventDrain` durable path + the
+  `workflowInstanceId`/`toolCallId` correlation already in `ToolLoopEventEmitter`.
+- **42-4** (secret values to redact against).
+- **Unblocks:** every family — no `Destructive` tool ships without this trail.
+
+## Risks
+
+- **Redaction gaps.** A secret embedded in a nested arg or reflected in output could slip through.
+  Mitigation: a single centralized redactor at the emit boundary + a value-match denylist + the
+  grep-for-value test (shared with 42-4 AC4) run against every family.
+- **Hot-path cost.** Two extra durable events per tool call. Mitigation: emission is via the transient
+  list + batched drain (no per-call DB round-trip inside the engine), matching the testing-pipeline's
+  volume.
+
+## Estimated Effort
+
+Medium. ~3 days (new event family on an established emitter pattern + redaction + replay tests).
+</content>

--- a/docs/stories/epic-42/story-42-6/42-6-mcp-integration.md
+++ b/docs/stories/epic-42/story-42-6/42-6-mcp-integration.md
@@ -1,0 +1,115 @@
+# Story 42-6: MCP Integration
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As a **platform operator (single-user) or tenant_admin (SaaS)**, I want to register an **external MCP
+server** and have the tools it exposes appear in the tool registry — governed by the same permission,
+autonomy, secret, and audit rules as native tools — so that the catalog becomes open-ended: a new
+capability is a server registration, not a code change and redeploy.
+
+## Priority
+
+P1 / Wave 2 — the **dynamic-tool path** that makes the catalog extensible without shipping a class per
+tool. Depends on the full Wave-1 governance envelope (42-1–42-5); proves a non-native tool obeys it.
+
+## The gap (READ FIRST)
+
+The registry is compile-time static (42-1's gap): the only way to add a tool today is a class + a
+`Program.cs` DI line. There is **no MCP client, no external-tool ingestion, no dynamic catalog**. 42-1
+adds the `Register`/`Unregister` seam; this story is the first consumer of it — bridging MCP-exposed
+tools into `IToolExecutor` so they flow through the exact same resolve → gate → secret → execute → audit
+pipeline as `SearchCodeTool`.
+
+## Scope
+
+1. **An MCP client + `McpToolExecutor` adapter.** For each configured MCP server, discover its exposed
+   tools (name, description, JSON input schema — the MCP tool spec maps cleanly onto `IToolExecutor`'s
+   `ToolName`/`Description`/`InputSchema`) and register one `McpToolExecutor : IToolExecutor` per tool
+   via 42-1's dynamic `Register`. `ExecuteAsync` proxies the call to the MCP server over its transport
+   and maps the MCP result → `ToolExecutionResult` (**never throws** — a transport/protocol error is
+   `Success = false`, honoring the contract). Names are namespaced (`mcp:<server>:<tool>`) to avoid
+   collision with native tools.
+
+2. **Governance is mandatory, deny-by-default.** An MCP tool arrives with **no** permission class or
+   autonomy floor. Its `ToolDescriptor.Category = Mcp` and it inherits 42-1's fail-safe default
+   (`Destructive`, floor 100, deny-by-default) **until an operator/tenant_admin classifies it** via the
+   42-2 binding store (`allowed_roles`, `autonomy_floor`, `enabled`, `secret_binding_name`). So a freshly
+   registered MCP tool is **inert until explicitly granted** — never auto-trusted. (See epic Open
+   Question 2 on whether MCP tools may default to `ReadOnly` instead.)
+
+3. **Secret binding + audit, unchanged.** An MCP tool that needs a credential binds through 42-4
+   (`secret_binding_name` → `SecretRef`); its calls emit the 42-5 `TOOL.*` DCB family with the same
+   redaction. The MCP server's own auth (if any) is a bound secret like any other. Nothing about MCP
+   bypasses the envelope.
+
+4. **Registration surface + tenancy.** Config-driven server registration
+   (`Mcp:Servers:<name>:{ Endpoint, Transport, AuthSecretName }`) plus a management endpoint. **Tenancy
+   (epic Open Question 4):** in SaaS, decide whether a `tenant_admin` may register a tenant-scoped MCP
+   server (its tools registered into the tenant's view only, never the global singleton — see 42-1 Risk)
+   or whether the MCP allowlist is platform-owned. This story implements the **platform-owned** path
+   first (simpler, safe) and leaves per-tenant MCP registration as a documented follow-on if chosen.
+
+5. **Refresh / health.** MCP tool sets can change; a server going away must `Unregister` its tools
+   (loud, not a dangling executor that fails every call). A periodic/rediscovery refresh uses
+   `Unregister`+`Register` (42-1's replace path).
+
+## Acceptance Criteria
+
+1. A configured MCP server's tools are discovered and registered as `McpToolExecutor`s visible via
+   `GetAll`/`GetExecutor` with namespaced names (integration test against a stub MCP server).
+2. An MCP tool executes end-to-end through `ParallelToolExecutor` and maps success/error to
+   `ToolExecutionResult` without throwing (test drives a success, a protocol error, and a timeout).
+3. A newly registered MCP tool is **deny-by-default** — not resolvable to an agent until classified via
+   a 42-2 binding (test: agent resolve returns empty for the unclassified tool; grant a binding and it
+   becomes eligible).
+4. An MCP tool with a bound secret authenticates via 42-4 and emits redacted 42-5 `TOOL.*` events (test).
+5. Unregistering/removing a server removes its tools from the registry with no dangling executor (test).
+6. A destructive-classified MCP tool routes through 42-3's authorization exactly like a native
+   destructive tool (test).
+
+## Events
+
+Reuses 42-5's `TOOL.*` family for invocation. Adds `TOOL.MCP_SERVER_REGISTERED` /
+`TOOL.MCP_SERVER_REMOVED` (server name + tool count, **no auth secret**) for the catalog-change audit.
+
+## Single-user vs SaaS
+
+- **single-user:** the sole user registers MCP servers; tools classified against the user's bindings.
+- **SaaS:** platform-owned MCP allowlist by default (this story); per-tenant MCP registration is the
+  documented follow-on (Open Question 4). Either way, an MCP tool's secret is tenant-scoped (42-4) and
+  its calls are tenant-tagged in the audit — a tenant's MCP tool never reaches another tenant.
+
+## Dependencies
+
+- **42-1** (dynamic `Register`/`Unregister`, `ToolCategory.Mcp`, deny-by-default descriptor).
+- **42-2** (classification bindings), **42-3** (gating/authorization), **42-4** (secret binding),
+  **42-5** (audit) — the full envelope MCP tools inherit.
+- External: an MCP client library / SDK for the chosen transport.
+- **Unblocks:** open-ended catalog growth for Epic 41 and beyond without per-tool code.
+
+## Risks
+
+- **Trust surface.** An MCP server is external code exposing tools; auto-trusting it would reopen the
+  attack surface the epic closes. Mitigation: deny-by-default classification (AC3) + platform-owned
+  allowlist first + the same secret/audit envelope.
+- **Global-singleton mutation for a per-tenant server.** Registering a tenant's MCP tools into the
+  shared registry singleton would leak them cross-tenant. Mitigation: keep per-tenant MCP behind a
+  tenant-scoped registry view (deferred with the per-tenant path), platform-owned only in this story.
+- **Schema mismatch.** MCP input schemas may not satisfy `ToolCallValidator`'s constraints. Mitigation:
+  validate/normalize at registration; reject a tool whose schema can't be represented, loudly.
+
+## Estimated Effort
+
+Large. ~5–6 days (MCP client + adapter + lifecycle/refresh + the deny-by-default classification flow +
+tenancy decision).
+</content>

--- a/docs/stories/epic-42/story-42-7/42-7-cloud-vps-resource-tool.md
+++ b/docs/stories/epic-42/story-42-7/42-7-cloud-vps-resource-tool.md
@@ -1,0 +1,109 @@
+# Story 42-7: Cloud / VPS Resource Operations Tool (provider-abstracted)
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As an **agent running an infra, incident, or capacity workflow**, I want a **provider-abstracted
+cloud/VPS tool** to list, create, resize, and delete compute/resources — with delete/resize gated as
+`Destructive` and bound to the provider credential — so that an `infra` task or a `41-22` rollback can
+actually touch the VPS instead of shelling out unbound.
+
+## Priority
+
+P2 / Wave 3 — a tool family on the Wave-1 rails. Sequenced after 42-9/42-8 by Epic 41 demand (fewer 41
+workflows need raw cloud ops than need HTTP/flags), but it is the family that finally replaces
+`ShellExecute`-as-a-deploy-substitute for real infrastructure.
+
+## Scope
+
+1. **A provider abstraction, mirroring the Git/AI provider pattern.** Define `ICloudResourceProvider`
+   (list / create / resize / delete / describe a resource) and one reference driver — **Hetzner**
+   (the platform's own VPS host, per CLAUDE.md) — plus a **generic** driver seam so other providers grow
+   the way the 7 Git platforms / 8 AI providers did. The tool (`CloudResourceTool : IToolExecutor`)
+   dispatches to the configured provider; the LLM sees one tool with an `operation` + `resource` schema,
+   not per-provider tools.
+
+2. **Per-operation permission class** (the descriptor's class is the *ceiling*; the tool self-declares
+   per-operation and 42-3 gates each call):
+   | Operation | PermissionClass | Notes |
+   |---|---|---|
+   | `list` / `describe` | `ReadOnly` | safe at autonomy 70 |
+   | `create` | `Mutating` | reversible (delete undoes it) |
+   | `resize` | `Destructive` | risk of downtime / data movement |
+   | `delete` | `Destructive` | irreversible → routed to orchestrator/human by 42-3 |
+   Because a single `IToolExecutor` carries one `Descriptor`, model this as **operation-scoped
+   descriptors** (the tool exposes the max class as its descriptor and reports the actual class per call
+   to 42-3's gate) **or** split into `cloud_resource_read` (`ReadOnly`) and `cloud_resource_write`
+   (max `Destructive`) tools — **recommend the split** so gating is per-tool-clean (see AC1).
+
+3. **Secret binding.** Binds `SecretRequirement(SecretPurpose.ApiKey, "cloud/<provider>-token", Required)`
+   via 42-4 — tenant-scoped in SaaS (tenant A's Hetzner project token ≠ tenant B's), user-scoped in
+   single-user. The token never reaches logs/events/output (42-4/42-5).
+
+4. **Long ops suspend.** A create/resize that the provider runs async sets the descriptor's
+   `Suspends = true`: the tool starts the op, the workflow **suspends** (resumable-by-design), and
+   resumes on the provider's completion (poll or callback) — reusing the platform's resumable pattern
+   rather than blocking a worker thread. Failure is a loud `TOOL.FAILED` + the workflow's shared fail
+   edge.
+
+5. **Audit.** Every op emits 42-5 `TOOL.*` with `resourceId`/`operation`/`provider` tags (no token). A
+   `delete` carries the authorizing actor (orchestrator/human) from 42-3 in its lineage.
+
+## Acceptance Criteria
+
+1. `list`/`describe` resolve as `ReadOnly` (callable at autonomy 70); `delete`/`resize` are
+   `Destructive` and route through 42-3 authorization before execution (test per operation). If
+   implemented as read/write split tools, the split is asserted; if operation-scoped, the per-call class
+   reported to the gate is asserted.
+2. The tool dispatches through `ICloudResourceProvider` to the Hetzner driver; a stub-provider test
+   drives create → describe → delete without the tool knowing the concrete provider.
+3. The provider token binds tenant-scoped in SaaS / user-scoped in single-user (42-4) and never appears
+   in any emitted artifact (grep-for-value test).
+4. A long create suspends the workflow and resumes on completion (integration test with a stubbed async
+   provider) — no blocked worker thread, resumable across a crash.
+5. A `delete` records the authorizing actor in its `TOOL.*` lineage (test).
+6. Provider/transport failure yields `Success = false` + `TOOL.FAILED`, never a throw or silent success.
+
+## Events
+
+Reuses 42-5 `TOOL.INVOKED/SUCCEEDED/FAILED` with cloud tags. No new family.
+
+## Single-user vs SaaS
+
+- **single-user:** the user's cloud token; authorization of destructive ops routes to the single
+  orchestrator/user.
+- **SaaS:** tenant-scoped token; destructive ops route to the tenant orchestrator/role. A tenant's cloud
+  operations and credentials never cross the tenant boundary.
+
+## Epic 41 consumers
+
+`deployment-pipeline` (infra tasks dispatched by 41-29), **41-22** (incident response / rollback —
+recreate/replace a node), **41-23** (capacity & health review — list/describe to assess capacity).
+
+## Dependencies
+
+- **42-1** (descriptor, `Suspends`), **42-3** (per-op gating + destructive authorization), **42-4**
+  (token binding — hard-blocked on the Epic 29 reveal path), **42-5** (audit).
+- **Epic 41 / 41-29** (`infra` `TaskKind` dispatch → `deployment-pipeline`) as the consumer.
+
+## Risks
+
+- **Operation-scoped vs split-tool modeling** (AC1). A single descriptor can't express four different
+  classes cleanly; the read/write split is the recommended resolution — flag for design sign-off.
+- **Irreversible ops.** A wrongly-authorized `delete` is unrecoverable. Mitigation: `Destructive` +
+  always-route-to-actor (42-3) + full lineage (42-5); consider an always-escalate acceptance-rules class
+  for `delete` regardless of autonomy (Epic 39 policy, not tool code).
+
+## Estimated Effort
+
+Large. ~5–6 days (provider abstraction + Hetzner driver + suspend/resume + destructive gating wiring).
+</content>

--- a/docs/stories/epic-42/story-42-8/42-8-feature-flag-deploy-control-tools.md
+++ b/docs/stories/epic-42/story-42-8/42-8-feature-flag-deploy-control-tools.md
@@ -1,0 +1,104 @@
+# Story 42-8: Feature-Flag & Deploy-Control Tools
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As an **agent running a deploy, promotion, or incident workflow**, I want tools to **read/flip feature
+flags** and to **trigger, promote, and roll back a deploy** — with prod-impacting operations gated as
+`Destructive` and bound to the provider credential — so that a `deployment-pipeline` promotion or a
+`41-22` kill-switch/rollback is a first-class governed capability, not a shell script.
+
+## Priority
+
+P2 / Wave 3 — the **release-control family**. Grouped because feature-flag toggling and deploy
+control are the same governance shape (release-affecting mutations, prod-gated) and share the descriptor
++ secret + suspend + audit wiring.
+
+## Scope
+
+### Part A — Feature-flag / config toggle tool (`FeatureFlagTool`)
+
+1. **Provider-abstracted flag interface** (`IFeatureFlagProvider`: read / set / list a flag; one
+   reference driver + generic seam). One `IToolExecutor` the LLM sees; provider chosen by config/binding.
+2. **Permission class by environment.** `read`/`list` = `ReadOnly`; setting a **non-prod** flag =
+   `Mutating`; setting a **prod** flag or a **kill-switch** = `Destructive` (routed to orchestrator/human
+   by 42-3). The prod-vs-non-prod distinction comes from the flag/env passed in the call, checked at the
+   gate — recommend a read/write split as in 42-7 for clean per-tool classing.
+3. **Secret:** `SecretRequirement(ApiKey, "flags/<provider>", Required)`, tenant/user-scoped via 42-4.
+
+### Part B — Deploy control tool (`DeployControlTool`)
+
+1. **Provider-abstracted deploy interface** (`IDeployControlProvider`: trigger / promote / rollback /
+   status of a deploy; one reference driver aligned to the platform's deploy path — Docker Compose on the
+   Hetzner VPS per CLAUDE.md — plus a generic seam).
+2. **Permission class by target.** `status` = `ReadOnly`; `trigger`/`promote` to **staging** =
+   `Mutating`; `trigger`/`promote` to **prod** and any `rollback` = `Destructive`. Prod
+   promotion/rollback routes to the orchestrator/human via 42-3 — and note Epic 39 already models
+   "final production-deploy authorization for regulated/breaking changes" as an **always-escalate
+   acceptance-rules class**, so prod deploy stays a human decision by *policy*, not tool code (Epic 41
+   out-of-scope item). This tool *executes* an authorized deploy; it never *decides* to skip the gate.
+3. **Secret:** `SecretRequirement(ApiKey | SigningKey, "deploy/<platform>", Required)`, scoped via 42-4.
+4. **Long deploys suspend.** `Suspends = true`: trigger the deploy, suspend the workflow, resume on
+   completion (poll/callback) — resumable-by-design, no blocked worker (mirrors 42-7 §4 and the existing
+   `deployment-pipeline` semantics).
+
+## Acceptance Criteria
+
+1. Flag `read`/`list` resolve `ReadOnly`; a **prod** flag set is `Destructive` and routes through 42-3
+   authorization before applying (test); a **non-prod** set is `Mutating` and runs at its floor (test).
+2. Deploy `status` is `ReadOnly`; **staging** trigger/promote is `Mutating`; **prod** promote and any
+   `rollback` are `Destructive` and route to the actor (test per operation).
+3. Both tools dispatch through their provider interface to the reference driver via a stub-provider test
+   (no concrete-provider knowledge in the tool).
+4. Credentials bind tenant/user-scoped (42-4) and never appear in any emitted artifact (grep test).
+5. A prod deploy that hits an always-escalate acceptance class routes to a human regardless of autonomy
+   level (test — the tool does not bypass the Epic 39 policy gate).
+6. A long deploy suspends and resumes on completion; failure yields `Success = false` + `TOOL.FAILED`,
+   never a throw or silent success.
+7. A `rollback` records the authorizing actor in its `TOOL.*` lineage (test).
+
+## Events
+
+Reuses 42-5 `TOOL.*` with `flag`/`environment` and `deploy`/`target`/`status` tags. No new family.
+
+## Single-user vs SaaS
+
+- **single-user:** the user's flag/deploy credentials; prod authorizations route to the single
+  orchestrator/user.
+- **SaaS:** tenant-scoped credentials and config (a tenant flips only its own flags / drives only its own
+  deploys); prod authorizations route to the tenant orchestrator/role, tenant-isolated.
+
+## Epic 41 consumers
+
+`deployment-pipeline` (promotion + rollback for infra tasks via 41-29), **41-22** (incident kill-switch
++ rollback), **41-24** (release-notes trigger keyed off a promote), 41-29 `infra` `TaskKind`.
+
+## Dependencies
+
+- **42-1** (descriptor, `Suspends`), **42-3** (prod-gating + authorization), **42-4** (secret binding —
+  hard-blocked on the Epic 29 reveal path), **42-5** (audit).
+- **Epic 39** always-escalate acceptance-rules class for prod deploy (policy, reused not rebuilt).
+- **Epic 41 / 41-29** consumers.
+
+## Risks
+
+- **Prod blast radius.** A wrongly-authorized prod flag/deploy is high-impact. Mitigation: `Destructive`
+  + 42-3 actor-authorization + the Epic 39 always-escalate class for prod + full 42-5 lineage.
+- **Env detection.** Prod-vs-non-prod must be reliable (a flag mislabeled non-prod escapes the gate).
+  Mitigation: env comes from validated config/binding, not free-text from the model; unknown env → treat
+  as prod (fail-safe).
+
+## Estimated Effort
+
+Large. ~5–6 days (two provider abstractions + reference drivers + suspend/resume + prod-gating wiring),
+shared plumbing keeps it from being two separate larges.
+</content>

--- a/docs/stories/epic-42/story-42-9/42-9-authenticated-http-external-api-tool.md
+++ b/docs/stories/epic-42/story-42-9/42-9-authenticated-http-external-api-tool.md
@@ -1,0 +1,116 @@
+# Story 42-9: Authenticated HTTP / External-API Tool
+
+Status: drafted
+
+## MANDATORY: Before You Code
+
+**ALL contributors MUST read and follow the comprehensive development process:**
+
+[BEFORE_YOU_CODE.md](../../../guides/BEFORE_YOU_CODE.md)
+
+Then check the knowledge base: `.dev/spikes/`, `.dev/bugs/`, `.dev/findings/`, `.dev/decisions/`.
+
+## User Story
+
+As an **agent running a workflow that must reach an external service**, I want a **generic authenticated
+HTTP tool** that makes one REST call to a **host-and-method-allowlisted, credential-bound** endpoint, so
+that a stakeholder update, a standup digest, or a docs publish can actually be posted — without opening a
+raw egress hole or leaking the credential.
+
+## Priority
+
+P2 / Wave 3 — **ship first among the families.** It unblocks the most Epic 41 workflows (41-5, 41-7,
+41-24/25/26 all need "post this artifact somewhere") for the least surface, and it is the safe,
+general-purpose capability the platform is missing most.
+
+## The gap (READ FIRST)
+
+An agent that produces a stakeholder update (41-5) or a standup digest (41-7) has **no way to deliver
+it** — the six built-ins can write a file, commit, and shell, but there is no governed way to POST to
+Slack/Jira/a webhook. `ShellExecute` + `curl` is the current de-facto path — unbound, unaudited, and
+egress-unbounded (and `ActionGate` even blocks common `curl | bash` patterns). This story gives a
+first-class, allowlisted, credential-bound HTTP capability.
+
+## Scope
+
+1. **`HttpRequestTool : IToolExecutor`.** One call = one request to a **bound endpoint**. The tool does
+   **not** accept an arbitrary URL from the model; it accepts an **endpoint key** (resolved via the 42-2
+   binding's `config` to a base host + a **host+method allowlist**) plus a path/body/headers the model
+   fills. A request to a host or method not in the binding's allowlist is rejected loudly (SSRF / egress
+   containment). This keeps the model from being tricked into hitting arbitrary or internal hosts
+   (defense against prompt-injected exfiltration — consistent with `ContentSanitizer`/`ActionGate`
+   posture).
+
+2. **Permission class.** `ReadOnly` for a GET-only binding; `Mutating` for a binding that permits
+   POST/PUT/PATCH/DELETE (the default). Rarely `Destructive` — a specific binding an operator marks so
+   (e.g. an endpoint that tears something down) inherits destructive routing via 42-3. Class comes from
+   the **binding**, not the model's method choice, so it can't be downgraded by the caller.
+
+3. **Secret binding.** `SecretRequirement(SecretPurpose.ApiKey, "http/<endpoint-key>", Required)` via
+   42-4 — injected as the configured auth (header/bearer/basic per binding `config`), tenant-scoped in
+   SaaS / user-scoped in single-user. The credential is applied at call time and **never** echoed into
+   `Output` (a response body that reflects the token is redacted before the result leaves `ExecuteAsync`)
+   or into 42-5 events.
+
+4. **Response handling.** Truncate large responses (`ToolOutputHelper.Truncate`), cap body size, honor
+   the per-tool timeout (the `ParallelToolExecutor` linked-CTS pattern). A non-2xx is a normal
+   `ToolExecutionResult` (`Success = false` with the redacted status/body) — not a throw.
+
+5. **Docs-publish note.** For 41-24/25/26 "publish", the delivery is often either a git push (existing
+   `GitOperationsTool` to the wiki repo) **or** an HTTP POST to a docs host — this tool covers the HTTP
+   flavor; the git flavor already exists. The workflow declares whichever it needs (42-3 resolution).
+
+## Acceptance Criteria
+
+1. The tool rejects a request to a host/method outside the binding's allowlist, loudly (test — SSRF/egress
+   containment); an in-allowlist request succeeds against a stub server.
+2. The endpoint key resolves to host+auth via the 42-2 binding; the model cannot supply a raw arbitrary
+   URL (test asserts an off-allowlist or raw-URL attempt is rejected).
+3. Permission class comes from the binding, not the request method — a `ReadOnly` (GET-only) binding
+   rejects a POST attempt (test); it can't be escalated by the caller.
+4. Auth credential binds tenant/user-scoped (42-4), is applied at call time, and never appears in
+   `Output` or any 42-5 event, even when the response reflects it (grep-for-value test).
+5. Non-2xx yields `Success = false` with redacted status/body; timeout yields a `TOOL.FAILED`; neither
+   throws.
+6. A destructive-marked binding routes through 42-3 authorization (test).
+
+## Events
+
+Reuses 42-5 `TOOL.*` with `endpointKey`/`method`/`statusCode` tags (never URL query secrets, never auth).
+No new family.
+
+## Single-user vs SaaS
+
+- **single-user:** the user's endpoint bindings + credentials; the user owns the host allowlist.
+- **SaaS:** tenant-scoped bindings + credentials; a tenant can reach only the endpoints its
+  `tenant_admin` bound, with the tenant's own credential — a tenant's egress and secrets never cross the
+  boundary.
+
+## Epic 41 consumers
+
+**41-5** (stakeholder / status update → post to Slack/Jira/email webhook), **41-7** (standup digest
+publish), **41-24/25/26** (docs / release-notes / runbook publish, HTTP flavor), and any future
+integration workflow — the most broadly-consumed family in the epic.
+
+## Dependencies
+
+- **42-1** (descriptor), **42-2** (endpoint-key binding + host/method allowlist in `config`), **42-3**
+  (gating; destructive-binding authorization), **42-4** (auth secret — hard-blocked on the Epic 29
+  reveal path), **42-5** (audit + redaction).
+- **Existing:** `ToolOutputHelper.Truncate`, the `ParallelToolExecutor` timeout pattern,
+  `ContentSanitizer`/`ErrorRedactor`.
+- **Epic 41** 41-5/41-7/41-24/25/26 consumers.
+
+## Risks
+
+- **SSRF / egress / exfiltration.** A generic HTTP tool is the classic prompt-injection exfiltration
+  vector. Mitigation: **no raw URL from the model** — endpoint-key + host/method allowlist from the
+  binding, class from the binding not the method, and the same sanitize/redact envelope. This is the
+  central design constraint, not an afterthought.
+- **Response-reflected secrets.** An endpoint that echoes the auth token in its body. Mitigation: the
+  grep-for-value redactor at the `ExecuteAsync`/emit boundary (AC4).
+
+## Estimated Effort
+
+Medium. ~3–4 days (single tool, but the allowlist/SSRF containment + redaction carry the weight).
+</content>


### PR DESCRIPTION
## Epic 42 — Agent Capability & Tool Layer

The missing foundation under Epic 41. Tamma's workflows produce typed documents and dispatch them by kind, and an agent can act through the tool-execution framework in `Tamma.Activities/LlmCall/Tools/` — but that framework is **coding-only** and closed:

- **6 tools, all coding:** `FileRead`, `FileWrite`, `GitOperations`, `RunTests`, `SearchCode`, `ShellExecute`. No first-class tool to reach a cloud/VPS resource, flip a feature flag, drive a deploy, or call an external API.
- **Compile-time-static registry** — adding a tool means shipping a class + a DI line; no dynamic/per-tenant registration, **no MCP path**.
- **A tool declares no governance** — `IToolExecutor` exposes `ToolName`/`Description`/`InputSchema`/`ExecuteAsync` and nothing about who may call it, at what autonomy, what credential it needs, or how destructive it is.
- **No credential binding, no durable tool-use audit** — `ShellExecute` has silently stood in for a real capability layer.

You can plan a "deploy to VPS", "publish docs", or "toggle a flag" workflow (Epic 41), but the agent it dispatches can't actually *act*. This epic fixes that.

### The 9 stories
- **42-1** Tool contract + registry evolution — a `ToolDescriptor` via a default interface member (the 6 built-ins compile unchanged), dynamic `Register`/`Unregister`, **deny-by-default**.
- **42-2** Tool binding & config store — `tool_bindings` (user_id XOR tenant_id), mirroring the Prompt Store's per-mode resolution.
- **42-3** Per-tool permission + autonomy gating — `ResolveToolsActivity` returns only enabled + role-permitted + `AutonomyFloor ≤ live dial` + non-destructive tools; destructive/above-floor routes to the orchestrator over Epic 39's `AcceptanceRequest` channel.
- **42-4** Credential/secret binding — per-mode via Epic 29's `ISecretStore`; no secret in logs.
- **42-5** Durable `TOOL.INVOKED/SUCCEEDED/FAILED` DCB audit (redacted, tagged), alongside the ephemeral `TOOL_LOOP.*` SSE stream.
- **42-6** MCP integration — external servers register tools via the dynamic path, deny-by-default until classified.
- **42-7** Cloud/VPS resource ops tool (provider-abstracted).
- **42-8** Feature-flag & deploy-control tools (release-control family).
- **42-9** Authenticated HTTP/external-API tool (host+method-allowlisted, SSRF-contained) — **ships first**, unblocks the most Epic 41 workflows.

### Tool-contract additions (grounded in the real `IToolExecutor`)
Keep the 4 members; add a `ToolDescriptor` (default interface member, deny-by-default fallback): `Category` (Native/Mcp/ProviderAbstracted), `PermissionClass` (ReadOnly/Mutating/Command/Destructive), `AutonomyFloor` (70–100), `RequiredSecret` (keyed to Epic 29's `SecretPurpose`), `Suspends`. Registry gains thread-safe `Register`/`Unregister` on top of the DI-seeded set.

### Permission + autonomy gating (both modes)
Mirrors the Prompt Store: single-user → bindings keyed `user_id`; SaaS → keyed `tenant_id` (`tenant_owner`/`tenant_admin` own; members get resolved grants + 403 on write). Destructive/above-floor tools are routed to the orchestrator/human, not dropped — "the acceptor is an actor, not a branch."

### Tool-family table
| Family | Does | Class | Secret | Epic 41 consumers |
|---|---|---|---|---|
| Cloud/VPS (42-7) | list/create/resize/delete VPS | ReadOnly→Destructive | Hetzner token | deployment-pipeline, 41-22, 41-23 |
| Feature-flag (42-8) | read/flip flags | Mutating/Destructive (prod) | flag provider key | deployment-pipeline, 41-22 |
| Deploy control (42-8) | trigger/promote/rollback | Destructive (prod) | api/signing key | deployment-pipeline, 41-22, 41-24 |
| HTTP/external (42-9) | one allowlisted authenticated REST call | Mutating | per-endpoint key | 41-5/7, 41-24/25/26 |
| MCP (42-6) | anything an MCP server exposes | deny-by-default | per server | open-ended |

### Correction to CLAUDE.md
The "ISecretStore does not yet exist" note is **stale** — Epic 29 Story 29-1 landed `ISecretStore`/`SecretRef`/`SecretScope`/`SecretPurpose`/`ISecretAccessAuditor`. The real open gap is an **audited reveal-to-runtime-consumer** path (the store never returns plaintext through its public API) — filed as a hard dependency on an Epic 29 extension; the human-assigned path works without it.

### Open design questions (in the epic — your call)
1. **Secret reveal for runtime execution** — a reveal-to-consumer API vs. a store-calls-on-behalf injection seam (the biggest decision).
2. **Descriptor default** — deny/Destructive-by-default (chosen) vs. MCP tools defaulting to ReadOnly.
3. **Destructive-tool routing** — reuse the accept-gate `AcceptanceRequest` verbatim or a sibling `ToolAuthorizationRequest` on the same channel.
4. **MCP tenancy** — may a `tenant_admin` register tenant-scoped MCP servers, or is the allowlist platform-owned (ships platform-owned first)?
5. **Per-operation vs. per-tool classes** — cloud/flag/deploy tools have per-op classes (list=ReadOnly, delete=Destructive); 42-7/42-8 recommend splitting into read/write tools for clean per-tool gating.

Docs only — no code, no migrations.


---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_