### PR TITLE
fix(core): make UuidV7.NewGuid() monotonic within a millisecond (kills the 1/5018 flake)

### DIFF
--- a/apps/tamma-elsa/src/Tamma.Core/Documents/UuidV7.cs
+++ b/apps/tamma-elsa/src/Tamma.Core/Documents/UuidV7.cs
@@ -14,28 +14,87 @@ namespace Tamma.Core.Documents;
 /// bumped to 9+, swap the body for <c>Guid.CreateVersion7</c> behind this same
 /// static surface.
 /// </para>
+///
+/// <para><b>Intra-millisecond monotonicity.</b> A bare v7 whose sub-timestamp
+/// bytes are pure random is NOT monotonic within a single millisecond — two ids
+/// minted in the same ms sort by their random tails, not their creation order.
+/// Consumers that read back "in id order" and expect enqueue order (the
+/// <c>channel_outbox</c> FIFO replay, document lineage) then flake. So the
+/// process-time <see cref="NewGuid()"/> path applies RFC 9562 §6.2 "fixed-length
+/// dedicated counter": a lock-guarded 12-bit counter occupies the 4 low bits of
+/// byte 6 and all of byte 7 — immediately after the timestamp and ahead of the
+/// random tail, so <c>(timestamp, counter)</c> dominates the sort. The counter
+/// resets each new millisecond and increments within one; on the (4096/ms/process)
+/// overflow it rolls the pinned timestamp forward a millisecond. The clock is also
+/// pinned monotonic (a backwards system clock cannot lower an already-issued
+/// timestamp). Result: successive <see cref="NewGuid()"/> calls are strictly
+/// increasing.</para>
+///
+/// <para>The explicit-<see cref="DateTimeOffset"/> overload stays pure (random
+/// tail, no shared counter) so callers that stamp an arbitrary timestamp — e.g.
+/// <c>DocumentEnvelope</c> — remain deterministic and order purely by the
+/// timestamp they supply.</para>
 /// </summary>
 public static class UuidV7
 {
-    /// <summary>Mint a new UUID v7 stamped with the current UTC time.</summary>
-    public static Guid NewGuid() => NewGuid(DateTimeOffset.UtcNow);
+    // Monotonic-counter state for the process-time NewGuid() path. Guarded by
+    // _lock. _lastUnixMs is pinned non-decreasing; _counter is the 12-bit
+    // intra-millisecond sequence packed into byte6[low nibble] + byte7.
+    private static readonly object _lock = new();
+    private static long _lastUnixMs = -1;
+    private static int _counter;
+    private const int CounterMax = 0x0FFF; // 12 bits → 4096 ids per ms per process
+
+    /// <summary>
+    /// Mint a new UUID v7 stamped with the current UTC time. Successive calls are
+    /// strictly increasing (monotonic even within a millisecond) — see the type
+    /// remarks.
+    /// </summary>
+    public static Guid NewGuid()
+    {
+        long unixMs;
+        int counter;
+
+        lock (_lock)
+        {
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            if (now > _lastUnixMs)
+            {
+                // Fresh millisecond: adopt it and restart the counter.
+                _lastUnixMs = now;
+                _counter = 0;
+            }
+            else if (_counter >= CounterMax)
+            {
+                // Counter exhausted for this ms (or the clock went backwards and
+                // we're pinned): roll into the next ms to stay strictly ordered.
+                _lastUnixMs++;
+                _counter = 0;
+            }
+            else
+            {
+                // Same (or pinned) millisecond: advance the sequence.
+                _counter++;
+            }
+
+            unixMs = _lastUnixMs;
+            counter = _counter;
+        }
+
+        return Build(unixMs, counter);
+    }
 
     /// <summary>
     /// Mint a UUID v7 stamped with <paramref name="timestamp"/>. Overload exists
-    /// so the time-ordering property is deterministically testable.
+    /// so the time-ordering property is deterministically testable; it is pure
+    /// (random sub-timestamp bytes, no shared counter) and orders solely by the
+    /// supplied timestamp.
     /// </summary>
     public static Guid NewGuid(DateTimeOffset timestamp)
     {
         Span<byte> bytes = stackalloc byte[16];
 
-        // Bytes 0..5: 48-bit big-endian Unix-millisecond timestamp.
-        long unixMs = timestamp.ToUnixTimeMilliseconds();
-        bytes[0] = (byte)(unixMs >> 40);
-        bytes[1] = (byte)(unixMs >> 32);
-        bytes[2] = (byte)(unixMs >> 24);
-        bytes[3] = (byte)(unixMs >> 16);
-        bytes[4] = (byte)(unixMs >> 8);
-        bytes[5] = (byte)unixMs;
+        WriteTimestamp(bytes, timestamp.ToUnixTimeMilliseconds());
 
         // Bytes 6..15: random.
         RandomNumberGenerator.Fill(bytes[6..]);
@@ -49,5 +108,42 @@ public static class UuidV7
         // Construct big-endian so byte- and string-comparison are both
         // time-ordered (net8's Guid(ReadOnlySpan<byte>, bool) ctor).
         return new Guid(bytes, bigEndian: true);
+    }
+
+    /// <summary>
+    /// Build a v7 with a monotonic 12-bit <paramref name="counter"/> in
+    /// byte6[low nibble]+byte7 (right after the timestamp, before the random tail)
+    /// so <c>(timestamp, counter)</c> dominates the big-endian sort.
+    /// </summary>
+    private static Guid Build(long unixMs, int counter)
+    {
+        Span<byte> bytes = stackalloc byte[16];
+
+        WriteTimestamp(bytes, unixMs);
+
+        // Bytes 8..15 random (the counter fully owns bytes 6..7, so only the tail
+        // needs entropy; ties on (timestamp, counter) never occur in a process).
+        RandomNumberGenerator.Fill(bytes[8..]);
+
+        // Byte 6: version nibble 7 | high 4 bits of the 12-bit counter.
+        bytes[6] = (byte)(0x70 | ((counter >> 8) & 0x0F));
+        // Byte 7: low 8 bits of the counter.
+        bytes[7] = (byte)(counter & 0xFF);
+
+        // RFC 4122 variant (10xx) in the high bits of byte 8.
+        bytes[8] = (byte)((bytes[8] & 0x3F) | 0x80);
+
+        return new Guid(bytes, bigEndian: true);
+    }
+
+    private static void WriteTimestamp(Span<byte> bytes, long unixMs)
+    {
+        // Bytes 0..5: 48-bit big-endian Unix-millisecond timestamp.
+        bytes[0] = (byte)(unixMs >> 40);
+        bytes[1] = (byte)(unixMs >> 32);
+        bytes[2] = (byte)(unixMs >> 24);
+        bytes[3] = (byte)(unixMs >> 16);
+        bytes[4] = (byte)(unixMs >> 8);
+        bytes[5] = (byte)unixMs;
     }
 }

--- a/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/UuidV7Tests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Core.Tests/Documents/UuidV7Tests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Concurrent;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Core.Documents;
+
+namespace Tamma.Core.Tests.Documents;
+
+/// <summary>
+/// Pins the ordering guarantees of <see cref="UuidV7"/>. The
+/// intra-millisecond-monotonicity case is the regression guard for the
+/// long-standing <c>ChannelOutboxRepositoryTests.Enqueue_ListUnacked_OrderedByUuidV7Id</c>
+/// flake: a bare v7 with a random sub-timestamp tail sorts same-ms ids by
+/// randomness, so the outbox FIFO replay (ORDER BY id) occasionally came back
+/// out of enqueue order. The fixed-length dedicated counter makes successive
+/// <see cref="UuidV7.NewGuid()"/> calls strictly increasing.
+/// </summary>
+[TestFixture]
+public class UuidV7Tests
+{
+    [Test]
+    public void NewGuid_IsStrictlyIncreasing_EvenWithinTheSameMillisecond()
+    {
+        // 10k rapid mints almost all land in a handful of milliseconds, so a
+        // non-monotonic generator fails this virtually every run.
+        const int n = 10_000;
+        var ids = new Guid[n];
+        for (var i = 0; i < n; i++)
+            ids[i] = UuidV7.NewGuid();
+
+        for (var i = 1; i < n; i++)
+            ids[i].CompareTo(ids[i - 1]).Should().BePositive(
+                "UuidV7.NewGuid() must be strictly increasing across successive calls (id #{0})", i);
+
+        ids.Distinct().Should().HaveCount(n, "every minted id must be unique");
+    }
+
+    [Test]
+    public void NewGuid_IsVersion7AndRfc4122Variant()
+    {
+        var bytes = UuidV7.NewGuid().ToByteArray(bigEndian: true);
+        (bytes[6] & 0xF0).Should().Be(0x70, "the version nibble must be 7");
+        (bytes[8] & 0xC0).Should().Be(0x80, "the variant bits must be RFC 4122 (10xx)");
+    }
+
+    [Test]
+    public void NewGuid_IsMonotonicUnderConcurrency()
+    {
+        // Many threads minting at once must still yield globally unique,
+        // lock-serialized ids (no torn counter / duplicate).
+        var bag = new ConcurrentBag<Guid>();
+        Parallel.For(0, 20_000, _ => bag.Add(UuidV7.NewGuid()));
+        bag.Distinct().Should().HaveCount(bag.Count, "concurrent mints must not collide");
+    }
+
+    [Test]
+    public void NewGuid_WithTimestamp_OrdersBySuppliedTimestamp()
+    {
+        var t0 = DateTimeOffset.UtcNow;
+        var earlier = UuidV7.NewGuid(t0);
+        var later = UuidV7.NewGuid(t0.AddMilliseconds(5));
+
+        later.CompareTo(earlier).Should().BePositive(
+            "the explicit-timestamp overload orders by the supplied timestamp");
+    }
+}


### PR DESCRIPTION
## Kill the long-standing 1/5018 CI flake at its source

The flake — `ChannelOutboxRepositoryTests.Enqueue_ListUnacked_OrderedByUuidV7Id`, which cost several re-triggers this session — was **finally named by the CI `.trx` diagnostic** added earlier. This is the root-cause fix.

### Root cause
`UuidV7.NewGuid()` filled bytes 6–15 with **pure random** after the 48-bit ms timestamp. Two ids minted in the **same millisecond** therefore sort by their random tails, not creation order. `ChannelOutboxRepository.ListUnackedAsync` does `.OrderBy(m => m.Id)`, so `ContainInOrder(a, b, c)` flaked whenever the three enqueues landed in one ms — and, more broadly, the outbox FIFO replay could return messages out of enqueue order.

### The fix
Apply RFC 9562 §6.2 **"fixed-length dedicated counter"** to the process-time `NewGuid()` path: a lock-guarded **12-bit counter** occupies byte 6's low nibble + byte 7 — immediately after the timestamp and ahead of the random tail — so `(timestamp, counter)` dominates the big-endian sort. The counter resets each new millisecond, increments within one, and on the 4096/ms/process overflow rolls the pinned timestamp forward a ms. The pinned timestamp is also non-decreasing, so a backwards system clock can't lower an already-issued value. **Successive `NewGuid()` calls are now strictly increasing** — which is exactly what the outbox replay and document lineage assume.

The **explicit-`DateTimeOffset` overload stays pure** (random tail, no shared counter), so `DocumentEnvelope` and the deterministic time-ordering tests are unaffected.

### Tests
New `UuidV7Tests` pin the guarantees:
- **10k rapid mints strictly increasing** — the regression guard; fails virtually every run on the old generator, passes deterministically now.
- version-7 / RFC-4122-variant bits.
- 20k-way **concurrent** uniqueness (lock correctness).
- the explicit overload orders by its supplied timestamp.

### Verification
- `dotnet build`: **0 errors**.
- `Tamma.Core.Tests`: **444 passed** (440 + 4 new).
- `Tamma.Activities.Tests` (fast gate): **2522 passed**.
- No schema change.

### Related
Completes task #33 — part (a) was the CI `.trx` diagnostic (already on main) that named this test; part (b) is this stabilization.

Two files: `src/Tamma.Core/Documents/UuidV7.cs`, `tests/Tamma.Core.Tests/Documents/UuidV7Tests.cs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_