### PR TITLE
[diagnostic] CI-cancellation probe — same head as #512 on a differently-named branch

### DIFF
--- a/.dev/findings/engine-di-composition-gaps-found-by-e2e.md
+++ b/.dev/findings/engine-di-composition-gaps-found-by-e2e.md
@@ -1,0 +1,472 @@
+# 2026-08-13 — engine defects surfaced by the engine-driven E2E
+
+> Scope note: items 2 and 7 are OPEN composition gaps; everything else is a
+> REAL runtime defect the E2E surfaced in the autonomous loop itself — every
+> one shipped latent because no test had ever driven the loop through a real
+> engine process end-to-end. All non-open items are FIXED in the same change
+> that added the E2E.
+
+**Status:** open follow-ups. Found while booting the REAL `Tamma.ElsaServer`
+binary under `ASPNETCORE_ENVIRONMENT=Development` for the engine-driven
+autonomous E2E (`EngineFullStackFixture`) — Development turns on
+`ValidateOnBuild`/`ValidateScopes`, which the deployed engine (Production)
+never runs, so both defects ship latent today.
+
+## 1. `LifecycleReEntryService` is unresolvable in every engine composition — FIXED (HTTP seam)
+
+`Program.cs` registered the REAL `ILifecycleReEntryService` (39-10/39-11) as
+the default, but its dependency `IDocumentInstanceRepository` is only
+registered by `AddTammaData(...)` — which **only Tamma.Api calls**. The engine
+never registers it, so any `ComputeReEntryPositionActivity` execution in the
+deployed engine faulted at service resolution (masked to a per-activity
+incident by `ContinueWithIncidentsStrategy`, so lifecycles silently lost crash
+re-entry).
+
+**Why "just disable it" was NOT enough (E2E runs 29–30):** the 39-14
+`plan-review` shim is a latest-accepted READ (`FetchLatestAcceptedDocument` →
+approved/needsHuman). With the Null seam the read can never see the plan the
+lifecycle just accepted, so **every** engine-driven cycle terminated
+needs-human — re-entry-disabled is not a degraded mode there, it is a
+structurally-dead autonomous loop.
+
+**Fix (same change):** the engine host now defaults to
+`HttpLifecycleReEntryService` — the latest-accepted read over the API's own
+39-11 HTTP surface (`GET /api/documents/issues/{issueId}/latest` + `GET
+/api/documents/{documentId}`), deliberately coarser than the real service
+(accepted → `Complete`, else `Produce`; mid-flight `Review`/`Accept` positions
+degrade to a fresh produce). Fail-closed: a transport/HTTP failure throws a
+retryable `TammaError`, never a silent "Fresh". It does NOT extend
+`TammaApiClient` (whose surface is exactly pinned by the 43-8 mediation sweep;
+an internal read does not belong on the effect plane).
+`Documents:ReEntryDisabled=true` still swaps in the Null seam. Pinned by
+`HttpLifecycleReEntryServiceTests`.
+
+## 2. `HourlyAnalyticsRollupScheduler` is a captive-dependency violation
+
+The singleton hosted service takes the **scoped** Elsa `IWorkflowDispatcher`
+(made scoped by Elsa's own registration) in its constructor. Development scope
+validation refuses to build the host; Production silently promotes the
+dispatcher (captive dependency). The scheduler should resolve the dispatcher
+per-tick from an `IServiceScopeFactory` scope (the
+`TenantScheduledTriggerService` pattern in the same directory).
+
+*E2E stance:* the fixture runs the engine as Production (matching deployment),
+documented at the env-var site in `EngineFullStackFixture`.
+
+## 3. `Output.Set(context, null)` binds to the Variable overload and NREs
+
+`CheckLimitsActivity.RunAsync`'s HAPPY path (`StopReason.Set(context, null)`)
+threw `NullReferenceException` inside Elsa's
+`OutputExtensions.Set[T](Output<T>, ActivityExecutionContext, Variable<T>)` —
+a literal `null` argument binds to the **Variable overload**, not the value
+overload, and the extension dereferences the null Variable. Consequence: the
+ADL orchestrator could NEVER reach `DispatchCycle` (CheckLimits faulted before
+emitting its `Continue` outcome on every pass; `ContinueWithIncidentsStrategy`
+recorded an incident and the loop went to cooldown). The engine-driven E2E is
+what surfaced it — no prior test drove the orchestrator through a real engine.
+
+**Fixed (2026-08-13):** `CheckLimitsActivity` (empty string per its own
+"empty if continuing" contract) and `SelectWorkItemActivity`'s
+NothingFound/NeedsTriage paths (typed `(string?)null`).
+
+**Open inventory** — the same literal-null pattern exists at these sites and
+will NRE if ever hit; fix by typing the null or setting a real default:
+`Review/EscalateReviewActivity.cs:242`, `Review/DeliverGuidanceActivity.cs:107,161`,
+`Review/WaitForFixesActivity.cs:125,143`,
+`AgentDispatch/DispatchAgentWorkflowActivity.cs:235`.
+
+## 4. `DispatchWorkflowDefinitionRequest` takes a VERSION id — every background dispatch passed the definition id
+
+Elsa 3.5's `DispatchWorkflowDefinitionRequest(string definitionVersionId)`
+ctor takes the definition **version** id (`"AdlOrchestratorWorkflow:v1"`), and
+every activity/scheduler dispatch site passed the definition id
+(`"single-issue-cycle"`), so the dispatch queue handler answered
+`WorkflowGraphNotFoundException` for EVERY background dispatch: the
+orchestrator could never start a cycle, never restart itself, never dispatch
+triage; the analytics rollup and the 41-30 scheduled triggers never fired.
+Latent because every one of these dispatches is fire-and-forget-with-swallow
+by design. **Fixed:** `Tamma.Activities.Core.PublishedWorkflowDispatch`
+resolves the published version id first; all five sites (DispatchCycle,
+DispatchAdl, DispatchTriage, HourlyAnalyticsRollupScheduler,
+TenantScheduledTriggerService) now route through it.
+
+## 5. `TestingWorkflow.MakeOutput` made the store populator skip HALF-A-DOZEN workflows
+
+`MakeOutput` typed its value parameter `Func<ActivityExecutionContext,
+object>`; `Input<object>` has no matching delegate ctor, so `new(value)`
+bound the LITERAL ctor and the Func itself became the input's literal value.
+Serializing that definition threw `NotSupportedException` inside
+`DefaultWorkflowDefinitionStorePopulator.PopulateStoreAsync`, which ABORTS the
+whole populate loop — every workflow after TestingWorkflow in enumeration
+order (`testing-pipeline`, `triage-context-gathering`, `triage-item-cycle`,
+`triage-po-decision`, `update-issue-status`) was silently absent from the
+registry, and every `DispatchWorkflow("update-issue-status")` in every cycle
+faulted "No published version… found". **Fixed:** the parameter is
+`Func<ExpressionExecutionContext, object>` (the delegate-expression ctor).
+
+## 6. Literal-null `Input<T>` defaults are DROPPED by the definition-store round-trip
+
+`EmitCycleEventActivity`'s optional inputs default to `new((string?)null)`;
+the JSON round-trip through the workflow-definition store drops a
+literal-null expression, the materialized input is null, and `Input.Get`
+throws `"<name> is required."` — faulting every CYCLE.STARTED/COMPLETED emit
+(the cycle only wires StepId/ErrorDetail on failure emits). **Fixed** with
+`GetOrDefault` reads in `EmitCycleEventActivity`; the same trap exists
+wherever an optional input defaulted to a literal null is read via `.Get`
+after a store round-trip.
+
+## 7. Engine rollup fan-out needs `ITenantDbContextFactory` (open)
+
+`hourly-analytics-rollup`'s fan-out activity resolves
+`Tamma.Data.Abstractions.ITenantDbContextFactory`, which no engine
+composition registers (same family as item 1) — the rollup workflow now
+DISPATCHES correctly (item 4) but faults at fan-out in an engine-only
+deployment. Open, same fix direction as item 1.
+
+## 8. A bare `Activity` does NOT auto-complete — 24 emit activities hung their workflow forever
+
+Elsa 3.5: a class deriving from bare `Activity` (not `CodeActivity`) must call
+`await context.CompleteActivityAsync()` itself; returning from `ExecuteAsync`
+leaves the activity — and therefore the workflow — `Running` forever, with **no
+incident, no bookmark, nothing in the journal** (the E2E found
+`single-issue-cycle` parked at its FIRST emit node, `EmitCycleStarted`, with
+empty bookmarks and zero incidents). `EmitEscalationEventActivity` was the
+single emit that carried the correct pattern ("Complete on the default outcome
+so a mid-flow emit node continues to the next activity"); the other 24
+`Emit*EventActivity` classes ended with `return default;` and would each hang
+whichever workflow reached them first. **Fixed (2026-08-13):** all 24 now
+`await context.CompleteActivityAsync()` (dated comment at each site). Rule for
+new activities: derive from `CodeActivity` (auto-completes), or complete
+explicitly.
+
+## 9. `Input.Get` throws "is required." whenever the evaluated value is null — every optional emit input read via `.Get`
+
+Companion to item 6, broader: `Input<T>.Get(context)` throws
+`"<name> is required."` for ANY null evaluated value — including an input
+**explicitly wired** with a typed null (`new Input<string?>((string?)null)`),
+proven by a standalone in-memory probe (no store round-trip involved). So every
+OPTIONAL input in every emit activity read via `.Get` was a landmine: the first
+workflow to leave one unwired (or wire an expression that evaluates null at
+runtime, e.g. `ErrorDetail` on a success emit) faults the emit. **Fixed
+(2026-08-13):** the 25 `Emit*EventActivity` classes (the 24 of item 8 +
+`EmitEscalationEventActivity`) now read all inputs with `GetOrDefault`; every
+call site already tolerated null/default. Also fixed:
+`InitAdlConfigActivity` — its five layered-override inputs are all optional,
+and the self-restart dispatch (`DispatchAdlActivity`) passes only `configJson`,
+so EVERY successor orchestrator instance faulted its own init with
+"Repository is required." (the E2E's restart loop surfaced it). Left alone
+(out of the loop's path, `.Get` reads still present):
+`EmitCleanupTerminalEventActivity`, `EmitDeleteTerminalEventActivity`,
+`EmitHourCompletedActivity` — same trap if their optional inputs are ever left
+unwired.
+
+## 10. Store-rehydrated activities have NULL ctor-injected members — five HTTP activities silently fell back to `localhost:3100` / mock
+
+A workflow loaded from the definition store is materialized by the JSON
+serializer through each activity's `[JsonConstructor]` (parameterless) — so
+`IConfiguration` / `IHttpClientFactory` / `ILogger` ctor fields are **null in
+the real engine**, and the null `Logger` swallowed every warning that would
+have said so. Consequences observed in the E2E: `ResolveConventionsActivity` /
+`ResolvePromptFromRegistryActivity` sent every resolve to the
+`http://localhost:3100` default (both also DISCARDED a configured
+`Engine:CallbackUrl` whenever the factory was null — a second bug in the same
+line); `SelectWorkItemActivity` silently used `SimulateCandidates()` instead
+of real work selection; `ReadRepoConventionsActivity`,
+`StoreFindingsActivity`, `StoreRoleFindingActivity`,
+`FetchUntriagedItemsActivity`, `ReportCycleResultActivity` all took their
+mock/skip paths. **Fixed (2026-08-13)** with the ctor-or-`context.GetService`
+idiom that `TriggerCIActivity`/`UpdateIssueStatusActivity`/the git activities
+already used. Still on the old pattern (off the loop's happy path, fail loud
+or log-and-skip): `CommitFixActivity` (throws), `TDD/CommitChangesActivity`,
+`TDD/RevertRefactoringActivity`. Rule for new activities: never read a
+ctor-injected service without the `?? context.GetService<T>()` fallback.
+
+## 11. `GET /api/engine/issues` serves label OBJECTS; both engine consumers parsed `List<string>` — intake silently empty
+
+`PlatformEngineCallbackService.IssueToJson` writes GitHub-shaped
+`labels: [{"name":"..."}]` (the pinned wire shape), but
+`WorkItem.Labels` declared `List<string>` — so `SelectWorkItemActivity` and
+`FetchUntriagedItemsActivity` threw `JsonException` inside a log-and-swallow
+catch and the real intake returned ZERO candidates on every tick (the loop ran
+"clean repo" forever). The prior regression suite
+(`EngineIssuesResponseTests`) green-lit this because its "exact body shape"
+sample used plain-string labels — a wrong sample of the very wire it pinned.
+**Fixed (2026-08-13):** `LabelNamesConverter` accepts both shapes (objects for
+the wire, plain strings for the internal WorkItemJson round-trip),
+`WorkItem.Url` maps `html_url`, and the regression suite now pins the REAL
+object-shaped body alongside the internal shape.
+
+## 12. Single-user service-plane calls never bind the personal tenant — the autonomy gate 500'd every engine LLM call
+
+The single-user contract everywhere ("single-user binds a personal tenant
+up-front; the ambient context carries it" — `LifecycleReEntryService`,
+`DocumentInstanceRepository`, `AcceptanceRulesRepository`) was only satisfied
+for AUTHENTICATED dashboard requests: `EnsurePersonalTenantMiddleware` bailed
+on `IsAuthenticated != true`, and the engine's mediated service calls
+(`Tamma:ApiToken` — `POST /api/v1/llm/call`, git callbacks, event drain) carry
+no user claim. So every tenant-resident read those calls trigger threw
+"requires an ambient tenant id"; the 43-x autonomy gate — CORRECTLY — treated
+the failed base-rules read as unreadable and failed CLOSED (AlwaysHuman /
+denied), and every engine LLM call answered 500 forever. The gate posture is
+right (F6: a blip must not discard the user's always-escalate floor); the bug
+was upstream: the READ had no ambient home to succeed against. **Fixed
+(2026-08-13):** in single-user mode, an anonymous/service request with no
+resolved tenant now resolves the sole user (`ISoleUserProvider` — the same
+resolution the gate itself uses) and binds — minting + synchronously
+provisioning on first touch, serialized against concurrent service bursts —
+their personal tenant; SaaS behavior untouched (mode short-circuit first);
+pre-setup deployments (no owner configured, users table empty) pass through
+tenant-less as before. Pinned in `EnsurePersonalTenantMiddlewareTests` (9
+tests).
+
+## 12b. Same split inside `AgentRegistryService`: claims-only principal ⇒ `AGENT_UNRESOLVED` on every engine call
+
+After the item-12 fix bound the ambient tenant, the llm/call path advanced to
+persona resolution and STILL failed: `AgentRegistryService.ResolvePrincipal`
+answered the single-user principal from HTTP CLAIMS ONLY, so a service-plane
+call resolved `(null, null)` — while the autonomy gate resolved the SAME
+request's principal to the sole user via `ISoleUserProvider`. The seeded
+default-persona enablement (user-keyed) was invisible to a nobody-principal,
+so every engine call failed loud with `AGENT_UNRESOLVED`
+(`agent.default_persona.none` despite `agent.enablement.seed_default_applied`
+for the same persona seconds earlier). **Fixed (2026-08-13):** single-user
+claims-less resolution falls back to the same `ISoleUserProvider` seam the
+gate uses (cached after first success; pre-setup deployments unchanged).
+Rule: every single-user principal resolution must go through the sole-user
+seam, not HTTP claims — a service call has no claims.
+
+## 13. The singleton `IProviderCredentialResolver` captured the scoped `IEventRepository` — first llm/call 500s on a Development host
+
+`AddProviderCredentialResolution` registers the resolver as a SINGLETON (the
+BYOK-cache contract) whose factory resolved the SCOPED `IEventRepository` from
+the singleton's root provider — a captive dependency. Production silently
+promotes it (one DbContext-backed repository living forever inside the
+singleton); a Development host (`ValidateScopes`) throws "Cannot resolve
+scoped service ... from root provider" on the FIRST credential resolution —
+500ing every `POST /api/v1/llm/call`. Same family as item 2
+(`HourlyAnalyticsRollupScheduler`), API-side this time. **Fixed
+(2026-08-13):** the resolver keeps its singleton lifetime and audits through a
+scope-per-append `ScopePerCallEventRepository` adapter
+(`IServiceScopeFactory`), the `TenantScheduledTriggerService` pattern.
+
+## 14. Workflow VARIABLES are EPHEMERAL across suspend/resume unless a storage driver is set
+
+`builder.WithVariable(...)` declares a variable with NO storage driver, so its
+value lives only in the in-memory workflow state — the FIRST timer/event
+bookmark suspension serializes the instance and every undriven variable comes
+back EMPTY ("empty state json" post-resume). All ~1000 `WithVariable`
+declarations across the 49 CLR workflows now chain `.Persisted()`
+(`VariablePersistenceExtensions` — sets
+`StorageDriverType = typeof(WorkflowInstanceStorageDriver)`), so values survive
+suspend/resume. Pinned by the workflow structure tests.
+
+## 15. A long in-activity `Task.Delay` holds the Elsa dispatch worker slot — the cooldown deadlocked the whole loop
+
+`CooldownActivity` slept `Task.Delay(cooldownSeconds)` **inside** the activity,
+which occupies the runtime's dispatch slot for the whole cooldown: with the E2E
+config (3600 s) every subsequently dispatched workflow — all of the cycle's
+llm-calls included — queued behind the sleeping orchestrator and the loop
+deadlocked itself. The activity now only EMITS the audit pair; the actual wait
+is a stock `Elsa.Scheduling.Activities.Delay` node ("CooldownWait", a timer
+bookmark that SUSPENDS the instance) sequenced right after it in
+`AdlOrchestratorWorkflow`. Pinned by `AdlLoopDurabilityTests`.
+
+## 16. Single-user decision gates suspend TENANTLESS; the resume endpoint looked up only the tenant-scoped bookmark name
+
+`WaitForDocumentDecisionActivity` folds the tenant into the bookmark name. A
+single-user cycle dispatches its gates with an EMPTY tenant, but the API's
+service-plane binding hands every caller the sole user's PERSONAL tenant — so
+the resume seam computed `document-decision-{tenant}-{session}` while the gate
+was suspended on `document-decision--{session}`: 404, "no decision waiting",
+while the gate waited forever (the deployed single-user dashboard accept has
+the same bug). `DocumentDecisionResumeEndpoint` now falls back to the
+tenantless name for the SAME session when the tenant-scoped lookup misses —
+one principal, two spellings. SaaS gates always carry their tenant, so the
+fallback matches nothing cross-tenant.
+
+## 17. The API's rate limiter throttled the autonomous loop it hosts (429 storm)
+
+The fixed `ConfigRead`/`ProviderExecute` limits were sized for a human
+dashboard, not for a 7-role panel fanning out through the engine: one cycle
+produced 1452 rejected requests (each engine retry re-amplifying ×4). The four
+policies now read their limits from configuration
+(`RateLimits:ConfigRead` etc., defaults unchanged), and the E2E fixture raises
+them — a deployed autonomous instance must do the same or it throttles itself.
+
+## 18. `POST /api/prompts/render` 500'd on numeric/boolean variables
+
+The render DTO declared `Dictionary<string, string>` — the engine's variable
+payloads carry numbers and booleans (`issueNumber`, `reEntry`), which
+System.Text.Json refuses to bind to `string` (500 before the handler).
+The DTO now takes `Dictionary<string, JsonElement>` and stringifies per kind
+(String → GetString, everything else → GetRawText). Pinned by the prompt
+endpoint tests.
+
+## 19. Reviewer replies have TWO consumers with TWO shapes — declaring `documentType` routes them through the 39-9 ring
+
+`SingleReviewerWorkflow` (39-7 panel path) declares `documentType="review"`,
+so the API's 39-9 content-validation ring validates the reply against the
+REVIEW registry validator — the legacy verdict JSON (`{"verdict":"approve"}`)
+does not satisfy it, and every panel member exhausted the repair ring (48×
+`DOCUMENT.VALIDATED.FAILED` in one run). The cycle's own
+plan-review/task-review parse the LEGACY verdict directly (no documentType).
+The scripted provider therefore serves BOTH shapes: qualified
+`{role}/{action}@review` cells answer the canonical approving `Review`;
+bare `{role}/{action}` cells answer the legacy verdict. Pinned by
+`ScriptedCycleScriptValidityTests`.
+
+## 20. `InitAdlConfigActivity` silently ignored camelCase `configJson`
+
+The orchestrator's `configJson` input deserialized with default (exact-case)
+options, so `{"cooldownSeconds": 3600}` parsed to the DEFAULT 10 s cooldown —
+18 cycles stormed in one E2E window before the loop was reined in. Now
+`PropertyNameCaseInsensitive = true`.
+
+## 21. `ReportCycleResultActivity` faulted on its OPTIONAL `Error` input ("Error is required.")
+
+Item 9's family, one more member: the activity read `Error.Get(context)` — on
+every exit path with no error (success, needsHuman, deferred) the evaluated
+value is null and `.Get` THROWS, so the report activity faulted after doing
+its work. Now `GetOrDefault`.
+
+## 22. ASP.NET route values keep `%2F` ENCODED — the issue-id document routes silently matched nothing
+
+Issue ids are `{owner}/{repo}#{n}`, so every correct caller of
+`GET /api/documents/issues/{issueId}/latest` (and `/lineage`) escapes the id
+into one path segment (`tamma-bot%2Ftest-repo%231`). ASP.NET Core decodes
+route values EXCEPT the encoded slash (anti-path-splitting), so the handler
+received `tamma-bot%2Ftest-repo#1` — which matched no store row and returned a
+perfectly healthy-looking **empty 200**. Effect: the engine's latest-accepted
+read (item 1's HTTP seam) found nothing, the plan-review shim escalated a plan
+the lifecycle had JUST accepted, and the cycle died needs-human with zero
+warnings anywhere (E2E run 30). The handlers now fold the leftover `%2F`
+(`FoldEncodedSlashes` — deliberately NOT a full second unescape, which would
+double-decode literal percent escapes).
+
+## 23. Two mediation paths chose DIFFERENT LLM providers for the same role
+
+The `llm-call` workflow resolves its provider chain (caller > DB agent config >
+`Llm:DefaultProviderChain`) and passes the chosen provider EXPLICITLY on each
+`/api/v1/llm/call`; the engine's direct single-shot path (`MediatedLlmText` —
+every TDD/debug/refactor activity) passed NO provider, so the API's
+`ManagedAgent` fell back to the resolved persona's provider. A deployment whose
+selected chain holds no key for the persona default (the E2E: chain=scripted,
+persona=claude→anthropic, no anthropic key) fails ONLY on the second path —
+run 33 died `PROVIDER_CREDENTIAL_UNAVAILABLE` at the first TDD write-tests
+after 29 successful scripted calls. `MediatedLlmText` now applies the same
+deployment-tier selection (first allowlist-passing entry of
+`Llm:DefaultProviderChain`; null → persona default as before).
+
+## 24. Dispatch-result numbers rehydrate as `long`/`JsonElement` — `is int` silently loses a REAL PR number
+
+A child workflow's `SetOutput` int crosses the parent's suspension as a JSON
+number, which Elsa's object rehydration infers as `long` (or leaves as
+`JsonElement`) — never `int`. Booleans survive as CLR bools, which is why the
+sibling gates' `s is true` checks passed while the cycle's
+`n is int num` PR-number extraction was silently false for a PR that EXISTS:
+run 32 failed `PrOk` 200 ms after `GIT.PR_OPENED.SUCCESS`.
+`SingleIssueCycleWorkflow.CoerceInt` (int/long/double/decimal/string/
+JsonElement) now backs the extraction; `DebuggingWorkflow` had already learned
+the int/long half of this lesson independently (line ~1225).
+
+## 25. `testing-pipeline` never captured its callers' inputs — the CI wait suspended with an empty repository and the DG-5 listing HID it
+
+Every dispatcher of `testing-pipeline` (TddWorkflow, CiWithDebugRetry,
+Debugging, Mentorship) passes `SessionId`/`Repository`/`Branch`/`SkillLevel` —
+and nothing in `TestingWorkflow` ever read them (declaring a same-named
+VARIABLE does not bind a workflow INPUT). The variables kept their defaults,
+`WaitForCIResultsActivity` suspended with `repository=""`, and the DG-5
+`/elsa/api/ci/waits` listing — which fail-closed skips blank-repository
+payloads — silently HID the wait: no CI seat could ever resume it, and every
+TDD leg could only exit via the timeout. The init step now captures all four
+inputs (run 36). Same family as item 20 (an input nobody reads is not an
+error anywhere).
+
+## 26. The TDD test-syntax validator runs `tsc --noEmit` on jest-style `.ts` test files
+
+`ValidateTestSyntaxActivity` type-checks generated `.ts`/`.tsx` test files
+with a bare `tsc --noEmit` — jest globals (`describe`/`it`/`expect`) fail
+type resolution outside a project with test typings, so ANY jest-style
+TypeScript test the LLM writes is rejected as a syntax error when `tsc`
+happens to be on PATH (run 35: three debug-retry attempts, all
+`test-syntax-invalid`, cycle error) and silently skipped when it is not —
+environment-dependent behavior. The scripted cycle sidesteps it with `.js`
+test files (no validator wired for JavaScript — deterministic skip); the
+real fix (a jest-aware tsconfig for the dry-run, or skipping known-framework
+globals) is recorded here, not attempted.
+
+## 27. `ExecuteAgentActivity` failed EVERY execution in a real engine (item-10 family) — and the loop silently degraded
+
+The task loop's primary path is agent execution (`TddForTask`,
+`ExecuteAgentActivity` → `AgentExecutorFactory` → Local/GitHubActions
+executor). Store-rehydrated instances carry a NULL ctor-injected factory, so
+every execution failed instantly ("AgentExecutorFactory not registered", 2 ms)
+and the loop fell through to its debug-retry leg — which "worked", masking the
+fact that the REAL implementer (the agent that commits actual code to the
+branch) never ran once. Fixed with the ctor-or-GetService idiom (run 38).
+
+## 28. The TDD fallback leg's `CommitChangesActivity` fabricates commit SHAs — `COMMIT.CREATED.SUCCESS` for commits that never happened
+
+Two independent lies compose on the fallback path:
+(a) the rehydrated activity's `_configuration` is null, so
+`_configuration?["Engine:CallbackUrl"]` reads null and the code silently takes
+its `SimulateCommit` branch — emitting `COMMIT.CREATED.SUCCESS` with a
+**fabricated SHA** onto the audit stream (run 38: 2 "successful commits",
+`head == base`, an EMPTY PR that Gitea refused to merge);
+(b) even with DI intact, the "real" path POSTs `action=git_commit` to
+`POST /api/engine/execute-task` — which is an LLM-proxy bridge that does not
+implement git operations at all. The activity cannot create a real commit by
+EITHER path. OPEN: the fallback TDD leg needs a real commit seam (the
+mediated contents API, or dispatching the agent executor); until then its
+green terminal must not be read as "code landed". The E2E's real-commit proof
+rides the agent-executor path (item 27), not this one.
+
+## 29. The self-merge race: the merged-PR webhook fires BEFORE `WaitForPRMerged` registers — the once-only delivery was lost
+
+When Tamma performs the merge ITSELF (the merge-approval gate's happy path),
+the platform delivers `pull_request closed(merged=true)` immediately —
+observed **1 second before** the cycle transitioned into
+`WaitForPRMergedActivity` and registered its bookmark (run 39: forward → 404
+"no suspended bookmark" at 22:54:46; bookmark registered 22:54:47.6). The
+delivery is once-only, so every SELF-merged cycle — the autonomous loop's
+normal case, every platform — could only finish through the 12 h SLA
+needs-human handoff. **Fixed (reconcile-on-register):**
+`PrMergedResumeEndpoint` buffers a bookmark-miss delivery in the singleton
+`PendingPrMergeBuffer` keyed by the qualified bookmark name (202, no longer a
+plain 404) and `WaitForPRMergedActivity` consumes it at registration,
+completing `Merged` without suspending. In-memory on purpose — the buffer
+bridges a seconds-wide in-process ordering race; an engine restart inside the
+window still lands on the wait's durable 12 h SLA edge. Cross-tenant safety
+holds (the buffer key IS the caller's tenant-qualified name). Pinned by
+`PrMergedResumeEndpointTests`.
+
+## 30. Gitea answers the merge endpoint "405: Please try again later" while its ASYNC mergeability check runs — the driver treated it as terminal
+
+After any head push or PR edit (the cycle un-drafts via a title PATCH seconds
+before merging), Gitea recomputes mergeability asynchronously and the merge
+endpoint answers 405 "Please try again later" until it settles. The driver
+treated that as a terminal `NOT_MERGEABLE` and the merge-approval gate
+escalated a perfectly mergeable squash to a human (runs 37–38).
+`GiteaPlatformClient.MergePullRequestAsync` now retries exactly that answer
+(bounded, backoff); every other failure stays terminal. Pinned by
+`GiteaMergeabilityRetryClassifierTests`. (Run 38 also showed the retry alone
+is insufficient when the PR is EMPTY — see item 28 — which is why both fixes
+were needed.)
+
+## 31. OPEN — Elsa dispatch-queue serialization race can LOSE a queued dispatch ("Collection was modified")
+
+Observed once (run 40, ~1-in-15 frequency): the engine's workflow dispatch
+queue processor crashed serializing a queued item
+(`PolymorphicDictionaryConverter.Write` →
+`InvalidOperationException: Collection was modified; enumeration operation may
+not execute` → "An unhandled exception occurred while processing the queue")
+while the dispatching parent was still executing (its fire-and-forget notify
+dispatches run concurrently with the queue's serialization of the same
+in-flight state). The queued `pull-request` dispatch was consumed by the crash
+and never ran; later items processed fine; the parent cycle suspended forever
+on `WaitForCompletion`. This is an Elsa 3.5 runtime-level race (their
+serializer enumerating a dictionary the executing workflow still mutates) —
+not fixed here. Mitigation direction: serialize dispatch inputs eagerly
+(deep-copy at enqueue), or upstream fix. A cycle that stalls with a dispatched
+child that never appears in the instance list + this queue crash in the log is
+THIS defect.

--- a/.dev/findings/engine-di-composition-gaps-found-by-e2e.md
+++ b/.dev/findings/engine-di-composition-gaps-found-by-e2e.md
@@ -470,3 +470,59 @@ not fixed here. Mitigation direction: serialize dispatch inputs eagerly
 (deep-copy at enqueue), or upstream fix. A cycle that stalls with a dispatched
 child that never appears in the instance list + this queue crash in the log is
 THIS defect.
+
+## 32. The provider allowlist's config extension point was DEAD on the main LLM path — FIXED
+
+`Security:ProviderAllowlist:AdditionalProviders` is the documented way to
+admit a self-hosted or custom provider, and `ProviderAllowlist` binds it
+correctly — but `InlineToolLoopRunner.LoadProviderConfig` validated against
+`ProviderAllowlist.IsAllowedDefault`, a static convenience built from a
+`DefaultInstance` that is constructed with NO options. So a configured
+provider passed selection (chain resolution, agent config) and was then
+rejected at the last moment with "Provider 'x' is not in the allowlist,
+rejecting", after which the caller silently fell back to the platform default
+— in the E2E, a real vendor with no credentials, so every LLM call answered
+200 with empty content and the loop produced nothing. No deployment could ever
+have used the extension point on this path. **Fixed (2026-08-14):** the runner
+binds `Security:ProviderAllowlist` from its injected `IConfiguration` (cached
+per runner) and consults that instance; the built-in defaults still apply when
+nothing is configured. The E2E fixture now sets the entry as well — enablement,
+chain selection AND allowlisting are all required for a provider to serve a
+call, and it had only the first two.
+
+## 33. Nine MORE `Output.Set(context, null)` NRE sites (item 3's class was not fully swept) — FIXED
+
+Item 3 fixed the sites the first pass found; nine survived and each NRE'd at
+runtime the moment its activity ran: `UpdateIssueStatusActivity` (×2 — this one
+faulted mid-cycle in run 47), `WaitForPRMergedActivity`, `EscalateReviewActivity`,
+`DeliverGuidanceActivity` (×2), `WaitForFixesActivity` (×2),
+`DispatchAgentWorkflowActivity`. The compiler flags every instance as CS8625
+("cannot convert null literal to non-nullable reference type") because the
+literal binds the `Variable<T>` overload, so the warning list IS the detector.
+**Fixed (2026-08-14):** all nine pass a typed null; `grep -rn "\.Set(context,
+null)" src/` now returns zero.
+
+## 34. Background ticks are TENANT-LESS, so every background actor in a single-user deployment is gated off forever — FIXED
+
+A background tick has no HTTP scope, so `EnsurePersonalTenantMiddleware` (the
+item-12 fix) never runs and the ambient tenant is null. Every tenant-resident
+read the autonomy gate performs then throws ("AcceptanceRulesRepository
+requires an ambient tenant id"), the gate CORRECTLY reads unreadable policy as
+fail-closed, and `Apply` skips the tick — permanently, for every actor
+(`outbox-smtp-sender`, `task-queue-processor`, ...), at one ERROR log per tick
+(818 in a single 14-minute E2E run). This is a production defect in any
+single-user deployment, not a test artifact. **Fixed (2026-08-14):**
+`BackgroundActionGate` binds the sole user's EXISTING personal tenant onto the
+tick's scope before evaluating (`ISoleUserProvider` + membership lookup — the
+same seam the middleware uses). Read-only on purpose: minting a tenant belongs
+to a user request, so pre-setup deployments behave exactly as before, and the
+gate's fail-closed posture is untouched.
+
+## 35. Harness: one 5s docker probe failed 23 tests on a cold CI runner — FIXED
+
+`DockerAvailability` probed `docker info` exactly once with a 5s budget. A
+cold GitHub runner exceeded it, `RequireOrSkip` threw under
+`PLATFORMS_REQUIRE_DOCKER=true`, and all 23 Gitea+Forgejo tests failed
+OneTimeSetUp on an infrastructure hiccup (PR #512, 2026-08-14). **Fixed:**
+where docker is required (CI) the probe retries within a 60s budget; on a
+laptop it keeps the single fast probe so test discovery never stalls.

--- a/.dev/findings/external-ci-run-cancellations-pr-511.md
+++ b/.dev/findings/external-ci-run-cancellations-pr-511.md
@@ -1,19 +1,26 @@
-# 2026-08-13 — external CI-run cancellations on PR #511
+# 2026-08-13 — external CI-run cancellations on PR #511 (and #512)
 
 **Status:** open — prime suspect identified, identity unconfirmed. Recorded so it is not re-litigated.
 
 ## What happened
 
-Five CI runs on branch `claude/wiki-docs-sync-r31nvo` (PR #511, the Epic 31 merge branch)
-were cancelled **externally, mid-run**:
+Six CI runs on branch `claude/wiki-docs-sync-r31nvo` were cancelled
+**externally, mid-run** — five while the branch carried PR #511 (the Epic 31
+merge branch) and one after it was restarted from `main` for PR #512, which
+shows the pattern follows the BRANCH (or the actor watching it), not one PR:
 
-| Date | Head commit |
-|---|---|
-| 2026-08-09 | `316d170` |
-| 2026-08-09 | `cffb83f` |
-| 2026-08-09 | `5659446` |
-| 2026-08-13 | `7474d97` |
-| 2026-08-13 | `fde545c` |
+| Date | Head commit | PR |
+|---|---|---|
+| 2026-08-09 | `316d170` | #511 |
+| 2026-08-09 | `cffb83f` | #511 |
+| 2026-08-09 | `5659446` | #511 |
+| 2026-08-13 | `7474d97` | #511 |
+| 2026-08-13 | `fde545c` | #511 |
+| 2026-08-13 | `43a85a0` (20:39Z) | #512 |
+
+One further #512 cancellation — `c0c518f` (17:25Z) — is NOT counted here: the
+next checkpoint pushed while it ran, so ordinary superseded-run concurrency
+explains it.
 
 ## What was ruled out (verified at the time)
 

--- a/.dev/findings/external-ci-run-cancellations-pr-511.md
+++ b/.dev/findings/external-ci-run-cancellations-pr-511.md
@@ -1,0 +1,42 @@
+# 2026-08-13 — external CI-run cancellations on PR #511
+
+**Status:** open — prime suspect identified, identity unconfirmed. Recorded so it is not re-litigated.
+
+## What happened
+
+Five CI runs on branch `claude/wiki-docs-sync-r31nvo` (PR #511, the Epic 31 merge branch)
+were cancelled **externally, mid-run**:
+
+| Date | Head commit |
+|---|---|
+| 2026-08-09 | `316d170` |
+| 2026-08-09 | `cffb83f` |
+| 2026-08-09 | `5659446` |
+| 2026-08-13 | `7474d97` |
+| 2026-08-13 | `fde545c` |
+
+## What was ruled out (verified at the time)
+
+- **No competing push** — no newer commit landed on the branch while any of the
+  five runs was in flight, so GitHub's own superseded-run cancellation does not apply.
+- **No human actor** — the repository owner confirmed nobody cancelled them by hand.
+- **No concurrency-group collision** — every workflow's `concurrency` group was
+  checked and all groups are distinct; none of the five cancellations can be a
+  same-group preemption.
+
+## Prime suspect
+
+The **deployed Tamma instance's own automation** reacting to its repository's
+PR/CI events (the platform watches its own repo — self-maintenance is the
+product), cancelling runs it believes are stale or superseded.
+
+## Resolution path
+
+1. **Org audit log** — query `action:workflow_run` around the five timestamps;
+   the audit entry carries the cancelling identity (app installation vs user).
+2. **Watch for recurrence** on this branch's runs (the Epic 31 follow-up work
+   continues on `claude/wiki-docs-sync-r31nvo`); any new cancellation should be
+   captured with its `workflow_run` audit row immediately.
+3. If the canceller is the deployed Tamma instance, file the bug against its
+   run-supersession logic (it must never cancel runs on a repo/branch it does
+   not own the head of) before re-enabling that automation against this repo.

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/AnalyzeReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/AnalyzeReviewActivity.cs
@@ -70,7 +70,7 @@ public class AnalyzeReviewActivity : Activity
     {
         var repository = Repository.Get(context);
         var prNumber = PrNumber.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         try
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyReviewFixesActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ApplyReviewFixesActivity.cs
@@ -81,7 +81,7 @@ public class ApplyReviewFixesActivity : Activity
         var analysisJson = AnalysisJson.Get(context);
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
-        var externalLlmResponse = LlmFixResponse.Get(context);
+        var externalLlmResponse = LlmFixResponse.GetOrDefault(context);
 
         try
         {
@@ -114,7 +114,7 @@ public class ApplyReviewFixesActivity : Activity
 
                 response = useMock
                     ? SimulateFixGeneration(analysis)
-                    : await MediatedLlmText.CompleteAsync(context, "implementer", prompt, context.CancellationToken);
+                    : await MediatedLlmText.CompleteAsync(context, "developer", prompt, context.CancellationToken, action: "implement-fix");
             }
 
             var result = ParseFixResponse(response, analysis);

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CheckLimitsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CheckLimitsActivity.cs
@@ -85,8 +85,14 @@ public class CheckLimitsActivity : TammaOutcomeActivity
             return;
         }
 
-        // All checks passed
-        StopReason.Set(context, null);
+        // All checks passed.
+        // 2026-08-13 (found by the engine-driven E2E): a literal `null` here
+        // binds to Elsa's Set(Output<T>, ctx, Variable<T>) overload, whose null
+        // Variable dereference throws NRE — so the HAPPY path of this activity
+        // ALWAYS faulted and the orchestrator could never reach DispatchCycle.
+        // The typed empty string keeps the "empty if continuing" output
+        // contract while binding to the value overload.
+        StopReason.Set(context, string.Empty);
         Logger?.LogInformation(
             "Limits OK: {Active}/{Max} active instances",
             activeCount, maxConcurrent);

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CheckPlatformCapabilityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CheckPlatformCapabilityActivity.cs
@@ -80,7 +80,7 @@ public class CheckPlatformCapabilityActivity : Activity
     {
         var repository = Repository.Get(context) ?? "";
         var capability = Capability.Get(context) ?? "";
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         GitCapabilitiesResponse? response = null;

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ClosePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ClosePullRequestActivity.cs
@@ -78,7 +78,7 @@ public class ClosePullRequestActivity : Activity
     {
         var repository = Repository.Get(context) ?? "";
         var prNumber = PrNumber.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var request = new GitClosePrRequest
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CooldownActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CooldownActivity.cs
@@ -32,11 +32,20 @@ public class CooldownActivity : TammaAsyncActivity
         Logger = logger;
     }
 
-    protected override async Task RunAsync(ActivityExecutionContext context)
+    protected override Task RunAsync(ActivityExecutionContext context)
     {
-        var seconds = Seconds.Get(context);
-        Logger?.LogInformation("Cooldown: waiting {Seconds}s before next cycle", seconds);
-        await Task.Delay(TimeSpan.FromSeconds(seconds));
+        // 2026-08-13 (engine-driven E2E): this activity EMITS the ADL.COOLDOWN
+        // audit pair and completes immediately — the actual wait is the stock
+        // scheduling Delay node the orchestrator sequences right after it
+        // ("CooldownWait", a timer bookmark that SUSPENDS the instance). The
+        // old in-process Task.Delay held the runtime's dispatch slot for the
+        // whole cooldown, so a real 3600s cooldown queued every subsequently
+        // dispatched workflow (all of the cycle's llm-calls included) behind
+        // the sleeping orchestrator and the loop deadlocked itself.
+        var seconds = Seconds.GetOrDefault(context);
+        Logger?.LogInformation(
+            "Cooldown: {Seconds}s until the next cycle (timer-bookmark wait follows)", seconds);
+        return Task.CompletedTask;
     }
 
     public override Dictionary<string, object?> BuildStartData(ActivityExecutionContext context) => new()

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateBranchActivity.cs
@@ -111,7 +111,7 @@ public class CreateBranchActivity : Activity
         var issueTitle = IssueTitle.Get(context) ?? "";
         var baseBranch = string.IsNullOrWhiteSpace(BaseBranch.Get(context)) ? DefaultBaseBranch : BaseBranch.Get(context)!;
         var strategy = string.IsNullOrWhiteSpace(ConflictStrategy.Get(context)) ? DefaultConflictStrategy : ConflictStrategy.Get(context)!;
-        var tenantId = NormalizeTenant(TenantId.Get(context));
+        var tenantId = NormalizeTenant(TenantId.GetOrDefault(context));
 
         // The candidate branch name is generated engine-side (pure, token-free);
         // the API performs the idempotent conflict-resolution + create + validate.

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreatePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreatePullRequestActivity.cs
@@ -119,14 +119,14 @@ public class CreatePullRequestActivity : Activity
         var baseBranch = BaseBranch.Get(context) ?? "main";
         var issueNumber = IssueNumber.Get(context);
         var issueTitle = IssueTitle.Get(context) ?? "";
-        var planJson = PlanJson.Get(context);
+        var planJson = PlanJson.GetOrDefault(context);
         var draft = Draft.Get(context);
-        var aiBody = AiBody.Get(context);
-        var changeSummary = ChangeSummary.Parse(ChangeSummaryJson.Get(context));
-        var testSummary = TestSummary.Parse(TestSummaryJson.Get(context));
-        var issueLabels = ParseStringList(IssueLabelsJson.Get(context));
-        var reviewers = ParseStringList(ReviewersJson.Get(context));
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var aiBody = AiBody.GetOrDefault(context);
+        var changeSummary = ChangeSummary.Parse(ChangeSummaryJson.GetOrDefault(context));
+        var testSummary = TestSummary.Parse(TestSummaryJson.GetOrDefault(context));
+        var issueLabels = ParseStringList(IssueLabelsJson.GetOrDefault(context));
+        var reviewers = ParseStringList(ReviewersJson.GetOrDefault(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var title = BuildTitle(issueNumber, issueTitle);
         var body = BuildBody(issueNumber, aiBody, planJson, changeSummary, testSummary);

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateReleaseActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/CreateReleaseActivity.cs
@@ -107,13 +107,13 @@ public class CreateReleaseActivity : Activity
     {
         var repository = Repository.Get(context) ?? "";
         var tag = TagName.Get(context) ?? "";
-        var targetRef = TargetRef.Get(context);
-        var name = ReleaseName.Get(context);
-        var body = Body.Get(context);
+        var targetRef = TargetRef.GetOrDefault(context);
+        var name = ReleaseName.GetOrDefault(context);
+        var body = Body.GetOrDefault(context);
         var draft = Draft.Get(context);
         var prerelease = Prerelease.Get(context);
         var issueNumber = IssueNumber.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var request = new GitCreateReleaseRequest
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchAdlActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchAdlActivity.cs
@@ -60,14 +60,6 @@ public class DispatchAdlActivity : TammaAsyncActivity
 
         var configJson = ConfigJson.Get(context);
 
-        var request = new DispatchWorkflowDefinitionRequest("adl-orchestrator")
-        {
-            Input = new Dictionary<string, object>
-            {
-                ["configJson"] = configJson,
-            },
-        };
-
         // DURABILITY (loop restart) — this dispatch is the ONLY thing that starts the
         // next ADL cycle: there is no cron trigger and no watchdog re-dispatching
         // `adl-orchestrator`. It is also the LAST step of the instance it restarts, so
@@ -76,12 +68,27 @@ public class DispatchAdlActivity : TammaAsyncActivity
         // a human dispatches one by hand. A transient blip (broker/DB/dispatcher) must
         // therefore never propagate: retry with backoff, and if every attempt fails,
         // say so at Critical rather than throwing. Deliberately bounded and short —
-        // this is an in-process dispatch, not an external API call.
+        // this is an in-process dispatch, not an external API call. The version-id
+        // resolve (2026-08-13 — the request ctor takes the VERSION id, not the
+        // definition id; see PublishedWorkflowDispatch) lives INSIDE the retry for
+        // the same reason.
         const int maxAttempts = 3;
         for (var attempt = 1; attempt <= maxAttempts; attempt++)
         {
             try
             {
+                var definitionVersionId = await Tamma.Activities.Core.PublishedWorkflowDispatch
+                    .ResolvePublishedVersionIdAsync(
+                        context.GetRequiredService<Elsa.Workflows.Management.IWorkflowDefinitionService>(),
+                        "adl-orchestrator");
+                var request = new DispatchWorkflowDefinitionRequest(definitionVersionId)
+                {
+                    Input = new Dictionary<string, object>
+                    {
+                        ["configJson"] = configJson,
+                    },
+                };
+
                 await dispatcher.DispatchAsync(request, default);
                 Logger?.LogInformation("Dispatched new ADL Orchestrator cycle");
                 return;

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchCycleActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchCycleActivity.cs
@@ -128,25 +128,35 @@ public class DispatchCycleActivity : TammaAsyncActivity
         };
 
         var instanceId = Guid.NewGuid().ToString();
-        var request = new DispatchWorkflowDefinitionRequest("single-issue-cycle")
-        {
-            Input = input,
-            InstanceId = instanceId,
-            // Story 43-14 (D5) — the cycle's correlation IS the cycle instance id.
-            // The RunCorrelation middleware puts this on the ambient during the
-            // cycle's execution, and CorrelationPropagatingWorkflowDispatcher
-            // propagates it to every sub-workflow — so the whole chain shares one
-            // ledger-visible correlation and a human's approval covers the run.
-            CorrelationId = instanceId,
-        };
 
         // FIRE & FORGET, and non-fatal by design. This activity sits upstream of the
         // orchestrator's cooldown → restart edge, so an exception here faults the
         // instance BEFORE it can dispatch its successor and the autonomous loop stops
         // permanently. Failing to start ONE issue cycle must cost that issue, never
-        // the loop — the issue is still selectable on the next tick.
+        // the loop — the issue is still selectable on the next tick. The version-id
+        // resolve lives INSIDE the try for the same reason (a transient DB read
+        // failure must never fault the loop).
         try
         {
+            // 2026-08-13 — the request ctor takes the VERSION id, not the definition
+            // id (see PublishedWorkflowDispatch: every background dispatch failed
+            // WorkflowGraphNotFound before this resolve step existed).
+            var definitionVersionId = await Tamma.Activities.Core.PublishedWorkflowDispatch
+                .ResolvePublishedVersionIdAsync(
+                    context.GetRequiredService<Elsa.Workflows.Management.IWorkflowDefinitionService>(),
+                    "single-issue-cycle");
+            var request = new DispatchWorkflowDefinitionRequest(definitionVersionId)
+            {
+                Input = input,
+                InstanceId = instanceId,
+                // Story 43-14 (D5) — the cycle's correlation IS the cycle instance id.
+                // The RunCorrelation middleware puts this on the ambient during the
+                // cycle's execution, and CorrelationPropagatingWorkflowDispatcher
+                // propagates it to every sub-workflow — so the whole chain shares one
+                // ledger-visible correlation and a human's approval covers the run.
+                CorrelationId = instanceId,
+            };
+
             await dispatcher.DispatchAsync(request, default);
 
             InstanceId.Set(context, instanceId);

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchTriageActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/DispatchTriageActivity.cs
@@ -60,17 +60,25 @@ public class DispatchTriageActivity : TammaAsyncActivity
             ["repository"] = Repository.Get(context),
         };
 
-        var request = new DispatchWorkflowDefinitionRequest("issue-triage")
-        {
-            Input = input,
-        };
-
         // FIRE & FORGET, and non-fatal by design. This activity sits upstream of the
         // orchestrator's cooldown → restart edge, so an exception here faults the
         // instance BEFORE it can dispatch its successor and the autonomous loop stops
         // permanently. Failing to triage one batch must cost one tick, never the loop.
+        // The version-id resolve lives INSIDE the try for the same reason.
         try
         {
+            // 2026-08-13 — the request ctor takes the VERSION id, not the definition
+            // id (see PublishedWorkflowDispatch: every background dispatch failed
+            // WorkflowGraphNotFound before this resolve step existed).
+            var definitionVersionId = await Tamma.Activities.Core.PublishedWorkflowDispatch
+                .ResolvePublishedVersionIdAsync(
+                    context.GetRequiredService<Elsa.Workflows.Management.IWorkflowDefinitionService>(),
+                    "issue-triage");
+            var request = new DispatchWorkflowDefinitionRequest(definitionVersionId)
+            {
+                Input = input,
+            };
+
             await dispatcher.DispatchAsync(request, default);
 
             Logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitBranchEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitBranchEventActivity.cs
@@ -59,13 +59,13 @@ public class EmitBranchEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? BranchEvents.CreatedFailed;
-        var issueNumber = IssueNumber.Get(context);
-        var repository = Repository.Get(context) ?? "";
-        var tenantId = BranchEvents.ParseTenantId(TenantId.Get(context));
-        var data = ParseData(DataJson.Get(context));
+        var type = EventType.GetOrDefault(context) ?? BranchEvents.CreatedFailed;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var tenantId = BranchEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var data = ParseData(DataJson.GetOrDefault(context));
 
         var evt = BuildTammaEvent(type, issueNumber, repository, tenantId, data);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -73,7 +73,8 @@ public class EmitBranchEventActivity : Activity
         _logger?.LogInformation(
             "Emitted {Type} for issue #{Issue} in {Repo}", type, issueNumber, repository);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitCycleEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitCycleEventActivity.cs
@@ -62,25 +62,33 @@ public class EmitCycleEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? CycleEvents.Failed;
+        var type = EventType.GetOrDefault(context) ?? CycleEvents.Failed;
 
+        // 2026-08-13 (found by the engine-driven E2E): the OPTIONAL inputs must
+        // be read with GetOrDefault. A literal-null Input default is DROPPED by
+        // the workflow-definition store's JSON round-trip, so an unwired input
+        // materializes as null and Input.Get throws "<name> is required." —
+        // which faulted EVERY CYCLE.STARTED/COMPLETED emit (the workflow only
+        // wires StepId/ErrorDetail on the failure emits).
         var evt = BuildTammaEvent(
             type,
-            issueNumber: IssueNumber.Get(context),
-            repository: Repository.Get(context),
-            tenantId: CycleEvents.ParseTenantId(TenantId.Get(context)),
-            stepId: StepId.Get(context),
-            errorDetail: ErrorDetail.Get(context));
+            issueNumber: IssueNumber.GetOrDefault(context),
+            repository: Repository.GetOrDefault(context),
+            tenantId: CycleEvents.ParseTenantId(TenantId.GetOrDefault(context)),
+            stepId: StepId.GetOrDefault(context),
+            errorDetail: ErrorDetail.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for issue #{Issue} repo {Repo} (step={Step})",
-            type, IssueNumber.Get(context), Repository.Get(context), StepId.Get(context));
+            type, IssueNumber.GetOrDefault(context), Repository.GetOrDefault(context),
+            StepId.GetOrDefault(context));
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitDeploymentEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitDeploymentEventActivity.cs
@@ -72,16 +72,16 @@ public class EmitDeploymentEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? DeployEvents.PipelineFailed;
-        var issueNumber = IssueNumber.Get(context);
-        var repository = Repository.Get(context) ?? "";
-        var mergeSha = MergeSha.Get(context) ?? "";
-        var stage = Stage.Get(context) ?? "";
-        var mode = Mode.Get(context) ?? "";
-        var tenantId = DeployEvents.ParseTenantId(TenantId.Get(context));
-        var data = ParseData(DataJson.Get(context));
+        var type = EventType.GetOrDefault(context) ?? DeployEvents.PipelineFailed;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var mergeSha = MergeSha.GetOrDefault(context) ?? "";
+        var stage = Stage.GetOrDefault(context) ?? "";
+        var mode = Mode.GetOrDefault(context) ?? "";
+        var tenantId = DeployEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var data = ParseData(DataJson.GetOrDefault(context));
 
         var evt = BuildTammaEvent(type, issueNumber, repository, mergeSha, stage, mode, tenantId, data);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -90,7 +90,8 @@ public class EmitDeploymentEventActivity : Activity
             "Emitted {Type} for issue #{Issue} stage {Stage} in {Repo}",
             type, issueNumber, string.IsNullOrEmpty(stage) ? "<pipeline>" : stage, repository);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitIssueStatusEventActivity.cs
@@ -59,13 +59,13 @@ public class EmitIssueStatusEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? IssueStatusEvents.UpdatedFailed;
-        var issueNumber = IssueNumber.Get(context);
-        var repository = Repository.Get(context) ?? "";
-        var tenantId = IssueStatusEvents.ParseTenantId(TenantId.Get(context));
-        var data = ParseData(DataJson.Get(context));
+        var type = EventType.GetOrDefault(context) ?? IssueStatusEvents.UpdatedFailed;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var tenantId = IssueStatusEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var data = ParseData(DataJson.GetOrDefault(context));
 
         var evt = BuildTammaEvent(type, issueNumber, repository, tenantId, data);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -73,7 +73,8 @@ public class EmitIssueStatusEventActivity : Activity
         _logger?.LogInformation(
             "Emitted {Type} for issue #{Issue} in {Repo}", type, issueNumber, repository);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeApprovalEventActivity.cs
@@ -68,15 +68,15 @@ public class EmitMergeApprovalEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? MergeApprovalEvents.Escalated;
-        var issueNumber = IssueNumber.Get(context);
-        var prNumber = PrNumber.Get(context);
-        var tenantId = MergeApprovalEvents.ParseTenantId(TenantId.Get(context));
-        var decision = Decision.Get(context);
-        var approver = Approver.Get(context);
-        var feedback = Feedback.Get(context);
+        var type = EventType.GetOrDefault(context) ?? MergeApprovalEvents.Escalated;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var prNumber = PrNumber.GetOrDefault(context);
+        var tenantId = MergeApprovalEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var decision = Decision.GetOrDefault(context);
+        var approver = Approver.GetOrDefault(context);
+        var feedback = Feedback.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, issueNumber, prNumber, tenantId, decision, approver, feedback);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -85,7 +85,8 @@ public class EmitMergeApprovalEventActivity : Activity
             "Emitted {Type} for issue #{Issue} pr #{Pr} (decision={Decision}, approver={Approver})",
             type, issueNumber, prNumber, decision ?? "", approver ?? "");
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitMergeEventActivity.cs
@@ -64,14 +64,14 @@ public class EmitMergeEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? MergeEvents.Failed;
-        var issueNumber = IssueNumber.Get(context);
-        var prNumber = PrNumber.Get(context);
-        var repository = Repository.Get(context) ?? "";
-        var tenantId = MergeEvents.ParseTenantId(TenantId.Get(context));
-        var data = ParseData(DataJson.Get(context));
+        var type = EventType.GetOrDefault(context) ?? MergeEvents.Failed;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var prNumber = PrNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var tenantId = MergeEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var data = ParseData(DataJson.GetOrDefault(context));
 
         var evt = BuildTammaEvent(type, issueNumber, prNumber, repository, tenantId, data);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -80,7 +80,8 @@ public class EmitMergeEventActivity : Activity
             "Emitted {Type} for PR #{Pr} / issue #{Issue} in {Repo}",
             type, prNumber, issueNumber, repository);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitPrEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitPrEventActivity.cs
@@ -74,14 +74,14 @@ public class EmitPrEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? PrEvents.CreatedFailed;
-        var issueNumber = IssueNumber.Get(context);
-        var repository = Repository.Get(context) ?? "";
-        var prNumber = PrNumber.Get(context);
-        var tenantId = PrEvents.ParseTenantId(TenantId.Get(context));
-        var dataJson = DataJson.Get(context);
+        var type = EventType.GetOrDefault(context) ?? PrEvents.CreatedFailed;
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var prNumber = PrNumber.GetOrDefault(context);
+        var tenantId = PrEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var dataJson = DataJson.GetOrDefault(context);
 
         var data = ParseData(dataJson);
 
@@ -98,7 +98,8 @@ public class EmitPrEventActivity : Activity
             "Emitted {Type} for issue #{Issue} pr #{Pr} in {Repo}",
             type, issueNumber, prNumber, repository);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitReviewFixEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitReviewFixEventActivity.cs
@@ -57,14 +57,14 @@ public class EmitReviewFixEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? ReviewFixEvents.AppliedFailed;
-        var repository = Repository.Get(context) ?? "";
-        var prNumber = PrNumber.Get(context);
-        var issueNumber = IssueNumber.Get(context);
-        var tenantId = ReviewFixEvents.ParseTenantId(TenantId.Get(context));
-        var data = ParseData(DataJson.Get(context));
+        var type = EventType.GetOrDefault(context) ?? ReviewFixEvents.AppliedFailed;
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var prNumber = PrNumber.GetOrDefault(context);
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var tenantId = ReviewFixEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var data = ParseData(DataJson.GetOrDefault(context));
 
         var evt = BuildTammaEvent(type, repository, prNumber, issueNumber, tenantId, data);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -73,7 +73,8 @@ public class EmitReviewFixEventActivity : Activity
             "Emitted {Type} for pr #{Pr} in {Repo} (issue #{Issue})",
             type, prNumber, repository, issueNumber);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTddDebugEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTddDebugEventActivity.cs
@@ -73,17 +73,17 @@ public class EmitTddDebugEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TddDebugEvents.RetryExhausted;
-        var storyId = StoryId.Get(context);
-        var issueNumber = IssueNumber.Get(context);
-        var repository = Repository.Get(context);
-        var tenantId = TddDebugEvents.ParseTenantId(TenantId.Get(context));
-        var attempt = Attempt.Get(context);
-        var maxRetries = MaxRetries.Get(context);
-        var finishReason = FinishReason.Get(context);
-        var errorDetail = ErrorDetail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? TddDebugEvents.RetryExhausted;
+        var storyId = StoryId.GetOrDefault(context);
+        var issueNumber = IssueNumber.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context);
+        var tenantId = TddDebugEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var attempt = Attempt.GetOrDefault(context);
+        var maxRetries = MaxRetries.GetOrDefault(context);
+        var finishReason = FinishReason.GetOrDefault(context);
+        var errorDetail = ErrorDetail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, storyId, issueNumber, repository, tenantId, attempt, maxRetries, finishReason, errorDetail);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -92,7 +92,8 @@ public class EmitTddDebugEventActivity : Activity
             "Emitted {Type} for story {Story} issue #{Issue} (attempt={Attempt}/{Max}, reason={Reason})",
             type, storyId, issueNumber, attempt, maxRetries, finishReason);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageContextEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageContextEventActivity.cs
@@ -67,15 +67,15 @@ public class EmitTriageContextEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TriageContextEvents.Failed;
-        var repository = Repository.Get(context) ?? "";
-        var itemNumber = ItemNumber.Get(context);
-        var tenantId = TriageContextEvents.ParseTenantId(TenantId.Get(context));
-        var itemType = ItemType.Get(context);
-        var contextStatus = ContextStatus.Get(context);
-        var contextJsonLength = ContextJsonLength.Get(context);
+        var type = EventType.GetOrDefault(context) ?? TriageContextEvents.Failed;
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var itemNumber = ItemNumber.GetOrDefault(context);
+        var tenantId = TriageContextEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var itemType = ItemType.GetOrDefault(context);
+        var contextStatus = ContextStatus.GetOrDefault(context);
+        var contextJsonLength = ContextJsonLength.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, repository, itemNumber, tenantId, itemType, contextStatus, contextJsonLength);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -84,7 +84,8 @@ public class EmitTriageContextEventActivity : Activity
             "Emitted {Type} for item #{Item} in {Repo} (itemType={ItemType}, status={Status}, len={Len})",
             type, itemNumber, repository, itemType, contextStatus, contextJsonLength);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageCycleEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageCycleEventActivity.cs
@@ -80,19 +80,19 @@ public class EmitTriageCycleEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TriageCycleEvents.Failed;
-        var repository = Repository.Get(context) ?? "";
-        var itemKey = ItemKey.Get(context);
-        var itemNumber = ItemNumber.Get(context);
-        var tenantId = TriageCycleEvents.ParseTenantId(TenantId.Get(context));
-        var itemSource = ItemSource.Get(context);
-        var type2 = Type.Get(context);
-        var priority = Priority.Get(context);
-        var automation = Automation.Get(context);
-        var decisionStatus = DecisionStatus.Get(context);
-        var reason = Reason.Get(context);
+        var type = EventType.GetOrDefault(context) ?? TriageCycleEvents.Failed;
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var itemKey = ItemKey.GetOrDefault(context);
+        var itemNumber = ItemNumber.GetOrDefault(context);
+        var tenantId = TriageCycleEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var itemSource = ItemSource.GetOrDefault(context);
+        var type2 = Type.GetOrDefault(context);
+        var priority = Priority.GetOrDefault(context);
+        var automation = Automation.GetOrDefault(context);
+        var decisionStatus = DecisionStatus.GetOrDefault(context);
+        var reason = Reason.GetOrDefault(context);
 
         var evt = BuildTammaEvent(
             type, repository, itemKey, itemNumber, tenantId, itemSource,
@@ -104,7 +104,8 @@ public class EmitTriageCycleEventActivity : Activity
             "Emitted {Type} for {ItemKey} in {Repo} (source={Source}, status={Status})",
             type, itemKey, repository, itemSource, decisionStatus);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriageEventActivity.cs
@@ -68,15 +68,15 @@ public class EmitTriageEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TriageEvents.PanelFailed;
-        var repository = Repository.Get(context) ?? "";
-        var itemNumber = ItemNumber.Get(context);
-        var tenantId = TriageEvents.ParseTenantId(TenantId.Get(context));
-        var roleCount = RoleCount.Get(context);
-        var succeededCount = SucceededCount.Get(context);
-        var failedRolesJson = FailedRolesJson.Get(context);
+        var type = EventType.GetOrDefault(context) ?? TriageEvents.PanelFailed;
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var itemNumber = ItemNumber.GetOrDefault(context);
+        var tenantId = TriageEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var roleCount = RoleCount.GetOrDefault(context);
+        var succeededCount = SucceededCount.GetOrDefault(context);
+        var failedRolesJson = FailedRolesJson.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, repository, itemNumber, tenantId, roleCount, succeededCount, failedRolesJson);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -85,7 +85,8 @@ public class EmitTriageEventActivity : Activity
             "Emitted {Type} for item #{Item} in {Repo} (roles={Roles}, succeeded={Succeeded})",
             type, itemNumber, repository, roleCount, succeededCount);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriagePoDecisionEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/EmitTriagePoDecisionEventActivity.cs
@@ -81,26 +81,27 @@ public class EmitTriagePoDecisionEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TriagePoDecisionEvents.Failed;
-        var repository = Repository.Get(context) ?? "";
-        var itemNumber = ItemNumber.Get(context);
-        var tenantId = TriagePoDecisionEvents.ParseTenantId(TenantId.Get(context));
+        var type = EventType.GetOrDefault(context) ?? TriagePoDecisionEvents.Failed;
+        var repository = Repository.GetOrDefault(context) ?? "";
+        var itemNumber = ItemNumber.GetOrDefault(context);
+        var tenantId = TriagePoDecisionEvents.ParseTenantId(TenantId.GetOrDefault(context));
 
         var evt = BuildTammaEvent(
             type, repository, itemNumber, tenantId,
-            DecisionStatus.Get(context), Priority.Get(context), Type.Get(context),
-            Complexity.Get(context), Automation.Get(context),
-            ProviderUsed.Get(context), CostUsd.Get(context), Error.Get(context));
+            DecisionStatus.GetOrDefault(context), Priority.GetOrDefault(context), Type.GetOrDefault(context),
+            Complexity.GetOrDefault(context), Automation.GetOrDefault(context),
+            ProviderUsed.GetOrDefault(context), CostUsd.GetOrDefault(context), Error.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for item #{Item} in {Repo} (status={Status}, provider={Provider})",
-            type, itemNumber, repository, DecisionStatus.Get(context), ProviderUsed.Get(context));
+            type, itemNumber, repository, DecisionStatus.GetOrDefault(context), ProviderUsed.GetOrDefault(context));
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/FetchUntriagedItemsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/FetchUntriagedItemsActivity.cs
@@ -70,16 +70,22 @@ public class FetchUntriagedItemsActivity : TammaAsyncActivity
         var repo = Repository.Get(context);
         var items = new List<TriageItem>();
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        var useMock = _configuration?.GetValue<bool>("Anthropic:UseMock") ?? false;
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom).
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        var useMock = configuration?.GetValue<bool>("Anthropic:UseMock") ?? false;
 
         if (useMock)
         {
             items = SimulateItems();
         }
-        else if (!string.IsNullOrEmpty(callbackUrl) && _httpClientFactory != null)
+        else if (!string.IsNullOrEmpty(callbackUrl) && httpClientFactory != null)
         {
-            var httpClient = _httpClientFactory.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
 
             // Fetch open issues
             try

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/InitAdlConfigActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/InitAdlConfigActivity.cs
@@ -78,13 +78,28 @@ public class InitAdlConfigActivity : TammaActivity
         // Start from defaults
         var config = new AdlConfig();
 
+        // 2026-08-13 (engine-driven E2E): ALL the layered-override inputs are
+        // OPTIONAL and must be read with GetOrDefault — .Get throws
+        // "<name> is required." on a null evaluated value, and the
+        // self-restart dispatch (DispatchAdlActivity) passes only configJson,
+        // so every successor orchestrator instance faulted its own init here.
         // Layer 1: Parse configJson if provided
-        var configJson = ConfigJson.Get(context);
+        var configJson = ConfigJson.GetOrDefault(context);
         if (!string.IsNullOrWhiteSpace(configJson))
         {
             try
             {
-                config = JsonSerializer.Deserialize<AdlConfig>(configJson) ?? config;
+                // 2026-08-13 (engine-driven E2E): case-INSENSITIVE on purpose.
+                // Callers dispatch camelCase config ({"cooldownSeconds":3600});
+                // the default case-sensitive deserialize silently ignored every
+                // camelCase member, so the orchestrator ran with
+                // CooldownSeconds=10 and re-selected the same still-open issue
+                // every ten seconds — 25 restarts and 18 concurrent cycles for
+                // one issue in a single E2E window.
+                config = JsonSerializer.Deserialize<AdlConfig>(
+                             configJson,
+                             new JsonSerializerOptions { PropertyNameCaseInsensitive = true })
+                         ?? config;
             }
             catch (JsonException ex)
             {
@@ -93,19 +108,19 @@ public class InitAdlConfigActivity : TammaActivity
         }
 
         // Layer 2: Direct input overrides
-        var repoInput = Repository.Get(context);
+        var repoInput = Repository.GetOrDefault(context);
         if (!string.IsNullOrEmpty(repoInput))
             config.Repository = repoInput;
 
-        var labelsInput = IssueLabels.Get(context);
+        var labelsInput = IssueLabels.GetOrDefault(context);
         if (labelsInput is { Length: > 0 })
             config.IssueLabels = labelsInput;
 
-        var botInput = BotAssignee.Get(context);
+        var botInput = BotAssignee.GetOrDefault(context);
         if (!string.IsNullOrEmpty(botInput))
             config.BotAssignee = botInput;
 
-        var branchInput = BaseBranch.Get(context);
+        var branchInput = BaseBranch.GetOrDefault(context);
         if (!string.IsNullOrEmpty(branchInput))
             config.BaseBranch = branchInput;
 

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/MergePullRequestActivity.cs
@@ -159,7 +159,7 @@ public class MergePullRequestActivity : TammaOutcomeActivity
         var strategy = NormalizeStrategy(MergeStrategy.Get(context));
         var autoDeleteBranch = AutoDeleteBranch.Get(context);
         var closeIssue = CloseAssociatedIssue.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var request = new GitMergePrRequest
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/PendingPrMergeBuffer.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/PendingPrMergeBuffer.cs
@@ -1,0 +1,66 @@
+using System.Collections.Concurrent;
+
+namespace Tamma.Activities.ADL;
+
+/// <summary>
+/// 2026-08-13 (engine-driven E2E run 39) — the SELF-MERGE RACE buffer for the
+/// cycle's merged-PR wait.
+///
+/// <para><b>The race.</b> When Tamma itself performs the merge (the
+/// merge-approval gate's happy path), the platform's merged-PR webhook fires
+/// IMMEDIATELY — observed 1 s BEFORE the cycle transitioned into
+/// <see cref="WaitForPRMergedActivity"/> and registered its bookmark. The
+/// webhook forward then 404'd ("no suspended bookmark"), the once-only
+/// delivery was lost, and a successfully merged PR sat on the 12 h SLA before
+/// escalating needs-human — on every self-merged cycle, every platform.</para>
+///
+/// <para><b>The fix (reconcile-on-register).</b> The resume endpoint, on a
+/// bookmark miss, RECORDS the merge here keyed by the bookmark name it
+/// computed; the wait activity CONSUMES the record before suspending and, on a
+/// hit, completes its <c>Merged</c> outcome immediately — no webhook is lost
+/// within the process lifetime. In-memory is deliberate: the buffer only
+/// bridges a seconds-wide in-process ordering race, the entry is consumed by
+/// the very next wait registration, and an engine restart inside that window
+/// still falls back to the wait's durable 12 h SLA edge (the pre-existing
+/// exception path). Entries expire after <see cref="Ttl"/> so a merge webhook
+/// for a wait that never registers (a cycle that faulted before reaching the
+/// wait) cannot leak.</para>
+/// </summary>
+public sealed class PendingPrMergeBuffer
+{
+    private static readonly TimeSpan Ttl = TimeSpan.FromHours(1);
+
+    private readonly ConcurrentDictionary<string, (string? MergeSha, DateTimeOffset At)> _pending =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Record a merged-PR notification that found no suspended wait.</summary>
+    public void Record(string bookmarkName, string? mergeSha)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(bookmarkName);
+        Sweep();
+        _pending[bookmarkName] = (mergeSha, DateTimeOffset.UtcNow);
+    }
+
+    /// <summary>
+    /// Consume (remove + return) a recorded merge for this bookmark name.
+    /// True exactly once per recorded notification.
+    /// </summary>
+    public bool TryConsume(string bookmarkName, out string? mergeSha)
+    {
+        mergeSha = null;
+        if (string.IsNullOrWhiteSpace(bookmarkName)) return false;
+        if (!_pending.TryRemove(bookmarkName, out var entry)) return false;
+        if (DateTimeOffset.UtcNow - entry.At > Ttl) return false; // expired — fall to the SLA path.
+        mergeSha = entry.MergeSha;
+        return true;
+    }
+
+    private void Sweep()
+    {
+        var cutoff = DateTimeOffset.UtcNow - Ttl;
+        foreach (var (key, value) in _pending)
+        {
+            if (value.At < cutoff) _pending.TryRemove(key, out _);
+        }
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ReopenPullRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ReopenPullRequestActivity.cs
@@ -76,7 +76,7 @@ public class ReopenPullRequestActivity : Activity
     {
         var repository = Repository.Get(context) ?? "";
         var prNumber = PrNumber.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var request = new GitReopenPrRequest
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ReportCycleResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ReportCycleResultActivity.cs
@@ -59,13 +59,19 @@ public class ReportCycleResultActivity : TammaAsyncActivity
         context.WorkflowExecutionContext.Output["exitReason"] = reason;
         context.WorkflowExecutionContext.Output["issueNumber"] = issueNumber;
 
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom).
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
         // Call engine callback if configured
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (!string.IsNullOrEmpty(callbackUrl) && _httpClientFactory != null)
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        if (!string.IsNullOrEmpty(callbackUrl) && httpClientFactory != null)
         {
             try
             {
-                var httpClient = _httpClientFactory.CreateClient();
+                var httpClient = httpClientFactory.CreateClient();
                 var payload = new
                 {
                     exitReason = reason,

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/ReportCycleResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/ReportCycleResultActivity.cs
@@ -53,7 +53,10 @@ public class ReportCycleResultActivity : TammaAsyncActivity
     {
         var reason = Reason.Get(context);
         var issueNumber = IssueNumber.Get(context);
-        var error = Error.Get(context);
+        // 2026-08-13 (engine-driven E2E): Input<T>.Get THROWS "Error is required."
+        // on any null evaluated value — an OPTIONAL input must read GetOrDefault,
+        // or every non-error exit path (needsHuman included) faults right here.
+        var error = Error.GetOrDefault(context);
 
         // Set workflow output
         context.WorkflowExecutionContext.Output["exitReason"] = reason;

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/SelectWorkItemActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/SelectWorkItemActivity.cs
@@ -94,7 +94,15 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
         var excludeLabels = ExcludeLabels.Get(context);
         var bot = BotAssignee.Get(context);
 
-        var useMock = _configuration?.GetValue<bool>("Anthropic:UseMock") ?? false;
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom). Without this
+        // the real engine SILENTLY fell back to SimulateCandidates (null Logger
+        // swallowed the warning) instead of selecting real work via the API.
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
+        var useMock = configuration?.GetValue<bool>("Anthropic:UseMock") ?? false;
 
         List<WorkItem> candidates;
         int untriaged;
@@ -106,7 +114,8 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
         }
         else
         {
-            (candidates, untriaged) = await FetchCandidates(repo, autoLabels, excludeLabels, bot);
+            (candidates, untriaged) = await FetchCandidates(
+                configuration, httpClientFactory, repo, autoLabels, excludeLabels, bot);
         }
 
         UntriagedCount.Set(context, untriaged);
@@ -116,9 +125,11 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
             if (untriaged > 0)
             {
                 // No auto-labeled issues, but untriaged ones exist → triage them
-                WorkItemJson.Set(context, null);
-                WorkItemType.Set(context, null);
-                WorkItemTitle.Set(context, null);
+                // 2026-08-13 (same trap as CheckLimitsActivity.StopReason): a literal
+                // null binds to Elsa's Set(Output, ctx, Variable) overload and NREs.
+                WorkItemJson.Set(context, (string?)null);
+                WorkItemType.Set(context, (string?)null);
+                WorkItemTitle.Set(context, (string?)null);
                 Priority.Set(context, "normal");
 
                 Logger?.LogInformation("No work items ready, but {Count} untriaged issues found", untriaged);
@@ -126,9 +137,9 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
                 return;
             }
 
-            WorkItemJson.Set(context, null);
-            WorkItemType.Set(context, null);
-            WorkItemTitle.Set(context, null);
+            WorkItemJson.Set(context, (string?)null);
+            WorkItemType.Set(context, (string?)null);
+            WorkItemTitle.Set(context, (string?)null);
             Priority.Set(context, "none");
 
             Logger?.LogInformation("No work items found — repo is clean");
@@ -160,6 +171,7 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
     }
 
     private async Task<(List<WorkItem> candidates, int untriaged)> FetchCandidates(
+        IConfiguration? configuration, IHttpClientFactory? httpClientFactory,
         string repo, string[] autoLabels, string[] excludeLabels, string bot)
     {
         var candidates = new List<WorkItem>();
@@ -167,14 +179,14 @@ public class SelectWorkItemActivity : TammaOutcomeActivity
 
         try
         {
-            var callbackUrl = _configuration?["Engine:CallbackUrl"];
-            if (string.IsNullOrEmpty(callbackUrl))
+            var callbackUrl = configuration?["Engine:CallbackUrl"];
+            if (string.IsNullOrEmpty(callbackUrl) || httpClientFactory == null)
             {
                 Logger?.LogWarning("No Engine:CallbackUrl configured, using mock candidates");
                 return (SimulateCandidates(), 0);
             }
 
-            var httpClient = _httpClientFactory!.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
 
             // Fetch issues via engine callback
             var response = await httpClient.GetAsync(
@@ -306,9 +318,72 @@ public class WorkItem
     public string? Body { get; set; }
     public string Type { get; set; } = "issue";
     public string Priority { get; set; } = "normal";
+
+    /// <summary>
+    /// 2026-08-13 (engine-driven E2E): <c>GET /api/engine/issues</c> serves
+    /// GitHub-shaped label OBJECTS (<c>[{"name":"tamma-auto"}]</c> — the shape
+    /// pinned by <c>EngineCallbackContractTests</c> / <c>IssueToJson</c>), but
+    /// this model declared <c>List&lt;string&gt;</c>, so BOTH consumers
+    /// (SelectWorkItem / FetchUntriagedItems) threw <see cref="JsonException"/>
+    /// inside a log-and-swallow catch and the real intake path returned zero
+    /// candidates on every tick. The converter accepts both shapes (plain
+    /// strings keep working for the internal WorkItemJson round-trip).
+    /// </summary>
+    [JsonConverter(typeof(LabelNamesConverter))]
     public List<string> Labels { get; set; } = new();
+
     public string? Assignee { get; set; }
+
+    [JsonPropertyName("html_url")]
     public string? Url { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public Dictionary<string, object?> Metadata { get; set; } = new();
+}
+
+/// <summary>
+/// Reads a labels array whose elements are either plain strings
+/// (<c>["a"]</c> — the internal WorkItemJson round-trip shape) or objects with
+/// a <c>name</c> property (<c>[{"name":"a"}]</c> — the platform-proxy shape of
+/// <c>GET /api/engine/issues</c>). Always writes plain strings.
+/// </summary>
+public sealed class LabelNamesConverter : JsonConverter<List<string>>
+{
+    public override List<string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var labels = new List<string>();
+        if (reader.TokenType != JsonTokenType.StartArray)
+            throw new JsonException("labels must be an array");
+
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonTokenType.String:
+                    labels.Add(reader.GetString() ?? string.Empty);
+                    break;
+                case JsonTokenType.StartObject:
+                    using (var doc = JsonDocument.ParseValue(ref reader))
+                    {
+                        if (doc.RootElement.TryGetProperty("name", out var name)
+                            && name.ValueKind == JsonValueKind.String)
+                        {
+                            labels.Add(name.GetString() ?? string.Empty);
+                        }
+                    }
+                    break;
+                default:
+                    throw new JsonException($"Unexpected labels element token: {reader.TokenType}");
+            }
+        }
+
+        return labels;
+    }
+
+    public override void Write(Utf8JsonWriter writer, List<string> value, JsonSerializerOptions options)
+    {
+        writer.WriteStartArray();
+        foreach (var label in value) writer.WriteStringValue(label);
+        writer.WriteEndArray();
+    }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/SetPullRequestDraftActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/SetPullRequestDraftActivity.cs
@@ -95,7 +95,7 @@ public class SetPullRequestDraftActivity : Activity
         var repository = Repository.Get(context) ?? "";
         var prNumber = PrNumber.Get(context);
         var draft = Draft.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var request = new GitPrDraftRequest
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
@@ -104,14 +104,19 @@ public class UpdateIssueStatusActivity : Activity
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
+        // 2026-08-13 (found by the engine-driven E2E): OPTIONAL inputs must be
+        // read with GetOrDefault — literal-null Input defaults are dropped by
+        // the workflow-definition store's JSON round-trip, and .Get on the
+        // materialized null input throws "<name> is required." (which faulted
+        // every notify child that did not wire removeLabels/prNumber/…).
         var repo = Repository.Get(context);
-        var issueNum = IssueNumber.Get(context);
-        var message = Message.Get(context) ?? "";
-        var addLabels = AddLabels.Get(context);
-        var removeLabels = RemoveLabels.Get(context);
-        var prNumber = PrNumber.Get(context);
-        var prUrl = PrUrl.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var issueNum = IssueNumber.GetOrDefault(context);
+        var message = Message.GetOrDefault(context) ?? "";
+        var addLabels = AddLabels.GetOrDefault(context);
+        var removeLabels = RemoveLabels.GetOrDefault(context);
+        var prNumber = PrNumber.GetOrDefault(context);
+        var prUrl = PrUrl.GetOrDefault(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
 
         var body = ComposeBody(message, prNumber, prUrl);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/UpdateIssueStatusActivity.cs
@@ -168,8 +168,8 @@ public class UpdateIssueStatusActivity : Activity
     private void SetSuccess(ActivityExecutionContext context)
     {
         Updated.Set(context, true);
-        ErrorCode.Set(context, null);
-        Error.Set(context, null);
+        ErrorCode.Set(context, (string?)null);
+        Error.Set(context, (string?)null);
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForDeploymentApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForDeploymentApprovalActivity.cs
@@ -122,9 +122,9 @@ public class WaitForDeploymentApprovalActivity : TammaOutcomeActivity
     protected override Task RunAsync(ActivityExecutionContext context)
     {
         var issueNumber = IssueNumber.Get(context);
-        var mergeSha = MergeSha.Get(context);
-        var tenantId = TenantId.Get(context);
-        var repository = Repository.Get(context);
+        var mergeSha = MergeSha.GetOrDefault(context);
+        var tenantId = TenantId.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context);
         var bookmarkName = BookmarkName(tenantId, repository, issueNumber, mergeSha);
 
         Logger?.LogInformation(
@@ -183,7 +183,7 @@ public class WaitForDeploymentApprovalActivity : TammaOutcomeActivity
     public override Dictionary<string, object?> BuildStartData(ActivityExecutionContext context) => new()
     {
         ["issueNumber"] = IssueNumber.Get(context),
-        ["mergeSha"] = MergeSha.Get(context) ?? "",
+        ["mergeSha"] = MergeSha.GetOrDefault(context) ?? "",
         ["stage"] = "production",
     };
 

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForMergeApprovalActivity.cs
@@ -146,8 +146,8 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
     {
         var issueNumber = IssueNumber.Get(context);
         var prNumber = PrNumber.Get(context);
-        var tenantId = TenantId.Get(context);
-        var repository = Repository.Get(context);
+        var tenantId = TenantId.GetOrDefault(context);
+        var repository = Repository.GetOrDefault(context);
         var bookmarkName = BookmarkName(tenantId, repository, issueNumber, prNumber);
 
         Logger?.LogInformation(
@@ -208,7 +208,7 @@ public class WaitForMergeApprovalActivity : TammaOutcomeActivity
     {
         ["issueNumber"] = IssueNumber.Get(context),
         ["prNumber"] = PrNumber.Get(context),
-        ["prUrl"] = PrUrl.Get(context) ?? "",
+        ["prUrl"] = PrUrl.GetOrDefault(context) ?? "",
         // IMPORTANT-1 — forward-compatible audit signal; enforcement (FR-34) deferred.
         ["breakingChange"] = BreakingChange.Get(context),
     };

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
@@ -63,6 +63,7 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
     public const int DefaultTimeoutMinutes = 720;
 
     private readonly IConfiguration? _configuration;
+    private readonly PendingPrMergeBuffer? _pendingMerges;
 
     public override string? EventType => "CYCLE.PR.MERGE.WAIT";
 
@@ -86,10 +87,14 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
     [JsonConstructor]
     public WaitForPRMergedActivity() { }
 
-    public WaitForPRMergedActivity(ILogger<WaitForPRMergedActivity> logger, IConfiguration configuration)
+    public WaitForPRMergedActivity(
+        ILogger<WaitForPRMergedActivity> logger,
+        IConfiguration configuration,
+        PendingPrMergeBuffer? pendingMerges = null)
     {
         Logger = logger;
         _configuration = configuration;
+        _pendingMerges = pendingMerges;
     }
 
     /// <summary>
@@ -115,11 +120,31 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
     /// </summary>
     public static string LegacyBookmarkName(int prNumber) => $"pr-merged-{prNumber}";
 
-    protected override Task RunAsync(ActivityExecutionContext context)
+    protected override async Task RunAsync(ActivityExecutionContext context)
     {
         var prNumber = PRNumber.Get(context);
         var tenantId = TenantId.GetOrDefault(context);
         var repository = Repository.GetOrDefault(context);
+
+        // 0) RECONCILE-ON-REGISTER (2026-08-13, engine-driven E2E run 39): when
+        //    Tamma performs the merge ITSELF, the platform's merged-PR webhook
+        //    fires immediately — observed 1 s BEFORE this activity registered
+        //    its bookmark, so the once-only forward 404'd and the merged cycle
+        //    sat on the 12 h SLA. The resume endpoint buffers such early
+        //    notifications keyed by this exact bookmark name; consume it here
+        //    and short-circuit to Merged instead of suspending.
+        var buffer = _pendingMerges ?? context.GetService<PendingPrMergeBuffer>();
+        if (buffer is not null
+            && buffer.TryConsume(BookmarkName(tenantId, repository, prNumber), out var bufferedSha))
+        {
+            MergeSha.Set(context, bufferedSha);
+            Logger?.LogInformation(
+                "PR #{PRNumber} merge notification arrived BEFORE the wait registered — " +
+                "consumed from the reconcile buffer (sha: {MergeSha}); completing Merged without suspending",
+                prNumber, bufferedSha ?? "unknown");
+            await context.CompleteActivityWithOutcomesAsync("Merged");
+            return;
+        }
 
         // 1) Merge bookmark — resumed by the merged-PR webhook through the
         //    engine-side PrMergedResumeEndpoint (tenant+repo-qualified name).
@@ -141,8 +166,6 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
         Logger?.LogInformation(
             "Waiting for PR #{PRNumber} to be merged; durable SLA timeout armed at +{SlaMinutes}min",
             prNumber, slaMinutes);
-
-        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPRMergedActivity.cs
@@ -191,7 +191,7 @@ public class WaitForPRMergedActivity : TammaOutcomeActivity
     /// </summary>
     private async ValueTask OnTimeoutAsync(ActivityExecutionContext context)
     {
-        MergeSha.Set(context, null);
+        MergeSha.Set(context, (string?)null);
 
         Logger?.LogWarning(
             "Merge SLA expired (durable timeout) for PR #{PRNumber} — taking the TimedOut edge",

--- a/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPlanApprovalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/ADL/WaitForPlanApprovalActivity.cs
@@ -67,7 +67,7 @@ public class WaitForPlanApprovalActivity : Activity
     protected override void Execute(ActivityExecutionContext context)
     {
         var issueNumber = IssueNumber.Get(context);
-        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.Get(context));
+        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.GetOrDefault(context));
         var bookmarkName = $"adl-plan-approval-{issueNumber}";
 
         _logger?.LogInformation(
@@ -118,7 +118,7 @@ public class WaitForPlanApprovalActivity : Activity
         // resuming edge so the approver / feedback context is captured durably (a rejection is
         // a LOUD error-status row, never a silent approve).
         var issueNumber = IssueNumber.Get(context);
-        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.Get(context));
+        var tenantId = PlanApprovalEvents.ParseTenantId(TenantId.GetOrDefault(context));
         TammaEventEmitter.Emit(context, this, _logger,
             BuildTammaEvent(
                 PlanApprovalEvents.DecisionEventType(result.Decision),

--- a/apps/tamma-elsa/src/Tamma.Activities/AI/ClaudeAnalysisActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AI/ClaudeAnalysisActivity.cs
@@ -77,7 +77,7 @@ public class ClaudeAnalysisActivity : CodeActivity<ClaudeAnalysisOutput>
         var sessionId = SessionId.Get(context);
         var analysisType = AnalysisType.Get(context);
         var content = Content.Get(context);
-        var additionalContext = Context.Get(context);
+        var additionalContext = Context.GetOrDefault(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
 
         _logger?.LogInformation(
@@ -96,7 +96,8 @@ public class ClaudeAnalysisActivity : CodeActivity<ClaudeAnalysisOutput>
             var response = useMock
                 ? SimulateClaudeResponse(analysisType)
                 : await MediatedLlmText.CompleteAsync(
-                    context, "reviewer", $"{systemPrompt}\n\n{userPrompt}", context.CancellationToken);
+                    context, "senior_developer", $"{systemPrompt}\n\n{userPrompt}", context.CancellationToken,
+                    action: "code-review");
 
             var result = ParseResponse(response, analysisType);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/AI/SuggestionGeneratorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AI/SuggestionGeneratorActivity.cs
@@ -71,8 +71,8 @@ public class SuggestionGeneratorActivity : CodeActivity<SuggestionsOutput>
         var sessionId = SessionId.Get(context);
         var juniorId = JuniorId.Get(context);
         var suggestionType = SuggestionType.Get(context);
-        var codeContext = CodeContext.Get(context);
-        var analysisResults = AnalysisResults.Get(context);
+        var codeContext = CodeContext.GetOrDefault(context);
+        var analysisResults = AnalysisResults.GetOrDefault(context);
         var maxSuggestions = MaxSuggestions.Get(context);
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/CollectAgentResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/CollectAgentResultsActivity.cs
@@ -177,7 +177,7 @@ public class CollectAgentResultsActivity : Activity, ITammaActivity
             Conclusion: Conclusion.Get(context) ?? "unknown",
             WorkflowRunUrl: string.Empty,
             DurationSeconds: 0,
-            ArtifactsUrl: ArtifactsUrl.Get(context) ?? string.Empty);
+            ArtifactsUrl: ArtifactsUrl.GetOrDefault(context) ?? string.Empty);
 
         try
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/DispatchAgentWorkflowActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/DispatchAgentWorkflowActivity.cs
@@ -232,7 +232,7 @@ public class DispatchAgentWorkflowActivity : Activity, ITammaActivity
     private void SetFailure(ActivityExecutionContext context, string message, DateTime dispatchedAt)
     {
         DispatchSuccess.Set(context, false);
-        WorkflowRunUrl.Set(context, null);
+        WorkflowRunUrl.Set(context, (string?)null);
         DispatchedAt.Set(context, dispatchedAt);
         ErrorMessage.Set(context, message);
     }

--- a/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ExecuteAgentActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/AgentDispatch/ExecuteAgentActivity.cs
@@ -164,7 +164,13 @@ public class ExecuteAgentActivity : Activity, ITammaActivity
         var startedAt = DateTime.UtcNow;
         TammaEventEmitter.EmitStart(context, this, this, _logger);
 
-        if (_factory is null)
+        // 2026-08-13 (engine-driven E2E run 38): store-rehydrated activities are
+        // built by the [JsonConstructor] with NULL ctor-injected members — the
+        // ctor-or-GetService idiom, or EVERY agent execution in a real engine
+        // fails instantly ("AgentExecutorFactory not registered") and the task
+        // loop silently degrades to its debug-retry leg.
+        var factory = _factory ?? context.GetService<AgentExecutorFactory>();
+        if (factory is null)
         {
             const string msg = "AgentExecutorFactory not registered — ExecuteAgentActivity requires DI.";
             _logger?.LogError(msg);
@@ -183,13 +189,13 @@ public class ExecuteAgentActivity : Activity, ITammaActivity
             PlanJson: PlanJson.Get(context),
             SessionId: SessionId.Get(context),
             AgentProvider: AgentProvider.Get(context),
-            AgentConfigJson: AgentConfigJson.Get(context),
+            AgentConfigJson: AgentConfigJson.GetOrDefault(context),
             WorkflowFileName: "tamma-agent.yml",
             TimeoutMinutes: TimeoutMinutes.Get(context));
 
         try
         {
-            var executor = _factory.Create(ModeOverride.Get(context));
+            var executor = factory.Create(ModeOverride.GetOrDefault(context));
             context.SetVariable("AgentExecutionMode", executor.Mode);
 
             _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/EmitAmbiguityEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Ambiguity/EmitAmbiguityEventActivity.cs
@@ -64,17 +64,17 @@ public class EmitAmbiguityEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? AmbiguityEvents.Failed;
-        var sessionId = SessionId.Get(context);
-        var issueId = IssueId.Get(context);
-        var tenantId = AmbiguityEvents.ParseTenantId(TenantId.Get(context));
-        var score = Score.Get(context);
-        var ambiguityCount = AmbiguityCount.Get(context);
-        var confidence = Confidence.Get(context);
-        var threshold = Threshold.Get(context);
-        var detail = Detail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? AmbiguityEvents.Failed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var tenantId = AmbiguityEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var score = Score.GetOrDefault(context);
+        var ambiguityCount = AmbiguityCount.GetOrDefault(context);
+        var confidence = Confidence.GetOrDefault(context);
+        var threshold = Threshold.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, score, ambiguityCount, confidence, threshold, detail);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -83,7 +83,8 @@ public class EmitAmbiguityEventActivity : Activity
             "Emitted {Type} for ambiguity session {Session} issue {Issue} (score={Score})",
             type, sessionId, issueId, score);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/DeliverQuestionsActivity.cs
@@ -77,7 +77,7 @@ public class DeliverQuestionsActivity : CodeActivity<DeliveryResult>
         var juniorId = JuniorId.Get(context);
         var questionsJson = QuestionsJson.Get(context);
         var attemptNumber = AttemptNumber.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Assessment/GenerateQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Assessment/GenerateQuestionsActivity.cs
@@ -71,7 +71,7 @@ public class GenerateQuestionsActivity : CodeActivity<QuestionSet>
         var storyId = StoryId.Get(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
         var storyContext = StoryContext.Get(context) ?? string.Empty;
-        var previousAttemptJson = PreviousAttemptJson.Get(context);
+        var previousAttemptJson = PreviousAttemptJson.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Generating assessment questions for session {SessionId}, skill level {SkillLevel}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/ClassifyBlockerActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/ClassifyBlockerActivity.cs
@@ -61,9 +61,9 @@ public class ClassifyBlockerActivity : CodeActivity<BlockerDiagnosisResult>
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var signals = Signals.Get(context);
-        var aiResponse = AIDiagnosisResponse.Get(context);
+        var aiResponse = AIDiagnosisResponse.GetOrDefault(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
-        var blockerContext = BlockerContext.Get(context);
+        var blockerContext = BlockerContext.GetOrDefault(context);
 
         _logger?.LogInformation("Classifying blocker from {SuccessfulCollectors}/{TotalCollectors} signals",
             signals.SuccessfulCollectors, signals.TotalCollectors);

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCIStatusActivity.cs
@@ -64,7 +64,7 @@ public class CollectCIStatusActivity : CodeActivity<CIStatusSignal>
     {
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCommunicationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectCommunicationActivity.cs
@@ -49,7 +49,7 @@ public class CollectCommunicationActivity : CodeActivity<CommunicationSignal>
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var slackId = SlackId.Get(context);
+        var slackId = SlackId.GetOrDefault(context);
         var juniorId = JuniorId.Get(context);
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectGitActivityActivity.cs
@@ -69,7 +69,7 @@ public class CollectGitActivityActivity : CodeActivity<GitActivitySignal>
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
         var lookbackHours = LookbackHours.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/CollectInactivityActivity.cs
@@ -67,7 +67,7 @@ public class CollectInactivityActivity : CodeActivity<InactivitySignal>
         var repository = Repository.Get(context);
         var branchName = BranchName.Get(context);
         var thresholdMinutes = InactivityThresholdMinutes.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EmitBlockerEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EmitBlockerEventActivity.cs
@@ -79,21 +79,21 @@ public class EmitBlockerEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? BlockerEvents.DiagnosedFailed;
-        var sessionId = SessionId.Get(context);
-        var storyId = StoryId.Get(context);
-        var juniorId = JuniorId.Get(context);
-        var tenantRaw = TenantId.Get(context);
+        var type = EventType.GetOrDefault(context) ?? BlockerEvents.DiagnosedFailed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var storyId = StoryId.GetOrDefault(context);
+        var juniorId = JuniorId.GetOrDefault(context);
+        var tenantRaw = TenantId.GetOrDefault(context);
         var tenantId = BlockerEvents.ParseTenantId(tenantRaw);
-        var blockerType = BlockerType.Get(context);
-        var severity = Severity.Get(context);
-        var level = Level.Get(context);
-        var attempt = Attempt.Get(context);
-        var confidence = Confidence.Get(context);
-        var progressType = ProgressType.Get(context);
-        var resolutionSeconds = ResolutionTimeSeconds.Get(context);
+        var blockerType = BlockerType.GetOrDefault(context);
+        var severity = Severity.GetOrDefault(context);
+        var level = Level.GetOrDefault(context);
+        var attempt = Attempt.GetOrDefault(context);
+        var confidence = Confidence.GetOrDefault(context);
+        var progressType = ProgressType.GetOrDefault(context);
+        var resolutionSeconds = ResolutionTimeSeconds.GetOrDefault(context);
 
         // Metrics first — they must fire on the matching transition regardless of the
         // (best-effort) durable event append. Tenant tag uses the parsed canonical form
@@ -110,7 +110,8 @@ public class EmitBlockerEventActivity : Activity
             "Emitted {Type} for session {Session} story {Story} (level={Level}, attempt={Attempt})",
             type, sessionId, storyId, level, attempt);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     private static void RecordMetric(

--- a/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Blocker/EscalateToSeniorActivity.cs
@@ -117,7 +117,7 @@ public class EscalateToSeniorActivity : Activity
         var severity = BlockerSeverity.Get(context);
         var diagnosisDetails = DiagnosisDetails.Get(context);
         var previousAttempts = PreviousAttempts.Get(context) ?? new List<string>();
-        var signals = Signals.Get(context);
+        var signals = Signals.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Escalating blocker to senior: Session={SessionId}, Type={BlockerType}, Severity={Severity}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/DeliverClarifyingQuestionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/DeliverClarifyingQuestionsActivity.cs
@@ -71,10 +71,10 @@ public class DeliverClarifyingQuestionsActivity : CodeActivity<ClarifyDeliveryRe
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
-        var repository = Repository.Get(context);
+        var repository = Repository.GetOrDefault(context);
         var issueNumber = IssueNumber.Get(context);
         var questionsJson = QuestionsJson.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var ct = context.CancellationToken;
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Clarify/EmitClarifyEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Clarify/EmitClarifyEventActivity.cs
@@ -58,15 +58,15 @@ public class EmitClarifyEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? ClarifyEvents.QuestionsFailed;
-        var sessionId = SessionId.Get(context);
-        var issueId = IssueId.Get(context);
-        var tenantId = ClarifyEvents.ParseTenantId(TenantId.Get(context));
-        var channel = Channel.Get(context);
-        var questionCount = QuestionCount.Get(context);
-        var detail = Detail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? ClarifyEvents.QuestionsFailed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var tenantId = ClarifyEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var channel = Channel.GetOrDefault(context);
+        var questionCount = QuestionCount.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, channel, questionCount, detail);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -75,7 +75,8 @@ public class EmitClarifyEventActivity : Activity
             "Emitted {Type} for clarify session {Session} issue {Issue} (questions={Count})",
             type, sessionId, issueId, questionCount);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/CodeIndex/UpdateCodeIndexActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/CodeIndex/UpdateCodeIndexActivity.cs
@@ -54,8 +54,8 @@ public class UpdateCodeIndexActivity : CodeActivity
     {
         try
         {
-            var changedFilesRaw = ChangedFilesJson.Get(context);
-            var repositoryPath = RepositoryPath.Get(context);
+            var changedFilesRaw = ChangedFilesJson.GetOrDefault(context);
+            var repositoryPath = RepositoryPath.GetOrDefault(context);
 
             List<string>? changedFiles = null;
             if (!string.IsNullOrWhiteSpace(changedFilesRaw))

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/AssembleContextActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/AssembleContextActivity.cs
@@ -64,12 +64,12 @@ public class AssembleContextActivity : CodeActivity<AssembledContext>
 
     protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var storyMetadata = StoryMetadata.Get(context);
-        var recentCommits = RecentCommits.Get(context);
-        var fileContents = FileContents.Get(context);
-        var testResults = TestResults.Get(context);
-        var sessionHistory = SessionHistory.Get(context);
-        var similarPatterns = SimilarPatterns.Get(context);
+        var storyMetadata = StoryMetadata.GetOrDefault(context);
+        var recentCommits = RecentCommits.GetOrDefault(context);
+        var fileContents = FileContents.GetOrDefault(context);
+        var testResults = TestResults.GetOrDefault(context);
+        var sessionHistory = SessionHistory.GetOrDefault(context);
+        var similarPatterns = SimilarPatterns.GetOrDefault(context);
         var purpose = Purpose.Get(context);
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchRecentCommitsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchRecentCommitsActivity.cs
@@ -69,7 +69,7 @@ public class FetchRecentCommitsActivity : CodeActivity<RecentCommitsResult>
         var storyId = StoryId.Get(context);
         var daysBack = DaysBack.Get(context);
         var maxCommits = MaxCommits.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/FetchTestResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/FetchTestResultsActivity.cs
@@ -59,7 +59,7 @@ public class FetchTestResultsActivity : CodeActivity<TestResultsData>
     {
         var repositoryUrl = RepositoryUrl.Get(context);
         var storyId = StoryId.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/ReadRepoConventionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/ReadRepoConventionsActivity.cs
@@ -55,9 +55,15 @@ public class ReadRepoConventionsActivity : TammaAsyncActivity
         var repo = Repository.Get(context);
         var conventions = "";
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom).
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
 
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+
+        if (string.IsNullOrEmpty(callbackUrl) || httpClientFactory == null)
         {
             Logger?.LogWarning(
                 "No Engine:CallbackUrl configured — cannot read repo conventions for {Repo}",
@@ -68,7 +74,7 @@ public class ReadRepoConventionsActivity : TammaAsyncActivity
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
             var url = $"{callbackUrl.TrimEnd('/')}/api/engine/repo-config?repo={Uri.EscapeDataString(repo)}";
 
             Logger?.LogInformation("Fetching repo config from {Url}", url);

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/ResolveConventionsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/ResolveConventionsActivity.cs
@@ -134,13 +134,23 @@ public class ResolveConventionsActivity : TammaAsyncActivity
         // fail-fast (caller bug — same contract as the prompt activity).
         ValidateTaxonomy(role, action);
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        // 2026-08-13 (engine-driven E2E): a store-rehydrated activity is built
+        // by the [JsonConstructor], so the ctor-injected members are NULL in
+        // the real engine — resolve from the execution context (the
+        // ctor-or-GetService idiom TriggerCIActivity/ApplyTriageResultActivity
+        // use). The old code also DISCARDED a configured Engine:CallbackUrl
+        // whenever the factory was null, sending every resolve to the
+        // localhost:3100 default.
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        if (string.IsNullOrEmpty(callbackUrl))
         {
-            // No API base configured AND no DI-injected client — try the
-            // PromptRegistry fallback URL (matches prompt-activity behaviour
-            // for parity in dev/test bootstrap).
-            callbackUrl = _configuration?["PromptRegistry:BaseUrl"] ?? "http://localhost:3100";
+            // No API base configured — try the PromptRegistry fallback URL
+            // (matches prompt-activity behaviour for parity in dev/test
+            // bootstrap).
+            callbackUrl = configuration?["PromptRegistry:BaseUrl"] ?? "http://localhost:3100";
         }
 
         // Production blocker fix — use the named "tamma-engine" client (wired
@@ -150,7 +160,7 @@ public class ResolveConventionsActivity : TammaAsyncActivity
         // this, the API returns 401 in production and the activity maps that
         // to a non-retryable NO_ROW — permanently failing the workflow before
         // any LLM runs.
-        var httpClient = _httpClientFactory?.CreateClient("tamma-engine") ?? new HttpClient();
+        var httpClient = httpClientFactory?.CreateClient("tamma-engine") ?? new HttpClient();
 
         var (body, source, version) = await CallResolveAsync(httpClient, callbackUrl!, role, action, tenantId, Logger);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/StoreFindingsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/StoreFindingsActivity.cs
@@ -70,8 +70,14 @@ public class StoreFindingsActivity : TammaAsyncActivity
         var repo = Repository.Get(context);
         var issueNum = IssueNumber.Get(context);
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom).
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        if (string.IsNullOrEmpty(callbackUrl) || httpClientFactory == null)
         {
             // Mock: return fake context IDs
             ContextIdsJson.Set(context, JsonSerializer.Serialize(new[]
@@ -85,7 +91,7 @@ public class StoreFindingsActivity : TammaAsyncActivity
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
 
             var findings = new Dictionary<string, string>
             {

--- a/apps/tamma-elsa/src/Tamma.Activities/Context/StoreRoleFindingActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Context/StoreRoleFindingActivity.cs
@@ -64,8 +64,14 @@ public class StoreRoleFindingActivity : TammaAsyncActivity
         var role = Role.Get(context);
         var findings = FindingsJson.Get(context);
 
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        // 2026-08-13 (engine-driven E2E): store-rehydrated activities are built
+        // by the [JsonConstructor] with NULL ctor-injected members — resolve
+        // from the execution context (ctor-or-GetService idiom).
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        if (string.IsNullOrEmpty(callbackUrl) || httpClientFactory == null)
         {
             // Mock: return fake context ID
             ContextId.Set(context, $"ctx:{issueNum}:{role}");
@@ -74,7 +80,7 @@ public class StoreRoleFindingActivity : TammaAsyncActivity
 
         try
         {
-            var httpClient = _httpClientFactory.CreateClient();
+            var httpClient = httpClientFactory.CreateClient();
 
             var response = await httpClient.PostAsJsonAsync(
                 $"{callbackUrl.TrimEnd('/')}/api/engine/store-context",

--- a/apps/tamma-elsa/src/Tamma.Activities/Core/PublishedWorkflowDispatch.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Core/PublishedWorkflowDispatch.cs
@@ -1,0 +1,53 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Runtime.Requests;
+
+namespace Tamma.Activities.Core;
+
+/// <summary>
+/// 2026-08-13 (found by the engine-driven E2E) — the ONE correct way to build a
+/// <see cref="DispatchWorkflowDefinitionRequest"/> from a workflow DEFINITION id.
+///
+/// <para><b>The defect this exists to prevent:</b> the request's constructor
+/// parameter is <c>definitionVersionId</c> — the VERSION id (e.g.
+/// <c>"AdlOrchestratorWorkflow:v1"</c>), NOT the definition id
+/// (<c>"adl-orchestrator"</c>). Every background dispatch site in the codebase
+/// passed the definition id, so the queue handler answered
+/// <c>WorkflowGraphNotFoundException</c> for EVERY activity-driven dispatch —
+/// the ADL orchestrator could never start a single-issue cycle, the loop could
+/// never restart itself, triage never dispatched, and the analytics rollup
+/// never ran. It ships latent because the dispatchers are fire-and-forget by
+/// design (a dispatch failure is logged and swallowed so the loop survives) —
+/// nothing red ever surfaced until the engine-driven E2E asserted the cycle
+/// actually runs.</para>
+/// </summary>
+public static class PublishedWorkflowDispatch
+{
+    /// <summary>
+    /// Resolve the PUBLISHED version id for <paramref name="definitionId"/> —
+    /// the value <see cref="DispatchWorkflowDefinitionRequest"/>'s constructor
+    /// actually requires. Throws when no published version exists — callers
+    /// keep their existing fire-and-forget catch posture.
+    /// </summary>
+    public static async Task<string> ResolvePublishedVersionIdAsync(
+        IWorkflowDefinitionService definitionService,
+        string definitionId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(definitionService);
+        ArgumentException.ThrowIfNullOrWhiteSpace(definitionId);
+
+        var definition = await definitionService
+            .FindWorkflowDefinitionAsync(definitionId, VersionOptions.Published, ct)
+            .ConfigureAwait(false);
+
+        if (definition is null)
+        {
+            throw new InvalidOperationException(
+                $"No PUBLISHED workflow definition found for definition id '{definitionId}' — "
+                + "cannot dispatch (DispatchWorkflowDefinitionRequest requires the VERSION id).");
+        }
+
+        return definition.Id;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectGitHistoryActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectGitHistoryActivity.cs
@@ -61,7 +61,7 @@ public class CollectGitHistoryActivity : CodeActivity<GitHistoryContext>
         var repositoryUrl = RepositoryUrl.Get(context);
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectRelevantCodeActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectRelevantCodeActivity.cs
@@ -66,7 +66,7 @@ public class CollectRelevantCodeActivity : CodeActivity<RelevantCode>
         var repositoryUrl = RepositoryUrl.Get(context);
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectTestResultsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/CollectTestResultsActivity.cs
@@ -67,7 +67,7 @@ public class CollectTestResultsActivity : CodeActivity<TestResultsContext>
         var branchName = BranchName.Get(context);
         var mode = DebugContextMode.Get(context);
         var errorOutput = ErrorOutput.Get(context) ?? string.Empty;
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/EmitDebugEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/EmitDebugEventActivity.cs
@@ -74,30 +74,31 @@ public class EmitDebugEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? DebugEvents.Escalated;
+        var type = EventType.GetOrDefault(context) ?? DebugEvents.Escalated;
 
         var evt = BuildTammaEvent(
             type,
-            sessionId: SessionId.Get(context),
-            storyId: StoryId.Get(context),
-            mode: Mode.Get(context),
-            tenantId: DebugEvents.ParseTenantId(TenantId.Get(context)),
-            iteration: Iteration.Get(context),
-            maxIterations: MaxIterations.Get(context),
-            hypothesis: Hypothesis.Get(context),
-            fixSucceeded: FixSucceeded.Get(context),
-            reason: Reason.Get(context));
+            sessionId: SessionId.GetOrDefault(context),
+            storyId: StoryId.GetOrDefault(context),
+            mode: Mode.GetOrDefault(context),
+            tenantId: DebugEvents.ParseTenantId(TenantId.GetOrDefault(context)),
+            iteration: Iteration.GetOrDefault(context),
+            maxIterations: MaxIterations.GetOrDefault(context),
+            hypothesis: Hypothesis.GetOrDefault(context),
+            fixSucceeded: FixSucceeded.GetOrDefault(context),
+            reason: Reason.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for session {Session} story {Story} (mode={Mode}, iteration={Iteration}/{Max}, reason={Reason})",
-            type, SessionId.Get(context), StoryId.Get(context), Mode.Get(context),
-            Iteration.Get(context), MaxIterations.Get(context), Reason.Get(context));
+            type, SessionId.GetOrDefault(context), StoryId.GetOrDefault(context), Mode.GetOrDefault(context),
+            Iteration.GetOrDefault(context), MaxIterations.GetOrDefault(context), Reason.GetOrDefault(context));
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/RefineHypothesisActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/RefineHypothesisActivity.cs
@@ -83,7 +83,7 @@ public class RefineHypothesisActivity : CodeActivity<DiagnosisResult>
             // Mediated call-LLM (no direct provider key in the engine). "senior_developer"
             // is the canonical analytical role the API can resolve; the free-text
             // "debugger" label 422s. See AIDiagnosisActivity for the same cut-over.
-            var response = await MediatedLlmText.CompleteAsync(context, "senior_developer", prompt, context.CancellationToken);
+            var response = await MediatedLlmText.CompleteAsync(context, "senior_developer", prompt, context.CancellationToken, action: "debug-rootcause");
             var result = ParseRefinementResponse(response);
 
             _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Debug/WriteRegressionTestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Debug/WriteRegressionTestActivity.cs
@@ -87,7 +87,7 @@ public class WriteRegressionTestActivity : CodeActivity<TestGenerationResult>
             var prompt = BuildTestPrompt(storyId, bugDescription, hypothesisJson, codeContext);
             // Mediated call-LLM (no direct provider key in the engine). "tester" is the
             // canonical role the API resolves for test authoring. See AIDiagnosisActivity.
-            var response = await MediatedLlmText.CompleteAsync(context, "tester", prompt, context.CancellationToken);
+            var response = await MediatedLlmText.CompleteAsync(context, "tester", prompt, context.CancellationToken, action: "write-regression-test");
             var result = ParseTestResponse(response);
 
             if (result.Success)

--- a/apps/tamma-elsa/src/Tamma.Activities/Decomposition/EmitDecompositionEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Decomposition/EmitDecompositionEventActivity.cs
@@ -55,14 +55,14 @@ public class EmitDecompositionEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? DecompositionEvents.Failed;
-        var sessionId = SessionId.Get(context);
-        var issueId = IssueId.Get(context);
-        var tenantId = DecompositionEvents.ParseTenantId(TenantId.Get(context));
-        var subtaskCount = SubtaskCount.Get(context);
-        var detail = Detail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? DecompositionEvents.Failed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var tenantId = DecompositionEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var subtaskCount = SubtaskCount.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, subtaskCount, detail);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -71,7 +71,8 @@ public class EmitDecompositionEventActivity : Activity
             "Emitted {Type} for decomposition session {Session} issue {Issue} (subtasks={Count})",
             type, sessionId, issueId, subtaskCount);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/DeliverDesignProposalActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/DeliverDesignProposalActivity.cs
@@ -71,10 +71,10 @@ public class DeliverDesignProposalActivity : CodeActivity<DesignDeliveryResult>
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
-        var repository = Repository.Get(context);
+        var repository = Repository.GetOrDefault(context);
         var issueNumber = IssueNumber.Get(context);
         var proposalJson = ProposalJson.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var ct = context.CancellationToken;
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Design/EmitDesignEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Design/EmitDesignEventActivity.cs
@@ -61,16 +61,16 @@ public class EmitDesignEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? DesignEvents.ProposalFailed;
-        var sessionId = SessionId.Get(context);
-        var issueId = IssueId.Get(context);
-        var tenantId = DesignEvents.ParseTenantId(TenantId.Get(context));
-        var channel = Channel.Get(context);
-        var alternativeCount = AlternativeCount.Get(context);
-        var detail = Detail.Get(context);
-        var reviewer = Reviewer.Get(context);
+        var type = EventType.GetOrDefault(context) ?? DesignEvents.ProposalFailed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var tenantId = DesignEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var channel = Channel.GetOrDefault(context);
+        var alternativeCount = AlternativeCount.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
+        var reviewer = Reviewer.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, channel, alternativeCount, detail, reviewer);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -79,7 +79,8 @@ public class EmitDesignEventActivity : Activity
             "Emitted {Type} for design session {Session} issue {Issue} (alternatives={Count})",
             type, sessionId, issueId, alternativeCount);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
@@ -108,6 +108,7 @@ public class ComputeReEntryPositionActivity : Activity
                 "Re-entering {DocumentType} for issue {IssueId} at {ResumeAt}: {Basis}",
                 documentType, issueId, position.ResumeAt, position.Basis);
         }
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/ComputeReEntryPositionActivity.cs
@@ -75,10 +75,10 @@ public class ComputeReEntryPositionActivity : Activity
                 retryable: false,
                 severity: TammaErrorSeverity.High);
 
-        var issueId = IssueId.Get(context) ?? "";
-        var documentType = DocumentType.Get(context) ?? "";
-        var tenantId = DocumentEvents.ParseTenantId(TenantId.Get(context));
-        var correlationId = CorrelationId.Get(context);
+        var issueId = IssueId.GetOrDefault(context) ?? "";
+        var documentType = DocumentType.GetOrDefault(context) ?? "";
+        var tenantId = DocumentEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var correlationId = CorrelationId.GetOrDefault(context);
 
         var position = await service
             .ReconstructAsync(tenantId, issueId, documentType, context.CancellationToken)

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDocumentEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDocumentEventActivity.cs
@@ -82,25 +82,25 @@ public class EmitDocumentEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? DocumentEvents.Escalated;
-        var documentId = DocumentId.Get(context);
-        var documentType = DocumentType.Get(context);
-        var round = Round.Get(context);
-        var issueId = IssueId.Get(context);
-        var correlationId = CorrelationId.Get(context);
-        var sessionId = SessionId.Get(context);
-        var tenantId = DocumentEvents.ParseTenantId(TenantId.Get(context));
-        var detail = Detail.Get(context);
-        var dataJson = DataJson.Get(context);
+        var type = EventType.GetOrDefault(context) ?? DocumentEvents.Escalated;
+        var documentId = DocumentId.GetOrDefault(context);
+        var documentType = DocumentType.GetOrDefault(context);
+        var round = Round.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var correlationId = CorrelationId.GetOrDefault(context);
+        var sessionId = SessionId.GetOrDefault(context);
+        var tenantId = DocumentEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var detail = Detail.GetOrDefault(context);
+        var dataJson = DataJson.GetOrDefault(context);
 
         var evt = BuildTammaEvent(
             type, documentId, documentType, round, issueId, correlationId, sessionId, tenantId, detail, dataJson);
 
         // D6 — override the auto-minted id with the pre-minted transition event id
         // when supplied, so the store's correlating_event_id resolves to THIS row.
-        var eventId = EventId.Get(context);
+        var eventId = EventId.GetOrDefault(context);
         if (!string.IsNullOrWhiteSpace(eventId) && Guid.TryParse(eventId, out var preMinted))
             evt.Id = preMinted;
 
@@ -110,7 +110,8 @@ public class EmitDocumentEventActivity : Activity
             "Emitted {Type} for document {Doc} ({DocType}) round {Round} issue {Issue}",
             type, documentId, documentType, round, issueId);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDomainLifecycleEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitDomainLifecycleEventActivity.cs
@@ -79,26 +79,27 @@ public class EmitDomainLifecycleEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? "";
+        var type = EventType.GetOrDefault(context) ?? "";
         var evt = BuildTammaEvent(
             type,
-            IssueId.Get(context),
-            Repository.Get(context),
-            CorrelationId.Get(context),
-            ParseTenantId(TenantId.Get(context)),
-            DocumentId.Get(context),
-            Detail.Get(context),
-            DataJson.Get(context));
+            IssueId.GetOrDefault(context),
+            Repository.GetOrDefault(context),
+            CorrelationId.GetOrDefault(context),
+            ParseTenantId(TenantId.GetOrDefault(context)),
+            DocumentId.GetOrDefault(context),
+            Detail.GetOrDefault(context),
+            DataJson.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for issue {Issue} document {Doc}",
-            type, IssueId.Get(context), DocumentId.Get(context));
+            type, IssueId.GetOrDefault(context), DocumentId.GetOrDefault(context));
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitEscalationEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/EmitEscalationEventActivity.cs
@@ -86,28 +86,28 @@ public class EmitEscalationEventActivity : Activity
 
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? ApprovalEvents.EscalationTriggered;
+        var type = EventType.GetOrDefault(context) ?? ApprovalEvents.EscalationTriggered;
 
         var evt = BuildTammaEvent(
             type,
-            EscalationId.Get(context),
-            Outcome.Get(context),
-            LineageJson.Get(context),
-            RulesReference.Get(context),
-            Channel.Get(context),
-            IssueId.Get(context),
-            DocumentId.Get(context),
-            DocumentType.Get(context),
-            CorrelationId.Get(context),
-            SessionId.Get(context),
-            ApprovalEvents.ParseTenantId(TenantId.Get(context)),
-            Detail.Get(context));
+            EscalationId.GetOrDefault(context),
+            Outcome.GetOrDefault(context),
+            LineageJson.GetOrDefault(context),
+            RulesReference.GetOrDefault(context),
+            Channel.GetOrDefault(context),
+            IssueId.GetOrDefault(context),
+            DocumentId.GetOrDefault(context),
+            DocumentType.GetOrDefault(context),
+            CorrelationId.GetOrDefault(context),
+            SessionId.GetOrDefault(context),
+            ApprovalEvents.ParseTenantId(TenantId.GetOrDefault(context)),
+            Detail.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for escalation {EscalationId} (outcome={Outcome}, document={DocumentId})",
-            type, EscalationId.Get(context), Outcome.Get(context), DocumentId.Get(context));
+            type, EscalationId.GetOrDefault(context), Outcome.GetOrDefault(context), DocumentId.GetOrDefault(context));
 
         // Complete on the default outcome so a mid-flow emit node continues to the next activity
         // (the escalated exit region wires this before its terminal). A plain Activity does not

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/FetchLatestAcceptedDocumentActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/FetchLatestAcceptedDocumentActivity.cs
@@ -88,9 +88,9 @@ public class FetchLatestAcceptedDocumentActivity : Activity
             return;
         }
 
-        var issueId = IssueId.Get(context) ?? string.Empty;
-        var documentType = DocumentTypeKey.Get(context) ?? string.Empty;
-        var tenantId = DocumentEvents.ParseTenantId(TenantId.Get(context));
+        var issueId = IssueId.GetOrDefault(context) ?? string.Empty;
+        var documentType = DocumentTypeKey.GetOrDefault(context) ?? string.Empty;
+        var tenantId = DocumentEvents.ParseTenantId(TenantId.GetOrDefault(context));
 
         if (string.IsNullOrWhiteSpace(issueId) || string.IsNullOrWhiteSpace(documentType))
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/FetchLatestAcceptedDocumentActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/FetchLatestAcceptedDocumentActivity.cs
@@ -84,6 +84,7 @@ public class FetchLatestAcceptedDocumentActivity : Activity
         {
             _logger?.LogWarning(
                 "No ILifecycleReEntryService registered; FetchLatestAcceptedDocument reports not-found (fail-closed).");
+            await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete
             return;
         }
 
@@ -92,7 +93,10 @@ public class FetchLatestAcceptedDocumentActivity : Activity
         var tenantId = DocumentEvents.ParseTenantId(TenantId.Get(context));
 
         if (string.IsNullOrWhiteSpace(issueId) || string.IsNullOrWhiteSpace(documentType))
+        {
+            await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete
             return;
+        }
 
         try
         {
@@ -103,13 +107,19 @@ public class FetchLatestAcceptedDocumentActivity : Activity
             // Only a Complete position carries an ACCEPTED revision (D8 compose path).
             if (position.ResumeAt != LifecycleResumeStage.Complete ||
                 position.ExistingDocumentId is not Guid docId)
+            {
+                await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete
                 return;
+            }
 
             var envelope = await service
                 .GetDocumentBodyAsync(tenantId, docId, context.CancellationToken)
                 .ConfigureAwait(false);
             if (envelope is null)
+            {
+                await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete
                 return;
+            }
 
             var revision = position.ExistingRevision ?? 1;
             var rounds = Enumerable.Range(1, Math.Max(revision, 1)).ToArray();
@@ -132,5 +142,6 @@ public class FetchLatestAcceptedDocumentActivity : Activity
                 "FetchLatestAcceptedDocument read failed for issue {IssueId} type {DocumentType}; reporting not-found.",
                 issueId, documentType);
         }
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/HttpLifecycleReEntryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/HttpLifecycleReEntryService.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+
+namespace Tamma.Activities.Documents;
+
+/// <summary>
+/// 2026-08-13 (engine-driven E2E follow-up) — the ENGINE-HOST implementation of
+/// <see cref="ILifecycleReEntryService"/>: a latest-accepted read over the API's
+/// 39-11 HTTP surface (<c>GET /api/documents/issues/{issueId}/latest</c> +
+/// <c>GET /api/documents/{documentId}</c>).
+///
+/// <para><b>Why it exists.</b> The REAL <see cref="LifecycleReEntryService"/> reads
+/// the document store in-process (<c>IDocumentInstanceRepository</c> +
+/// <c>IEventRepository</c>) — dependencies only the API host composes; the engine
+/// host has no tenant-routed store connection at all, so registering the real
+/// service there is a landmine that detonates at first resolution. Until this
+/// service existed the engine shipped with the Null seam permanently selected,
+/// which made <c>FetchLatestAcceptedDocumentActivity</c> structurally blind: the
+/// <c>plan-review</c> shim could NEVER see the plan the lifecycle had just
+/// accepted, so every engine-driven cycle terminated needs-human.</para>
+///
+/// <para><b>Deliberately coarser than the real service.</b> The API surface exposes
+/// the latest-ACCEPTED read, not the DCB event fold — so this implementation
+/// reconstructs only the two positions that read can prove:
+/// <see cref="LifecycleResumeStage.Complete"/> (an accepted document of the type
+/// exists) and <see cref="LifecycleResumeStage.Produce"/> (none does). Mid-flight
+/// positions (<c>Review</c>/<c>Accept</c>) degrade to a fresh Produce — exactly the
+/// pre-re-entry behaviour, and strictly better than the Null seam (which cannot
+/// even see Complete). The consumers in the engine's binding graph
+/// (<see cref="FetchLatestAcceptedDocumentActivity"/>, the plan-review shim, the
+/// plan-generation consumes-read) only branch on Complete, so they lose
+/// nothing.</para>
+///
+/// <para><b>Fail-closed.</b> A transport failure or non-success status (other than
+/// the document fetch's 404) THROWS a retryable <see cref="TammaError"/> — never a
+/// silent "Fresh", which would read as "no accepted document" and re-produce work
+/// that already exists. Callers already treat a throw as not-found-fail-closed
+/// (<c>FetchLatestAcceptedDocumentActivity</c>'s catch) or surface it
+/// (<c>ComputeReEntryPositionActivity</c>).</para>
+///
+/// <para><b>Not a mediation-surface change.</b> This is a READ of Tamma's own API
+/// over the engine→API internal hop (the <c>ReportCycleResultActivity</c> callback
+/// precedent), not an external effect — it deliberately does NOT extend
+/// <c>TammaApiClient</c>, whose public surface is exactly pinned by the 43-8
+/// mediation sweep (adding read methods there would mean re-seeding a shrink-only
+/// ratchet for a plain internal read).</para>
+/// </summary>
+public sealed class HttpLifecycleReEntryService : ILifecycleReEntryService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly string _baseUrl;
+    private readonly string? _token;
+    private readonly ILogger<HttpLifecycleReEntryService> _logger;
+
+    public HttpLifecycleReEntryService(
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration,
+        ILogger<HttpLifecycleReEntryService> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _baseUrl = (configuration?["Tamma:ApiUrl"]
+                    ?? Environment.GetEnvironmentVariable("TAMMA_API_URL")
+                    ?? "http://localhost:3000").TrimEnd('/');
+        _token = configuration?["Tamma:ApiToken"]
+                 ?? Environment.GetEnvironmentVariable("TAMMA_API_TOKEN");
+    }
+
+    public async Task<LifecycleResumePosition> ReconstructAsync(
+        Guid? tenantId, string issueId, string documentTypeKey, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(issueId))
+            return LifecycleResumePosition.Fresh(documentTypeKey, "No issue id supplied; running fresh.");
+
+        var url = $"{_baseUrl}/api/documents/issues/{Uri.EscapeDataString(issueId)}/latest";
+        using var response = await SendAsync(url, tenantId, ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+            throw ReadFailed(url, response.StatusCode);
+
+        var latest = await response.Content
+            .ReadFromJsonAsync<LatestAcceptedDocuments>(DocumentJson.Options, ct)
+            .ConfigureAwait(false);
+
+        var entry = latest?.Documents
+            .FirstOrDefault(d => string.Equals(d.DocumentType, documentTypeKey, StringComparison.Ordinal));
+        if (entry is null)
+            return LifecycleResumePosition.Fresh(
+                documentTypeKey,
+                $"No accepted '{documentTypeKey}' for issue '{issueId}' (HTTP latest-accepted read); running fresh.");
+
+        return new LifecycleResumePosition
+        {
+            DocumentTypeKey = documentTypeKey,
+            ResumeAt = LifecycleResumeStage.Complete,
+            ExistingDocumentId = entry.Id,
+            ExistingRevision = entry.Revision,
+            Basis = $"'{documentTypeKey}' revision {entry.Revision} accepted (HTTP latest-accepted read).",
+        };
+    }
+
+    public async Task<DocumentEnvelope?> GetDocumentBodyAsync(
+        Guid? tenantId, Guid documentId, CancellationToken ct)
+    {
+        if (documentId == Guid.Empty) return null;
+
+        var url = $"{_baseUrl}/api/documents/{documentId}";
+        using var response = await SendAsync(url, tenantId, ct).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound) return null;
+        if (!response.IsSuccessStatusCode)
+            throw ReadFailed(url, response.StatusCode);
+
+        var entry = await response.Content
+            .ReadFromJsonAsync<LineageDocumentEntry>(DocumentJson.Options, ct)
+            .ConfigureAwait(false);
+        return entry is null ? null : MapEnvelope(entry);
+    }
+
+    // ── transport ─────────────────────────────────────────────────────────
+
+    private async Task<HttpResponseMessage> SendAsync(string url, Guid? tenantId, CancellationToken ct)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient(nameof(HttpLifecycleReEntryService));
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            if (!string.IsNullOrWhiteSpace(_token))
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            // Single-user gates dispatch tenantless — the API's service-plane
+            // binding resolves the sole user's personal tenant; SaaS calls carry
+            // the explicit scope (the TammaApiClient X-Tenant-Id convention).
+            if (tenantId is Guid t && t != Guid.Empty)
+                request.Headers.TryAddWithoutValidation("X-Tenant-Id", t.ToString());
+            return await client.SendAsync(request, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogWarning(ex, "Re-entry HTTP read transport failure");
+            throw new TammaError(
+                "DOCUMENT.REENTRY.HTTP_READ_FAILED",
+                $"Re-entry read failed in transport: {ex.GetType().Name}.",
+                retryable: true,
+                severity: TammaErrorSeverity.Medium);
+        }
+    }
+
+    private TammaError ReadFailed(string url, HttpStatusCode status)
+    {
+        // URL omitted from the log line (TammaApiClient F-note: interpolated ids
+        // do not belong on the rotating warn log; the status is the triage signal).
+        _logger.LogWarning("Re-entry HTTP read returned {Status}", (int)status);
+        return new TammaError(
+            "DOCUMENT.REENTRY.HTTP_READ_FAILED",
+            $"Re-entry read returned HTTP {(int)status}.",
+            retryable: true,
+            severity: TammaErrorSeverity.Medium);
+    }
+
+    // ── wire entry → envelope (the LifecycleReEntryService.MapEnvelope shape) ──
+
+    private static DocumentEnvelope MapEnvelope(LineageDocumentEntry entry)
+    {
+        JsonElement payload;
+        if (entry.Body.ValueKind is JsonValueKind.Undefined)
+        {
+            using var doc = JsonDocument.Parse("{}");
+            payload = doc.RootElement.Clone();
+        }
+        else
+        {
+            payload = entry.Body.Clone();
+        }
+
+        return new DocumentEnvelope
+        {
+            Id = entry.Id,
+            Type = entry.DocumentType,
+            // The lineage wire entry carries no schemaVersion/correlationId — the
+            // consumers of this read (FetchLatestAcceptedDocumentActivity) use only
+            // Id/Type/Payload; the anchors below are honest reconstructions.
+            SchemaVersion = 1,
+            IssueId = entry.IssueId,
+            CorrelationId = entry.IssueId,
+            ParentDocumentId = entry.ParentDocumentId,
+            SupersedesDocumentId = entry.SupersedesDocumentId,
+            Audience = entry.Audience,
+            ProducedBy = new DocumentProducer
+            {
+                Role = entry.ProducedByRole,
+                Action = entry.ProducedByAction,
+                WorkflowDefinitionId = "llm-call",
+            },
+            State = MapState(entry.Status),
+            CreatedAt = entry.CreatedAt,
+            UpdatedAt = entry.UpdatedAt,
+            Payload = payload,
+        };
+    }
+
+    /// <summary>Store status wire → envelope state (the
+    /// <see cref="LifecycleReEntryService"/> guard-path mapping, verbatim).</summary>
+    private static DocumentState MapState(string? status) => status switch
+    {
+        "draft" => DocumentState.Draft,
+        "validated" => DocumentState.Validated,
+        "in_review" => DocumentState.Reviewed,
+        "accepted" => DocumentState.Accepted,
+        "rejected" => DocumentState.Rejected,
+        "escalated" => DocumentState.Escalated,
+        // 'superseded' has no envelope state of its own; treat as a validated draft
+        // for reconstruction purposes (the guard only re-enters non-superseded rows).
+        "superseded" => DocumentState.Validated,
+        _ => DocumentState.Draft,
+    };
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
@@ -87,6 +87,7 @@ public class PersistDocumentInstanceActivity : Activity
         }
 
         _logger?.LogInformation("Persisted document instance (tenant {Tenant})", tenantId);
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
     }
 
     private static TammaError Failed(string message, Exception? inner) => new(

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/PersistDocumentInstanceActivity.cs
@@ -65,8 +65,8 @@ public class PersistDocumentInstanceActivity : Activity
             ?? throw Failed(
                 "TammaApiClient is not registered — the engine cannot reach the document store.", null);
 
-        Guid? correlatingEventId = Guid.TryParse(CorrelatingEventId.Get(context), out var g) ? g : null;
-        var tenantId = TenantId.Get(context);
+        Guid? correlatingEventId = Guid.TryParse(CorrelatingEventId.GetOrDefault(context), out var g) ? g : null;
+        var tenantId = TenantId.GetOrDefault(context);
 
         try
         {

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/PublishAcceptanceRequestActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/PublishAcceptanceRequestActivity.cs
@@ -101,5 +101,6 @@ public class PublishAcceptanceRequestActivity : Activity
                 "suspends (delivery is 39-18's outbox job), continuing.",
                 request.DecisionSessionId);
         }
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentDecisionActivity.cs
@@ -130,7 +130,7 @@ public class WaitForDocumentDecisionActivity : Activity
     protected override void Execute(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
-        var tenantId = TenantId.Get(context);
+        var tenantId = TenantId.GetOrDefault(context);
         var requestedAtUtc = RequestedAtUtc.Get(context);
 
         // D4 — fail LOUD if the durationMs basis is missing/unparseable, rather than
@@ -151,8 +151,8 @@ public class WaitForDocumentDecisionActivity : Activity
         // orchestrator (D6 — every request routes to the orchestrator).
         TammaEventEmitter.Emit(context, this, _logger, BuildRequestedEvent(
             sessionId, tenantId,
-            IssueId.Get(context), DocumentId.Get(context), DocumentType.Get(context),
-            CorrelationId.Get(context), RulesReference.Get(context), requestedAtUtc));
+            IssueId.GetOrDefault(context), DocumentId.GetOrDefault(context), DocumentType.GetOrDefault(context),
+            CorrelationId.GetOrDefault(context), RulesReference.GetOrDefault(context), requestedAtUtc));
 
         _logger?.LogInformation(
             "Waiting for document decision: bookmark={BookmarkName} for session {SessionId}",
@@ -180,16 +180,16 @@ public class WaitForDocumentDecisionActivity : Activity
 
         // D7 — the authoritative rules reference is the server-stamped activity input, not the
         // resume echo, so orchestrator decisions stay auditable.
-        var rulesReference = RulesReference.Get(context);
+        var rulesReference = RulesReference.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Document decision resumed: kind={Kind} channel={Channel} decider={Decider} durationMs={Duration}",
             read.DecisionKind, read.Channel, read.DeciderId ?? "<none>", durationMs);
 
         TammaEventEmitter.Emit(context, this, _logger, BuildProvidedEvent(
-            SessionId.Get(context), TenantId.Get(context),
-            IssueId.Get(context), DocumentId.Get(context), DocumentType.Get(context),
-            CorrelationId.Get(context), rulesReference, read, durationMs));
+            SessionId.Get(context), TenantId.GetOrDefault(context),
+            IssueId.GetOrDefault(context), DocumentId.GetOrDefault(context), DocumentType.GetOrDefault(context),
+            CorrelationId.GetOrDefault(context), rulesReference, read, durationMs));
 
         context.Set(DecisionJson, read.DecisionJson);
         context.Set(Feedback, read.Feedback);

--- a/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentInputActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Documents/WaitForDocumentInputActivity.cs
@@ -101,7 +101,7 @@ public class WaitForDocumentInputActivity : Activity
     protected override void Execute(ActivityExecutionContext context)
     {
         var sessionId = SessionId.Get(context);
-        var tenantId = TenantId.Get(context);
+        var tenantId = TenantId.GetOrDefault(context);
         var bookmarkName = InputBookmarkName(tenantId, sessionId);
 
         _logger?.LogInformation(
@@ -124,7 +124,7 @@ public class WaitForDocumentInputActivity : Activity
         var slaMinutes = supplied;
         if (slaMinutes <= 0)
         {
-            var configKey = TimeoutConfigKey.Get(context);
+            var configKey = TimeoutConfigKey.GetOrDefault(context);
             if (!string.IsNullOrWhiteSpace(configKey))
                 slaMinutes = _configuration?.GetValue<int?>(configKey) ?? 0;
         }

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/EmailActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/EmailActivity.cs
@@ -79,7 +79,7 @@ public class EmailActivity : CodeActivity<EmailOperationResult>
         var body = Body.Get(context);
         var template = Template.Get(context);
         var templateData = TemplateData.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/GitHubActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/GitHubActivity.cs
@@ -82,12 +82,12 @@ public class GitHubActivity : CodeActivity<GitHubOperationResult>
     {
         var action = Action.Get(context);
         var repository = Repository.Get(context);
-        var storyId = StoryId.Get(context);
-        var branchName = BranchName.Get(context) ?? (storyId != null ? $"feature/{storyId}" : null);
-        var prNumber = PullRequestNumber.Get(context);
-        var prTitle = PrTitle.Get(context);
-        var prBody = PrBody.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var storyId = StoryId.GetOrDefault(context);
+        var branchName = BranchName.GetOrDefault(context) ?? (storyId != null ? $"feature/{storyId}" : null);
+        var prNumber = PullRequestNumber.GetOrDefault(context);
+        var prTitle = PrTitle.GetOrDefault(context);
+        var prBody = PrBody.GetOrDefault(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/JiraActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/JiraActivity.cs
@@ -75,11 +75,11 @@ public class JiraActivity : CodeActivity<JiraOperationResult>
     {
         var action = Action.Get(context);
         var ticketId = TicketId.Get(context);
-        var status = Status.Get(context);
-        var comment = Comment.Get(context);
-        var prUrl = PullRequestUrl.Get(context);
+        var status = Status.GetOrDefault(context);
+        var comment = Comment.GetOrDefault(context);
+        var prUrl = PullRequestUrl.GetOrDefault(context);
         var customFields = CustomFields.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Integration/SlackActivity.cs
@@ -98,12 +98,12 @@ public class SlackActivity : CodeActivity<SlackOperationResult>
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var action = Action.Get(context);
-        var channel = Channel.Get(context);
-        var userId = UserId.Get(context);
+        var channel = Channel.GetOrDefault(context);
+        var userId = UserId.GetOrDefault(context);
         var message = Message.Get(context);
-        var sessionId = SessionId.Get(context);
+        var sessionId = SessionId.GetOrDefault(context);
         var messageType = MessageType.Get(context);
-        var tenantId = NormalizeTenant(TenantId.Get(context));
+        var tenantId = NormalizeTenant(TenantId.GetOrDefault(context));
 
         _logger?.LogInformation("Executing Slack action {Action} (mediated)", action);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmActivity.cs
@@ -124,12 +124,12 @@ public class CallLlmActivity : Activity
     {
         var providerName = ProviderName.Get(context);
         var userPrompt = UserPrompt.Get(context);
-        var modelOverride = ModelOverride.Get(context);
+        var modelOverride = ModelOverride.GetOrDefault(context);
         var maxTokens = MaxTokens.Get(context);
         var temperature = Temperature.Get(context);
-        var toolsJson = ToolsJson.Get(context);
+        var toolsJson = ToolsJson.GetOrDefault(context);
         var attemptNumber = AttemptNumber.Get(context);
-        var tenantIdRaw = TenantId.Get(context);
+        var tenantIdRaw = TenantId.GetOrDefault(context);
 
         var tools = DeserializeTools(toolsJson)?.Select(t => t.Name).ToList();
         // Story 43-14 (AC4) — the RUN correlation (the cycle instance id, threaded

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/CallLlmInlineActivity.cs
@@ -166,18 +166,18 @@ public class CallLlmInlineActivity : CodeActivity
         var inputJson = InputJsonProp.Get(context);
         var providerName = ProviderNameProp.Get(context);
         var systemPrompt = SystemPromptProp.Get(context);
-        var toolsJson = ToolsJsonProp.Get(context);
+        var toolsJson = ToolsJsonProp.GetOrDefault(context);
         var attemptNumber = AttemptNumberProp.Get(context);
         var enableToolLoop = EnableToolLoopProp.Get(context);
-        var toolLoopConfigJson = ToolLoopConfigJsonProp.Get(context);
-        var tenantIdRaw = TenantIdProp.Get(context);
-        var agentRole = AgentRoleProp.Get(context);
-        var action = ActionProp.Get(context);
-        var renderedPrompt = RenderedPromptProp.Get(context);
-        var variablesJson = VariablesJsonProp.Get(context);
+        var toolLoopConfigJson = ToolLoopConfigJsonProp.GetOrDefault(context);
+        var tenantIdRaw = TenantIdProp.GetOrDefault(context);
+        var agentRole = AgentRoleProp.GetOrDefault(context);
+        var action = ActionProp.GetOrDefault(context);
+        var renderedPrompt = RenderedPromptProp.GetOrDefault(context);
+        var variablesJson = VariablesJsonProp.GetOrDefault(context);
         var registryMaxTokens = RegistryMaxTokensProp.Get(context);
-        var documentType = DocumentTypeProp.Get(context);
-        var issueId = IssueIdProp.Get(context);
+        var documentType = DocumentTypeProp.GetOrDefault(context);
+        var issueId = IssueIdProp.GetOrDefault(context);
 
         var input = ParseInput(inputJson);
         var toolLoopConfig = ParseToolLoopConfig(toolLoopConfigJson);

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedLlmText.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/MediatedLlmText.cs
@@ -34,7 +34,13 @@ internal static class MediatedLlmText
         ActivityExecutionContext context,
         string role,
         string prompt,
-        CancellationToken ct)
+        CancellationToken ct,
+        // 2026-08-13 (engine-driven E2E run 34): the taxonomy ACTION of the call.
+        // This path passed no action, which (a) hid the call's identity from the
+        // audit tags and (b) left the scripted provider's role/action key empty —
+        // every TDD/debug single-shot missed its cell ("[tester/, *]"). Callers
+        // pass their canonical wire action (a real Prompts/{role}/{action}.md cell).
+        string? action = null)
     {
         var apiClient = context.GetRequiredService<TammaApiClient>();
         var tenantId = ResolveTenantId(context);
@@ -46,8 +52,20 @@ internal static class MediatedLlmText
             // blank-role default of "assistant" (neither canonical nor aliased)
             // would fail every such call.
             Role = string.IsNullOrWhiteSpace(role) ? "developer" : role,
+            Action = string.IsNullOrWhiteSpace(action) ? null : action,
             Prompt = prompt,
             EnableToolLoop = false,
+            // 2026-08-13 (engine-driven E2E run 33): honour the SAME deployment-tier
+            // provider selection the llm-call workflow applies (LlmCallWorkflow's
+            // ResolveChain: caller > DB chain > Llm:DefaultProviderChain). This
+            // direct path passed NO provider, so ManagedAgent fell back to the
+            // persona's provider — the two mediation paths chose DIFFERENT
+            // providers for the same role, and a deployment whose selected chain
+            // holds no key for the persona default fails only on THIS path
+            // (observed: TDD write-tests failing PROVIDER_CREDENTIAL_UNAVAILABLE
+            // on anthropic while every llm-call ran scripted). Null when the
+            // deployment sets no chain — the persona default then applies as before.
+            Provider = ResolveConfiguredProvider(context),
             // Story 43-14 (AC4) — the RUN correlation, not the sub-workflow's id.
             CorrelationId = string.IsNullOrWhiteSpace(context.WorkflowExecutionContext.CorrelationId)
                 ? context.WorkflowExecutionContext.Id
@@ -81,6 +99,30 @@ internal static class MediatedLlmText
         }
 
         return response.Text!;
+    }
+
+    /// <summary>
+    /// The deployment-tier provider selection: the FIRST allowlist-passing entry of
+    /// <c>Llm:DefaultProviderChain</c>, or null when the deployment configures no
+    /// chain (the API's persona/agent-config default then applies). Mirrors the
+    /// config tier of <c>LlmCallWorkflow.ResolveChain</c> — this single-shot path
+    /// has no caller/DB chain, so the config tier is the only one that can apply.
+    /// </summary>
+    internal static string? ResolveConfiguredProvider(ActivityExecutionContext context)
+    {
+        var configuration = context.GetService<Microsoft.Extensions.Configuration.IConfiguration>();
+        if (configuration is null) return null;
+
+        var chain = Microsoft.Extensions.Configuration.ConfigurationBinder
+            .Get<string[]>(configuration.GetSection("Llm:DefaultProviderChain"));
+        if (chain is null || chain.Length == 0) return null;
+
+        var allowlist = context.GetService<Tamma.Activities.Security.ProviderAllowlist>()
+                        ?? new Tamma.Activities.Security.ProviderAllowlist();
+        return chain
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p.Trim())
+            .FirstOrDefault(p => allowlist.IsAllowed(p));
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/Models/LlmCallModels.cs
@@ -398,6 +398,20 @@ public class LlmProviderConfig
 
     /// <summary>Whether this provider is enabled.</summary>
     public bool Enabled { get; set; } = true;
+
+    // ── Scripted-provider call keys (2026-08-13, additive) ──────────────
+    // Set per-call by ManagedAgent so the opt-in in-process "scripted"
+    // provider can key its deterministic response on the call's identity.
+    // NEVER serialized onto any provider wire body (the request builders read
+    // only messages/model/params) and ignored by every HTTP provider.
+
+    /// <summary>Agent role wire token of the call being served (e.g.
+    /// "architect"). Null outside the managed-agent path.</summary>
+    public string? CallRole { get; set; }
+
+    /// <summary>Role+action wire token of the call being served (e.g.
+    /// "plan-system-design"). Null when the call has no action.</summary>
+    public string? CallAction { get; set; }
 }
 
 // ============================================================

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/ResolveAgentConfigActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/ResolveAgentConfigActivity.cs
@@ -45,7 +45,7 @@ public class ResolveAgentConfigActivity : CodeActivity
     {
         var logger = context.GetRequiredService<ILogger<ResolveAgentConfigActivity>>();
         var role = AgentRoleProp.Get(context) ?? "assistant";
-        var systemPromptOverride = SystemPromptOverrideProp.Get(context);
+        var systemPromptOverride = SystemPromptOverrideProp.GetOrDefault(context);
 
         // Priority 1: Caller override
         if (!string.IsNullOrWhiteSpace(systemPromptOverride))

--- a/apps/tamma-elsa/src/Tamma.Activities/LlmCall/ResolvePromptFromRegistryActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/LlmCall/ResolvePromptFromRegistryActivity.cs
@@ -146,12 +146,21 @@ public class ResolvePromptFromRegistryActivity : TammaAsyncActivity
         // activity emits FAILED and rethrows.
         ValidateTaxonomy(role, action);
 
+        // 2026-08-13 (engine-driven E2E): a store-rehydrated activity is built
+        // by the [JsonConstructor], so the ctor-injected members are NULL in
+        // the real engine — resolve from the execution context (the
+        // ctor-or-GetService idiom). The old code also DISCARDED a configured
+        // Engine:CallbackUrl whenever the factory was null, sending every
+        // prompt render to the localhost:3100 default.
+        var configuration = _configuration ?? context.GetService<IConfiguration>();
+        var httpClientFactory = _httpClientFactory ?? context.GetService<IHttpClientFactory>();
+
         // Try the prompt registry
-        var callbackUrl = _configuration?["Engine:CallbackUrl"];
-        if (string.IsNullOrEmpty(callbackUrl) || _httpClientFactory == null)
+        var callbackUrl = configuration?["Engine:CallbackUrl"];
+        if (string.IsNullOrEmpty(callbackUrl))
         {
             // No API available — try local prompt registry URL
-            callbackUrl = _configuration?["PromptRegistry:BaseUrl"] ?? "http://localhost:3100";
+            callbackUrl = configuration?["PromptRegistry:BaseUrl"] ?? "http://localhost:3100";
         }
 
         // Production blocker fix — use the named "tamma-engine" client (wired
@@ -161,7 +170,7 @@ public class ResolvePromptFromRegistryActivity : TammaAsyncActivity
         // configured. Without this, the API returns 401 in production and
         // the activity maps that to a non-retryable NO_ROW — permanently
         // failing the workflow before any LLM runs.
-        var httpClient = _httpClientFactory?.CreateClient("tamma-engine") ?? new HttpClient();
+        var httpClient = httpClientFactory?.CreateClient("tamma-engine") ?? new HttpClient();
 
         // Parse variables
         Dictionary<string, object>? variables = null;

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/CodeReviewActivity.cs
@@ -84,7 +84,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
         var storyId = StoryId.Get(context);
         var juniorId = JuniorId.Get(context);
         var action = Action.Get(context);
-        var prNumber = PullRequestNumber.Get(context);
+        var prNumber = PullRequestNumber.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Code review action {Action} for junior {JuniorId} on story {StoryId}",
@@ -170,7 +170,7 @@ public class CodeReviewActivity : CodeActivity<CodeReviewOutput>
             };
         }
 
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/DiagnoseBlockerActivity.cs
@@ -77,8 +77,8 @@ public class DiagnoseBlockerActivity : CodeActivity<BlockerDiagnosisOutput>
         var sessionId = SessionId.Get(context);
         var storyId = StoryId.Get(context);
         var juniorId = JuniorId.Get(context);
-        var blockerContext = BlockerContext.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var blockerContext = BlockerContext.GetOrDefault(context);
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/FlowNodeActivities.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/FlowNodeActivities.cs
@@ -794,7 +794,7 @@ public class EscalateToSeniorActivity : Activity
         var logger = context.GetRequiredService<ILogger<EscalateToSeniorActivity>>();
         var repository = context.GetRequiredService<IMentorshipSessionRepository>();
         var sessionId = SessionId.Get(context);
-        var reason = Reason.Get(context);
+        var reason = Reason.GetOrDefault(context);
 
         logger.LogWarning(
             "Escalating session {SessionId} to senior developer. Reason: {Reason}",
@@ -955,7 +955,7 @@ public class FailSessionActivity : Activity
         var logger = context.GetRequiredService<ILogger<FailSessionActivity>>();
         var repository = context.GetRequiredService<IMentorshipSessionRepository>();
         var sessionId = SessionId.Get(context);
-        var reason = Reason.Get(context);
+        var reason = Reason.GetOrDefault(context);
 
         logger.LogError("Session {SessionId} failed. Reason: {Reason}", sessionId, reason ?? "Unknown");
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MergeCompleteActivity.cs
@@ -83,7 +83,7 @@ public class MergeCompleteActivity : CodeActivity<MergeCompleteOutput>
         var juniorId = JuniorId.Get(context);
         var prNumber = PullRequestNumber.Get(context);
         var autoMerge = AutoMerge.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MonitorImplementationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/MonitorImplementationActivity.cs
@@ -81,7 +81,7 @@ public class MonitorImplementationActivity : CodeActivity<ProgressOutput>
         var juniorId = JuniorId.Get(context);
         var monitoringDuration = MonitoringDuration.Get(context);
         var checkInterval = CheckInterval.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/ProvideGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/ProvideGuidanceActivity.cs
@@ -73,7 +73,7 @@ public class ProvideGuidanceActivity : CodeActivity<GuidanceOutput>
         var juniorId = JuniorId.Get(context);
         var storyId = StoryId.Get(context);
         var blockerType = BlockerType.Get(context);
-        var issueContext = IssueContext.Get(context);
+        var issueContext = IssueContext.GetOrDefault(context);
         var guidanceLevel = GuidanceLevel.Get(context);
 
         _logger?.LogInformation(

--- a/apps/tamma-elsa/src/Tamma.Activities/Mentorship/QualityGateCheckActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Mentorship/QualityGateCheckActivity.cs
@@ -77,7 +77,7 @@ public class QualityGateCheckActivity : CodeActivity<QualityGateOutput>
         var storyId = StoryId.Get(context);
         var minCoverage = MinCoverage.Get(context);
         var allowWarnings = AllowWarnings.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Policy/CheckActionGateActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Policy/CheckActionGateActivity.cs
@@ -155,9 +155,9 @@ public class CheckActionGateActivity : Activity
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var actionKey = ActionKey.Get(context) ?? "";
-        var correlationId = Normalize(CorrelationId.Get(context))
+        var correlationId = Normalize(CorrelationId.GetOrDefault(context))
             ?? context.WorkflowExecutionContext.Id;
-        var tenantId = Normalize(TenantId.Get(context));
+        var tenantId = Normalize(TenantId.GetOrDefault(context));
 
         GovernanceEvaluateResponse? response = null;
         try
@@ -168,9 +168,9 @@ public class CheckActionGateActivity : Activity
                 response = await apiClient.EvaluateGovernanceAsync(
                     new GovernanceEvaluateRequest(
                         actionKey,
-                        Normalize(Role.Get(context)),
-                        Normalize(Operation.Get(context)),
-                        Normalize(Target.Get(context)),
+                        Normalize(Role.GetOrDefault(context)),
+                        Normalize(Operation.GetOrDefault(context)),
+                        Normalize(Target.GetOrDefault(context)),
                         correlationId),
                     tenantId,
                     context.CancellationToken).ConfigureAwait(false);

--- a/apps/tamma-elsa/src/Tamma.Activities/Research/EmitResearchEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Research/EmitResearchEventActivity.cs
@@ -58,15 +58,15 @@ public class EmitResearchEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? ResearchEvents.Failed;
-        var sessionId = SessionId.Get(context);
-        var issueId = IssueId.Get(context);
-        var tenantId = ResearchEvents.ParseTenantId(TenantId.Get(context));
-        var findingCount = FindingCount.Get(context);
-        var confidence = Confidence.Get(context);
-        var detail = Detail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? ResearchEvents.Failed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var issueId = IssueId.GetOrDefault(context);
+        var tenantId = ResearchEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var findingCount = FindingCount.GetOrDefault(context);
+        var confidence = Confidence.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(type, sessionId, issueId, tenantId, findingCount, confidence, detail);
         TammaEventEmitter.Emit(context, this, _logger, evt);
@@ -75,7 +75,8 @@ public class EmitResearchEventActivity : Activity
             "Emitted {Type} for research session {Session} issue {Issue} (findings={Count})",
             type, sessionId, issueId, findingCount);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/BindCodeReviewConfigActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/BindCodeReviewConfigActivity.cs
@@ -75,7 +75,7 @@ public class BindCodeReviewConfigActivity : CodeActivity
         var resolved = Resolve(
             _configuration,
             MaxIterationsInput.Get(context),
-            MergeStrategyInput.Get(context));
+            MergeStrategyInput.GetOrDefault(context));
 
         MaxIterations.Set(context, resolved.MaxIterations);
         MergeStrategy.Set(context, resolved.MergeStrategy);

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/BuildCodeReviewResultActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/BuildCodeReviewResultActivity.cs
@@ -72,13 +72,13 @@ public class BuildCodeReviewResultActivity : CodeActivity<CodeReviewWorkflowResu
             Success = Success.Get(context),
             FinalStatus = FinalStatus.Get(context),
             PRNumber = prNumber > 0 ? prNumber : null,
-            PRUrl = PRUrl.Get(context),
-            MergeSha = MergeSha.Get(context),
+            PRUrl = PRUrl.GetOrDefault(context),
+            MergeSha = MergeSha.GetOrDefault(context),
             TotalIterations = totalIterations,
             ReviewRounds = totalIterations + 1,
             WasEscalated = WasEscalated.Get(context),
-            EscalationResolution = EscalationResolution.Get(context),
-            Message = Message.Get(context),
+            EscalationResolution = EscalationResolution.GetOrDefault(context),
+            Message = Message.GetOrDefault(context),
             CompletedAt = DateTime.UtcNow
         };
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/CreatePRActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/CreatePRActivity.cs
@@ -80,8 +80,8 @@ public class CreatePRActivity : CodeActivity<PRCreationResult>
         var storyId = StoryId.Get(context);
         var juniorId = JuniorId.Get(context);
         var baseBranch = BaseBranch.Get(context);
-        var headBranch = HeadBranch.Get(context) ?? $"feature/{storyId}";
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var headBranch = HeadBranch.GetOrDefault(context) ?? $"feature/{storyId}";
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         var correlationId = context.WorkflowExecutionContext.Id;
         var apiClient = _apiClient ?? context.GetRequiredService<TammaApiClient>();
         var ct = context.CancellationToken;

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
@@ -91,7 +91,7 @@ public class DeliverGuidanceActivity : Activity
         var prNumber = PRNumber.Get(context);
         var iteration = Iteration.Get(context);
         var commentsJson = ReviewCommentsJson.Get(context);
-        var guidanceText = GuidanceText.Get(context);
+        var guidanceText = GuidanceText.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Delivering fix guidance for PR #{PRNumber}, iteration {Iteration}, session {SessionId}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/DeliverGuidanceActivity.cs
@@ -104,7 +104,7 @@ public class DeliverGuidanceActivity : Activity
             _logger?.LogWarning(
                 "No LLM guidance text for PR #{PRNumber}, iteration {Iteration}; routing to escalation",
                 prNumber, iteration);
-            Result.Set(context, null);
+            Result.Set(context, (FixGuidance?)null);
             await context.CompleteActivityWithOutcomesAsync("Failed");
             return;
         }
@@ -158,7 +158,7 @@ public class DeliverGuidanceActivity : Activity
         catch (Exception ex)
         {
             _logger?.LogError(ex, "Error delivering guidance for session {SessionId}", sessionId);
-            Result.Set(context, null);
+            Result.Set(context, (FixGuidance?)null);
             await context.CompleteActivityWithOutcomesAsync("Failed");
         }
     }

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EmitCodeReviewEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EmitCodeReviewEventActivity.cs
@@ -73,19 +73,19 @@ public class EmitCodeReviewEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? CodeReviewEvents.Failed;
-        var sessionId = SessionId.Get(context);
-        var storyId = StoryId.Get(context);
-        var juniorId = JuniorId.Get(context);
-        var tenantId = CodeReviewEvents.ParseTenantId(TenantId.Get(context));
-        var prNumber = PrNumber.Get(context);
-        var prUrl = PrUrl.Get(context);
-        var iteration = Iteration.Get(context);
-        var mergeSha = MergeSha.Get(context);
-        var reason = Reason.Get(context);
-        var detail = Detail.Get(context);
+        var type = EventType.GetOrDefault(context) ?? CodeReviewEvents.Failed;
+        var sessionId = SessionId.GetOrDefault(context);
+        var storyId = StoryId.GetOrDefault(context);
+        var juniorId = JuniorId.GetOrDefault(context);
+        var tenantId = CodeReviewEvents.ParseTenantId(TenantId.GetOrDefault(context));
+        var prNumber = PrNumber.GetOrDefault(context);
+        var prUrl = PrUrl.GetOrDefault(context);
+        var iteration = Iteration.GetOrDefault(context);
+        var mergeSha = MergeSha.GetOrDefault(context);
+        var reason = Reason.GetOrDefault(context);
+        var detail = Detail.GetOrDefault(context);
 
         var evt = BuildTammaEvent(
             type, sessionId, storyId, juniorId, tenantId,
@@ -96,7 +96,8 @@ public class EmitCodeReviewEventActivity : Activity
             "Emitted {Type} for session {Session} story {Story} (pr=#{Pr}, iteration={Iteration})",
             type, sessionId, storyId, prNumber, iteration);
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
@@ -104,11 +104,11 @@ public class EscalateReviewActivity : Activity
         var sessionId = SessionId.Get(context);
         var prNumber = PRNumber.Get(context);
         var juniorId = JuniorId.Get(context);
-        var storyId = StoryId.Get(context);
-        var tenantId = TenantId.Get(context);
+        var storyId = StoryId.GetOrDefault(context);
+        var tenantId = TenantId.GetOrDefault(context);
         var reason = Reason.Get(context);
         var iterations = IterationsAttempted.Get(context);
-        var message = EscalationMessage.Get(context);
+        var message = EscalationMessage.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Escalating review for PR #{PRNumber}, reason: {Reason}, session {SessionId}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/EscalateReviewActivity.cs
@@ -239,7 +239,7 @@ public class EscalateReviewActivity : Activity
             "Senior-response SLA expired (durable timeout) for PR #{PRNumber}, session {SessionId} — taking the TimedOut outcome",
             prNumber, sessionId);
 
-        EscalationResponse.Set(context, null);
+        EscalationResponse.Set(context, (EscalationResponsePayload?)null);
         await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/MergeAndCompleteReviewActivity.cs
@@ -125,7 +125,7 @@ public class MergeAndCompleteReviewActivity : Activity
         var totalIterations = TotalIterations.Get(context);
         var verifyCi = VerifyCIBeforeMerge.Get(context);
         var deleteBranch = DeleteBranchAfterMerge.Get(context);
-        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.Get(context));
+        var tenantId = CreateBranchActivity.NormalizeTenant(TenantId.GetOrDefault(context));
         // Story 43-14 (AC4) — the RUN correlation (cycle instance id, threaded as
         // the Elsa correlation), not the merge sub-workflow's own id, so the
         // ?correlationId= this passes to DeleteBranchAsync matches the human's
@@ -152,7 +152,7 @@ public class MergeAndCompleteReviewActivity : Activity
                 return;
             }
 
-            var headBranch = HeadBranch.Get(context);
+            var headBranch = HeadBranch.GetOrDefault(context);
             if (string.IsNullOrWhiteSpace(headBranch))
                 headBranch = $"feature/{storyId}";
 

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/RequestReviewActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/RequestReviewActivity.cs
@@ -64,7 +64,7 @@ public class RequestReviewActivity : CodeActivity<RequestReviewOutput>
         var prNumber = PRNumber.Get(context);
         var storyId = StoryId.Get(context);
         var juniorId = JuniorId.Get(context);
-        var reviewers = Reviewers.Get(context);
+        var reviewers = Reviewers.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Requesting review on PR #{PRNumber} for session {SessionId}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/ValidateCodeReviewInputsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/ValidateCodeReviewInputsActivity.cs
@@ -71,10 +71,10 @@ public class ValidateCodeReviewInputsActivity : CodeActivity
     protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
         var result = Validate(
-            StoryId.Get(context),
-            RepositoryUrl.Get(context),
-            JuniorId.Get(context),
-            ReviewerIdsJson.Get(context),
+            StoryId.GetOrDefault(context),
+            RepositoryUrl.GetOrDefault(context),
+            JuniorId.GetOrDefault(context),
+            ReviewerIdsJson.GetOrDefault(context),
             LoadReviewerPool());
 
         if (!result.IsValid)

--- a/apps/tamma-elsa/src/Tamma.Activities/Review/WaitForFixesActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Review/WaitForFixesActivity.cs
@@ -122,7 +122,7 @@ public class WaitForFixesActivity : Activity
             "Fix-submission window expired (durable timeout) for PR #{PRNumber}, iteration {Iteration} — taking the TimedOut outcome",
             prNumber, iteration);
 
-        FixesPayload.Set(context, null);
+        FixesPayload.Set(context, (FixesSubmittedPayload?)null);
         await context.CompleteActivityWithOutcomesAsync("TimedOut");
     }
 
@@ -140,7 +140,7 @@ public class WaitForFixesActivity : Activity
                 "Fix submission timed out for PR #{PRNumber}, iteration {Iteration}",
                 prNumber, iteration);
 
-            FixesPayload.Set(context, null);
+            FixesPayload.Set(context, (FixesSubmittedPayload?)null);
             await context.CompleteActivityWithOutcomesAsync("TimedOut");
             return;
         }

--- a/apps/tamma-elsa/src/Tamma.Activities/Security/ScriptedProviderPosture.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Security/ScriptedProviderPosture.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Configuration;
+
+namespace Tamma.Activities.Security;
+
+/// <summary>
+/// Epic 31 P5 follow-up (2026-08-13) — the SHARED posture for the "scripted"
+/// LLM provider: a deterministic, in-process test provider that unblocks the
+/// engine-driven autonomous E2E (no fake/echo provider existed before it; see
+/// tests/Tamma.Platforms.IntegrationTests/GiteaFullStackE2ETests.cs).
+///
+/// <para><b>Opt-in only, structurally.</b> The provider key is NOT in
+/// <see cref="ProviderAllowlist"/>'s defaults and its catalogue classification
+/// is <c>Allowlisted=false</c> (the defensive non-selectable convention), so a
+/// deployment that never sets <see cref="FlagKey"/> cannot select it — not via
+/// a provider chain, not via an agent config, not via a request override
+/// (the credential resolver's allowlist check refuses it first).</para>
+///
+/// <para><b>Impossible to enable in production, structurally.</b>
+/// <see cref="AssertAllowed"/> THROWS at host startup when the flag is set on
+/// a deployment carrying any SaaS/production signal (explicit
+/// <c>Tamma:Mode=saas</c>, a <c>Tamma:TenantSharedSecret</c>, or a
+/// <c>ConnectionStrings:ControlPlane</c> — the exact CLAUDE.md mode-detection
+/// signals mirrored by <c>TammaModeProvider.Resolve</c>). Defense in depth:
+/// even if a host skipped the assert, the SaaS provider gate fails closed on
+/// an unknown provider (<c>SaaSProviderGate</c> denies non-catalogued keys)
+/// and <c>HttpProviderClient</c> refuses the non-HTTP transport.</para>
+///
+/// <para>This type lives in Tamma.Activities so BOTH hosts (Tamma.Api, which
+/// serves the responses, and Tamma.ElsaServer, which only allow-lists the key
+/// for chain resolution) share one flag and one guard.</para>
+/// </summary>
+public static class ScriptedProviderPosture
+{
+    /// <summary>The single opt-in flag, shared by both hosts.</summary>
+    public const string FlagKey = "Llm:EnableScriptedProvider";
+
+    /// <summary>The canonical provider key.</summary>
+    public const string ProviderKey = "scripted";
+
+    /// <summary>Whether the scripted provider is opted in on this host.</summary>
+    public static bool IsEnabled(IConfiguration configuration)
+        => string.Equals(configuration[FlagKey], "true", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether this configuration carries any SaaS/production deployment signal
+    /// (mirrors <c>TammaModeProvider.Resolve</c>'s inference exactly).
+    /// </summary>
+    public static bool HasProductionSignal(IConfiguration configuration)
+    {
+        var explicitMode = configuration["Tamma:Mode"];
+        if (!string.IsNullOrWhiteSpace(explicitMode)
+            && explicitMode.Trim().Equals("saas", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return !string.IsNullOrWhiteSpace(configuration["Tamma:TenantSharedSecret"])
+            || !string.IsNullOrWhiteSpace(configuration.GetConnectionString("ControlPlane"));
+    }
+
+    /// <summary>
+    /// Fail-loud structural guard: enabled + production signal ⇒ the host
+    /// REFUSES to start. Returns true when the provider is enabled and allowed.
+    /// </summary>
+    public static bool AssertAllowed(IConfiguration configuration)
+    {
+        if (!IsEnabled(configuration))
+        {
+            return false;
+        }
+
+        if (HasProductionSignal(configuration))
+        {
+            throw new InvalidOperationException(
+                $"{FlagKey}=true is refused on this deployment: a SaaS/production signal is present " +
+                "(Tamma:Mode=saas, Tamma:TenantSharedSecret, or ConnectionStrings:ControlPlane). " +
+                "The scripted LLM provider is a deterministic TEST provider and must never be " +
+                "registrable on a production-shaped host. Remove the flag or the SaaS config.");
+        }
+
+        return true;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/AnalyzeCodeActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/AnalyzeCodeActivity.cs
@@ -92,7 +92,7 @@ public class AnalyzeCodeActivity : CodeActivity<RefactoringAnalysis>
 
             var response = useMock
                 ? SimulateAnalysis()
-                : await MediatedLlmText.CompleteAsync(context, "reviewer", prompt, context.CancellationToken);
+                : await MediatedLlmText.CompleteAsync(context, "senior_developer", prompt, context.CancellationToken, action: "plan-refactor");
 
             var result = ParseAnalysisResponse(response, confidenceThreshold);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/ApplyRefactoringActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/ApplyRefactoringActivity.cs
@@ -92,7 +92,7 @@ public class ApplyRefactoringActivity : CodeActivity<RefactoringResult>
 
             var response = useMock
                 ? SimulateRefactoring(implementationCode)
-                : await MediatedLlmText.CompleteAsync(context, "implementer", prompt, context.CancellationToken);
+                : await MediatedLlmText.CompleteAsync(context, "developer", prompt, context.CancellationToken, action: "refactor");
 
             var result = ParseRefactoringResponse(response);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteImplementationActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteImplementationActivity.cs
@@ -80,8 +80,8 @@ public class WriteImplementationActivity : CodeActivity<ImplementationResult>
         var storyId = StoryId.Get(context);
         var taskDescription = TaskDescription.Get(context);
         var testCode = TestCode.Get(context);
-        var testFailureOutput = TestFailureOutput.Get(context);
-        var codeContext = CodeContext.Get(context);
+        var testFailureOutput = TestFailureOutput.GetOrDefault(context);
+        var codeContext = CodeContext.GetOrDefault(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
 
         _logger?.LogInformation(
@@ -96,7 +96,7 @@ public class WriteImplementationActivity : CodeActivity<ImplementationResult>
 
             var response = useMock
                 ? SimulateImplementation(taskDescription)
-                : await MediatedLlmText.CompleteAsync(context, "implementer", prompt, context.CancellationToken);
+                : await MediatedLlmText.CompleteAsync(context, "developer", prompt, context.CancellationToken, action: "implement-feature");
 
             var result = ParseImplementationResponse(response);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteTestsActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TDD/WriteTestsActivity.cs
@@ -86,10 +86,10 @@ public class WriteTestsActivity : CodeActivity<TestGenerationResult>
         var storyId = StoryId.Get(context);
         var taskDescription = TaskDescription.Get(context);
         var taskFiles = TaskFiles.Get(context) ?? new List<string>();
-        var codeContext = CodeContext.Get(context);
+        var codeContext = CodeContext.GetOrDefault(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
         var isRewrite = IsRewrite.Get(context);
-        var previousTestCode = PreviousTestCode.Get(context);
+        var previousTestCode = PreviousTestCode.GetOrDefault(context);
 
         _logger?.LogInformation(
             "TDD RED phase: Writing {Action} tests for task in story {StoryId}, session {SessionId}, skill level {SkillLevel}",
@@ -103,7 +103,7 @@ public class WriteTestsActivity : CodeActivity<TestGenerationResult>
 
             var response = useMock
                 ? SimulateTestGeneration(taskDescription, taskFiles, isRewrite)
-                : await MediatedLlmText.CompleteAsync(context, "tester", prompt, context.CancellationToken);
+                : await MediatedLlmText.CompleteAsync(context, "tester", prompt, context.CancellationToken, action: "write-tests");
 
             var result = ParseTestGenerationResponse(response, taskFiles);
 

--- a/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/TenantLifecycle/EmitCleanupTerminalEventActivity.cs
@@ -644,7 +644,7 @@ public sealed class EmitCleanupTerminalEventActivity : TammaAsyncActivity
         Logger ??= context.GetService<ILogger<EmitCleanupTerminalEventActivity>>();
 
         var tenantId = ResolveTenantId(context);
-        var note = Note.Get(context);
+        var note = Note.GetOrDefault(context);
 
         var failedSteps = CleanupWorkflowState.GetFailedSteps(context);
         var succeededSteps = CleanupWorkflowState.GetSucceededSteps(context);

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/CheckCoverageActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/CheckCoverageActivity.cs
@@ -50,7 +50,7 @@ public class CheckCoverageActivity : CodeActivity<CoverageCheckResult>
     {
         var ciResults = CIResults.Get(context);
         var skillLevel = Math.Clamp(SkillLevel.Get(context), 1, 5);
-        var coverageOverride = MinCoverageOverride.Get(context);
+        var coverageOverride = MinCoverageOverride.GetOrDefault(context);
 
         var thresholds = QualityThresholds.ForSkillLevel(skillLevel);
         var requiredCoverage = coverageOverride ?? thresholds.MinCoveragePercent;

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/CommitFixActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/CommitFixActivity.cs
@@ -81,7 +81,7 @@ public class CommitFixActivity : CodeActivity<CommitFixResult>
         var fixedIssues = FixedIssues.Get(context) ?? new List<QualityIssue>();
         var attemptNumber = AttemptNumber.Get(context);
         var maxAttempts = MaxAttempts.Get(context);
-        var fixDescription = FixDescription.Get(context);
+        var fixDescription = FixDescription.GetOrDefault(context);
 
         _logger?.LogInformation(
             "Committing auto-fix attempt {Attempt}/{Max} for session {SessionId}",

--- a/apps/tamma-elsa/src/Tamma.Activities/Testing/EmitTestingEventActivity.cs
+++ b/apps/tamma-elsa/src/Tamma.Activities/Testing/EmitTestingEventActivity.cs
@@ -85,34 +85,35 @@ public class EmitTestingEventActivity : Activity
         _logger = logger;
     }
 
-    protected override ValueTask ExecuteAsync(ActivityExecutionContext context)
+    protected override async ValueTask ExecuteAsync(ActivityExecutionContext context)
     {
-        var type = EventType.Get(context) ?? TestingEvents.GateFailed;
+        var type = EventType.GetOrDefault(context) ?? TestingEvents.GateFailed;
 
         var evt = BuildTammaEvent(
             type,
-            sessionId: SessionId.Get(context),
-            repository: Repository.Get(context),
-            branch: Branch.Get(context),
-            runId: RunId.Get(context),
-            tenantId: TestingEvents.ParseTenantId(TenantId.Get(context)),
-            attempt: Attempt.Get(context),
-            maxAttempts: MaxAttempts.Get(context),
-            outcome: Outcome.Get(context),
-            score: Score.Get(context),
-            skillLevel: SkillLevel.Get(context),
-            filesChanged: FilesChanged.Get(context),
-            escalationReason: EscalationReason.Get(context),
-            errorDetail: ErrorDetail.Get(context));
+            sessionId: SessionId.GetOrDefault(context),
+            repository: Repository.GetOrDefault(context),
+            branch: Branch.GetOrDefault(context),
+            runId: RunId.GetOrDefault(context),
+            tenantId: TestingEvents.ParseTenantId(TenantId.GetOrDefault(context)),
+            attempt: Attempt.GetOrDefault(context),
+            maxAttempts: MaxAttempts.GetOrDefault(context),
+            outcome: Outcome.GetOrDefault(context),
+            score: Score.GetOrDefault(context),
+            skillLevel: SkillLevel.GetOrDefault(context),
+            filesChanged: FilesChanged.GetOrDefault(context),
+            escalationReason: EscalationReason.GetOrDefault(context),
+            errorDetail: ErrorDetail.GetOrDefault(context));
 
         TammaEventEmitter.Emit(context, this, _logger, evt);
 
         _logger?.LogInformation(
             "Emitted {Type} for session {Session} repo {Repo} (run={Run}, attempt={Attempt}/{Max}, outcome={Outcome})",
-            type, SessionId.Get(context), Repository.Get(context), RunId.Get(context),
-            Attempt.Get(context), MaxAttempts.Get(context), Outcome.Get(context));
+            type, SessionId.GetOrDefault(context), Repository.GetOrDefault(context), RunId.GetOrDefault(context),
+            Attempt.GetOrDefault(context), MaxAttempts.GetOrDefault(context), Outcome.GetOrDefault(context));
 
-        return default;
+        await context.CompleteActivityAsync(); // 2026-08-13 — bare Activity does NOT auto-complete (see EmitEscalationEventActivity precedent); without this the workflow hangs here forever
+        return;
     }
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Dtos/Prompts/PromptDtos.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Dtos/Prompts/PromptDtos.cs
@@ -1,7 +1,15 @@
 namespace Tamma.Api.Dtos.Prompts;
 
 public record UpsertPromptRequest(string Template, string? SystemPrompt, string[]? Variables, bool? EnableTools, int? MaxTokens);
-public record RenderPromptRequest(Dictionary<string, string> Variables);
+/// <summary>
+/// 2026-08-13 (engine-driven E2E): variables arrive as ARBITRARY JSON values —
+/// the engine's document-produce path sends numbers (e.g.
+/// <c>revisionNumber: 1</c>) alongside strings, and a
+/// <c>Dictionary&lt;string, string&gt;</c> binding rejected the whole body
+/// ("JSON value could not be converted to System.String"), 500ing every
+/// produce-leg prompt render. The endpoint stringifies each value.
+/// </summary>
+public record RenderPromptRequest(Dictionary<string, System.Text.Json.JsonElement> Variables);
 public record PromptResponse(string? Role, string? Action, string Template, string? SystemPrompt, string[]? Variables, bool EnableTools, int MaxTokens, string Source);
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/DocumentEndpoints.cs
@@ -22,6 +22,21 @@ namespace Tamma.Api.Endpoints;
 /// </summary>
 public static class DocumentEndpoints
 {
+    /// <summary>
+    /// 2026-08-13 (engine-driven E2E) — issue ids are <c>{owner}/{repo}#{n}</c>, so
+    /// every correct caller of the <c>/api/documents/issues/{issueId}/…</c> routes
+    /// escapes the id into ONE path segment (<c>tamma-bot%2Ftest-repo%231</c>).
+    /// ASP.NET Core route values decode everything EXCEPT the encoded slash
+    /// (<c>%2F</c> is deliberately left encoded to prevent path-splitting), so the
+    /// handler receives <c>tamma-bot%2Ftest-repo#1</c> — which matched no store row
+    /// and turned every engine-side latest-accepted read into a silent empty 200
+    /// (the plan-review shim then escalated a plan the lifecycle had just
+    /// accepted). Fold ONLY the leftover encoded slash — a full second unescape
+    /// would double-decode ids containing literal percent escapes.
+    /// </summary>
+    private static string FoldEncodedSlashes(string issueId) =>
+        issueId.Replace("%2F", "/", StringComparison.OrdinalIgnoreCase);
+
     // ─── GET /api/documents/issues/{issueId}/lineage (AC3) ────────────────────
 
     /// <summary>
@@ -42,6 +57,8 @@ public static class DocumentEndpoints
     {
         if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
             return Results.NotFound(new { error = "no_active_tenant" });
+
+        issueId = FoldEncodedSlashes(issueId);
 
         if (audience is not null && !ProseAudienceExtensions.TryParse(audience, out _))
             return Results.BadRequest(new
@@ -72,6 +89,7 @@ public static class DocumentEndpoints
         if (tc.TenantId is not Guid tenantId || tenantId == Guid.Empty)
             return Results.NotFound(new { error = "no_active_tenant" });
 
+        issueId = FoldEncodedSlashes(issueId);
         var rows = await repo.GetLatestAcceptedAsync(tenantId, issueId, ct).ConfigureAwait(false);
         var latest = LineageAssembler.AssembleLatest(issueId, rows);
         return Results.Json(latest, DocumentJson.Options, statusCode: StatusCodes.Status200OK);

--- a/apps/tamma-elsa/src/Tamma.Api/Endpoints/PromptEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Endpoints/PromptEndpoints.cs
@@ -414,7 +414,16 @@ public static class PromptEndpoints
         var userId = TryGetUserId(principal);
 
         // Ensure the role variable is always available if missing from the request.
-        var variables = new Dictionary<string, string>(req.Variables ?? new Dictionary<string, string>());
+        // 2026-08-13: variables are arbitrary JSON values on the wire (the
+        // engine's produce path sends numbers) — stringify per value: strings
+        // verbatim, everything else as raw JSON text.
+        var variables = new Dictionary<string, string>();
+        foreach (var (key, value) in req.Variables ?? new Dictionary<string, System.Text.Json.JsonElement>())
+        {
+            variables[key] = value.ValueKind == System.Text.Json.JsonValueKind.String
+                ? value.GetString() ?? string.Empty
+                : value.GetRawText();
+        }
         variables.TryAdd("role", role);
 
         // Story 27-18 — resolution fails loud; translate TammaError into the

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/AgentResolverServiceCollectionExtensions.cs
@@ -69,7 +69,12 @@ public static class AgentResolverServiceCollectionExtensions
             sp.GetRequiredService<IHttpContextAccessor>(),
             sp.GetService<IOptions<DefaultPersonaOptions>>(),
             sp.GetRequiredService<ITenantAgentEnablementReader>(),
-            sp.GetService<ILogger<AgentRegistryService>>()));
+            sp.GetService<ILogger<AgentRegistryService>>(),
+            // 2026-08-13 — single-user service-plane principal fallback (the
+            // engine's claims-less mediation calls resolve the sole user, the
+            // same seam the autonomy gate uses). Optional: unregistered on
+            // hosts without the governance extension.
+            sp.GetService<Tamma.Api.Services.Actions.ISoleUserProvider>()));
 
         // Story 32-15 — the persona/public prompt seam over the Epic 27 store.
         services.AddScoped<IPersonaPromptResolver, PersonaPromptResolver>();

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderCredentialServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ProviderCredentialServiceCollectionExtensions.cs
@@ -56,12 +56,21 @@ public static class ProviderCredentialServiceCollectionExtensions
         // shape so IRuntimeSecretResolver (the platform-key leg) is OPTIONAL:
         // single-user / no-secrets hosts may not have it registered, and the
         // resolver tolerates null (degrading the platform leg to "unset").
+        //
+        // 2026-08-13 (engine-driven E2E): IEventRepository is SCOPED, and this
+        // singleton's factory resolved it from the root provider — a captive
+        // dependency. Production silently promoted it (a single DbContext-backed
+        // repository living forever inside the singleton); a Development host
+        // (ValidateScopes) throws "Cannot resolve scoped service ... from root
+        // provider" on FIRST llm/call, 500ing the endpoint. The resolver keeps
+        // its singleton lifetime (the BYOK cache contract) and now audits
+        // through a scope-per-append adapter.
         services.TryAddSingleton<IProviderCredentialResolver>(sp =>
             new DefaultProviderCredentialResolver(
                 sp.GetRequiredService<ITenantProviderKeyReader>(),
                 sp.GetService<IRuntimeSecretResolver>(),
                 sp.GetRequiredService<IPlatformFallbackPolicy>(),
-                sp.GetRequiredService<IEventRepository>(),
+                new ScopePerCallEventRepository(sp.GetRequiredService<IServiceScopeFactory>()),
                 sp.GetRequiredService<ITammaModeProvider>(),
                 sp.GetRequiredService<ProviderAllowlist>(),
                 sp.GetRequiredService<ILogger<DefaultProviderCredentialResolver>>(),
@@ -71,5 +80,52 @@ public static class ProviderCredentialServiceCollectionExtensions
         services.TryAddSingleton<ProviderCredentialCacheInvalidator>();
 
         return services;
+    }
+
+    /// <summary>
+    /// 2026-08-13 — scope-per-call <see cref="IEventRepository"/> adapter for the
+    /// SINGLETON credential resolver (which only appends audit events). Each call
+    /// creates a DI scope, resolves the real scoped repository, and delegates —
+    /// the same pattern <c>TenantScheduledTriggerService</c> uses for its scoped
+    /// dependencies. Default-interface members (agent trail / time-travel reads)
+    /// are NOT forwarded: the resolver never calls them, and their defaults throw
+    /// loudly if that ever changes.
+    /// </summary>
+    private sealed class ScopePerCallEventRepository(IServiceScopeFactory scopes) : IEventRepository
+    {
+        private async Task<T> RunAsync<T>(Func<IEventRepository, Task<T>> call)
+        {
+            using var scope = scopes.CreateScope();
+            return await call(scope.ServiceProvider.GetRequiredService<IEventRepository>())
+                .ConfigureAwait(false);
+        }
+
+        public Task<Tamma.Data.Entities.DomainEvent> AppendAsync(Tamma.Data.Entities.DomainEvent evt)
+            => RunAsync(r => r.AppendAsync(evt));
+
+        public Task<Tamma.Data.Entities.DomainEvent?> GetByIdAsync(Guid id)
+            => RunAsync(r => r.GetByIdAsync(id));
+
+        public Task<List<Tamma.Data.Entities.DomainEvent>> QueryAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit)
+            => RunAsync(r => r.QueryAsync(tenantId, type, issueNumber, limit));
+
+        public Task<Tamma.Data.Entities.DomainEvent?> GetLastByTypeAsync(Guid tenantId, string type)
+            => RunAsync(r => r.GetLastByTypeAsync(tenantId, type));
+
+        public async Task ClearAsync(Guid tenantId)
+        {
+            using var scope = scopes.CreateScope();
+            await scope.ServiceProvider.GetRequiredService<IEventRepository>()
+                .ClearAsync(tenantId).ConfigureAwait(false);
+        }
+
+        public Task<(IReadOnlyList<Tamma.Data.Entities.DomainEvent> Events, int Total)> QueryWithPaginationAsync(
+            Guid? tenantId, string? type, int? issueNumber, int limit, int offset)
+            => RunAsync(r => r.QueryWithPaginationAsync(tenantId, type, issueNumber, limit, offset));
+
+        public Task<(IReadOnlyList<Tamma.Data.Entities.DomainEvent> Events, int Total)> ListByTenantAsync(
+            Guid tenantId, string? typePrefix, int limit, int offset)
+            => RunAsync(r => r.ListByTenantAsync(tenantId, typePrefix, limit, offset));
     }
 }

--- a/apps/tamma-elsa/src/Tamma.Api/Extensions/ScriptedLlmProviderServiceCollectionExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Extensions/ScriptedLlmProviderServiceCollectionExtensions.cs
@@ -1,0 +1,108 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.Agents.Scripted;
+
+namespace Tamma.Api.Extensions;
+
+/// <summary>
+/// 2026-08-13 (Epic 31 P5 follow-up) — registration for the opt-in "scripted"
+/// LLM provider, the deterministic in-process test provider that unblocks the
+/// engine-driven autonomous E2E.
+///
+/// <para><b>Structural posture</b> (see <see cref="ScriptedProviderPosture"/>):
+/// <list type="bullet">
+///   <item>Flag off (the default) ⇒ this method is a NO-OP: no responder, no
+///   allowlist widening, no credential decorator — the host is byte-identical
+///   to before this feature existed.</item>
+///   <item>Flag on + any SaaS/production signal ⇒ the host REFUSES TO START
+///   (<see cref="ScriptedProviderPosture.AssertAllowed"/> throws).</item>
+///   <item>Flag on, non-production ⇒ registers the responder, adds "scripted"
+///   to the DI allowlist options (the credential resolver's fail-closed
+///   allowlist check), and wraps the credential resolver so "scripted"
+///   resolves a placeholder key (the responder is in-process — no key exists
+///   or is ever sent anywhere).</item>
+/// </list></para>
+///
+/// <para>Call AFTER <see cref="ProviderCredentialServiceCollectionExtensions.AddProviderCredentialResolution"/>
+/// — the credential decorator wraps whatever resolver registration exists at
+/// call time (asserted, fail-loud).</para>
+/// </summary>
+public static class ScriptedLlmProviderServiceCollectionExtensions
+{
+    public static IServiceCollection AddScriptedLlmProvider(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        // Off (default) ⇒ no-op. On + production signal ⇒ THROWS (refuse to start).
+        if (!ScriptedProviderPosture.AssertAllowed(configuration))
+        {
+            return services;
+        }
+
+        // Optional per-test script overrides — fail-loud on a bad path.
+        var scriptPath = configuration[$"{ScriptedLlmProviderOptions.SectionName}:ScriptPath"];
+        var overrides = string.IsNullOrWhiteSpace(scriptPath)
+            ? null
+            : ScriptedLlmResponder.LoadOverrides(scriptPath);
+
+        services.AddSingleton<IScriptedLlmResponder>(sp => new ScriptedLlmResponder(
+            overrides, sp.GetService<ILogger<ScriptedLlmResponder>>()));
+
+        // Allow-list the key on THIS host only (DI options — the shipped
+        // ProviderAllowlist.DefaultProviders set is never touched).
+        services.PostConfigure<ProviderAllowlistOptions>(o =>
+        {
+            if (!o.AdditionalProviders.Contains(
+                    ScriptedProviderPosture.ProviderKey, StringComparer.OrdinalIgnoreCase))
+            {
+                o.AdditionalProviders.Add(ScriptedProviderPosture.ProviderKey);
+            }
+        });
+
+        // Wrap the already-registered credential resolver: "scripted" answers a
+        // placeholder credential; every other provider delegates untouched.
+        var inner = services.LastOrDefault(d =>
+            d.ServiceType == typeof(IProviderCredentialResolver));
+        if (inner is null)
+        {
+            throw new InvalidOperationException(
+                "AddScriptedLlmProvider must be called AFTER AddProviderCredentialResolution — " +
+                "no IProviderCredentialResolver registration found to decorate.");
+        }
+
+        services.Remove(inner);
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IProviderCredentialResolver),
+            sp => new ScriptedProviderCredentialResolver(
+                (IProviderCredentialResolver)CreateInner(sp, inner)),
+            inner.Lifetime));
+
+        return services;
+    }
+
+    private static object CreateInner(IServiceProvider sp, ServiceDescriptor inner)
+    {
+        if (inner.ImplementationInstance is not null)
+        {
+            return inner.ImplementationInstance;
+        }
+
+        if (inner.ImplementationFactory is not null)
+        {
+            return inner.ImplementationFactory(sp);
+        }
+
+        if (inner.ImplementationType is not null)
+        {
+            return ActivatorUtilities.CreateInstance(sp, inner.ImplementationType);
+        }
+
+        throw new InvalidOperationException(
+            "IProviderCredentialResolver registration has no implementation to decorate.");
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Middleware/EnsurePersonalTenantMiddleware.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Middleware/EnsurePersonalTenantMiddleware.cs
@@ -84,12 +84,6 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
             return;
         }
 
-        if (context.User.Identity?.IsAuthenticated != true)
-        {
-            await next(context);
-            return;
-        }
-
         // Already has tenant? Continue
         if (tenantContext.TenantId.HasValue)
         {
@@ -97,12 +91,100 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
             return;
         }
 
-        if (context.User.GetUserId() is not Guid userId)
+        Guid userId;
+        var claimsLess = false;
+        if (context.User.Identity?.IsAuthenticated == true
+            && context.User.GetUserId() is Guid claimUserId)
+        {
+            userId = claimUserId;
+        }
+        else if (modeProvider.Mode == TammaMode.SingleUser)
+        {
+            claimsLess = true;
+            // 2026-08-13 (engine-driven E2E, single-user mode-awareness):
+            // service-plane calls (the engine's Tamma:ApiToken mediation
+            // requests — llm/call, git callbacks, event drain) carry NO user
+            // claim, so the old IsAuthenticated gate left them tenant-less
+            // FOREVER, and every tenant-resident read they trigger
+            // (acceptance_rules_overrides via the 43-x autonomy gate,
+            // document instances, conventions overrides) threw "requires an
+            // ambient tenant id" — the autonomy gate then failed CLOSED and
+            // every engine LLM call answered 500. In single-user mode the
+            // principal of a service call IS the sole user (the same
+            // resolution SoleUserProvider gives the gate itself), so bind —
+            // and if need be mint — their personal tenant here, exactly like
+            // a first authenticated dashboard request would. SaaS behavior
+            // is untouched (the mode short-circuit above). Pre-setup
+            // deployments (no resolvable sole user / no users row) fall
+            // through tenant-less as before.
+            var soleUsers = context.RequestServices
+                .GetService<Tamma.Api.Services.Actions.ISoleUserProvider>();
+            if (soleUsers is null)
+            {
+                await next(context);
+                return;
+            }
+            try
+            {
+                userId = await soleUsers.GetSoleUserIdAsync(context.RequestAborted);
+            }
+            catch
+            {
+                // No configured owner and no users row — pre-setup deployment.
+                await next(context);
+                return;
+            }
+        }
+        else
         {
             await next(context);
             return;
         }
 
+        if (claimsLess)
+        {
+            // The CLAIMS-LESS (service-plane) binding is best-effort and MUST
+            // be invisible to hosts where it cannot work: auth-pipeline pins
+            // ("401 without the handler being reached") run against fixtures
+            // with no reachable database, and a thrown DbException here would
+            // convert their expected 401 into a 500. Any failure ⇒ proceed
+            // tenant-less, exactly as before this branch existed.
+            try
+            {
+                await BindOrMintAsync(
+                    context, tenantContext, tenantRepo, membershipRepo, userRepo, events,
+                    logger, userId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex,
+                    "Single-user service-plane tenant binding unavailable; proceeding tenant-less");
+            }
+        }
+        else
+        {
+            // The authenticated first-login path keeps its established
+            // failure contract: a provisioning failure PROPAGATES (an
+            // unprovisioned tenant cannot access tenant data — failing the
+            // first request with the real error beats a broken half-tenant).
+            await BindOrMintAsync(
+                context, tenantContext, tenantRepo, membershipRepo, userRepo, events,
+                logger, userId);
+        }
+
+        await next(context);
+    }
+
+    private async Task BindOrMintAsync(
+        HttpContext context,
+        ITenantContext tenantContext,
+        ITenantRepository tenantRepo,
+        ITenantMembershipRepository membershipRepo,
+        IUserRepository userRepo,
+        IEventRepository events,
+        ILogger<EnsurePersonalTenantMiddleware> logger,
+        Guid userId)
+    {
         // Existing-membership path
         var memberships = await membershipRepo.GetUserTenantsAsync(userId);
         if (memberships.Count > 0)
@@ -123,15 +205,52 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
                 logger.LogWarning(ex, "Failed to persist active tenant for user {UserId}", userId);
             }
 
-            await next(context);
             return;
         }
 
-        // Auto-create personal tenant path
+        // Auto-create personal tenant path. Serialized: service-plane calls
+        // (the single-user binding above) arrive in PARALLEL bursts from the
+        // engine, and two concurrent minters would create two personal tenants
+        // for the same sole user (the slug-retry loop happily side-steps the
+        // collision). One mints; the rest re-check and bind. The lock is
+        // RELEASED before the downstream pipeline runs.
+        await MintLock.WaitAsync(context.RequestAborted);
+        try
+        {
+            var remint = await membershipRepo.GetUserTenantsAsync(userId);
+            if (remint.Count > 0)
+            {
+                var won = remint.OrderByDescending(m => m.JoinedAt).First().TenantId;
+                tenantContext.SetTenantId(won);
+            }
+            else
+            {
+                await MintPersonalTenantAsync(
+                    context, tenantContext, tenantRepo, membershipRepo, userRepo, events,
+                    logger, userId);
+            }
+        }
+        finally
+        {
+            MintLock.Release();
+        }
+    }
+
+    private static readonly SemaphoreSlim MintLock = new(1, 1);
+
+    private async Task MintPersonalTenantAsync(
+        HttpContext context,
+        ITenantContext tenantContext,
+        ITenantRepository tenantRepo,
+        ITenantMembershipRepository membershipRepo,
+        IUserRepository userRepo,
+        IEventRepository events,
+        ILogger<EnsurePersonalTenantMiddleware> logger,
+        Guid userId)
+    {
         var user = await userRepo.GetByIdAsync(userId);
         if (user is null)
         {
-            await next(context);
             return;
         }
 
@@ -147,7 +266,6 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
             {
                 logger.LogError(
                     "Failed to generate unique personal tenant slug for user {UserId}", userId);
-                await next(context);
                 return;
             }
         }
@@ -161,10 +279,6 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
             OwnerId = userId,
         });
 
-        await membershipRepo.AddAsync(tenant.Id, userId, "owner");
-        await userRepo.UpdateActiveTenantAsync(userId, tenant.Id);
-        tenantContext.SetTenantId(tenant.Id);
-
         // Unified-tenancy Phase 3: the personal tenant is provisioned
         // synchronously (placement → role → schema → minted connection string →
         // migrations) so it is a first-class tenant from its first request.
@@ -172,9 +286,24 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
         // fallback) is gone — an unprovisioned tenant cannot access tenant
         // data at all, so failing the first request with the real error
         // beats limping on with a broken half-tenant.
+        //
+        // 2026-08-13 (engine-driven E2E): provision BEFORE the membership /
+        // users.tenant_id / ambient binding. The old order persisted
+        // users.tenant_id first, so PARALLEL requests resolved the tenant via
+        // TenantContextMiddleware source (4) mid-provision and threw
+        // TenantConnectionStringMissingException ("marked active but has no
+        // encrypted connection string") until the envelope landed; a provision
+        // FAILURE then left a permanently broken half-bound tenant. Now nothing
+        // points at the tenant until it is fully provisioned, and a failed
+        // provision leaves only an unreferenced row (the retry mints a fresh
+        // slug-suffixed tenant).
         var provisioning = context.RequestServices
             .GetRequiredService<ITenantProvisioningService>();
         await provisioning.ProvisionAsync(tenant.Id, context.RequestAborted);
+
+        await membershipRepo.AddAsync(tenant.Id, userId, "owner");
+        await userRepo.UpdateActiveTenantAsync(userId, tenant.Id);
+        tenantContext.SetTenantId(tenant.Id);
 
         // Story 32-16 (AC10) — seed the fresh single-user principal with the
         // platform default persona enabled (insert-missing-only) so the catalog
@@ -206,8 +335,6 @@ public class EnsurePersonalTenantMiddleware(RequestDelegate next)
         {
             logger.LogWarning(ex, "Failed to emit TENANT.AUTO_CREATED for user {UserId}", userId);
         }
-
-        await next(context);
     }
 
     private static async Task EmitEvent(

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -624,6 +624,15 @@ if (!string.IsNullOrWhiteSpace(
 // of provider-key resolution into the LLM call path (CallLlmInlineActivity).
 builder.Services.AddProviderCredentialResolution();
 
+// 2026-08-13 (Epic 31 P5 follow-up) — the OPT-IN scripted LLM provider (the
+// deterministic in-process test provider behind the engine-driven autonomous
+// E2E). Default: a NO-OP (flag off). Llm:EnableScriptedProvider=true on a
+// host carrying any SaaS/production signal REFUSES TO START (structural
+// guard, ScriptedProviderPosture). Must run AFTER
+// AddProviderCredentialResolution (it decorates the resolver so "scripted"
+// needs no key).
+builder.Services.AddScriptedLlmProvider(builder.Configuration);
+
 // Epic 46 — the live model-listing seam (46-0: IProviderModelCatalog — one
 // fetch/normalize/cache service behind the admin + tenant models routes) and
 // the persisted provider-settings store (46-1: IProviderSettingsStore — the

--- a/apps/tamma-elsa/src/Tamma.Api/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Program.cs
@@ -1138,30 +1138,37 @@ builder.Services.AddRateLimiter(options =>
 {
     options.RejectionStatusCode = 429;
 
+    // 2026-08-13 (engine-driven E2E): the four generic policies are
+    // config-overridable (shipped defaults unchanged). The engine's OWN
+    // mediated traffic (agent-config resolves — one per llm-call) rides
+    // "ConfigRead"; a busy autonomous cycle (7-role review panels × rounds)
+    // exceeds 100/min and the engine then churns retries against 429s. A
+    // single-box deployment can raise RateLimits:ConfigRead rather than
+    // throttling its own engine.
     options.AddFixedWindowLimiter("ConfigRead", o =>
     {
-        o.PermitLimit = 100;
+        o.PermitLimit = builder.Configuration.GetValue("RateLimits:ConfigRead", 100);
         o.Window = TimeSpan.FromMinutes(1);
         o.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
         o.QueueLimit = 0;
     });
     options.AddFixedWindowLimiter("ConfigWrite", o =>
     {
-        o.PermitLimit = 30;
+        o.PermitLimit = builder.Configuration.GetValue("RateLimits:ConfigWrite", 30);
         o.Window = TimeSpan.FromMinutes(1);
         o.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
         o.QueueLimit = 0;
     });
     options.AddFixedWindowLimiter("ProviderIngest", o =>
     {
-        o.PermitLimit = 500;
+        o.PermitLimit = builder.Configuration.GetValue("RateLimits:ProviderIngest", 500);
         o.Window = TimeSpan.FromMinutes(1);
         o.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
         o.QueueLimit = 0;
     });
     options.AddFixedWindowLimiter("ProviderExecute", o =>
     {
-        o.PermitLimit = 50;
+        o.PermitLimit = builder.Configuration.GetValue("RateLimits:ProviderExecute", 50);
         o.Window = TimeSpan.FromMinutes(1);
         o.QueueProcessingOrder = System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst;
         o.QueueLimit = 0;

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Actions/BackgroundActionGate.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Actions/BackgroundActionGate.cs
@@ -1,4 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Tamma.Api.Services.PromptStore;
+using Tamma.Data;
+using Tamma.Data.Repositories;
 using Tamma.Core.Actions;
 
 namespace Tamma.Api.Services.Actions;
@@ -110,6 +113,25 @@ public sealed class BackgroundActionGate : IBackgroundActionGate
                 return true;
             }
 
+            // 2026-08-14 (engine-driven E2E): a background tick has no HTTP
+            // scope, so EnsurePersonalTenantMiddleware never ran and the
+            // ambient tenant was NULL. In single-user mode every tenant-
+            // resident read the gate performs (acceptance_rules_overrides)
+            // then threw "requires an ambient tenant id", the gate CORRECTLY
+            // read that as unreadable policy and denied, and so EVERY
+            // background actor in a single-user deployment was gated off
+            // permanently (outbox sender, task-queue processor, ...) while
+            // logging an error per tick. Bind the sole user's existing
+            // personal tenant for this scope — the same seam the middleware
+            // uses. Read-only on purpose: minting a tenant belongs to a user
+            // request, so a pre-setup deployment still behaves as before.
+            if (tenantId is null)
+            {
+                await TryBindSingleUserTenantAsync(scope.ServiceProvider, deadline.Token)
+                    .ConfigureAwait(false);
+                tenantId = scope.ServiceProvider.GetService<ITenantContext>()?.TenantId;
+            }
+
             var principal = tenantId is Guid tid
                 ? GovernancePrincipal.ForTenant(tid)
                 : GovernancePrincipal.Platform;
@@ -164,6 +186,42 @@ public sealed class BackgroundActionGate : IBackgroundActionGate
 
             await TryEmitEvaluationFailedAsync(key, ex).ConfigureAwait(false);
             return true;
+        }
+    }
+
+    /// <summary>
+    /// Single-user only: bind the sole user's EXISTING personal tenant onto this
+    /// scope so the gate's tenant-resident policy reads have a home. Silent and
+    /// best-effort by design — every failure mode (SaaS, pre-setup, no
+    /// membership, missing seam) simply leaves the scope tenant-less, which is
+    /// exactly the behaviour that shipped before this bind existed.
+    /// </summary>
+    private static async Task TryBindSingleUserTenantAsync(
+        IServiceProvider services, CancellationToken ct)
+    {
+        try
+        {
+            var mode = services.GetService<ITammaModeProvider>();
+            if (mode is null || mode.Mode != TammaMode.SingleUser) return;
+
+            var tenantContext = services.GetService<ITenantContext>();
+            if (tenantContext is null || tenantContext.TenantId is not null) return;
+
+            var soleUsers = services.GetService<ISoleUserProvider>();
+            var memberships = services.GetService<ITenantMembershipRepository>();
+            if (soleUsers is null || memberships is null) return;
+
+            var userId = await soleUsers.GetSoleUserIdAsync(ct).ConfigureAwait(false);
+            var owned = await memberships.GetUserTenantsAsync(userId).ConfigureAwait(false);
+            if (owned.Count == 0) return;
+
+            tenantContext.SetTenantId(owned.OrderByDescending(m => m.JoinedAt).First().TenantId);
+        }
+        catch
+        {
+            // Pre-setup deployment (no owner configured / no users row), or any
+            // other resolution failure: leave the scope tenant-less. The gate's
+            // own fail-closed posture then applies unchanged.
         }
     }
 

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/AgentRegistryService.cs
@@ -51,7 +51,8 @@ public sealed class AgentRegistryService : IAgentRegistryService
         IHttpContextAccessor httpContext,
         IOptions<DefaultPersonaOptions>? defaultPersona = null,
         ITenantAgentEnablementReader? enablement = null,
-        ILogger<AgentRegistryService>? logger = null)
+        ILogger<AgentRegistryService>? logger = null,
+        Tamma.Api.Services.Actions.ISoleUserProvider? soleUsers = null)
     {
         _agents = agents;
         _selections = selections;
@@ -62,7 +63,19 @@ public sealed class AgentRegistryService : IAgentRegistryService
         _defaultPersona = defaultPersona?.Value ?? new DefaultPersonaOptions();
         _enablement = enablement;
         _logger = logger;
+        _soleUsers = soleUsers;
     }
+
+    // 2026-08-13 (engine-driven E2E, single-user mode-awareness): the service
+    // plane (the engine's Tamma:ApiToken mediation calls) carries no user
+    // claim, so claims-only principal resolution answered (null, null) in
+    // single-user mode — while the 43-x autonomy gate resolved the SAME
+    // request's principal to the sole user via ISoleUserProvider. The split
+    // meant the gate evaluated user X but the enablement read looked up
+    // NOBODY, so the seeded default-persona enablement was invisible and every
+    // engine LLM call failed AGENT_UNRESOLVED. Single-user claims-less
+    // resolution now falls back to the same sole-user seam the gate uses.
+    private readonly Tamma.Api.Services.Actions.ISoleUserProvider? _soleUsers;
 
     /// <inheritdoc />
     public (Guid? TenantId, Guid? UserId) ResolvePrincipal()
@@ -299,7 +312,29 @@ public sealed class AgentRegistryService : IAgentRegistryService
     // ── helpers ──
 
     private Guid? CurrentUserId()
-        => _httpContext.HttpContext?.User?.GetUserId();
+    {
+        var fromClaims = _httpContext.HttpContext?.User?.GetUserId();
+        if (fromClaims is not null || _mode.Mode == TammaMode.SaaS || _soleUsers is null)
+        {
+            return fromClaims;
+        }
+
+        // Single-user, no user claim (service-plane call): the principal IS the
+        // sole user — the same resolution the autonomy gate applies to this
+        // request. SoleUserProvider caches its success, so the sync bridge
+        // blocks at most once per process (config-first resolution never
+        // blocks at all).
+        try
+        {
+            return _soleUsers.GetSoleUserIdAsync().GetAwaiter().GetResult();
+        }
+        catch
+        {
+            // Pre-setup deployment (no owner configured, users table empty) —
+            // behave exactly as before this fallback existed.
+            return null;
+        }
+    }
 
     /// <summary>The calling principal as the 32-15/32-16 <see cref="Principal"/>
     /// record (exactly one of TenantId / UserId set per the mode).</summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
@@ -60,6 +60,11 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
     private readonly IProviderSettingsStore? _settingsStore;
     private readonly Tamma.Api.Services.Actions.ActionGateEventsService? _actionGateEvents;
     private readonly ToolLoopAuthorizationBroker? _authorizationBroker;
+    // 2026-08-13 — the opt-in in-process "scripted" provider seam. Registered
+    // ONLY when Llm:EnableScriptedProvider=true on a non-production host
+    // (AddScriptedLlmProvider); null everywhere else ⇒ the dispatch below is
+    // byte-identical to before the seam existed.
+    private readonly Scripted.IScriptedLlmResponder? _scriptedResponder;
 
     public InlineToolLoopRunner(
         ILogger<InlineToolLoopRunner>? logger,
@@ -91,7 +96,11 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
         // (registration decides): with it, a Seam B denial first checks whether a
         // correlation-standing grant already covers the run (one shell ask per run,
         // not per call). The sync gate above stays REQUIRED and untouched.
-        ToolLoopAuthorizationBroker? authorizationBroker = null)
+        ToolLoopAuthorizationBroker? authorizationBroker = null,
+        // 2026-08-13 — the opt-in scripted-provider responder. Optional
+        // trailing arg (the established pattern) so every existing composition
+        // is untouched; DI supplies it only when the flag is on.
+        Scripted.IScriptedLlmResponder? scriptedResponder = null)
     {
         _logger = logger;
         _httpClientFactory = httpClientFactory;
@@ -113,6 +122,7 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
         _settingsStore = settingsStore;
         _actionGateEvents = actionGateEvents;
         _authorizationBroker = authorizationBroker;
+        _scriptedResponder = scriptedResponder;
     }
 
     /// <inheritdoc />
@@ -232,12 +242,16 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
                         loopConfig.CompactionThreshold,
                         async (prompt, ct) =>
                         {
-                            // Make a single-turn summarization LLM call using the same provider
-                            var summaryResponse = dialect == ProviderWireDialect.Anthropic
-                                ? await CallAnthropicMessages(httpClient, providerConfig, model,
-                                    "You are a precise conversation summarizer.", prompt, 2048, 0.3, null)
-                                : await CallOpenAiCompatible(httpClient, providerConfig, model,
-                                    "You are a precise conversation summarizer.", prompt, 2048, 0.3, null);
+                            // Make a single-turn summarization LLM call using the same provider.
+                            // The scripted provider (2026-08-13) intercepts here too — a scripted
+                            // run must never open an HTTP socket, compaction included.
+                            var summaryResponse =
+                                TryScripted(providerName, providerConfig, model, repair, workflowInstanceId)
+                                ?? (dialect == ProviderWireDialect.Anthropic
+                                    ? await CallAnthropicMessages(httpClient, providerConfig, model,
+                                        "You are a precise conversation summarizer.", prompt, 2048, 0.3, null)
+                                    : await CallOpenAiCompatible(httpClient, providerConfig, model,
+                                        "You are a precise conversation summarizer.", prompt, 2048, 0.3, null));
 
                             return summaryResponse.Success ? summaryResponse.ResponseText : null;
                         },
@@ -252,10 +266,20 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
                 }
             }
 
-            // Call LLM with full conversation history
+            // Call LLM with full conversation history. The opt-in scripted
+            // provider (2026-08-13) intercepts BEFORE the wire dialects: when
+            // the responder is registered AND this provider is "scripted", the
+            // deterministic in-process response stands in for the HTTP call —
+            // everything else in the loop (validation ring, token accounting,
+            // events) runs identically.
             var llmSw = System.Diagnostics.Stopwatch.StartNew();
             NormalizedLlmResponse response;
-            if (dialect == ProviderWireDialect.Anthropic)
+            var scripted = TryScripted(providerName, providerConfig, model, repair, workflowInstanceId);
+            if (scripted is not null)
+            {
+                response = scripted;
+            }
+            else if (dialect == ProviderWireDialect.Anthropic)
             {
                 response = await CallAnthropicMultiTurn(
                     httpClient, providerConfig, model, messages, maxTokens, temperature, tools);
@@ -749,11 +773,13 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
                 // execution). Same client/config/tools declarations (Anthropic
                 // requires the tools when history carries tool blocks). Repair turns
                 // NEVER touch loopConfig.MaxSteps / completedTurns.
-                var repairResponse = dialect == ProviderWireDialect.Anthropic
-                    ? await CallAnthropicMultiTurn(
-                        httpClient, providerConfig, model, messages, maxTokens, temperature, tools)
-                    : await CallOpenAiMultiTurn(
-                        httpClient, providerConfig, model, messages, maxTokens, temperature, tools);
+                var repairResponse =
+                    TryScripted(providerName, providerConfig, model, repair, workflowInstanceId)
+                    ?? (dialect == ProviderWireDialect.Anthropic
+                        ? await CallAnthropicMultiTurn(
+                            httpClient, providerConfig, model, messages, maxTokens, temperature, tools)
+                        : await CallOpenAiMultiTurn(
+                            httpClient, providerConfig, model, messages, maxTokens, temperature, tools));
 
                 repairTurns++;
 
@@ -818,6 +844,33 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
         return $"Tool call denied by autonomy policy: '{toolName}'"
             + (decision.ActionKey is { } k ? $" (action '{k.ToWire()}')" : string.Empty)
             + $" {detail}. This action cannot run automatically; continue without it.";
+    }
+
+    /// <summary>
+    /// 2026-08-13 — the scripted-provider dispatch guard. Returns the
+    /// deterministic in-process response when (a) the responder is registered
+    /// (opt-in flag on a non-production host) AND (b) this call's provider is
+    /// the scripted key; null otherwise, in which case the caller proceeds to
+    /// the real wire dialects untouched. The response is keyed on the call's
+    /// (role, action) — stamped onto the provider config by ManagedAgent —
+    /// plus the 39-9 repair plan's document-type key.
+    /// </summary>
+    private NormalizedLlmResponse? TryScripted(
+        string providerName, LlmProviderConfig providerConfig, string model,
+        RepairRingPlan? repair, string correlationId)
+    {
+        if (_scriptedResponder is null || !_scriptedResponder.CanHandle(providerName))
+        {
+            return null;
+        }
+
+        return _scriptedResponder.Respond(new Scripted.ScriptedLlmCall(
+            providerName,
+            providerConfig.CallRole,
+            providerConfig.CallAction,
+            repair?.DocumentTypeKey,
+            model,
+            correlationId));
     }
 
     // =======================================================================

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/InlineToolLoopRunner.cs
@@ -2,6 +2,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Tamma.Activities.LlmCall;
 using Tamma.Activities.LlmCall.Credentials;
@@ -1322,6 +1323,22 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
     /// config → descriptor). With no settings store wired — or no rows saved —
     /// the output is byte-identical to the pre-46-1 resolution.
     /// </summary>
+    private ProviderAllowlist? _allowlist;
+
+    /// <summary>
+    /// The allowlist bound from <c>Security:ProviderAllowlist</c>, cached for
+    /// the runner's lifetime. Falls back to the built-in defaults when no
+    /// configuration is present (the pre-2026-08-14 behaviour).
+    /// </summary>
+    private ProviderAllowlist ResolveAllowlist()
+    {
+        if (_allowlist is not null) return _allowlist;
+
+        var options = new ProviderAllowlistOptions();
+        _configuration?.GetSection("Security:ProviderAllowlist").Bind(options);
+        return _allowlist = new ProviderAllowlist(Options.Create(options));
+    }
+
     internal LlmProviderConfig LoadProviderConfig(string providerName, Guid? tenantId)
     {
         // F5 — the allowlist carries CANONICAL keys only; catalogue aliases
@@ -1334,8 +1351,15 @@ public sealed class InlineToolLoopRunner : IInlineToolLoopRunner
             ?? ProviderCatalog.ResolveNonHttp(providerName)?.Key
             ?? providerName;
 
-        // Validate the canonical provider name against the allowlist
-        if (!ProviderAllowlist.IsAllowedDefault(canonicalName))
+        // Validate the canonical provider name against the allowlist.
+        // 2026-08-14 (engine-driven E2E): this used the CONFIG-BLIND static
+        // helper, so `Security:ProviderAllowlist:AdditionalProviders` — the
+        // documented extension point for self-hosted/custom providers — was
+        // dead on the main LLM path: a configured provider passed selection
+        // and then got rejected here, and the caller silently fell back to the
+        // platform default. Bind the configured allowlist instead (built once;
+        // the defaults still apply when nothing is configured).
+        if (!ResolveAllowlist().IsAllowed(canonicalName))
         {
             _logger?.LogWarning("Provider '{Provider}' is not in the allowlist, rejecting", providerName);
             return new LlmProviderConfig { Name = providerName, Enabled = false };

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/ManagedAgent.cs
@@ -310,6 +310,11 @@ public sealed class ManagedAgent : IManagedAgent
             {
                 Name = ctx.Provider,
                 ApiKey = credential.ApiKey, // request-scoped; dropped after the call
+                // 2026-08-13 — call identity keys for the opt-in scripted
+                // provider (deterministic response selection). Ignored by every
+                // HTTP provider; never serialized onto a wire body.
+                CallRole = request.Role,
+                CallAction = request.Action,
             };
 
             // ── Story 39-9 — build the deterministic repair-ring plan (AC1/AC9). ──

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/IScriptedLlmResponder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/IScriptedLlmResponder.cs
@@ -1,0 +1,49 @@
+using Tamma.Activities.LlmCall.Models;
+
+namespace Tamma.Api.Services.Agents.Scripted;
+
+/// <summary>
+/// One scripted LLM call as the tool-loop runner sees it (2026-08-13, the
+/// Epic 31 P5 LLM stub). The runner supplies the call's identity keys —
+/// <see cref="Role"/> / <see cref="Action"/> ride the provider config
+/// (<see cref="LlmProviderConfig.CallRole"/> / <see cref="LlmProviderConfig.CallAction"/>,
+/// stamped by <c>ManagedAgent</c>), <see cref="DocumentType"/> comes from the
+/// 39-9 repair plan when the wire request named one.
+/// </summary>
+/// <param name="Provider">The provider key ("scripted").</param>
+/// <param name="Role">Agent role wire token (e.g. "architect"); may be null.</param>
+/// <param name="Action">Role+action wire token (e.g. "plan-system-design"); may be null.</param>
+/// <param name="DocumentType">Document-type wire key the produced text must validate
+/// against (e.g. "plan"); null/empty when the call carries no typed document.</param>
+/// <param name="Model">Requested model id (informational only).</param>
+/// <param name="CorrelationId">Workflow correlation id (informational only).</param>
+public sealed record ScriptedLlmCall(
+    string Provider,
+    string? Role,
+    string? Action,
+    string? DocumentType,
+    string Model,
+    string CorrelationId);
+
+/// <summary>
+/// The in-process seam behind the opt-in "scripted" provider: deterministic
+/// canned responses keyed on (role, action, document-type), so the engine's
+/// cycle steps that think through <c>POST /api/v1/llm/call</c> can run with no
+/// network LLM at all. Registered ONLY when <c>Llm:EnableScriptedProvider=true</c>
+/// on a non-production host (see <c>ScriptedProviderPosture</c>); when absent,
+/// <c>InlineToolLoopRunner</c>'s behaviour is byte-identical to before.
+/// </summary>
+public interface IScriptedLlmResponder
+{
+    /// <summary>Whether this responder serves <paramref name="provider"/>
+    /// (the canonical "scripted" key or an alias).</summary>
+    bool CanHandle(string? provider);
+
+    /// <summary>
+    /// Produce the deterministic response for <paramref name="call"/>. NEVER
+    /// throws: an unscripted cell returns a FAILED response whose
+    /// <see cref="NormalizedLlmResponse.ErrorMessage"/> names the missing
+    /// script key(s) (a clear typed error, not a silent default).
+    /// </summary>
+    NormalizedLlmResponse Respond(ScriptedLlmCall call);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
@@ -38,6 +38,19 @@ public static class ScriptedCycleLibrary
     public const string ApproveReviewVerdict =
         """{"verdict":"approve","comments":"Scripted review: no blocking issues found; the artifact satisfies its contract.","suggestedChanges":"","issues":[]}""";
 
+    /// <summary>
+    /// 2026-08-13 (engine-driven E2E) — the CANONICAL approving Review, used
+    /// for every 39-7 PANEL reviewer cell. Reviewer llm-calls now declare
+    /// <c>documentType="review"</c> (SingleReviewerWorkflow — the call
+    /// produces a Review), so the API's 39-9 content-validation ring
+    /// validates the reply against the REVIEW registry validator, which the
+    /// legacy verdict shape does not satisfy. The subject is placeholder
+    /// data: 39-7's MapReviewerReply overrides it with the caller's
+    /// authoritative subject.
+    /// </summary>
+    public const string CanonicalReviewApprove =
+        """{"subject":{"kind":"document","documentId":"0192a8b0-0000-7abc-8def-00000000e2e0","documentType":"plan"},"decision":"approve","summary":"Scripted review: approved with no blocking issues.","issues":[]}""";
+
     /// <summary>Deploy/rollback stage reply — DeploymentPipelineWorkflow's
     /// ExtractStageResult is fail-closed and requires an explicit
     /// <c>status:"success"</c>.</summary>
@@ -70,17 +83,19 @@ public static class ScriptedCycleLibrary
             ["architect/context-scan"] = ContextScanFindings,
             ["product_owner/summarize-stakeholder"] = PoSummary,
 
-            // ── review cells (task review + the 39-7 reviewer panel roster;
-            //    one legacy-verdict approval serves both consumers) ──
-            ["architect/plan-review"] = ApproveReviewVerdict,
-            ["senior_developer/plan-review"] = ApproveReviewVerdict,
-            ["security/plan-review-security"] = ApproveReviewVerdict,
-            ["developer/review-feasibility"] = ApproveReviewVerdict,
-            ["tester/review-testability"] = ApproveReviewVerdict,
-            ["devops/review-operability"] = ApproveReviewVerdict,
-            ["product_owner/review-scope"] = ApproveReviewVerdict,
-            ["tech_writer/review-docs"] = ApproveReviewVerdict,
-            ["ux_designer/review-design"] = ApproveReviewVerdict,
+            // ── the 39-7 reviewer PANEL roster: CANONICAL Review approvals —
+            //    these calls declare documentType="review" and the 39-9 ring
+            //    validates them against the Review registry validator
+            //    (2026-08-13; the legacy verdict shape fails that ring) ──
+            ["architect/plan-review"] = CanonicalReviewApprove,
+            ["senior_developer/plan-review"] = CanonicalReviewApprove,
+            ["security/plan-review-security"] = CanonicalReviewApprove,
+            ["developer/review-feasibility"] = CanonicalReviewApprove,
+            ["tester/review-testability"] = CanonicalReviewApprove,
+            ["devops/review-operability"] = CanonicalReviewApprove,
+            ["product_owner/review-scope"] = CanonicalReviewApprove,
+            ["tech_writer/review-docs"] = CanonicalReviewApprove,
+            ["ux_designer/review-design"] = CanonicalReviewApprove,
 
             // ── code review + guidance (CodeReviewWorkflow stores the text) ──
             ["senior_developer/code-review"] = ApproveReviewVerdict,
@@ -109,8 +124,7 @@ public static class ScriptedCycleLibrary
             //    subject is placeholder data: every consumer (39-7's
             //    MapReviewerReply) overrides it with the caller's authoritative
             //    subject. ──
-            ["@review"] =
-                """{"subject":{"kind":"document","documentId":"0192a8b0-0000-7abc-8def-00000000e2e0","documentType":"plan"},"decision":"approve","summary":"Scripted review: approved with no blocking issues.","issues":[]}""",
+            ["@review"] = CanonicalReviewApprove,
         };
 
     /// <summary>

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
@@ -62,6 +62,42 @@ public static class ScriptedCycleLibrary
     public const string PoSummary =
         """{"summary":"Scripted PO summary: implement the seeded issue exactly as titled; scope is a single small change with tests.","links":[]}""";
 
+    // ── TDD single-shot cells (2026-08-13, engine-driven E2E run 34) ─────
+    // MediatedLlmText now threads the taxonomy action, so the TDD/debug
+    // activities' single-shot calls land on real {role}/{action} keys. Each
+    // payload matches ITS caller's parser exactly (pinned by
+    // ScriptedCycleScriptValidityTests):
+
+    /// <summary>tester/write-tests — WriteTestsActivity.ParseTestGenerationResponse.</summary>
+    public const string TddTestGeneration =
+        """{"testCode":"// scripted TDD tests (RED): assert the scripted feature contract\ndescribe('scripted feature', () => {\n  it('implements the required behavior', () => {\n    expect(true).toBe(false); // fails until the implementation lands\n  });\n  it('handles the edge case', () => {\n    expect(true).toBe(false);\n  });\n});","testFiles":["src/scripted/scripted-feature.test.js"],"testCount":2}""";
+
+    /// <summary>developer/implement-feature — WriteImplementationActivity.ParseImplementationResponse.</summary>
+    public const string TddImplementation =
+        """{"implementationCode":"// scripted implementation: minimum code to satisfy the scripted tests\nfunction scriptedFeature() {\n  return true;\n}","implementationFiles":["src/scripted/scripted-feature.js"]}""";
+
+    /// <summary>senior_developer/plan-refactor — AnalyzeCodeActivity: no suggestions,
+    /// so the TDD loop deterministically skips the refactor leg.</summary>
+    public const string TddNoRefactorNeeded =
+        """{"hasSuggestions":false,"confidence":0.2,"suggestions":[]}""";
+
+    /// <summary>developer/refactor — ApplyRefactoringActivity (only reachable if a
+    /// refactor is ever requested; a no-op keeps the loop deterministic).</summary>
+    public const string TddRefactorNoop =
+        """{"refactoredCode":"// scripted refactor: no changes required","filesChanged":[]}""";
+
+    /// <summary>senior_developer/debug-rootcause — RefineHypothesisActivity.ParseRefinementResponse.</summary>
+    public const string DebugHypotheses =
+        """{"analysis_summary":"Scripted diagnosis: the failure is the not-yet-implemented scripted feature.","hypotheses":[{"rank":1,"description":"Implementation missing for the scripted feature","confidence":0.9,"suggested_fix":"Implement scriptedFeature() to satisfy the failing tests","affected_files":["src/scripted/scripted-feature.js"]}]}""";
+
+    /// <summary>tester/write-regression-test — WriteRegressionTestActivity.ParseTestResponse.</summary>
+    public const string DebugRegressionTest =
+        """{"test_file_path":"src/scripted/scripted-regression.test.js","test_name":"scripted regression: feature contract holds","fails_as_expected":true}""";
+
+    /// <summary>developer/implement-fix — ApplyReviewFixesActivity.ParseFixResponse.</summary>
+    public const string ReviewFixGeneration =
+        """{"fixedCode":"// scripted fix: address the review comment with the minimum change","filesFixed":["src/scripted/scripted-feature.js"],"fixDescriptions":[]}""";
+
     private const string ContextScanFindings =
         "Scripted context scan: repository follows its documented conventions; no blockers, " +
         "no ambiguity; the change is small and self-contained.";
@@ -83,19 +119,43 @@ public static class ScriptedCycleLibrary
             ["architect/context-scan"] = ContextScanFindings,
             ["product_owner/summarize-stakeholder"] = PoSummary,
 
-            // ── the 39-7 reviewer PANEL roster: CANONICAL Review approvals —
-            //    these calls declare documentType="review" and the 39-9 ring
-            //    validates them against the Review registry validator
-            //    (2026-08-13; the legacy verdict shape fails that ring) ──
-            ["architect/plan-review"] = CanonicalReviewApprove,
-            ["senior_developer/plan-review"] = CanonicalReviewApprove,
-            ["security/plan-review-security"] = CanonicalReviewApprove,
-            ["developer/review-feasibility"] = CanonicalReviewApprove,
-            ["tester/review-testability"] = CanonicalReviewApprove,
-            ["devops/review-operability"] = CanonicalReviewApprove,
-            ["product_owner/review-scope"] = CanonicalReviewApprove,
-            ["tech_writer/review-docs"] = CanonicalReviewApprove,
-            ["ux_designer/review-design"] = CanonicalReviewApprove,
+            // ── review cells — TWO consumers, TWO shapes (2026-08-13):
+            //    * the 39-7 single-reviewer/panel path declares
+            //      documentType="review" (the 39-9 ring validates the reply
+            //      against the Review registry validator) → the QUALIFIED
+            //      {role}/{action}@review cells serve the CANONICAL Review;
+            //    * the cycle's own plan-review/task-review workflows parse the
+            //      LEGACY verdict JSON directly (no documentType) → the BARE
+            //      cells keep the verdict shape. Serving canonical to the
+            //      legacy parser turned every plan review into needs-human. ──
+            ["architect/plan-review@review"] = CanonicalReviewApprove,
+            ["senior_developer/plan-review@review"] = CanonicalReviewApprove,
+            ["security/plan-review-security@review"] = CanonicalReviewApprove,
+            ["developer/review-feasibility@review"] = CanonicalReviewApprove,
+            ["tester/review-testability@review"] = CanonicalReviewApprove,
+            ["devops/review-operability@review"] = CanonicalReviewApprove,
+            ["product_owner/review-scope@review"] = CanonicalReviewApprove,
+            ["tech_writer/review-docs@review"] = CanonicalReviewApprove,
+            ["ux_designer/review-design@review"] = CanonicalReviewApprove,
+
+            ["architect/plan-review"] = ApproveReviewVerdict,
+            ["senior_developer/plan-review"] = ApproveReviewVerdict,
+            ["security/plan-review-security"] = ApproveReviewVerdict,
+            ["developer/review-feasibility"] = ApproveReviewVerdict,
+            ["tester/review-testability"] = ApproveReviewVerdict,
+            ["devops/review-operability"] = ApproveReviewVerdict,
+            ["product_owner/review-scope"] = ApproveReviewVerdict,
+            ["tech_writer/review-docs"] = ApproveReviewVerdict,
+            ["ux_designer/review-design"] = ApproveReviewVerdict,
+
+            // ── TDD single-shot cells (MediatedLlmText, action threaded) ──
+            ["tester/write-tests"] = TddTestGeneration,
+            ["developer/implement-feature"] = TddImplementation,
+            ["senior_developer/plan-refactor"] = TddNoRefactorNeeded,
+            ["developer/refactor"] = TddRefactorNoop,
+            ["senior_developer/debug-rootcause"] = DebugHypotheses,
+            ["tester/write-regression-test"] = DebugRegressionTest,
+            ["developer/implement-fix"] = ReviewFixGeneration,
 
             // ── code review + guidance (CodeReviewWorkflow stores the text) ──
             ["senior_developer/code-review"] = ApproveReviewVerdict,

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedCycleLibrary.cs
@@ -1,0 +1,143 @@
+using Tamma.Core;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Services.Agents.Scripted;
+
+/// <summary>
+/// The BUILT-IN script for the single-issue cycle (2026-08-13) — the canned
+/// responses that let the ACTUAL AdlOrchestrator/SingleIssueCycle workflows
+/// drive one seeded issue from selection to merge with no network LLM.
+///
+/// <para><b>Where the payloads come from.</b> Typed documents are NOT
+/// hand-typed here: any call carrying a <c>documentType</c> falls back to that
+/// type's own first VALID <see cref="DocumentExample"/> from
+/// <see cref="DocumentTypeRegistry"/> — the same payloads the 39-x registry
+/// drift tests self-check against each type's validator, so they pass the
+/// 39-9 validation ring by construction. Explicit entries below exist only
+/// where cross-step coherence or routing matters more than the example's
+/// content (the review must APPROVE so the lifecycle routes to accept; the
+/// plan's task ids must match the test-spec's task bindings — which the
+/// shipped plan/test-spec examples already do: T-1/T-2 ↔ TC-1/TC-2).</para>
+///
+/// <para><b>Key syntax</b> (shared with the override file):
+/// <c>{role}/{action}@{documentType}</c> — most specific; <c>@{documentType}</c>
+/// — per-type default; <c>{role}/{action}</c> — free-text cells; <c>*</c> —
+/// catch-all (override files only; the built-in library deliberately ships
+/// none so an unscripted cell fails LOUD naming its key).</para>
+/// </summary>
+public static class ScriptedCycleLibrary
+{
+    /// <summary>
+    /// The reviewer reply used for EVERY bare reviewer cell. Deliberately the
+    /// LEGACY verdict shape, because it is the one shape BOTH consumers parse:
+    /// TaskReviewWorkflow reads <c>verdict</c> directly, and the 39-7
+    /// single-reviewer maps it through <c>Review.FromLegacyVerdictJson</c>
+    /// onto a valid approving <c>Review</c> (decision=approve, summary from
+    /// <c>comments</c>). Pinned by ScriptedCycleScriptValidityTests.
+    /// </summary>
+    public const string ApproveReviewVerdict =
+        """{"verdict":"approve","comments":"Scripted review: no blocking issues found; the artifact satisfies its contract.","suggestedChanges":"","issues":[]}""";
+
+    /// <summary>Deploy/rollback stage reply — DeploymentPipelineWorkflow's
+    /// ExtractStageResult is fail-closed and requires an explicit
+    /// <c>status:"success"</c>.</summary>
+    public const string StageSuccess =
+        """{"status":"success","detail":"scripted no-op stage execution"}""";
+
+    /// <summary>PO context summary — ContextGatheringWorkflow's ExtractPO
+    /// parses <c>{summary, links}</c> out of the reply.</summary>
+    public const string PoSummary =
+        """{"summary":"Scripted PO summary: implement the seeded issue exactly as titled; scope is a single small change with tests.","links":[]}""";
+
+    private const string ContextScanFindings =
+        "Scripted context scan: repository follows its documented conventions; no blockers, " +
+        "no ambiguity; the change is small and self-contained.";
+
+    /// <summary>
+    /// The built-in (role/action[@documentType] → response text) map. Keys are
+    /// produced by <see cref="ScriptedLlmResponder"/>'s normalizer (lowercase,
+    /// trimmed).
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> Responses { get; } =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // ── context gathering (free text; enableTools=true — the scripted
+            //    reply ends the turn with no tool calls) ──
+            ["developer/context-scan"] = ContextScanFindings,
+            ["tester/context-scan"] = ContextScanFindings,
+            ["security/context-scan"] = ContextScanFindings,
+            ["devops/context-scan"] = ContextScanFindings,
+            ["architect/context-scan"] = ContextScanFindings,
+            ["product_owner/summarize-stakeholder"] = PoSummary,
+
+            // ── review cells (task review + the 39-7 reviewer panel roster;
+            //    one legacy-verdict approval serves both consumers) ──
+            ["architect/plan-review"] = ApproveReviewVerdict,
+            ["senior_developer/plan-review"] = ApproveReviewVerdict,
+            ["security/plan-review-security"] = ApproveReviewVerdict,
+            ["developer/review-feasibility"] = ApproveReviewVerdict,
+            ["tester/review-testability"] = ApproveReviewVerdict,
+            ["devops/review-operability"] = ApproveReviewVerdict,
+            ["product_owner/review-scope"] = ApproveReviewVerdict,
+            ["tech_writer/review-docs"] = ApproveReviewVerdict,
+            ["ux_designer/review-design"] = ApproveReviewVerdict,
+
+            // ── code review + guidance (CodeReviewWorkflow stores the text) ──
+            ["senior_developer/code-review"] = ApproveReviewVerdict,
+            ["senior_developer/mentor-feedback"] =
+                "Scripted mentor feedback: the change is clean; keep tests colocated and prefer small commits.",
+
+            // ── PR description (PullRequestWorkflow captures the body) ──
+            ["tech_writer/summarize-changes"] =
+                "Scripted PR description: implements the seeded issue via the reviewed plan; " +
+                "tests ride the test-spec committed to this branch.",
+
+            // ── deployment pipeline (fail-closed status parsing) ──
+            ["devops/deploy"] = StageSuccess,
+            ["devops/rollback"] = StageSuccess,
+
+            // ── triage support (the orchestrator's NeedsTriage edge — covered
+            //    so a triage dispatch cannot strand the loop; the E2E seeds a
+            //    pre-labelled issue so the direct-select path is the one under
+            //    test) ──
+            ["product_owner/triage-intake"] = ApproveReviewVerdict,
+
+            // ── @review default: the registry's FIRST valid Review example is
+            //    a request-changes review (correct for the drift suite, wrong
+            //    for an autonomous run — it would loop revise rounds), so the
+            //    per-type default is overridden with a canonical APPROVE. The
+            //    subject is placeholder data: every consumer (39-7's
+            //    MapReviewerReply) overrides it with the caller's authoritative
+            //    subject. ──
+            ["@review"] =
+                """{"subject":{"kind":"document","documentId":"0192a8b0-0000-7abc-8def-00000000e2e0","documentType":"plan"},"decision":"approve","summary":"Scripted review: approved with no blocking issues.","issues":[]}""",
+        };
+
+    /// <summary>
+    /// The per-document-type fallback: the type's own first VALID example
+    /// payload (self-checked against the type's validator by the registry
+    /// drift tests). Returns null for an unknown type key or a type shipping
+    /// no valid example (both impossible for registered 39-x types — the drift
+    /// suite enforces ≥1 valid example per type — but this stays fail-soft so
+    /// the responder can compose its own typed missing-cell error).
+    /// </summary>
+    public static string? DocumentExampleFor(string documentTypeKey)
+    {
+        if (string.IsNullOrWhiteSpace(documentTypeKey))
+        {
+            return null;
+        }
+
+        IDocumentType type;
+        try
+        {
+            type = DocumentTypeRegistry.Resolve(documentTypeKey.Trim());
+        }
+        catch (TammaError)
+        {
+            return null;
+        }
+
+        return type.Examples.FirstOrDefault(e => e.IsValid)?.PayloadJson;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmProviderOptions.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmProviderOptions.cs
@@ -1,0 +1,25 @@
+namespace Tamma.Api.Services.Agents.Scripted;
+
+/// <summary>
+/// Config for the opt-in scripted LLM provider (2026-08-13). The ENABLE flag
+/// itself is NOT here — it is the shared
+/// <c>Tamma.Activities.Security.ScriptedProviderPosture.FlagKey</c>
+/// (<c>Llm:EnableScriptedProvider</c>), checked with the structural
+/// production-refusal guard at registration time. This section only carries
+/// the optional per-test script override file.
+/// </summary>
+public sealed class ScriptedLlmProviderOptions
+{
+    public const string SectionName = "Llm:ScriptedProvider";
+
+    /// <summary>
+    /// Optional path to a JSON script-override file:
+    /// <c>{ "responses": { "&lt;key&gt;": "&lt;response text&gt;", ... } }</c>
+    /// with keys in the <c>{role}/{action}[@{documentType}]</c> /
+    /// <c>@{documentType}</c> / <c>*</c> syntax. Entries override the built-in
+    /// <see cref="ScriptedCycleLibrary"/> per key. A set-but-unreadable path
+    /// fails registration LOUD (a test pointing at a missing script must not
+    /// silently run the default script).
+    /// </summary>
+    public string? ScriptPath { get; set; }
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
@@ -13,8 +13,8 @@ namespace Tamma.Api.Services.Agents.Scripted;
 ///
 /// <para><b>Key resolution order</b> (first hit wins; keys normalized to
 /// lowercase): <c>{role}/{action}@{documentType}</c> →
-/// <c>@{documentType}</c> → registry example for the document type →
-/// <c>{role}/{action}</c> → <c>*</c>. A miss returns a FAILED response
+/// <c>{role}/{action}</c> → <c>@{documentType}</c> → registry example for the
+/// document type → <c>*</c>. A miss returns a FAILED response
 /// (HTTP 422-shaped, non-retryable) whose error message names every key
 /// tried — the "unscripted cell" contract, never a silent default.</para>
 /// </summary>
@@ -145,7 +145,23 @@ public sealed class ScriptedLlmResponder : IScriptedLlmResponder
             var qualified = $"{cell}@{docType}";
             tried.Add(qualified);
             if (TryGet(qualified, out var t1)) return t1;
+        }
 
+        // 2026-08-13 (engine-driven E2E): the BARE role/action cell outranks the
+        // per-document-type default. A REVIEWER llm-call carries the SUBJECT's
+        // documentType (a plan review arrives as documentType='plan'), and the
+        // original order (@{doc} before {role}/{action}) answered it with the
+        // PLAN document example instead of the reviewer cell — every panel
+        // member's reply then failed Review validation until exhaustion
+        // (48× DOCUMENT.VALIDATED.FAILED documentType=review, four
+        // REVIEW_PANEL_UNDECIDABLE, run 22). A role/action the library scripts
+        // explicitly is ALWAYS more specific than "whatever document type the
+        // call happens to carry".
+        tried.Add(cell);
+        if (TryGet(cell, out var t3)) return t3;
+
+        if (docType.Length > 0)
+        {
             var typeDefault = $"@{docType}";
             tried.Add(typeDefault);
             if (TryGet(typeDefault, out var t2)) return t2;
@@ -156,9 +172,6 @@ public sealed class ScriptedLlmResponder : IScriptedLlmResponder
             var example = ScriptedCycleLibrary.DocumentExampleFor(docType);
             if (example is not null) return example;
         }
-
-        tried.Add(cell);
-        if (TryGet(cell, out var t3)) return t3;
 
         tried.Add("*");
         return TryGet("*", out var t4) ? t4 : null;

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
@@ -11,12 +11,14 @@ namespace Tamma.Api.Services.Agents.Scripted;
 /// (role, action, documentType) keys + the loaded script: same call ⇒ same
 /// response, zero tokens, zero cost, no network.
 ///
-/// <para><b>Key resolution order</b> (first hit wins; keys normalized to
-/// lowercase): <c>{role}/{action}@{documentType}</c> →
-/// <c>{role}/{action}</c> → <c>@{documentType}</c> → registry example for the
-/// document type → <c>*</c>. A miss returns a FAILED response
-/// (HTTP 422-shaped, non-retryable) whose error message names every key
-/// tried — the "unscripted cell" contract, never a silent default.</para>
+/// <para><b>Key resolution</b> (first hit wins; keys normalized to lowercase),
+/// tier-split on whether the call carries a documentType: a TYPED call resolves
+/// <c>{role}/{action}@{documentType}</c> → <c>@{documentType}</c> → the type's
+/// registry example → <c>*</c>; a documentType-LESS call resolves
+/// <c>{role}/{action}</c> → <c>*</c>. The tiers never cross — a bare cell can
+/// never answer a typed-document call (and vice versa). A miss returns a FAILED
+/// response (HTTP 422-shaped, non-retryable) whose error message names every
+/// key tried — the "unscripted cell" contract, never a silent default.</para>
 /// </summary>
 public sealed class ScriptedLlmResponder : IScriptedLlmResponder
 {
@@ -140,28 +142,25 @@ public sealed class ScriptedLlmResponder : IScriptedLlmResponder
     {
         var cell = $"{role}/{action}";
 
+        // 2026-08-13 (engine-driven E2E, tier split — run 34): a call WITH a
+        // documentType is a TYPED-DOCUMENT call — the reply must be that
+        // document (qualified cell → per-type default → the type's own registry
+        // example). A call WITHOUT one is a free-form/legacy call — the bare
+        // {role}/{action} cell serves it. The tiers deliberately do NOT
+        // cross-fall-through: letting a bare cell answer a typed call re-created
+        // run 22's failure in reverse (the TDD single-shot cell
+        // 'tester/write-tests' — free-text test code — intercepted the
+        // test-spec PRODUCER's documentType='test-spec' call, which must answer
+        // with a test-spec document). Reviewer calls are consistent under the
+        // split: the 39-7 panel declares documentType='review' and resolves the
+        // qualified/{@review} tier; the documentType-less plan-review /
+        // task-review parsers get the bare verdict cells.
         if (docType.Length > 0)
         {
             var qualified = $"{cell}@{docType}";
             tried.Add(qualified);
             if (TryGet(qualified, out var t1)) return t1;
-        }
 
-        // 2026-08-13 (engine-driven E2E): the BARE role/action cell outranks the
-        // per-document-type default. A REVIEWER llm-call carries the SUBJECT's
-        // documentType (a plan review arrives as documentType='plan'), and the
-        // original order (@{doc} before {role}/{action}) answered it with the
-        // PLAN document example instead of the reviewer cell — every panel
-        // member's reply then failed Review validation until exhaustion
-        // (48× DOCUMENT.VALIDATED.FAILED documentType=review, four
-        // REVIEW_PANEL_UNDECIDABLE, run 22). A role/action the library scripts
-        // explicitly is ALWAYS more specific than "whatever document type the
-        // call happens to carry".
-        tried.Add(cell);
-        if (TryGet(cell, out var t3)) return t3;
-
-        if (docType.Length > 0)
-        {
             var typeDefault = $"@{docType}";
             tried.Add(typeDefault);
             if (TryGet(typeDefault, out var t2)) return t2;
@@ -171,6 +170,11 @@ public sealed class ScriptedLlmResponder : IScriptedLlmResponder
             tried.Add($"(registry example for '{docType}')");
             var example = ScriptedCycleLibrary.DocumentExampleFor(docType);
             if (example is not null) return example;
+        }
+        else
+        {
+            tried.Add(cell);
+            if (TryGet(cell, out var t3)) return t3;
         }
 
         tried.Add("*");

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedLlmResponder.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Activities.Security;
+
+namespace Tamma.Api.Services.Agents.Scripted;
+
+/// <summary>
+/// The deterministic in-process implementation behind the opt-in "scripted"
+/// provider (2026-08-13, the Epic 31 P5 LLM stub). Pure function of the call's
+/// (role, action, documentType) keys + the loaded script: same call ⇒ same
+/// response, zero tokens, zero cost, no network.
+///
+/// <para><b>Key resolution order</b> (first hit wins; keys normalized to
+/// lowercase): <c>{role}/{action}@{documentType}</c> →
+/// <c>@{documentType}</c> → registry example for the document type →
+/// <c>{role}/{action}</c> → <c>*</c>. A miss returns a FAILED response
+/// (HTTP 422-shaped, non-retryable) whose error message names every key
+/// tried — the "unscripted cell" contract, never a silent default.</para>
+/// </summary>
+public sealed class ScriptedLlmResponder : IScriptedLlmResponder
+{
+    /// <summary>Error banner for an unscripted cell (pinned by tests).</summary>
+    public const string MissingCellError = "SCRIPTED_PROVIDER_MISSING_CELL";
+
+    private readonly IReadOnlyDictionary<string, string> _overrides;
+    private readonly ILogger<ScriptedLlmResponder>? _logger;
+
+    public ScriptedLlmResponder(
+        IReadOnlyDictionary<string, string>? overrides = null,
+        ILogger<ScriptedLlmResponder>? logger = null)
+    {
+        _overrides = overrides ?? new Dictionary<string, string>();
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Load the override map from a script file
+    /// (<c>{"responses": {key: text}}</c>). Fail-loud: a set-but-missing or
+    /// unparseable file throws — a test pointing at a wrong path must never
+    /// silently run the built-in script instead.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> LoadOverrides(string scriptPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(scriptPath);
+        if (!File.Exists(scriptPath))
+        {
+            throw new FileNotFoundException(
+                $"Scripted-provider script file not found: '{scriptPath}' " +
+                $"({ScriptedLlmProviderOptions.SectionName}:ScriptPath).", scriptPath);
+        }
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(scriptPath));
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (doc.RootElement.ValueKind != JsonValueKind.Object
+            || !doc.RootElement.TryGetProperty("responses", out var responses)
+            || responses.ValueKind != JsonValueKind.Object)
+        {
+            throw new InvalidOperationException(
+                $"Scripted-provider script file '{scriptPath}' must be an object with a " +
+                "'responses' object: { \"responses\": { \"role/action[@doc]\": \"text\" } }.");
+        }
+
+        foreach (var prop in responses.EnumerateObject())
+        {
+            if (prop.Value.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidOperationException(
+                    $"Scripted-provider script '{scriptPath}': key '{prop.Name}' must map to a string.");
+            }
+            map[Normalize(prop.Name)] = prop.Value.GetString() ?? string.Empty;
+        }
+
+        return map;
+    }
+
+    /// <inheritdoc />
+    public bool CanHandle(string? provider) =>
+        !string.IsNullOrWhiteSpace(provider)
+        && string.Equals(provider.Trim(), ScriptedProviderPosture.ProviderKey,
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc />
+    public NormalizedLlmResponse Respond(ScriptedLlmCall call)
+    {
+        ArgumentNullException.ThrowIfNull(call);
+
+        var role = Normalize(call.Role);
+        var action = Normalize(call.Action);
+        var docType = Normalize(call.DocumentType);
+
+        var tried = new List<string>();
+        var text = ResolveText(role, action, docType, tried);
+
+        if (text is null)
+        {
+            var detail =
+                $"{MissingCellError}: no scripted response for role='{role}', action='{action}', " +
+                $"documentType='{docType}'. Keys tried (in order): [{string.Join(", ", tried)}]. " +
+                "Add the cell to the script-override file " +
+                $"({ScriptedLlmProviderOptions.SectionName}:ScriptPath) or to ScriptedCycleLibrary.";
+
+            _logger?.LogWarning(
+                "Scripted provider miss: role={Role}, action={Action}, documentType={DocumentType}, " +
+                "correlationId={CorrelationId}", role, action, docType, call.CorrelationId);
+
+            // FAILED, non-retryable-shaped (422): ManagedAgent surfaces it as
+            // PROVIDER_ERROR with the preserved status; the engine's RetryCheck
+            // treats 4xx as non-transient, so the cycle fails LOUD, not slow.
+            return new NormalizedLlmResponse
+            {
+                Success = false,
+                HttpStatusCode = 422,
+                ErrorMessage = detail,
+                StopReason = StopReason.EndTurn,
+            };
+        }
+
+        _logger?.LogDebug(
+            "Scripted provider hit: role={Role}, action={Action}, documentType={DocumentType}, " +
+            "correlationId={CorrelationId}, chars={Chars}",
+            role, action, docType, call.CorrelationId, text.Length);
+
+        return new NormalizedLlmResponse
+        {
+            Success = true,
+            ResponseText = text,
+            Model = ScriptedProviderPosture.ProviderKey,
+            // Zero tokens on purpose: the scripted provider spends nothing, so
+            // budget/cost accounting stays truthful (cost basis computes to 0).
+            PromptTokens = 0,
+            CompletionTokens = 0,
+            HttpStatusCode = 200,
+            ToolCalls = null,
+            StopReason = StopReason.EndTurn,
+        };
+    }
+
+    private string? ResolveText(string role, string action, string docType, List<string> tried)
+    {
+        var cell = $"{role}/{action}";
+
+        if (docType.Length > 0)
+        {
+            var qualified = $"{cell}@{docType}";
+            tried.Add(qualified);
+            if (TryGet(qualified, out var t1)) return t1;
+
+            var typeDefault = $"@{docType}";
+            tried.Add(typeDefault);
+            if (TryGet(typeDefault, out var t2)) return t2;
+
+            // Registry fallback: the type's own first valid example — valid by
+            // the registry drift suite's self-check, so it passes the 39-9 ring.
+            tried.Add($"(registry example for '{docType}')");
+            var example = ScriptedCycleLibrary.DocumentExampleFor(docType);
+            if (example is not null) return example;
+        }
+
+        tried.Add(cell);
+        if (TryGet(cell, out var t3)) return t3;
+
+        tried.Add("*");
+        return TryGet("*", out var t4) ? t4 : null;
+    }
+
+    private bool TryGet(string key, out string? text)
+    {
+        if (_overrides.TryGetValue(key, out var fromOverride))
+        {
+            text = fromOverride;
+            return true;
+        }
+
+        if (ScriptedCycleLibrary.Responses.TryGetValue(key, out var builtIn))
+        {
+            text = builtIn;
+            return true;
+        }
+
+        text = null;
+        return false;
+    }
+
+    private static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToLowerInvariant();
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedProviderCredentialResolver.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Agents/Scripted/ScriptedProviderCredentialResolver.cs
@@ -1,0 +1,54 @@
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.Security;
+
+namespace Tamma.Api.Services.Agents.Scripted;
+
+/// <summary>
+/// Credential decorator for the opt-in scripted provider (2026-08-13):
+/// "scripted" needs NO key (the responder is in-process), so the decorator
+/// answers a fixed placeholder credential for it and delegates every other
+/// provider to the real BYOK→platform resolver untouched. Registered ONLY by
+/// <c>AddScriptedLlmProvider</c> (flag on + non-production host) — a normal
+/// deployment never has it in the container, so the fail-closed
+/// PROVIDER_CREDENTIAL_UNAVAILABLE posture for unknown providers is unchanged.
+/// </summary>
+public sealed class ScriptedProviderCredentialResolver : IProviderCredentialResolver
+{
+    /// <summary>Placeholder key value — never used on any wire.</summary>
+    public const string PlaceholderKey = "scripted-no-key";
+
+    private readonly IProviderCredentialResolver _inner;
+
+    public ScriptedProviderCredentialResolver(IProviderCredentialResolver inner)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+    }
+
+    public Task<ProviderCredential> ResolveAsync(
+        Guid? tenantId, string providerName, CancellationToken ct = default)
+    {
+        if (IsScripted(providerName))
+        {
+            return Task.FromResult(new ProviderCredential(
+                PlaceholderKey,
+                CredentialSource.Platform,
+                $"scripted:{ScriptedProviderPosture.ProviderKey}",
+                VersionNumber: null));
+        }
+
+        return _inner.ResolveAsync(tenantId, providerName, ct);
+    }
+
+    public void Invalidate(Guid? tenantId, string providerName)
+    {
+        if (!IsScripted(providerName))
+        {
+            _inner.Invalidate(tenantId, providerName);
+        }
+    }
+
+    private static bool IsScripted(string? providerName) =>
+        !string.IsNullOrWhiteSpace(providerName)
+        && string.Equals(providerName.Trim(), ScriptedProviderPosture.ProviderKey,
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/ElsaWorkflowService.cs
@@ -60,16 +60,21 @@ public partial class ElsaWorkflowService : IElsaWorkflowService
         {
             try
             {
+                // 2026-08-13 (engine-driven E2E): ANY HTTP response proves the
+                // server is REACHABLE — which is all this probe guards. The
+                // deployed engine does not mount an Elsa health module at
+                // /elsa/api/health (404), and requiring a 2xx there made every
+                // decision-resume proxy fail 502 against a perfectly healthy
+                // engine. Connection-level failures still retry below.
                 var response = await _httpClient.GetAsync("/elsa/api/health");
-                if (response.IsSuccessStatusCode)
+                lock (_healthCheckLock)
                 {
-                    lock (_healthCheckLock)
-                    {
-                        _healthChecked = true;
-                    }
-                    _logger.LogInformation("ELSA server health check passed at {Url}", _elsaServerUrl);
-                    return;
+                    _healthChecked = true;
                 }
+                _logger.LogInformation(
+                    "ELSA server reachability check passed at {Url} (HTTP {Status})",
+                    _elsaServerUrl, (int)response.StatusCode);
+                return;
             }
             catch (HttpRequestException ex)
             {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRepoAuthorizer.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Git/GitRepoAuthorizer.cs
@@ -68,11 +68,20 @@ public sealed class GitRepoAuthorizer : IGitRepoAuthorizer
         // The null/null allowance is legit ONLY in single-user mode; in SaaS a
         // null acting tenant or a null-TenantId (orphan) install fails OPEN under
         // plain nullable equality, so SaaS requires BOTH ids present and equal.
+        //
+        // 2026-08-13 (engine-driven E2E): single-user is grant-existence, not id
+        // equality. There is exactly ONE principal in single-user mode — the sole
+        // user owns every installation row — and the acting tenant may now be
+        // their PERSONAL tenant (bound ambient by EnsurePersonalTenantMiddleware
+        // for service-plane calls) while grant rows registered before/outside
+        // that tenant carry TenantId=null. Strict equality made the sole user
+        // "cross-tenant" against their own grant the moment the personal tenant
+        // bound. The no-installation deny above still applies unchanged.
         var authorized = _mode.Mode == TammaMode.SaaS
             ? tenantId is { } actingTenant
                 && installation.TenantId is { } installTenant
                 && installTenant == actingTenant
-            : installation.TenantId == tenantId;
+            : true;
 
         if (!authorized)
         {

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCatalog.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderCatalog.cs
@@ -347,6 +347,22 @@ public static class ProviderCatalog
             Allowlisted = false,
             Aliases = new[] { "claude-code-cli" },
         },
+        new NonHttpProviderDescriptor
+        {
+            // 2026-08-13 (Epic 31 P5 follow-up) — the deterministic in-process
+            // TEST provider that unblocks the engine-driven autonomous E2E.
+            // Allowlisted=false ON PURPOSE: like the claude-code family it is
+            // never selectable by default — enabling it requires the explicit
+            // Llm:EnableScriptedProvider flag (ScriptedProviderPosture), which
+            // additionally REFUSES to register on any SaaS/production-shaped
+            // host. Catalogued (rather than left unknown) so the keyset
+            // contract stays total: every provider key the platform ships is
+            // either an HTTP descriptor or an explicit non-HTTP classification.
+            Key = "scripted",
+            DisplayName = "Scripted test provider (in-process, opt-in)",
+            Transport = NonHttpProviderTransport.InProcess,
+            Allowlisted = false,
+        },
     };
 
     private static readonly FrozenDictionary<string, ProviderDescriptor> HttpByKey =

--- a/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderDescriptor.cs
+++ b/apps/tamma-elsa/src/Tamma.Api/Services/Providers/ProviderDescriptor.cs
@@ -49,6 +49,12 @@ public enum NonHttpProviderTransport
 
     /// <summary>Model Context Protocol server (zen-mcp).</summary>
     Mcp,
+
+    /// <summary>In-process scripted responder (the opt-in "scripted" test
+    /// provider, 2026-08-13). Served by <c>IScriptedLlmResponder</c> inside
+    /// the API's tool-loop runner — never over HTTP; <c>HttpProviderClient</c>
+    /// refuses it like every other non-HTTP transport.</summary>
+    InProcess,
 }
 
 /// <summary>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/CiWaitEndpoints.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/CiWaitEndpoints.cs
@@ -70,11 +70,27 @@ public static class CiWaitEndpoints
         string? TenantId,
         DateTimeOffset CreatedAt);
 
+    /// <summary>
+    /// 2026-08-13 (engine-driven E2E follow-up) — the optional result fields
+    /// are ADDITIVE: <c>WaitForCIResultsActivity.OnResumeAsync</c> has always
+    /// read TotalTests/PassedTests/FailedTests/CoveragePercentage/LintWarnings/
+    /// LintErrors from the resume input, but this endpoint only forwarded
+    /// Status+BuildPassed — so every DG-5 resume scored coverage 0 and the
+    /// quality gate classified a green build CRITICAL (coverage gap &gt; 20).
+    /// Null fields are omitted from the input, preserving the activity's
+    /// existing defaults byte-for-byte for old callers.
+    /// </summary>
     public sealed record ResumeRequest(
         string BookmarkId,
         string? RunId,
         string? Status,
-        bool BuildPassed);
+        bool BuildPassed,
+        int? TotalTests = null,
+        int? PassedTests = null,
+        int? FailedTests = null,
+        double? CoveragePercentage = null,
+        int? LintWarnings = null,
+        int? LintErrors = null);
 
     private static readonly JsonSerializerOptions PayloadJson = new()
     {
@@ -175,6 +191,15 @@ public static class CiWaitEndpoints
             ["Status"] = request.Status ?? "Unknown",
             ["BuildPassed"] = request.BuildPassed,
         };
+
+        // Additive result fields (2026-08-13) — forwarded ONLY when supplied,
+        // with the exact CLR types OnResumeAsync pattern-matches (int/double).
+        if (request.TotalTests is { } tt) input["TotalTests"] = tt;
+        if (request.PassedTests is { } pt) input["PassedTests"] = pt;
+        if (request.FailedTests is { } ft) input["FailedTests"] = ft;
+        if (request.CoveragePercentage is { } cp) input["CoveragePercentage"] = cp;
+        if (request.LintWarnings is { } lw) input["LintWarnings"] = lw;
+        if (request.LintErrors is { } le) input["LintErrors"] = le;
 
         var client = await workflowRuntime
             .CreateClientAsync(bookmark.WorkflowInstanceId, ct)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DocumentDecisionResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/DocumentDecisionResumeEndpoint.cs
@@ -89,6 +89,33 @@ public static class DocumentDecisionResumeEndpoint
             .FindManyAsync(new BookmarkFilter { Name = name }, ct)
             .ConfigureAwait(false)).ToList();
 
+        // 2026-08-13 (engine-driven E2E, single-user mode-awareness): the API's
+        // service-plane binding gives every caller the sole user's PERSONAL
+        // tenant, but a single-user cycle dispatches its gates with an EMPTY
+        // tenant — so the tenant-scoped name missed a gate that IS waiting
+        // (the deployed single-user dashboard accept 404s the same way). One
+        // principal, two spellings: when the tenant-scoped lookup misses, try
+        // the tenantless (platform-plane) name for the SAME session. SaaS
+        // gates always carry their tenant, so the fallback name matches
+        // nothing cross-tenant — and the session id itself is an unguessable
+        // per-gate uuidv7.
+        if (bookmarks.Count == 0 && !string.IsNullOrWhiteSpace(request.TenantId))
+        {
+            var tenantlessName = WaitForDocumentDecisionActivity
+                .DecisionBookmarkName(null, request.SessionId);
+            bookmarks = (await bookmarkStore
+                .FindManyAsync(new BookmarkFilter { Name = tenantlessName }, ct)
+                .ConfigureAwait(false)).ToList();
+            if (bookmarks.Count > 0)
+            {
+                logger.LogInformation(
+                    "Document-decision bookmark resolved via the tenantless fallback " +
+                    "({Tenantless}) — single-user gate dispatched without a tenant scope",
+                    tenantlessName);
+                name = tenantlessName;
+            }
+        }
+
         if (bookmarks.Count == 0)
         {
             logger.LogWarning(

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/PrMergedResumeEndpoint.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Endpoints/PrMergedResumeEndpoint.cs
@@ -66,6 +66,7 @@ public static class PrMergedResumeEndpoint
         [FromBody] ResumeRequest request,
         [FromServices] IBookmarkStore bookmarkStore,
         [FromServices] IWorkflowRuntime workflowRuntime,
+        [FromServices] PendingPrMergeBuffer pendingMerges,
         [FromServices] ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
@@ -95,16 +96,25 @@ public static class PrMergedResumeEndpoint
 
         if (bookmarks.Count == 0)
         {
-            // Idempotency: the SLA edge (or an earlier delivery) burned the
-            // bookmark — a late merge webhook is a benign no-op.
+            // 2026-08-13 (engine-driven E2E run 39) — the SELF-MERGE RACE: when
+            // Tamma performs the merge itself, this webhook forward can arrive
+            // BEFORE the cycle registers its wait (observed 1 s early). The
+            // delivery is once-only, so a plain 404 here LOSES the merge and
+            // the cycle sits on the 12 h SLA. Buffer the notification keyed by
+            // the qualified name; WaitForPRMergedActivity consumes it at
+            // registration (reconcile-on-register) and completes Merged without
+            // suspending. A late/duplicate delivery for an already-resumed wait
+            // is still harmless — the buffered entry expires unconsumed.
+            pendingMerges.Record(qualified, request.MergeSha);
             logger.LogInformation(
-                "No suspended pr-merged bookmark {Bookmark} — wait already resumed, timed out, or not this tenant/repo",
+                "No suspended pr-merged bookmark {Bookmark} — buffered for reconcile-on-register " +
+                "(wait not yet registered, already resumed, timed out, or not this tenant/repo)",
                 qualified);
-            return Results.NotFound(new
+            return Results.Accepted(value: new
             {
-                error = "bookmark_not_found",
+                buffered = true,
                 bookmark = qualified,
-                detail = "No PR-merged wait is currently suspended for this PR.",
+                detail = "No PR-merged wait is suspended yet; the notification is buffered for the wait's registration.",
             });
         }
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -428,6 +428,25 @@ builder.Services.Configure<ProviderAllowlistOptions>(
     builder.Configuration.GetSection("Security:ProviderAllowlist"));
 builder.Services.AddSingleton<ProviderAllowlist>();
 
+// 2026-08-13 (Epic 31 P5 follow-up) — the OPT-IN scripted LLM provider, engine
+// side. The engine never serves scripted responses (the responder lives in
+// Tamma.Api); all it does here is ALLOW-LIST the "scripted" key so the
+// LlmCallWorkflow provider chain can name it (Llm:DefaultProviderChain /
+// caller / agent-config chains — see LlmProviderChainHelper). Default: no-op.
+// Flag on + any SaaS/production signal ⇒ the engine REFUSES TO START (the same
+// structural guard as the API host).
+if (ScriptedProviderPosture.AssertAllowed(builder.Configuration))
+{
+    builder.Services.PostConfigure<ProviderAllowlistOptions>(o =>
+    {
+        if (!o.AdditionalProviders.Contains(
+                ScriptedProviderPosture.ProviderKey, StringComparer.OrdinalIgnoreCase))
+        {
+            o.AdditionalProviders.Add(ScriptedProviderPosture.ProviderKey);
+        }
+    });
+}
+
 // Story 32-5 (AC9) — the engine holds NO LLM provider key.
 //
 // The 32-3 engine credential-resolver wiring was DELETED here: after the Epic-32

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Program.cs
@@ -222,16 +222,21 @@ Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorE
         builder.Services,
         sp => sp.GetRequiredService<Tamma.Activities.Documents.EngineChannelPublisher>());
 
-// Story 39-10 (D1/D7) — crash re-entry. 39-11 has landed, so the REAL
-// LifecycleReEntryService (over IDocumentInstanceRepository + IEventRepository) is the
-// default. The Null seam stays a config-flag fallback: set Documents:ReEntryDisabled=true
+// Story 39-10 (D1/D7) — crash re-entry. 2026-08-13 (engine-driven E2E follow-up):
+// the ENGINE host default is the HTTP-backed read over the API's 39-11 surface —
+// the REAL LifecycleReEntryService needs IDocumentInstanceRepository/IEventRepository,
+// which only the API host composes (AddTammaData is API-only), so registering it
+// here was a first-resolution landmine; before the HTTP seam existed the engine
+// shipped with the Null seam permanently selected, which blinded the plan-review
+// shim's latest-accepted read and terminated every engine-driven cycle needs-human.
+// The Null seam stays a config-flag fallback: set Documents:ReEntryDisabled=true
 // to disable a bad latest-accepted read by DI swap WITHOUT touching the lifecycle.
 if (builder.Configuration.GetValue<bool>("Documents:ReEntryDisabled"))
     builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
         Tamma.Activities.Documents.NullLifecycleReEntryService>();
 else
     builder.Services.AddScoped<Tamma.Activities.Documents.ILifecycleReEntryService,
-        Tamma.Activities.Documents.LifecycleReEntryService>();
+        Tamma.Activities.Documents.HttpLifecycleReEntryService>();
 
 // Round-2 review M3 — bridge that polls platform_events for new
 // TENANT.CLEANUP.REQUESTED rows and re-publishes the matching Elsa
@@ -406,6 +411,14 @@ builder.Services.AddSingleton(_ =>
 builder.Services.AddScoped<Tamma.Activities.AgentDispatch.LocalExecutor>();
 builder.Services.AddScoped<Tamma.Activities.AgentDispatch.GitHubActionsExecutor>();
 builder.Services.AddScoped<Tamma.Activities.AgentDispatch.AgentExecutorFactory>();
+
+// 2026-08-13 (engine-driven E2E run 39) — the self-merge race buffer: a
+// merged-PR webhook that arrives BEFORE WaitForPRMerged registers its bookmark
+// is recorded here by PrMergedResumeEndpoint and consumed by the wait at
+// registration (reconcile-on-register). Singleton on purpose: the buffer
+// bridges an in-process ordering race; the durable 12h SLA stays the
+// restart-safe exception path.
+builder.Services.AddSingleton<Tamma.Activities.ADL.PendingPrMergeBuffer>();
 
 // Story 28-5 AC4 — optional pre-drop tenant backup (pg_dump). Disabled
 // by default; the DeleteTenantWorkflow's BackupTenantDatabaseActivity

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AcceptanceCriteriaAuthoringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AcceptanceCriteriaAuthoringWorkflow.cs
@@ -77,46 +77,46 @@ public class AcceptanceCriteriaAuthoringWorkflow : WorkflowBase
         // crashed, because DocumentLifecycleWorkflow mints a UUIDv7 when the input is
         // Guid.Empty — the caller had NO handle to correlate the accept decision with,
         // and the workflow exposed none on exit. That bites when 39-17/39-19 land.
-        var sessionId    = builder.WithVariable<Guid>();
-        var issueId      = builder.WithVariable<string>("IssueId", "");
-        var issueTitle   = builder.WithVariable<string>("IssueTitle", "");
-        var repository   = builder.WithVariable<string>("Repository", "");
-        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0);
-        var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
-        var conventions  = builder.WithVariable<string>("Conventions", "");
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId    = builder.WithVariable<Guid>().Persisted();
+        var issueId      = builder.WithVariable<string>("IssueId", "").Persisted();
+        var issueTitle   = builder.WithVariable<string>("IssueTitle", "").Persisted();
+        var repository   = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var workItemJson = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var conventions  = builder.WithVariable<string>("Conventions", "").Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Consumed upstream documents (D3 carrier / D4 lineage) ──────
-        var clarificationFound   = builder.WithVariable<bool>();
-        var clarificationDocId   = builder.WithVariable<string>("ClarificationDocId", "");
-        var clarificationJson    = builder.WithVariable<string>("ClarificationJson", "");
-        var clarificationLineage = builder.WithVariable<string>();
-        var findingsFound   = builder.WithVariable<bool>();
-        var findingsDocId   = builder.WithVariable<string>("FindingsDocId", "");
-        var findingsJson    = builder.WithVariable<string>("FindingsJson", "");
-        var findingsLineage = builder.WithVariable<string>();
+        var clarificationFound   = builder.WithVariable<bool>().Persisted();
+        var clarificationDocId   = builder.WithVariable<string>("ClarificationDocId", "").Persisted();
+        var clarificationJson    = builder.WithVariable<string>("ClarificationJson", "").Persisted();
+        var clarificationLineage = builder.WithVariable<string>().Persisted();
+        var findingsFound   = builder.WithVariable<bool>().Persisted();
+        var findingsDocId   = builder.WithVariable<string>("FindingsDocId", "").Persisted();
+        var findingsJson    = builder.WithVariable<string>("FindingsJson", "").Persisted();
+        var findingsLineage = builder.WithVariable<string>().Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D5) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var lifecycleDrafted  = builder.WithVariable<bool>();
-        var exitOutcome       = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId         = builder.WithVariable<string>("ExitDocId", "");
-        var criteriaJson      = builder.WithVariable<string>("CriteriaJson", "[]");
-        var criteriaCount     = builder.WithVariable<int>();
-        var parentDocumentId  = builder.WithVariable<string>("ParentDocumentId", "");
-        var failureDetail     = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus      = builder.WithVariable<string>();
+        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var lifecycleDrafted  = builder.WithVariable<bool>().Persisted();
+        var exitOutcome       = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId         = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var criteriaJson      = builder.WithVariable<string>("CriteriaJson", "[]").Persisted();
+        var criteriaCount     = builder.WithVariable<int>().Persisted();
+        var parentDocumentId  = builder.WithVariable<string>("ParentDocumentId", "").Persisted();
+        var failureDetail     = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus      = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
@@ -53,13 +53,13 @@ public class AdlOrchestratorWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var configJson = builder.WithVariable<string>("ConfigJson", "{}");
-        var repository = builder.WithVariable<string>("Repository", "");
-        var issueLabels = builder.WithVariable<string[]>("IssueLabels", Array.Empty<string>());
-        var botAssignee = builder.WithVariable<string>("BotAssignee", "tamma-bot");
-        var baseBranch = builder.WithVariable<string>("BaseBranch", "main");
-        var cooldownSeconds = builder.WithVariable<int>("CooldownSeconds", 10);
-        var maxConcurrent = builder.WithVariable<int>("MaxConcurrent", 1);
+        var configJson = builder.WithVariable<string>("ConfigJson", "{}").Persisted();
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueLabels = builder.WithVariable<string[]>("IssueLabels", Array.Empty<string>()).Persisted();
+        var botAssignee = builder.WithVariable<string>("BotAssignee", "tamma-bot").Persisted();
+        var baseBranch = builder.WithVariable<string>("BaseBranch", "main").Persisted();
+        var cooldownSeconds = builder.WithVariable<int>("CooldownSeconds", 10).Persisted();
+        var maxConcurrent = builder.WithVariable<int>("MaxConcurrent", 1).Persisted();
 
         // Deployment mode + tenant threaded to each dispatched cycle (and from
         // there into the deployment pipeline's production-approval gate). These
@@ -69,12 +69,12 @@ public class AdlOrchestratorWorkflow : WorkflowBase
         // empty and DispatchCycleActivity derives the real mode from configuration
         // (mirrors TammaModeProvider). A SaaS dispatcher / operator may still set
         // `mode`/`tenantId` on the orchestrator input to override per-instance.
-        var mode = builder.WithVariable<string>("Mode", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var mode = builder.WithVariable<string>("Mode", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
 
         // Selected work item data
-        var selectedItemJson = builder.WithVariable<string?>("SelectedItemJson", null);
-        var selectedIssueNumber = builder.WithVariable<int>("SelectedIssueNumber", 0);
+        var selectedItemJson = builder.WithVariable<string?>("SelectedItemJson", null).Persisted();
+        var selectedIssueNumber = builder.WithVariable<int>("SelectedIssueNumber", 0).Persisted();
 
         // ================================================================
         // 1. Load Config

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdlOrchestratorWorkflow.cs
@@ -169,6 +169,22 @@ public class AdlOrchestratorWorkflow : WorkflowBase
         };
         cooldown.SetDisplayText("Cooldown");
 
+        // 2026-08-13 (engine-driven E2E): the WAIT is a stock scheduling Delay
+        // (timer bookmark ⇒ the instance SUSPENDS and frees the dispatch
+        // worker). CooldownActivity used to Task.Delay in-process, which held
+        // the runtime's dispatch slot for the whole cooldown — with a real
+        // 3600s cooldown, every subsequently dispatched workflow (all the
+        // cycle's llm-calls included) queued behind the sleeping orchestrator
+        // and the loop deadlocked itself. CooldownActivity now only emits the
+        // ADL.COOLDOWN audit pair; this node does the waiting.
+        var cooldownWait = new Elsa.Scheduling.Activities.Delay(
+            ctx => TimeSpan.FromSeconds(Math.Max(1, cooldownSeconds.Get(ctx))))
+        {
+            Id = "CooldownWait",
+            Name = "Cooldown Wait",
+        };
+        cooldownWait.SetDisplayText("Cooldown Wait");
+
         // ================================================================
         // Exit paths
         // ================================================================
@@ -212,7 +228,7 @@ public class AdlOrchestratorWorkflow : WorkflowBase
             Activities =
             {
                 initConfig, selectWorkItem, dispatchTriage,
-                checkLimits, dispatchCycle, cooldown,
+                checkLimits, dispatchCycle, cooldown, cooldownWait,
                 exitNoIssues, exitLimits, dispatchAdl, finish
             },
             Connections =
@@ -239,8 +255,10 @@ public class AdlOrchestratorWorkflow : WorkflowBase
                 ConnectOutcome(checkLimits, "Continue", dispatchCycle),
                 Connect(dispatchCycle, cooldown),
 
-                // All paths: cooldown → dispatch new ADL → finish this instance
-                Connect(cooldown, dispatchAdl),
+                // All paths: cooldown (emit) → cooldown wait (timer bookmark)
+                // → dispatch new ADL → finish this instance
+                Connect(cooldown, cooldownWait),
+                Connect(cooldownWait, dispatchAdl),
                 Connect(dispatchAdl, finish),
             }
         };

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdrAuthoringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AdrAuthoringWorkflow.cs
@@ -72,46 +72,46 @@ public class AdrAuthoringWorkflow : WorkflowBase
         builder.Description = "Capture a significant technical decision as an audience-tagged prose ADR via the generic document lifecycle (produce → validate → review → revise → accept)";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var sessionId    = builder.WithVariable<Guid>();
-        var issueId      = builder.WithVariable<string>("IssueId", "");
-        var scopedIssueId = builder.WithVariable<string>("ScopedIssueId", "");
-        var repository   = builder.WithVariable<string>("Repository", "");
-        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0);
-        var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
-        var decisionContext = builder.WithVariable<string>("DecisionContext", "");
-        var audience     = builder.WithVariable<string>("Audience", "");
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId    = builder.WithVariable<Guid>().Persisted();
+        var issueId      = builder.WithVariable<string>("IssueId", "").Persisted();
+        var scopedIssueId = builder.WithVariable<string>("ScopedIssueId", "").Persisted();
+        var repository   = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var workItemJson = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var decisionContext = builder.WithVariable<string>("DecisionContext", "").Persisted();
+        var audience     = builder.WithVariable<string>("Audience", "").Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Consumed upstream documents (D2 — both optional, fail-closed) ──
-        var designFound   = builder.WithVariable<bool>();
-        var designDocId   = builder.WithVariable<string>("DesignDocId", "");
-        var designJson    = builder.WithVariable<string>("DesignJson", "");
-        var designLineage = builder.WithVariable<string>();
-        var findingsFound   = builder.WithVariable<bool>();
-        var findingsDocId   = builder.WithVariable<string>("FindingsDocId", "");
-        var findingsJson    = builder.WithVariable<string>("FindingsJson", "");
-        var findingsLineage = builder.WithVariable<string>();
+        var designFound   = builder.WithVariable<bool>().Persisted();
+        var designDocId   = builder.WithVariable<string>("DesignDocId", "").Persisted();
+        var designJson    = builder.WithVariable<string>("DesignJson", "").Persisted();
+        var designLineage = builder.WithVariable<string>().Persisted();
+        var findingsFound   = builder.WithVariable<bool>().Persisted();
+        var findingsDocId   = builder.WithVariable<string>("FindingsDocId", "").Persisted();
+        var findingsJson    = builder.WithVariable<string>("FindingsJson", "").Persisted();
+        var findingsLineage = builder.WithVariable<string>().Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var lifecycleDrafted  = builder.WithVariable<bool>();
-        var exitOutcome       = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId         = builder.WithVariable<string>("ExitDocId", "");
-        var adrJson           = builder.WithVariable<string>("AdrJson", "");
-        var acceptedAudience  = builder.WithVariable<string>("AcceptedAudience", "");
-        var failureDetail     = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus      = builder.WithVariable<string>();
+        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var lifecycleDrafted  = builder.WithVariable<bool>().Persisted();
+        var exitOutcome       = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId         = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var adrJson           = builder.WithVariable<string>("AdrJson", "").Persisted();
+        var acceptedAudience  = builder.WithVariable<string>("AcceptedAudience", "").Persisted();
+        var failureDetail     = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus      = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AmbiguityScoringWorkflow.cs
@@ -46,34 +46,34 @@ public class AmbiguityScoringWorkflow : WorkflowBase
         builder.Description = "Score how ambiguous/underspecified a requirement is via the generic document lifecycle; above-threshold routes to clarification as a typed outcome";
 
         // ── Inputs (legacy `threshold` input retired — the threshold is acceptance-rules config, 39-5) ──
-        var sessionId        = builder.WithVariable<Guid>();
-        var issueId          = builder.WithVariable<string>();
-        var requirement      = builder.WithVariable<string>();
-        var ambiguityContext = builder.WithVariable<string>();
-        var tenantId         = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId        = builder.WithVariable<Guid>().Persisted();
+        var issueId          = builder.WithVariable<string>().Persisted();
+        var requirement      = builder.WithVariable<string>().Persisted();
+        var ambiguityContext = builder.WithVariable<string>().Persisted();
+        var tenantId         = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var isAmbiguity     = builder.WithVariable<bool>();
-        var hasAssessment   = builder.WithVariable<bool>();
-        var exitStatus      = builder.WithVariable<string>("ExitStatus", "");
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
-        var score           = builder.WithVariable<double>();
-        var ambiguityCount  = builder.WithVariable<int>();
-        var confidence      = builder.WithVariable<double>();
-        var threshold       = builder.WithVariable<double>();
-        var decision        = builder.WithVariable<string>("Decision", "");
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus    = builder.WithVariable<string>();
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var isAmbiguity     = builder.WithVariable<bool>().Persisted();
+        var hasAssessment   = builder.WithVariable<bool>().Persisted();
+        var exitStatus      = builder.WithVariable<string>("ExitStatus", "").Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
+        var score           = builder.WithVariable<double>().Persisted();
+        var ambiguityCount  = builder.WithVariable<int>().Persisted();
+        var confidence      = builder.WithVariable<double>().Persisted();
+        var threshold       = builder.WithVariable<double>().Persisted();
+        var decision        = builder.WithVariable<string>("Decision", "").Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/AssessmentWorkflow.cs
@@ -52,48 +52,48 @@ public class AssessmentWorkflow : WorkflowBase
         builder.Description = "Evaluate junior developer's understanding of story requirements";
 
         // ── Workflow variables ──────────────────────────────────────────
-        var sessionId        = builder.WithVariable<Guid>();
-        var storyId          = builder.WithVariable<string>();
-        var juniorId         = builder.WithVariable<string>();
-        var skillLevel       = builder.WithVariable<int>();
-        var previousAttemptJson = builder.WithVariable<string>();
-        var tenantId         = builder.WithVariable<string>("TenantId", "");
-        var storyContext     = builder.WithVariable<string>();
-        var questionsJson    = builder.WithVariable<string>();
-        var juniorResponse   = builder.WithVariable<string>();
-        var analysisResultJson = builder.WithVariable<string>();
-        var responseReceived = builder.WithVariable<bool>();
-        var assessmentStatus = builder.WithVariable<AssessmentOutcomeStatus>();
-        var confidence       = builder.WithVariable<decimal>();
-        var nextState        = builder.WithVariable<MentorshipState>();
-        var gapsJson         = builder.WithVariable<string>();
-        var strengthsJson    = builder.WithVariable<string>();
-        var attemptNumber    = builder.WithVariable<int>();
+        var sessionId        = builder.WithVariable<Guid>().Persisted();
+        var storyId          = builder.WithVariable<string>().Persisted();
+        var juniorId         = builder.WithVariable<string>().Persisted();
+        var skillLevel       = builder.WithVariable<int>().Persisted();
+        var previousAttemptJson = builder.WithVariable<string>().Persisted();
+        var tenantId         = builder.WithVariable<string>("TenantId", "").Persisted();
+        var storyContext     = builder.WithVariable<string>().Persisted();
+        var questionsJson    = builder.WithVariable<string>().Persisted();
+        var juniorResponse   = builder.WithVariable<string>().Persisted();
+        var analysisResultJson = builder.WithVariable<string>().Persisted();
+        var responseReceived = builder.WithVariable<bool>().Persisted();
+        var assessmentStatus = builder.WithVariable<AssessmentOutcomeStatus>().Persisted();
+        var confidence       = builder.WithVariable<decimal>().Persisted();
+        var nextState        = builder.WithVariable<MentorshipState>().Persisted();
+        var gapsJson         = builder.WithVariable<string>().Persisted();
+        var strengthsJson    = builder.WithVariable<string>().Persisted();
+        var attemptNumber    = builder.WithVariable<int>().Persisted();
 
         // llm-call result containers
-        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
-        var questionLlm         = builder.WithVariable<IDictionary<string, object>?>();
-        var analysisLlm         = builder.WithVariable<IDictionary<string, object>?>();
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var questionLlm         = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var analysisLlm         = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // Success flags (fail-closed guards)
-        var questionsLlmOk  = builder.WithVariable<bool>();
-        var analysisLlmOk   = builder.WithVariable<bool>();
+        var questionsLlmOk  = builder.WithVariable<bool>().Persisted();
+        var analysisLlmOk   = builder.WithVariable<bool>().Persisted();
 
         // Variables to capture activity outputs via binding
-        var generatedQuestionSet = builder.WithVariable<QuestionSet>();
-        var deliveryResult       = builder.WithVariable<DeliveryResult>();
-        var waitJuniorResponse   = builder.WithVariable<string>();
-        var waitResponseReceived = builder.WithVariable<bool>();
-        var analysisOutput       = builder.WithVariable<AnalysisResult>();
-        var classifiedStatus     = builder.WithVariable<AssessmentOutcomeStatus>();
-        var classifiedConfidence = builder.WithVariable<decimal>();
-        var classifiedNextState  = builder.WithVariable<MentorshipState>();
+        var generatedQuestionSet = builder.WithVariable<QuestionSet>().Persisted();
+        var deliveryResult       = builder.WithVariable<DeliveryResult>().Persisted();
+        var waitJuniorResponse   = builder.WithVariable<string>().Persisted();
+        var waitResponseReceived = builder.WithVariable<bool>().Persisted();
+        var analysisOutput       = builder.WithVariable<AnalysisResult>().Persisted();
+        var classifiedStatus     = builder.WithVariable<AssessmentOutcomeStatus>().Persisted();
+        var classifiedConfidence = builder.WithVariable<decimal>().Persisted();
+        var classifiedNextState  = builder.WithVariable<MentorshipState>().Persisted();
 
         // Output variables (readable by parent workflow)
-        var outputResultJson  = builder.WithVariable<string>();
-        var outputNextState   = builder.WithVariable<string>();
-        var outputStatus      = builder.WithVariable<string>();
-        var outputSkillLevel  = builder.WithVariable<int>();
+        var outputResultJson  = builder.WithVariable<string>().Persisted();
+        var outputNextState   = builder.WithVariable<string>().Persisted();
+        var outputStatus      = builder.WithVariable<string>().Persisted();
+        var outputSkillLevel  = builder.WithVariable<int>().Persisted();
 
         // ── Step 1: Read inputs into variables ─────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BacklogPrioritizationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BacklogPrioritizationWorkflow.cs
@@ -93,59 +93,59 @@ public class BacklogPrioritizationWorkflow : WorkflowBase
         builder.Description = "Rank a candidate backlog item set into a typed BacklogOrdering (total order, rationale + value/effort per item, no ties) via the generic document lifecycle (produce → validate → review → revise → accept)";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var sessionId    = builder.WithVariable<Guid>();
-        var repository   = builder.WithVariable<string>("Repository", "");
-        var backlogScope = builder.WithVariable<string>("BacklogScope", "");
-        var itemsJson    = builder.WithVariable<string>("ItemsJson", "[]");
-        var repoContext  = builder.WithVariable<string>("RepoContext", "");
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId    = builder.WithVariable<Guid>().Persisted();
+        var repository   = builder.WithVariable<string>("Repository", "").Persisted();
+        var backlogScope = builder.WithVariable<string>("BacklogScope", "").Persisted();
+        var itemsJson    = builder.WithVariable<string>("ItemsJson", "[]").Persisted();
+        var repoContext  = builder.WithVariable<string>("RepoContext", "").Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── D2 anchor + the parsed candidate set ───────────────────────
-        var backlogAnchor     = builder.WithVariable<string>("BacklogAnchor", "");
-        var evidenceAnchors   = builder.WithVariable<object>("EvidenceAnchors", new List<string>());
-        var producerItemsJson = builder.WithVariable<string>("ProducerItemsJson", "[]");
-        var itemCount         = builder.WithVariable<int>("ItemCount", 0);
+        var backlogAnchor     = builder.WithVariable<string>("BacklogAnchor", "").Persisted();
+        var evidenceAnchors   = builder.WithVariable<object>("EvidenceAnchors", new List<string>()).Persisted();
+        var producerItemsJson = builder.WithVariable<string>("ProducerItemsJson", "[]").Persisted();
+        var itemCount         = builder.WithVariable<int>("ItemCount", 0).Persisted();
 
         // ── D3 per-item evidence reads (bounded, fail-closed) ──────────
-        var currentItemIssueId = builder.WithVariable<string>("CurrentItemIssueId", "");
-        var evidence      = builder.WithVariable<string>("Evidence", "");
-        var evidenceHits  = builder.WithVariable<int>("EvidenceHits", 0);
+        var currentItemIssueId = builder.WithVariable<string>("CurrentItemIssueId", "").Persisted();
+        var evidence      = builder.WithVariable<string>("Evidence", "").Persisted();
+        var evidenceHits  = builder.WithVariable<int>("EvidenceHits", 0).Persisted();
 
-        var triageFound   = builder.WithVariable<bool>();
-        var triageDocId   = builder.WithVariable<string>("TriageDocId", "");
-        var triageJson    = builder.WithVariable<string>("TriageJson", "");
-        var triageLineage = builder.WithVariable<string>();
+        var triageFound   = builder.WithVariable<bool>().Persisted();
+        var triageDocId   = builder.WithVariable<string>("TriageDocId", "").Persisted();
+        var triageJson    = builder.WithVariable<string>("TriageJson", "").Persisted();
+        var triageLineage = builder.WithVariable<string>().Persisted();
 
-        var researchFindingsFound   = builder.WithVariable<bool>();
-        var researchFindingsDocId   = builder.WithVariable<string>("ResearchFindingsDocId", "");
-        var researchFindingsJson    = builder.WithVariable<string>("ResearchFindingsJson", "");
-        var researchFindingsLineage = builder.WithVariable<string>();
+        var researchFindingsFound   = builder.WithVariable<bool>().Persisted();
+        var researchFindingsDocId   = builder.WithVariable<string>("ResearchFindingsDocId", "").Persisted();
+        var researchFindingsJson    = builder.WithVariable<string>("ResearchFindingsJson", "").Persisted();
+        var researchFindingsLineage = builder.WithVariable<string>().Persisted();
 
-        var triageContextFindingsFound   = builder.WithVariable<bool>();
-        var triageContextFindingsDocId   = builder.WithVariable<string>("TriageContextFindingsDocId", "");
-        var triageContextFindingsJson    = builder.WithVariable<string>("TriageContextFindingsJson", "");
-        var triageContextFindingsLineage = builder.WithVariable<string>();
+        var triageContextFindingsFound   = builder.WithVariable<bool>().Persisted();
+        var triageContextFindingsDocId   = builder.WithVariable<string>("TriageContextFindingsDocId", "").Persisted();
+        var triageContextFindingsJson    = builder.WithVariable<string>("TriageContextFindingsJson", "").Persisted();
+        var triageContextFindingsLineage = builder.WithVariable<string>().Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D6) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var lifecycleOrdered  = builder.WithVariable<bool>();
-        var exitOutcome   = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId     = builder.WithVariable<string>("ExitDocId", "");
-        var orderingJson  = builder.WithVariable<string>("OrderingJson", "[]");
-        var orderedCount  = builder.WithVariable<int>("OrderedCount", 0);
-        var failureDetail = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus  = builder.WithVariable<string>();
+        var lifecycleResult   = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var lifecycleOrdered  = builder.WithVariable<bool>().Persisted();
+        var exitOutcome   = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId     = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var orderingJson  = builder.WithVariable<string>("OrderingJson", "[]").Persisted();
+        var orderedCount  = builder.WithVariable<int>("OrderedCount", 0).Persisted();
+        var failureDetail = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus  = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs, build the D2 anchor, parse the item set ──
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BlockerDiagnosisWorkflow.cs
@@ -82,37 +82,37 @@ public class BlockerDiagnosisWorkflow : WorkflowBase
         // ============================================
         // Workflow Variables
         // ============================================
-        var sessionId = builder.WithVariable<Guid>();
-        var storyId = builder.WithVariable<string>();
-        var juniorId = builder.WithVariable<string>();
-        var tenantId = builder.WithVariable<string>();
-        var skillLevel = builder.WithVariable<int>();
-        var blockerContext = builder.WithVariable<string?>();
-        var repository = builder.WithVariable<string>();
-        var branchName = builder.WithVariable<string>();
+        var sessionId = builder.WithVariable<Guid>().Persisted();
+        var storyId = builder.WithVariable<string>().Persisted();
+        var juniorId = builder.WithVariable<string>().Persisted();
+        var tenantId = builder.WithVariable<string>().Persisted();
+        var skillLevel = builder.WithVariable<int>().Persisted();
+        var blockerContext = builder.WithVariable<string?>().Persisted();
+        var repository = builder.WithVariable<string>().Persisted();
+        var branchName = builder.WithVariable<string>().Persisted();
 
         // Signal variables
-        var gitSignal = builder.WithVariable<GitActivitySignal>();
-        var ciSignal = builder.WithVariable<CIStatusSignal>();
-        var inactivitySignal = builder.WithVariable<InactivitySignal>();
-        var communicationSignal = builder.WithVariable<CommunicationSignal>();
-        var aggregatedSignals = builder.WithVariable<AggregatedSignals>();
+        var gitSignal = builder.WithVariable<GitActivitySignal>().Persisted();
+        var ciSignal = builder.WithVariable<CIStatusSignal>().Persisted();
+        var inactivitySignal = builder.WithVariable<InactivitySignal>().Persisted();
+        var communicationSignal = builder.WithVariable<CommunicationSignal>().Persisted();
+        var aggregatedSignals = builder.WithVariable<AggregatedSignals>().Persisted();
 
         // Diagnosis variables
-        var llmDiagnosisOutput = builder.WithVariable<IDictionary<string, object>?>();
-        var diagnosisResult = builder.WithVariable<BlockerDiagnosisResult>();
+        var llmDiagnosisOutput = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var diagnosisResult = builder.WithVariable<BlockerDiagnosisResult>().Persisted();
 
         // Resolution tracking
-        var currentLevel = builder.WithVariable<string>("Hint");
-        var attempts = builder.WithVariable<int>(0);
-        var feedbackProvided = builder.WithVariable<List<string>>();
-        var startTime = builder.WithVariable<DateTime>();
-        var isResolved = builder.WithVariable<bool>(false);
-        var progressDetected = builder.WithVariable<bool>(false);
-        var progressTimedOut = builder.WithVariable<bool>(false);
-        var progressResult = builder.WithVariable<ProgressDetectionResult>();
+        var currentLevel = builder.WithVariable<string>("Hint").Persisted();
+        var attempts = builder.WithVariable<int>(0).Persisted();
+        var feedbackProvided = builder.WithVariable<List<string>>().Persisted();
+        var startTime = builder.WithVariable<DateTime>().Persisted();
+        var isResolved = builder.WithVariable<bool>(false).Persisted();
+        var progressDetected = builder.WithVariable<bool>(false).Persisted();
+        var progressTimedOut = builder.WithVariable<bool>(false).Persisted();
+        var progressResult = builder.WithVariable<ProgressDetectionResult>().Persisted();
         // Escalation SLA expired with no senior response → terminal Timeout (7-1G AC2).
-        var timedOut = builder.WithVariable<bool>(false);
+        var timedOut = builder.WithVariable<bool>(false).Persisted();
 
         // ============================================
         // Activities

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BranchCreationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/BranchCreationWorkflow.cs
@@ -48,19 +48,19 @@ public class BranchCreationWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var issueTitleVar = builder.WithVariable<string>("IssueTitle", "");
-        var baseBranchVar = builder.WithVariable<string>("BaseBranch", "main");
-        var conflictStrategyVar = builder.WithVariable<string>("ConflictStrategy", "suffix");
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var issueTitleVar = builder.WithVariable<string>("IssueTitle", "").Persisted();
+        var baseBranchVar = builder.WithVariable<string>("BaseBranch", "main").Persisted();
+        var conflictStrategyVar = builder.WithVariable<string>("ConflictStrategy", "suffix").Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
 
-        var branchNameVar = builder.WithVariable<string>("BranchName", "");
-        var baseShaVar = builder.WithVariable<string>("BaseSha", "");
-        var conflictResolvedVar = builder.WithVariable<bool>("ConflictResolved", false);
-        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
-        var errorVar = builder.WithVariable<string>("Error", "");
-        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
+        var branchNameVar = builder.WithVariable<string>("BranchName", "").Persisted();
+        var baseShaVar = builder.WithVariable<string>("BaseSha", "").Persisted();
+        var conflictResolvedVar = builder.WithVariable<bool>("ConflictResolved", false).Persisted();
+        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "").Persisted();
+        var errorVar = builder.WithVariable<string>("Error", "").Persisted();
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0).Persisted();
 
         // ================================================================
         // 1. Read inputs (derive issueTitle from workItemJson when not supplied —

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CiWithDebugRetryWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CiWithDebugRetryWorkflow.cs
@@ -44,17 +44,17 @@ public class CiWithDebugRetryWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var skillLevel = builder.WithVariable<int>("SkillLevel", 5);
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var skillLevel = builder.WithVariable<int>("SkillLevel", 5).Persisted();
         // Epic 31 review (F-high) — the cycle passes tenantId into this gate
         // (SingleIssueCycleWorkflow / MergeApprovalWorkflow both send it) and
         // this workflow used to DROP it, so the whole CI plane below ran
         // platform-scoped in SaaS. Named "TenantId" per the MediatedLlmText
         // ambient convention so EventPersistenceMiddleware tags this
         // instance's events with the tenant too.
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
         // ciRetryCount is always reset to 0 on workflow entry (see initInputs below)
         // so each invocation gets the full retry budget regardless of prior history.
         //
@@ -64,12 +64,12 @@ public class CiWithDebugRetryWorkflow : WorkflowBase
         // dispatches a fresh ci-with-debug-retry instance per CI check phase, so there
         // is no cross-invocation counter leakage. The originally reported bug (counter
         // persisting across re-entries) was stale — the reset logic was already correct.
-        var ciRetryCount = builder.WithVariable<int>("CiRetryCount", 0);
-        var maxRetries = builder.WithVariable<int>("MaxRetries", 3);
+        var ciRetryCount = builder.WithVariable<int>("CiRetryCount", 0).Persisted();
+        var maxRetries = builder.WithVariable<int>("MaxRetries", 3).Persisted();
 
         // DispatchWorkflow result capture
-        var testResult = builder.WithVariable<IDictionary<string, object>?>();
-        var debugResult = builder.WithVariable<IDictionary<string, object>?>();
+        var testResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var debugResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // INIT: Capture inputs

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ClarifyingQuestionsWorkflow.cs
@@ -50,42 +50,42 @@ public class ClarifyingQuestionsWorkflow : WorkflowBase
         builder.Description = "Resolve requirement ambiguity via two clarification-lifecycle runs (questions → suspend → resolution) over the generic document lifecycle";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var sessionId       = builder.WithVariable<Guid>();
-        var issueId         = builder.WithVariable<string>();
-        var requirement     = builder.WithVariable<string>();
-        var repository      = builder.WithVariable<string>();
-        var issueNumber     = builder.WithVariable<int>();
-        var ambiguityContext = builder.WithVariable<string>();
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId       = builder.WithVariable<Guid>().Persisted();
+        var issueId         = builder.WithVariable<string>().Persisted();
+        var requirement     = builder.WithVariable<string>().Persisted();
+        var repository      = builder.WithVariable<string>().Persisted();
+        var issueNumber     = builder.WithVariable<int>().Persisted();
+        var ambiguityContext = builder.WithVariable<string>().Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
-        var existingResolved = builder.WithVariable<bool>();
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
+        var existingResolved = builder.WithVariable<bool>().Persisted();
 
         // ── Run A / Run B state ────────────────────────────────────────
-        var runAResult      = builder.WithVariable<IDictionary<string, object>?>();
-        var runBResult      = builder.WithVariable<IDictionary<string, object>?>();
-        var runAAccepted    = builder.WithVariable<bool>();
-        var runBAccepted    = builder.WithVariable<bool>();
-        var questionsJson   = builder.WithVariable<string>("QuestionsJson", "{}");
-        var questionCount   = builder.WithVariable<int>();
-        var clarifiedJson   = builder.WithVariable<string>("ClarifiedJson", "{}");
-        var resolved        = builder.WithVariable<bool>();
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
+        var runAResult      = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var runBResult      = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var runAAccepted    = builder.WithVariable<bool>().Persisted();
+        var runBAccepted    = builder.WithVariable<bool>().Persisted();
+        var questionsJson   = builder.WithVariable<string>("QuestionsJson", "{}").Persisted();
+        var questionCount   = builder.WithVariable<int>().Persisted();
+        var clarifiedJson   = builder.WithVariable<string>("ClarifiedJson", "{}").Persisted();
+        var resolved        = builder.WithVariable<bool>().Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
 
         // ── Input-gate outputs ─────────────────────────────────────────
-        var deliveryResult  = builder.WithVariable<ClarifyDeliveryResult>();
-        var inputReceived   = builder.WithVariable<bool>();
-        var inputTimedOut   = builder.WithVariable<bool>();
-        var answers         = builder.WithVariable<string>("Answers", "");
+        var deliveryResult  = builder.WithVariable<ClarifyDeliveryResult>().Persisted();
+        var inputReceived   = builder.WithVariable<bool>().Persisted();
+        var inputTimedOut   = builder.WithVariable<bool>().Persisted();
+        var answers         = builder.WithVariable<string>("Answers", "").Persisted();
 
         // ── Outputs ────────────────────────────────────────────────────
-        var outputStatus        = builder.WithVariable<string>();
+        var outputStatus        = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CleanUpFailedTenantWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CleanUpFailedTenantWorkflow.cs
@@ -106,8 +106,8 @@ public class CleanUpFailedTenantWorkflow : WorkflowBase
             + "Each step runs independently with continue-on-error semantics; a single "
             + "terminal event reports the overall outcome.";
 
-        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty);
-        var note = builder.WithVariable<string?>("Note", null);
+        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty).Persisted();
+        var note = builder.WithVariable<string?>("Note", null).Persisted();
 
         // Round-2 review M3: starter trigger bound to the event the
         // bridge re-publishes for every TENANT.CLEANUP.REQUESTED row

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CodeReviewWorkflow.cs
@@ -61,45 +61,45 @@ public class CodeReviewWorkflow : WorkflowBase
         // ============================================
         // Workflow variables
         // ============================================
-        var sessionId = builder.WithVariable<string>("SessionId", "");
-        var sessionIdGuid = builder.WithVariable<Guid>("SessionIdGuid", Guid.Empty);
-        var storyId = builder.WithVariable<string>("StoryId", "");
-        var juniorId = builder.WithVariable<string>("JuniorId", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var repositoryUrl = builder.WithVariable<string>("RepositoryUrl", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var baseBranch = builder.WithVariable<string>("BaseBranch", "main");
-        var reviewerIdsJson = builder.WithVariable<string>("ReviewerIdsJson", "");
-        var resolvedReviewers = builder.WithVariable<string>("ResolvedReviewers", "");
-        var skillLevel = builder.WithVariable<int>("SkillLevel", 3);
-        var prNumber = builder.WithVariable<int>("PRNumber", 0);
-        var prUrl = builder.WithVariable<string>("PRUrl", "");
-        var iteration = builder.WithVariable<int>("Iteration", 0);
-        var maxIterations = builder.WithVariable<int>("MaxIterations", 5);
-        var maxIterationsInput = builder.WithVariable<int>("MaxIterationsInput", 0);
-        var mergeStrategyInput = builder.WithVariable<string>("MergeStrategyInput", "");
-        var reviewCommentsJson = builder.WithVariable<string>("ReviewCommentsJson", "[]");
-        var analysisText = builder.WithVariable<string>("AnalysisText", "");
-        var guidanceText = builder.WithVariable<string>("GuidanceText", "");
-        var validationError = builder.WithVariable<string>("ValidationError", "");
-        var escalationResolution = builder.WithVariable<string>("EscalationResolution", "");
-        var mergeShaVar = builder.WithVariable<string>("MergeSha", "");
+        var sessionId = builder.WithVariable<string>("SessionId", "").Persisted();
+        var sessionIdGuid = builder.WithVariable<Guid>("SessionIdGuid", Guid.Empty).Persisted();
+        var storyId = builder.WithVariable<string>("StoryId", "").Persisted();
+        var juniorId = builder.WithVariable<string>("JuniorId", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var repositoryUrl = builder.WithVariable<string>("RepositoryUrl", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var baseBranch = builder.WithVariable<string>("BaseBranch", "main").Persisted();
+        var reviewerIdsJson = builder.WithVariable<string>("ReviewerIdsJson", "").Persisted();
+        var resolvedReviewers = builder.WithVariable<string>("ResolvedReviewers", "").Persisted();
+        var skillLevel = builder.WithVariable<int>("SkillLevel", 3).Persisted();
+        var prNumber = builder.WithVariable<int>("PRNumber", 0).Persisted();
+        var prUrl = builder.WithVariable<string>("PRUrl", "").Persisted();
+        var iteration = builder.WithVariable<int>("Iteration", 0).Persisted();
+        var maxIterations = builder.WithVariable<int>("MaxIterations", 5).Persisted();
+        var maxIterationsInput = builder.WithVariable<int>("MaxIterationsInput", 0).Persisted();
+        var mergeStrategyInput = builder.WithVariable<string>("MergeStrategyInput", "").Persisted();
+        var reviewCommentsJson = builder.WithVariable<string>("ReviewCommentsJson", "[]").Persisted();
+        var analysisText = builder.WithVariable<string>("AnalysisText", "").Persisted();
+        var guidanceText = builder.WithVariable<string>("GuidanceText", "").Persisted();
+        var validationError = builder.WithVariable<string>("ValidationError", "").Persisted();
+        var escalationResolution = builder.WithVariable<string>("EscalationResolution", "").Persisted();
+        var mergeShaVar = builder.WithVariable<string>("MergeSha", "").Persisted();
         // Bound (#IMPORTANT) on the escalate→merge re-merge loop. Each time the merge-failure
         // escalation resolves and routes back to MergeAndComplete we increment this; once it
         // reaches the cap the run terminates as rejected (with a distinct, auditable event)
         // instead of cycling between merge and escalation forever.
-        var mergeRetryCount = builder.WithVariable<int>("MergeRetryCount", 0);
+        var mergeRetryCount = builder.WithVariable<int>("MergeRetryCount", 0).Persisted();
 
         // Config-resolved variables (filled by BindConfig)
-        var mergeStrategy = builder.WithVariable<MergeStrategy>("MergeStrategy", MergeStrategy.Squash);
-        var reviewTimeoutHours = builder.WithVariable<int>("ReviewTimeoutHours", 24);
-        var fixTimeoutHours = builder.WithVariable<int>("FixTimeoutHours", 1);
-        var verifyCi = builder.WithVariable<bool>("VerifyCIBeforeMerge", true);
-        var deleteBranch = builder.WithVariable<bool>("DeleteBranchAfterMerge", true);
+        var mergeStrategy = builder.WithVariable<MergeStrategy>("MergeStrategy", MergeStrategy.Squash).Persisted();
+        var reviewTimeoutHours = builder.WithVariable<int>("ReviewTimeoutHours", 24).Persisted();
+        var fixTimeoutHours = builder.WithVariable<int>("FixTimeoutHours", 1).Persisted();
+        var verifyCi = builder.WithVariable<bool>("VerifyCIBeforeMerge", true).Persisted();
+        var deleteBranch = builder.WithVariable<bool>("DeleteBranchAfterMerge", true).Persisted();
 
         // LLM dispatch result holders
-        var analyzeResult = builder.WithVariable<IDictionary<string, object>?>();
-        var guidanceResult = builder.WithVariable<IDictionary<string, object>?>();
+        var analyzeResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var guidanceResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ============================================
         // 0. Bind inputs (defect #1) — mirror AssessmentWorkflow input binding

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ContextGatheringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ContextGatheringWorkflow.cs
@@ -40,25 +40,25 @@ public class ContextGatheringWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var repository = builder.WithVariable<string>("Repository", "");
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
-        var workItemType = builder.WithVariable<string>("WorkItemType", "feature");
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var workItemJson = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var workItemType = builder.WithVariable<string>("WorkItemType", "feature").Persisted();
 
         // Accumulated findings
-        var devFindings = builder.WithVariable<string>("DevFindings", "{}");
-        var qaFindings = builder.WithVariable<string>("QAFindings", "{}");
-        var securityFindings = builder.WithVariable<string>("SecurityFindings", "{}");
-        var devopsFindings = builder.WithVariable<string>("DevOpsFindings", "{}");
-        var architectFindings = builder.WithVariable<string>("ArchitectFindings", "{}");
+        var devFindings = builder.WithVariable<string>("DevFindings", "{}").Persisted();
+        var qaFindings = builder.WithVariable<string>("QAFindings", "{}").Persisted();
+        var securityFindings = builder.WithVariable<string>("SecurityFindings", "{}").Persisted();
+        var devopsFindings = builder.WithVariable<string>("DevOpsFindings", "{}").Persisted();
+        var architectFindings = builder.WithVariable<string>("ArchitectFindings", "{}").Persisted();
 
         // Context IDs accumulated from per-role storage
-        var contextIds = builder.WithVariable<string>("ContextIds", "[]");
-        var poSummary = builder.WithVariable<string>("POSummary", "");
-        var links = builder.WithVariable<string>("Links", "[]");
+        var contextIds = builder.WithVariable<string>("ContextIds", "[]").Persisted();
+        var poSummary = builder.WithVariable<string>("POSummary", "").Persisted();
+        var links = builder.WithVariable<string>("Links", "[]").Persisted();
 
-        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // 1. Init

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CreateIssuesWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CreateIssuesWorkflow.cs
@@ -64,16 +64,16 @@ public class CreateIssuesWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var issuesJsonVar = builder.WithVariable<string>("IssuesJson", "[]");
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var issuesJsonVar = builder.WithVariable<string>("IssuesJson", "[]").Persisted();
         // MUST be literally "TenantId" — EventPersistenceMiddleware.ResolveTenantId
         // reads this exact variable name to tenant-tag the drained events (AC5).
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
 
-        var createdCountVar = builder.WithVariable<int>("CreatedCount", 0);
-        var failedCountVar = builder.WithVariable<int>("FailedCount", 0);
-        var skippedCountVar = builder.WithVariable<int>("SkippedCount", 0);
-        var issueNumbersJsonVar = builder.WithVariable<string>("IssueNumbersJson", "[]");
+        var createdCountVar = builder.WithVariable<int>("CreatedCount", 0).Persisted();
+        var failedCountVar = builder.WithVariable<int>("FailedCount", 0).Persisted();
+        var skippedCountVar = builder.WithVariable<int>("SkippedCount", 0).Persisted();
+        var issueNumbersJsonVar = builder.WithVariable<string>("IssueNumbersJson", "[]").Persisted();
 
         // ================================================================
         // 1. Read inputs

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CreateTenantWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/CreateTenantWorkflow.cs
@@ -63,13 +63,13 @@ public class CreateTenantWorkflow : WorkflowBase
             "Provision a new tenant: placement + role + schema + migration + encrypted creds + activate.";
 
         // ── Workflow variables ───────────────────────────────────────────
-        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty);
-        var attempt = builder.WithVariable<int>("Attempt", 1);
-        var databaseId = builder.WithVariable<string>("DatabaseId", "");
-        var schemaName = builder.WithVariable<string>("SchemaName", "");
-        var roleName = builder.WithVariable<string>("RoleName", "");
-        var generatedPassword = builder.WithVariable<string>("GeneratedPassword", "");
-        var tenantConnectionString = builder.WithVariable<string>("TenantConnectionString", "");
+        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty).Persisted();
+        var attempt = builder.WithVariable<int>("Attempt", 1).Persisted();
+        var databaseId = builder.WithVariable<string>("DatabaseId", "").Persisted();
+        var schemaName = builder.WithVariable<string>("SchemaName", "").Persisted();
+        var roleName = builder.WithVariable<string>("RoleName", "").Persisted();
+        var generatedPassword = builder.WithVariable<string>("GeneratedPassword", "").Persisted();
+        var tenantConnectionString = builder.WithVariable<string>("TenantConnectionString", "").Persisted();
 
         // ── Inputs ────────────────────────────────────────────────────────
         var initInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebugDiagnosisWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebugDiagnosisWorkflow.cs
@@ -50,35 +50,35 @@ public class DebugDiagnosisWorkflow : WorkflowBase
         builder.Description = "Produce a typed root-cause Diagnosis via the generic document lifecycle (produce → validate → review → revise → accept)";
 
         // ── Inputs (debug context carried into the producer cell) ──────
-        var sessionId       = builder.WithVariable<string>("SessionId", "");
-        var issueId         = builder.WithVariable<string>("IssueId", "");
-        var mode            = builder.WithVariable<string>("Mode", "RuntimeError");
-        var errorContext    = builder.WithVariable<string>("ErrorContext", "");
-        var codeContext     = builder.WithVariable<string>("CodeContext", "");
-        var gitContext      = builder.WithVariable<string>("GitContext", "");
-        var testContext     = builder.WithVariable<string>("TestContext", "");
-        var reproContext    = builder.WithVariable<string>("ReproductionContext", "");
-        var previousContext = builder.WithVariable<string>("PreviousContext", "");
-        var supersedesDocId = builder.WithVariable<string>("SupersedesDocumentId", "");
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId       = builder.WithVariable<string>("SessionId", "").Persisted();
+        var issueId         = builder.WithVariable<string>("IssueId", "").Persisted();
+        var mode            = builder.WithVariable<string>("Mode", "RuntimeError").Persisted();
+        var errorContext    = builder.WithVariable<string>("ErrorContext", "").Persisted();
+        var codeContext     = builder.WithVariable<string>("CodeContext", "").Persisted();
+        var gitContext      = builder.WithVariable<string>("GitContext", "").Persisted();
+        var testContext     = builder.WithVariable<string>("TestContext", "").Persisted();
+        var reproContext    = builder.WithVariable<string>("ReproductionContext", "").Persisted();
+        var previousContext = builder.WithVariable<string>("PreviousContext", "").Persisted();
+        var supersedesDocId = builder.WithVariable<string>("SupersedesDocumentId", "").Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D8) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var hypothesesJson  = builder.WithVariable<string>("HypothesesJson", "[]");
-        var failureReason   = builder.WithVariable<string>("FailureReason", "");
-        var outputStatus    = builder.WithVariable<string>("OutputStatus", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var hypothesesJson  = builder.WithVariable<string>("HypothesesJson", "[]").Persisted();
+        var failureReason   = builder.WithVariable<string>("FailureReason", "").Persisted();
+        var outputStatus    = builder.WithVariable<string>("OutputStatus", "").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebuggingWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DebuggingWorkflow.cs
@@ -61,66 +61,66 @@ public class DebuggingWorkflow : WorkflowBase
         builder.Version = WorkflowVersions.ComputedVersion;
 
         // ---- Workflow variables ----
-        var sessionId = builder.WithVariable<Guid>();
-        var storyId = builder.WithVariable<string>();
-        var debugContextMode = builder.WithVariable<string>();
-        var errorOutput = builder.WithVariable<string>();
-        var relevantFiles = builder.WithVariable<string>();
-        var issueDescription = builder.WithVariable<string>();
-        var repositoryUrl = builder.WithVariable<string>();
-        var branchName = builder.WithVariable<string>();
-        var skillLevel = builder.WithVariable<int>();
+        var sessionId = builder.WithVariable<Guid>().Persisted();
+        var storyId = builder.WithVariable<string>().Persisted();
+        var debugContextMode = builder.WithVariable<string>().Persisted();
+        var errorOutput = builder.WithVariable<string>().Persisted();
+        var relevantFiles = builder.WithVariable<string>().Persisted();
+        var issueDescription = builder.WithVariable<string>().Persisted();
+        var repositoryUrl = builder.WithVariable<string>().Persisted();
+        var branchName = builder.WithVariable<string>().Persisted();
+        var skillLevel = builder.WithVariable<int>().Persisted();
         // Named "TenantId" so MediatedLlmText.ResolveTenantId + the event drain resolve
         // the tenant scope from this ambient variable (SaaS prompts/conventions/creds).
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
 
         // Typed result variables for collector activity outputs (bound via Output<T>)
-        var collectErrorsResult = builder.WithVariable<ErrorMessages>();
-        var collectCodeResult = builder.WithVariable<RelevantCode>();
-        var collectGitResult = builder.WithVariable<GitHistoryContext>();
-        var collectTestsResult = builder.WithVariable<TestResultsContext>();
-        var collectReproResult = builder.WithVariable<ReproductionSteps>();
+        var collectErrorsResult = builder.WithVariable<ErrorMessages>().Persisted();
+        var collectCodeResult = builder.WithVariable<RelevantCode>().Persisted();
+        var collectGitResult = builder.WithVariable<GitHistoryContext>().Persisted();
+        var collectTestsResult = builder.WithVariable<TestResultsContext>().Persisted();
+        var collectReproResult = builder.WithVariable<ReproductionSteps>().Persisted();
 
         // Gathered context variables (string serializations consumed by AIDiagnosis)
-        var errorMessages = builder.WithVariable<string>();
-        var relevantCode = builder.WithVariable<string>();
-        var gitHistory = builder.WithVariable<string>();
-        var testResults = builder.WithVariable<string>();
-        var reproductionSteps = builder.WithVariable<string>();
+        var errorMessages = builder.WithVariable<string>().Persisted();
+        var relevantCode = builder.WithVariable<string>().Persisted();
+        var gitHistory = builder.WithVariable<string>().Persisted();
+        var testResults = builder.WithVariable<string>().Persisted();
+        var reproductionSteps = builder.WithVariable<string>().Persisted();
 
         // Typed result variables for diagnosis/hypothesis activities
-        var selectedHypothesisVar = builder.WithVariable<Hypothesis?>();
-        var refinedDiagnosisVar = builder.WithVariable<DiagnosisResult>();
+        var selectedHypothesisVar = builder.WithVariable<Hypothesis?>().Persisted();
+        var refinedDiagnosisVar = builder.WithVariable<DiagnosisResult>().Persisted();
 
         // Story 39-15 (D4) — the debug-diagnosis lifecycle binding replaces AIDiagnosisActivity.
-        var priorDiagnosisId = builder.WithVariable<string>("PriorDiagnosisId", "");
-        var diagnosisLifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var diagnosisDocumentId = builder.WithVariable<string>("DiagnosisDocumentId", "");
-        var diagnosisFailureReason = builder.WithVariable<string>("DiagnosisFailureReason", "");
-        var diagnosisProducedFlag = builder.WithVariable<bool>();
+        var priorDiagnosisId = builder.WithVariable<string>("PriorDiagnosisId", "").Persisted();
+        var diagnosisLifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var diagnosisDocumentId = builder.WithVariable<string>("DiagnosisDocumentId", "").Persisted();
+        var diagnosisFailureReason = builder.WithVariable<string>("DiagnosisFailureReason", "").Persisted();
+        var diagnosisProducedFlag = builder.WithVariable<bool>().Persisted();
         // 39-10 re-entry position (the child lifecycle owns the accept-gate bookmark).
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson = builder.WithVariable<string>();
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson = builder.WithVariable<string>().Persisted();
 
         // Diagnosis & loop variables
-        var hypothesesJson = builder.WithVariable<string>();
-        var iterationContextJson = builder.WithVariable<string>();
-        var currentIteration = builder.WithVariable<int>();
-        var maxIterations = builder.WithVariable<int>();
-        var selectedHypothesisJson = builder.WithVariable<string>();
-        var debugStartTime = builder.WithVariable<string>();
-        var debugResultJson = builder.WithVariable<string>();
-        var allFilesModified = builder.WithVariable<string>();
-        var attemptsJson = builder.WithVariable<string>();
-        var regressionTestWritten = builder.WithVariable<bool>();
-        var contextGatherDone = builder.WithVariable<bool>();
-        var debugStatus = builder.WithVariable<string>();
-        var escalationReason = builder.WithVariable<string>();
-        var runTestsOutput = builder.WithVariable<IDictionary<string, object>?>();
-        var applyFixOutput = builder.WithVariable<IDictionary<string, object>?>();
-        var regressionRunOutput = builder.WithVariable<IDictionary<string, object>?>();
-        var regressionTestResultVar = builder.WithVariable<TestGenerationResult>();
-        var compileReportResultVar = builder.WithVariable<DebugReport>();
+        var hypothesesJson = builder.WithVariable<string>().Persisted();
+        var iterationContextJson = builder.WithVariable<string>().Persisted();
+        var currentIteration = builder.WithVariable<int>().Persisted();
+        var maxIterations = builder.WithVariable<int>().Persisted();
+        var selectedHypothesisJson = builder.WithVariable<string>().Persisted();
+        var debugStartTime = builder.WithVariable<string>().Persisted();
+        var debugResultJson = builder.WithVariable<string>().Persisted();
+        var allFilesModified = builder.WithVariable<string>().Persisted();
+        var attemptsJson = builder.WithVariable<string>().Persisted();
+        var regressionTestWritten = builder.WithVariable<bool>().Persisted();
+        var contextGatherDone = builder.WithVariable<bool>().Persisted();
+        var debugStatus = builder.WithVariable<string>().Persisted();
+        var escalationReason = builder.WithVariable<string>().Persisted();
+        var runTestsOutput = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var applyFixOutput = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var regressionRunOutput = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var regressionTestResultVar = builder.WithVariable<TestGenerationResult>().Persisted();
+        var compileReportResultVar = builder.WithVariable<DebugReport>().Persisted();
 
         // ---- Activities ----
 

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeleteTenantWorkflow.cs
@@ -74,8 +74,8 @@ public class DeleteTenantWorkflow : WorkflowBase
             + "clean up CP relationships. Each step runs continue-on-error; a single "
             + "terminal event reports the overall outcome.";
 
-        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty);
-        var attempt = builder.WithVariable<int>("Attempt", 1);
+        var tenantId = builder.WithVariable<Guid>("TenantId", Guid.Empty).Persisted();
+        var attempt = builder.WithVariable<int>("Attempt", 1).Persisted();
 
         // ── Starter trigger — bridged from TENANT.DELETE.REQUESTED ──────
         var trigger = new Event(DeleteRequestedEventName)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DeploymentPipelineWorkflow.cs
@@ -122,43 +122,43 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var mergeSha = builder.WithVariable<string>("MergeSha", "");
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var mode = builder.WithVariable<string>("Mode", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false);
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var mergeSha = builder.WithVariable<string>("MergeSha", "").Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var mode = builder.WithVariable<string>("Mode", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false).Persisted();
 
         // Fail-closed default — overwritten only by an explicit terminal.
-        var deploymentStatus = builder.WithVariable<string>("DeploymentStatus", "failed");
-        var completedStages = builder.WithVariable<string>("CompletedStages", "[]");
-        var currentStage = builder.WithVariable<string>("CurrentStage", "");
-        var stageResult = builder.WithVariable<string>("StageResult", "");
-        var stageError = builder.WithVariable<string>("StageError", "");
-        var rollbackStatus = builder.WithVariable<string>("RollbackStatus", "");
-        var releaseTag = builder.WithVariable<string>("ReleaseTag", "");
+        var deploymentStatus = builder.WithVariable<string>("DeploymentStatus", "failed").Persisted();
+        var completedStages = builder.WithVariable<string>("CompletedStages", "[]").Persisted();
+        var currentStage = builder.WithVariable<string>("CurrentStage", "").Persisted();
+        var stageResult = builder.WithVariable<string>("StageResult", "").Persisted();
+        var stageError = builder.WithVariable<string>("StageError", "").Persisted();
+        var rollbackStatus = builder.WithVariable<string>("RollbackStatus", "").Persisted();
+        var releaseTag = builder.WithVariable<string>("ReleaseTag", "").Persisted();
         // Epic 38 follow-up #21 — the real release-step outputs (was the hardcoded
         // "deferred"). CreateReleaseActivity sets these on its outcome.
-        var releaseStatus = builder.WithVariable<string>("ReleaseStatus", "");
-        var releaseUrl = builder.WithVariable<string>("ReleaseUrl", "");
+        var releaseStatus = builder.WithVariable<string>("ReleaseStatus", "").Persisted();
+        var releaseUrl = builder.WithVariable<string>("ReleaseUrl", "").Persisted();
         // #21 audit fidelity — CreateRelease's ErrorCode is captured in its OWN
         // variable, kept SEPARATE from the shared `stageError` that seeds a
         // PIPELINE.SUCCESS `reason`. A release-step failure is surfaced via
         // releaseStatus="failed" + the loud RELEASE.CREATED.FAILED event, never as the
         // success event's reason (which stays reserved for genuine stage failures).
-        var releaseError = builder.WithVariable<string>("ReleaseError", "");
+        var releaseError = builder.WithVariable<string>("ReleaseError", "").Persisted();
 
-        var decisionVar = builder.WithVariable<string>("Decision", "");
-        var feedbackVar = builder.WithVariable<string>("Feedback", "");
-        var approverVar = builder.WithVariable<string>("Approver", "");
+        var decisionVar = builder.WithVariable<string>("Decision", "").Persisted();
+        var feedbackVar = builder.WithVariable<string>("Feedback", "").Persisted();
+        var approverVar = builder.WithVariable<string>("Approver", "").Persisted();
 
         // Per-stage retry counters (FR-16 — bounded retry + escalation).
-        var qaRetries = builder.WithVariable<int>("QaRetries", 0);
-        var uatRetries = builder.WithVariable<int>("UatRetries", 0);
-        var prodRetries = builder.WithVariable<int>("ProdRetries", 0);
+        var qaRetries = builder.WithVariable<int>("QaRetries", 0).Persisted();
+        var uatRetries = builder.WithVariable<int>("UatRetries", 0).Persisted();
+        var prodRetries = builder.WithVariable<int>("ProdRetries", 0).Persisted();
 
-        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // 1. Init
@@ -295,8 +295,8 @@ public class DeploymentPipelineWorkflow : WorkflowBase
         //    silently disagreed with the edges, so the predicate is now monotone on
         //    its own — if a future author re-points the Denied edge back at this
         //    decision, the worst case is an extra human wait, never a free deploy.
-        var gateOutcome = builder.WithVariable<string>("ProdGateOutcome", "");
-        var gateReason = builder.WithVariable<string>("ProdGateReason", "");
+        var gateOutcome = builder.WithVariable<string>("ProdGateOutcome", "").Persisted();
+        var gateReason = builder.WithVariable<string>("ProdGateReason", "").Persisted();
         var checkProdGate = new CheckActionGateActivity
         {
             Id = "CheckProdDeployGate", Name = "Check Prod Deploy Gate",

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignDeliveryWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignDeliveryWorkflow.cs
@@ -30,14 +30,14 @@ public class DesignDeliveryWorkflow : WorkflowBase
         builder.Version = WorkflowVersions.ComputedVersion;
         builder.Description = "Deliver a design proposal to the issue and emit DESIGN.PROPOSAL.GENERATED/DELIVERED before the accept gate";
 
-        var sessionId    = builder.WithVariable<Guid>();
-        var issueId      = builder.WithVariable<string>();
-        var repository   = builder.WithVariable<string>();
-        var issueNumber  = builder.WithVariable<int>();
-        var proposalJson = builder.WithVariable<string>();
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var alternativeCount = builder.WithVariable<int>();
-        var deliveryResult = builder.WithVariable<DesignDeliveryResult>();
+        var sessionId    = builder.WithVariable<Guid>().Persisted();
+        var issueId      = builder.WithVariable<string>().Persisted();
+        var repository   = builder.WithVariable<string>().Persisted();
+        var issueNumber  = builder.WithVariable<int>().Persisted();
+        var proposalJson = builder.WithVariable<string>().Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var alternativeCount = builder.WithVariable<int>().Persisted();
+        var deliveryResult = builder.WithVariable<DesignDeliveryResult>().Persisted();
 
         var readInputs = new SetVariable
         {

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DesignProposalWorkflow.cs
@@ -51,38 +51,38 @@ public class DesignProposalWorkflow : WorkflowBase
         builder.Description = "Generate a reviewed technical design proposal via the generic document lifecycle (produce → validate → review → deliver → accept gate)";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var sessionId    = builder.WithVariable<Guid>();
-        var issueId      = builder.WithVariable<string>();
-        var requirement  = builder.WithVariable<string>();
-        var repository   = builder.WithVariable<string>();
-        var issueNumber  = builder.WithVariable<int>();
-        var constraints  = builder.WithVariable<string>();
-        var conventions  = builder.WithVariable<string>();
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId    = builder.WithVariable<Guid>().Persisted();
+        var issueId      = builder.WithVariable<string>().Persisted();
+        var requirement  = builder.WithVariable<string>().Persisted();
+        var repository   = builder.WithVariable<string>().Persisted();
+        var issueNumber  = builder.WithVariable<int>().Persisted();
+        var constraints  = builder.WithVariable<string>().Persisted();
+        var conventions  = builder.WithVariable<string>().Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var lifecycleRejected = builder.WithVariable<bool>();
-        var exitStatus      = builder.WithVariable<string>("ExitStatus", "");
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var proposalJson    = builder.WithVariable<string>("ProposalJson", "{}");
-        var alternativeCount = builder.WithVariable<int>();
-        var decisionNotes   = builder.WithVariable<string>("DecisionNotes", "");
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
-        var approved        = builder.WithVariable<bool>();
-        var outputStatus    = builder.WithVariable<string>();
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var lifecycleRejected = builder.WithVariable<bool>().Persisted();
+        var exitStatus      = builder.WithVariable<string>("ExitStatus", "").Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var proposalJson    = builder.WithVariable<string>("ProposalJson", "{}").Persisted();
+        var alternativeCount = builder.WithVariable<int>().Persisted();
+        var decisionNotes   = builder.WithVariable<string>("DecisionNotes", "").Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var approved        = builder.WithVariable<bool>().Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentLifecycleWorkflow.cs
@@ -67,32 +67,32 @@ public class DocumentLifecycleWorkflow : WorkflowBase
             "lifecycle for any registered document type";
 
         // ── Loop state (D1 — ONE variable) ─────────────────────────────
-        var stateJson = builder.WithVariable<string>("LifecycleState", "");
+        var stateJson = builder.WithVariable<string>("LifecycleState", "").Persisted();
 
         // ── Plain producer-dispatch vars (default "" so the drift scanner
         //    materialises the three llm-call dispatches as DATA-DRIVEN, D3) ──
-        var producerRole = builder.WithVariable<string>("ProducerRole", "");
-        var producerAction = builder.WithVariable<string>("ProducerAction", "");
-        var producerVariablesJson = builder.WithVariable<string>("ProducerVariablesJson", "{}");
-        var documentType = builder.WithVariable<string>("DocumentType", "");
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var correlationId = builder.WithVariable<string>("CorrelationId", "");
-        var reviewDefId = builder.WithVariable<string>("ReviewDefinitionId", DefaultReviewDefinitionId);
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var producerRole = builder.WithVariable<string>("ProducerRole", "").Persisted();
+        var producerAction = builder.WithVariable<string>("ProducerAction", "").Persisted();
+        var producerVariablesJson = builder.WithVariable<string>("ProducerVariablesJson", "{}").Persisted();
+        var documentType = builder.WithVariable<string>("DocumentType", "").Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var correlationId = builder.WithVariable<string>("CorrelationId", "").Persisted();
+        var reviewDefId = builder.WithVariable<string>("ReviewDefinitionId", DefaultReviewDefinitionId).Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
         // Story 39-15 (D3) — optional cross-document validation context (default "" = skip).
         // When non-empty it is forwarded to the type's IDocumentType.ValidateWithContext at
         // VALIDATE, so a type (currently TestSpec) can check a binding that cannot be seen
         // payload-only (a test case referencing a task not in the consumed plan).
-        var validationContextJson = builder.WithVariable<string>("ValidationContextJson", "");
+        var validationContextJson = builder.WithVariable<string>("ValidationContextJson", "").Persisted();
 
         // ── Denormalised scalars for emit tags / gate inputs ───────────
-        var sessionId = builder.WithVariable<string>("SessionId", "");
-        var currentDocId = builder.WithVariable<string>("CurrentDocumentId", "");
-        var currentDocJson = builder.WithVariable<string>("CurrentDocumentJson", "");
-        var currentRound = builder.WithVariable<int>("CurrentRound", 0);
-        var rulesReference = builder.WithVariable<string>("RulesReference", "");
-        var acceptRequestedAtUtc = builder.WithVariable<string>("AcceptRequestedAtUtc", "");
-        var acceptanceRequestJson = builder.WithVariable<string>("AcceptanceRequestJson", "");
+        var sessionId = builder.WithVariable<string>("SessionId", "").Persisted();
+        var currentDocId = builder.WithVariable<string>("CurrentDocumentId", "").Persisted();
+        var currentDocJson = builder.WithVariable<string>("CurrentDocumentJson", "").Persisted();
+        var currentRound = builder.WithVariable<int>("CurrentRound", 0).Persisted();
+        var rulesReference = builder.WithVariable<string>("RulesReference", "").Persisted();
+        var acceptRequestedAtUtc = builder.WithVariable<string>("AcceptRequestedAtUtc", "").Persisted();
+        var acceptanceRequestJson = builder.WithVariable<string>("AcceptanceRequestJson", "").Persisted();
 
         // ── Story 39-11 (D6 / AC7) persist↔emit linkage ────────────────
         // The pre-minted DOCUMENT.* transition event id, minted ONCE per
@@ -102,32 +102,32 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         // (EmitDocumentEventActivity.EventId) and the adjacent persist
         // (PersistDocumentInstanceActivity.CorrelatingEventId) so the
         // domain_events row and the document_instances row share one id.
-        var transitionEventId = builder.WithVariable<string>("TransitionEventId", "");
+        var transitionEventId = builder.WithVariable<string>("TransitionEventId", "").Persisted();
 
         // ── Dispatch result containers ─────────────────────────────────
-        var produceResult = builder.WithVariable<IDictionary<string, object>?>();
-        var repairResult = builder.WithVariable<IDictionary<string, object>?>();
-        var reviseResult = builder.WithVariable<IDictionary<string, object>?>();
-        var reviewResult = builder.WithVariable<IDictionary<string, object>?>();
+        var produceResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var repairResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var reviseResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var reviewResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Routing flags ──────────────────────────────────────────────
-        var producedOk = builder.WithVariable<bool>("ProducedOk", false);
-        var lastDispatchOk = builder.WithVariable<bool>("LastDispatchOk", false);
-        var validationOk = builder.WithVariable<bool>("ValidationOk", false);
-        var ambiguityOver = builder.WithVariable<bool>("AmbiguityOver", false);
-        var reviewRoute = builder.WithVariable<string>("ReviewRoute", "");
-        var clampedRoute = builder.WithVariable<string>("ClampedRoute", "");
-        var escalateOutcome = builder.WithVariable<string>("EscalateOutcome", "");
-        var reviewDecisionWire = builder.WithVariable<string>("ReviewDecisionWire", "approve");
-        var reviewHasBlocking = builder.WithVariable<bool>("ReviewHasBlocking", false);
+        var producedOk = builder.WithVariable<bool>("ProducedOk", false).Persisted();
+        var lastDispatchOk = builder.WithVariable<bool>("LastDispatchOk", false).Persisted();
+        var validationOk = builder.WithVariable<bool>("ValidationOk", false).Persisted();
+        var ambiguityOver = builder.WithVariable<bool>("AmbiguityOver", false).Persisted();
+        var reviewRoute = builder.WithVariable<string>("ReviewRoute", "").Persisted();
+        var clampedRoute = builder.WithVariable<string>("ClampedRoute", "").Persisted();
+        var escalateOutcome = builder.WithVariable<string>("EscalateOutcome", "").Persisted();
+        var reviewDecisionWire = builder.WithVariable<string>("ReviewDecisionWire", "approve").Persisted();
+        var reviewHasBlocking = builder.WithVariable<bool>("ReviewHasBlocking", false).Persisted();
 
         // ── Gate outputs ───────────────────────────────────────────────
-        var decisionJson = builder.WithVariable<string>("DecisionJson", "");
-        var decisionChannel = builder.WithVariable<string>("DecisionChannel", "orchestrator");
+        var decisionJson = builder.WithVariable<string>("DecisionJson", "").Persisted();
+        var decisionChannel = builder.WithVariable<string>("DecisionChannel", "orchestrator").Persisted();
         // Story 39-13 (D6d) — the decider's notes/feedback, surfaced on the terminal as the
         // additive `decisionNotes` output so a lifecycle binding can mirror the legacy
         // Detail on DESIGN.PROPOSAL.APPROVED/REJECTED. Additive-only, like 39-12's documentJson.
-        var decisionFeedback = builder.WithVariable<string>("DecisionFeedback", "");
+        var decisionFeedback = builder.WithVariable<string>("DecisionFeedback", "").Persisted();
 
         // ── Story 39-13 (D5/D6c) — optional pre-ACCEPT delivery hook ────
         // When `deliveryWorkflowDefinitionId` is non-empty the lifecycle dispatches that
@@ -136,26 +136,26 @@ public class DocumentLifecycleWorkflow : WorkflowBase
         // the human decides while keeping the legacy GENERATED/DELIVERED emits on the durable
         // drain. A crash re-entry that resumes AT ACCEPT skips it (DeliveryReEntryGate) so
         // delivery — and its legacy emits — happen exactly once per delivered revision.
-        var deliveryDefId = builder.WithVariable<string>("DeliveryWorkflowDefinitionId", "");
-        var deliveryRepository = builder.WithVariable<string>("DeliveryRepository", "");
-        var deliveryIssueNumber = builder.WithVariable<int>("DeliveryIssueNumber", 0);
-        var deliveryResult = builder.WithVariable<IDictionary<string, object>?>();
+        var deliveryDefId = builder.WithVariable<string>("DeliveryWorkflowDefinitionId", "").Persisted();
+        var deliveryRepository = builder.WithVariable<string>("DeliveryRepository", "").Persisted();
+        var deliveryIssueNumber = builder.WithVariable<int>("DeliveryIssueNumber", 0).Persisted();
+        var deliveryResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Story 39-10 re-entry (D6) ──────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>("ReEntryPositionJson", "");
-        var reEntryDocJson = builder.WithVariable<string>("ReEntryDocumentJson", "");
-        var reEntryStage = builder.WithVariable<string>("ReEntryStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>("ReEntryPositionJson", "").Persisted();
+        var reEntryDocJson = builder.WithVariable<string>("ReEntryDocumentJson", "").Persisted();
+        var reEntryStage = builder.WithVariable<string>("ReEntryStage", "produce").Persisted();
 
         // ── Terminal outputs ───────────────────────────────────────────
-        var outStatus = builder.WithVariable<string>("OutStatus", "");
-        var outOutcome = builder.WithVariable<string>("OutOutcome", "");
-        var outDocId = builder.WithVariable<string>("OutDocId", "");
-        var outLifecycleResult = builder.WithVariable<string>("OutLifecycleResult", "{}");
+        var outStatus = builder.WithVariable<string>("OutStatus", "").Persisted();
+        var outOutcome = builder.WithVariable<string>("OutOutcome", "").Persisted();
+        var outDocId = builder.WithVariable<string>("OutDocId", "").Persisted();
+        var outLifecycleResult = builder.WithVariable<string>("OutLifecycleResult", "{}").Persisted();
         // Story 39-12 (D4) — the accepted revision's PAYLOAD body (not the envelope, not the
         // lineage). A lifecycle binding (e.g. IssueDecompositionWorkflow) needs the typed body to
         // project its own domain output (subtask count, decomposition JSON); the lineage on
         // lifecycleResult only carries id+state. Empty when no draft was ever produced.
-        var outDocJson = builder.WithVariable<string>("OutDocJson", "");
+        var outDocJson = builder.WithVariable<string>("OutDocJson", "").Persisted();
 
         // ================================================================
         // Init — read + validate inputs (D2/D4), mint session, seed state

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/DocumentReviewWorkflow.cs
@@ -45,27 +45,27 @@ public class DocumentReviewWorkflow : WorkflowBase
             "panel producer, mapping their outputs onto the 39-6 D10 review contract";
 
         // ── Inputs (39-6 D10) + derived ──
-        var documentType = builder.WithVariable<string>("DocumentType", "");
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var correlationId = builder.WithVariable<string>("CorrelationId", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
-        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "");
-        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
-        var contentJson = builder.WithVariable<string>("ContentJson", "{}");
-        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
-        var isPanel = builder.WithVariable<bool>("IsPanel", false);
+        var documentType = builder.WithVariable<string>("DocumentType", "").Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var correlationId = builder.WithVariable<string>("CorrelationId", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
+        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "").Persisted();
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "").Persisted();
+        var contentJson = builder.WithVariable<string>("ContentJson", "{}").Persisted();
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}").Persisted();
+        var isPanel = builder.WithVariable<bool>("IsPanel", false).Persisted();
 
         // ── Dispatch results ──
-        var producerResult = builder.WithVariable<IDictionary<string, object>?>();
+        var producerResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Outputs ──
-        var outSuccess = builder.WithVariable<bool>("OutSuccess", false);
-        var outReviewJson = builder.WithVariable<string>("OutReviewJson", "");
-        var outReviewDocId = builder.WithVariable<string>("OutReviewDocId", "");
-        var outFailureKind = builder.WithVariable<string>("OutFailureKind", "");
-        var outUndecidableReason = builder.WithVariable<string>("OutUndecidableReason", "");
-        var outMemberReviews = builder.WithVariable<string>("OutMemberReviews", "[]");
+        var outSuccess = builder.WithVariable<bool>("OutSuccess", false).Persisted();
+        var outReviewJson = builder.WithVariable<string>("OutReviewJson", "").Persisted();
+        var outReviewDocId = builder.WithVariable<string>("OutReviewDocId", "").Persisted();
+        var outFailureKind = builder.WithVariable<string>("OutFailureKind", "").Persisted();
+        var outUndecidableReason = builder.WithVariable<string>("OutUndecidableReason", "").Persisted();
+        var outMemberReviews = builder.WithVariable<string>("OutMemberReviews", "[]").Persisted();
 
         // ================================================================
         // Init — resolve rules + mode, build subject + reviewer variables

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/LlmProviderChainHelper.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/LlmProviderChainHelper.cs
@@ -1,0 +1,72 @@
+using Tamma.Activities.Security;
+
+namespace Tamma.ElsaServer.Workflows.Helpers;
+
+/// <summary>
+/// 2026-08-13 — the pure provider-chain resolution behind
+/// <c>LlmCallWorkflow.ResolveChain</c>, extracted so it is unit-testable
+/// without an Elsa execution context.
+///
+/// <para><b>Precedence</b> (first non-empty wins): caller-supplied chain →
+/// DB agent-config chain → <c>Llm:DefaultProviderChain</c> configuration →
+/// the hardcoded default (<c>anthropic, openai, openrouter</c>).</para>
+///
+/// <para><b>Allowlist.</b> The chain is filtered through the DI-configured
+/// <see cref="ProviderAllowlist"/> (defaults + <c>Security:ProviderAllowlist:
+/// AdditionalProviders</c>) — previously this filter ran against the STATIC
+/// default instance, which silently ignored the AdditionalProviders config the
+/// rejection message itself told operators to use. The config-registered
+/// allowlist is what makes the opt-in "scripted" provider selectable in the
+/// engine-driven E2E (and any self-hosted custom provider selectable at all).
+/// An all-rejected chain still fails loud, naming the config key.</para>
+/// </summary>
+public static class LlmProviderChainHelper
+{
+    /// <summary>Config key for the deployment-default provider chain.</summary>
+    public const string DefaultChainConfigKey = "Llm:DefaultProviderChain";
+
+    /// <summary>The legacy hardcoded default chain (unchanged).</summary>
+    public static readonly IReadOnlyList<string> HardcodedDefaultChain =
+        new[] { "anthropic", "openai", "openrouter" };
+
+    /// <summary>Resolve + filter the chain. Throws on an all-rejected chain.</summary>
+    public static List<string> Resolve(
+        IReadOnlyList<string>? callerChain,
+        IReadOnlyList<string>? dbChain,
+        IReadOnlyList<string>? configChain,
+        ProviderAllowlist allowlist)
+    {
+        ArgumentNullException.ThrowIfNull(allowlist);
+
+        var chain =
+            FirstNonEmpty(callerChain)
+            ?? FirstNonEmpty(dbChain)
+            ?? FirstNonEmpty(configChain)
+            ?? HardcodedDefaultChain;
+
+        var filtered = allowlist.FilterAllowed(chain);
+        if (filtered.Count == 0)
+        {
+            // All providers rejected — fail with a clear error, never a silent fallback.
+            throw new InvalidOperationException(
+                $"All providers in chain were rejected by allowlist: [{string.Join(", ", chain)}]. " +
+                "Configure allowed providers via Security:ProviderAllowlist:AdditionalProviders.");
+        }
+
+        return filtered;
+    }
+
+    private static IReadOnlyList<string>? FirstNonEmpty(IReadOnlyList<string>? chain)
+    {
+        if (chain is null)
+        {
+            return null;
+        }
+
+        var cleaned = chain
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => p.Trim())
+            .ToList();
+        return cleaned.Count > 0 ? cleaned : null;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/VariablePersistenceExtensions.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/Helpers/VariablePersistenceExtensions.cs
@@ -1,0 +1,40 @@
+using Elsa.Workflows;
+using Elsa.Workflows.Memory;
+
+namespace Tamma.ElsaServer.Workflows;
+
+/// <summary>
+/// 2026-08-13 (engine-driven E2E) — the variable-persistence seam every CLR
+/// workflow in this assembly uses.
+///
+/// <para><b>Why this exists.</b> An Elsa 3.5 <see cref="Variable"/> with no
+/// explicit storage driver is EPHEMERAL: <c>VariablePersistenceManager</c>
+/// only persists variables that carry a persistent
+/// <see cref="Variable.StorageDriverType"/>, so every parent-workflow variable
+/// silently reset to its default across ANY suspend/resume boundary — a
+/// sub-workflow dispatch with <c>WaitForCompletion</c>, a document-decision
+/// bookmark, a CI wait. The engine-driven E2E surfaced it as
+/// <c>document-lifecycle</c> faulting with "empty state json" right after its
+/// produce dispatch resumed (and, earlier, as post-resume dispatches carrying
+/// empty <c>repository</c> into the context-scan stores). Every long-running
+/// workflow here suspends, so every declared variable must be
+/// workflow-storage backed.</para>
+///
+/// <para>Direct property assignment rather than Elsa's
+/// <c>WithWorkflowStorage()</c> extension: the workflow STRUCTURE tests build
+/// definitions through a mocked <c>IWorkflowBuilder</c>, and this seam stays
+/// null-tolerant so a harness that answers <c>null</c> for an unconfigured
+/// overload fails at the assertion that cares, not inside variable
+/// plumbing.</para>
+/// </summary>
+public static class VariablePersistenceExtensions
+{
+    public static Variable<T> Persisted<T>(this Variable<T> variable)
+    {
+        if (variable is not null)
+        {
+            variable.StorageDriverType = typeof(WorkflowInstanceStorageDriver);
+        }
+        return variable!;
+    }
+}

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupScheduler.cs
@@ -71,6 +71,9 @@ public sealed class HourlyAnalyticsRollupSchedulerOptions
 public sealed class HourlyAnalyticsRollupScheduler : BackgroundService
 {
     private readonly IWorkflowDispatcher _dispatcher;
+    // 2026-08-13 — per-fire scope for the (scoped) IWorkflowDefinitionService
+    // used by the version-id resolve (see PublishedWorkflowDispatch).
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly IOptions<HourlyAnalyticsRollupSchedulerOptions> _options;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<HourlyAnalyticsRollupScheduler> _logger;
@@ -85,6 +88,7 @@ public sealed class HourlyAnalyticsRollupScheduler : BackgroundService
 
     public HourlyAnalyticsRollupScheduler(
         IWorkflowDispatcher dispatcher,
+        IServiceScopeFactory scopeFactory,
         IOptions<HourlyAnalyticsRollupSchedulerOptions> options,
         TimeProvider timeProvider,
         ILogger<HourlyAnalyticsRollupScheduler> logger,
@@ -92,10 +96,12 @@ public sealed class HourlyAnalyticsRollupScheduler : BackgroundService
         IRollupSchedulerLeaderLock? leaderLock = null)
     {
         ArgumentNullException.ThrowIfNull(dispatcher);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(logger);
         _dispatcher = dispatcher;
+        _scopeFactory = scopeFactory;
         _options = options;
         _timeProvider = timeProvider;
         _logger = logger;
@@ -196,16 +202,30 @@ public sealed class HourlyAnalyticsRollupScheduler : BackgroundService
         }
 
         var instanceId = Guid.NewGuid().ToString();
-        var request = new DispatchWorkflowDefinitionRequest(
-            HourlyAnalyticsRollupWorkflow.DefinitionId)
-        {
-            InstanceId = instanceId,
-            // No input variables — the workflow infers the target hour
-            // from the current clock.
-        };
 
         try
         {
+            // 2026-08-13 — the request ctor takes the VERSION id, not the
+            // definition id (see PublishedWorkflowDispatch: this dispatch died
+            // WorkflowGraphNotFound in the queue on every fire before this
+            // resolve existed). Resolved per-fire from a fresh scope — the
+            // definition service is scoped.
+            string definitionVersionId;
+            using (var scope = _scopeFactory.CreateScope())
+            {
+                definitionVersionId = await Tamma.Activities.Core.PublishedWorkflowDispatch
+                    .ResolvePublishedVersionIdAsync(
+                        scope.ServiceProvider.GetRequiredService<Elsa.Workflows.Management.IWorkflowDefinitionService>(),
+                        HourlyAnalyticsRollupWorkflow.DefinitionId, ct);
+            }
+
+            var request = new DispatchWorkflowDefinitionRequest(definitionVersionId)
+            {
+                InstanceId = instanceId,
+                // No input variables — the workflow infers the target hour
+                // from the current clock.
+            };
+
             // Newer Elsa versions take a DispatchWorkflowOptions as the
             // second parameter (cancellation token lives in options).
             // The empty-options default keeps the call shape minimal.

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/HourlyAnalyticsRollupWorkflow.cs
@@ -67,12 +67,12 @@ public class HourlyAnalyticsRollupWorkflow : WorkflowBase
             "Rolls platform_events + per-tenant domain_events into platform_analytics_hourly.";
 
         // ── Variables ────────────────────────────────────────────────────
-        var targetHour = builder.WithVariable<DateTime>("TargetHour", DateTime.MinValue);
-        var tenantsSuccess = builder.WithVariable<int>("TenantsSuccess", 0);
-        var tenantsFailed = builder.WithVariable<int>("TenantsFailed", 0);
+        var targetHour = builder.WithVariable<DateTime>("TargetHour", DateTime.MinValue).Persisted();
+        var tenantsSuccess = builder.WithVariable<int>("TenantsSuccess", 0).Persisted();
+        var tenantsFailed = builder.WithVariable<int>("TenantsFailed", 0).Persisted();
         // Story 36-2 — dimensional fan-out success/failure counts.
-        var dimTenantsSuccess = builder.WithVariable<int>("DimTenantsSuccess", 0);
-        var dimTenantsFailed = builder.WithVariable<int>("DimTenantsFailed", 0);
+        var dimTenantsSuccess = builder.WithVariable<int>("DimTenantsSuccess", 0).Persisted();
+        var dimTenantsFailed = builder.WithVariable<int>("DimTenantsFailed", 0).Persisted();
 
         // ── Step 1: resolve the target hour from input or now-1 ─────────
         var initBucket = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueDecompositionWorkflow.cs
@@ -81,43 +81,43 @@ public class IssueDecompositionWorkflow : WorkflowBase
         builder.Description = "Decompose a complex issue into an ordered set of implementable sub-tasks via the generic document lifecycle (produce → validate → review → revise → accept)";
 
         // ── Workflow variables (inputs) ────────────────────────────────
-        var sessionId       = builder.WithVariable<Guid>();
-        var issueId         = builder.WithVariable<string>();
-        var issueTitle      = builder.WithVariable<string>();
-        var repository      = builder.WithVariable<string>();
-        var issueNumber     = builder.WithVariable<int>();
-        var workItemJson    = builder.WithVariable<string>();
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId       = builder.WithVariable<Guid>().Persisted();
+        var issueId         = builder.WithVariable<string>().Persisted();
+        var issueTitle      = builder.WithVariable<string>().Persisted();
+        var repository      = builder.WithVariable<string>().Persisted();
+        var issueNumber     = builder.WithVariable<int>().Persisted();
+        var workItemJson    = builder.WithVariable<string>().Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Context (consumes side) ────────────────────────────────────
-        var decompositionContext = builder.WithVariable<string>();
-        var contextIds      = builder.WithVariable<string>("[]");
+        var decompositionContext = builder.WithVariable<string>().Persisted();
+        var contextIds      = builder.WithVariable<string>("[]").Persisted();
 
         // ── 39-10 re-entry position (D7) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── Dispatched-workflow result containers ──────────────────────
-        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Typed lifecycle exit (D2 — routed values, never raw output) ─
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitStatus      = builder.WithVariable<string>("ExitStatus", "");
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var decompositionJson = builder.WithVariable<string>("DecompositionJson", "{}");
-        var subtaskCount    = builder.WithVariable<int>();
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitStatus      = builder.WithVariable<string>("ExitStatus", "").Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var decompositionJson = builder.WithVariable<string>("DecompositionJson", "{}").Persisted();
+        var subtaskCount    = builder.WithVariable<int>().Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
 
         // ── Output ─────────────────────────────────────────────────────
-        var outputStatus    = builder.WithVariable<string>();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs (BuildWorkItem kept as the internal composer) ──
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueTriageWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/IssueTriageWorkflow.cs
@@ -46,16 +46,16 @@ public class IssueTriageWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
         // Tenant id threaded from this workflow's input through to each cycle dispatch so
         // a SaaS caller's per-item TRIAGE.ISSUE.* events carry the tenant tag (the cycle
         // forwards it onward to its context/panel/PO sub-workflows). Empty in single-user
         // mode → platform-scope events (honest default — no fabricated tenant).
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var itemsJson = builder.WithVariable<string>("ItemsJson", "[]");
-        var currentItemIndex = builder.WithVariable<int>("CurrentItemIndex", 0);
-        var totalItems = builder.WithVariable<int>("TotalItems", 0);
-        var currentItemJson = builder.WithVariable<string>("CurrentItemJson", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var itemsJson = builder.WithVariable<string>("ItemsJson", "[]").Persisted();
+        var currentItemIndex = builder.WithVariable<int>("CurrentItemIndex", 0).Persisted();
+        var totalItems = builder.WithVariable<int>("TotalItems", 0).Persisted();
+        var currentItemJson = builder.WithVariable<string>("CurrentItemJson", "").Persisted();
 
         // ================================================================
         // 1. Fetch Untriaged Items

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
@@ -61,59 +61,59 @@ public class LlmCallWorkflow : WorkflowBase
         // ============================================================
 
         // Input variables (populated from workflow input)
-        var agentRoleVar = builder.WithVariable<string>("AgentRole", "assistant");
-        var actionVar = builder.WithVariable<string>("Action", "");
-        var variablesJsonVar = builder.WithVariable<string>("VariablesJson", "{}");
-        var taskPromptVar = builder.WithVariable<string>("TaskPrompt", "");
-        var contextVar = builder.WithVariable<string>("Context", "");
-        var sessionIdVar = builder.WithVariable<string>("SessionId", "");
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var agentRoleVar = builder.WithVariable<string>("AgentRole", "assistant").Persisted();
+        var actionVar = builder.WithVariable<string>("Action", "").Persisted();
+        var variablesJsonVar = builder.WithVariable<string>("VariablesJson", "{}").Persisted();
+        var taskPromptVar = builder.WithVariable<string>("TaskPrompt", "").Persisted();
+        var contextVar = builder.WithVariable<string>("Context", "").Persisted();
+        var sessionIdVar = builder.WithVariable<string>("SessionId", "").Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
 
         // Story 39-9 (D10) — additive/optional repair-ring inputs. Default empty ⇒
         // zero behaviour change for the 30+ existing dispatchers. documentType is the
         // wire KEY gating the server-side repair ring; issueId rides through for the
         // LLM.* event tags; contentValidation surfaces the wire block back to callers.
-        var documentTypeVar = builder.WithVariable<string>("DocumentType", "");
-        var issueIdVar = builder.WithVariable<string>("IssueId", "");
-        var contentValidationVar = builder.WithVariable<string>("ContentValidationJson", "");
+        var documentTypeVar = builder.WithVariable<string>("DocumentType", "").Persisted();
+        var issueIdVar = builder.WithVariable<string>("IssueId", "").Persisted();
+        var contentValidationVar = builder.WithVariable<string>("ContentValidationJson", "").Persisted();
 
         // Legacy input support
-        var inputVar = builder.WithVariable<string>("InputJson", "");
+        var inputVar = builder.WithVariable<string>("InputJson", "").Persisted();
 
         // State variables
-        var circuitBreakerStatesVar = builder.WithVariable<string>("CircuitBreakerStatesJson", "{}");
-        var budgetStateVar = builder.WithVariable<string>("BudgetStateJson", "{}");
-        var diagnosticsListVar = builder.WithVariable<string>("DiagnosticsListJson", "[]");
-        var workflowOutputVar = builder.WithVariable<string>("WorkflowOutputJson", "");
-        var successVar = builder.WithVariable<bool>("CallSucceeded", false);
-        var currentProviderVar = builder.WithVariable<string>("CurrentProvider", "");
-        var lastDiagnosticVar = builder.WithVariable<string>("LastDiagnostic", "");
-        var lastResponseVar = builder.WithVariable<string>("LastResponse", "");
-        var attemptNumberVar = builder.WithVariable<int>("AttemptNumber", 1);
-        var maxRetriesVar = builder.WithVariable<int>("MaxRetries", 3);
-        var providerChainVar = builder.WithVariable<object>("ProviderChain", new List<string>());
-        var systemPromptOverrideVar = builder.WithVariable<string>("SystemPromptOverride", "");
-        var resolvedSystemPromptVar = builder.WithVariable<string>("ResolvedSystemPrompt", "");
-        var resolvedToolsJsonVar = builder.WithVariable<string>("ResolvedToolsJson", "");
+        var circuitBreakerStatesVar = builder.WithVariable<string>("CircuitBreakerStatesJson", "{}").Persisted();
+        var budgetStateVar = builder.WithVariable<string>("BudgetStateJson", "{}").Persisted();
+        var diagnosticsListVar = builder.WithVariable<string>("DiagnosticsListJson", "[]").Persisted();
+        var workflowOutputVar = builder.WithVariable<string>("WorkflowOutputJson", "").Persisted();
+        var successVar = builder.WithVariable<bool>("CallSucceeded", false).Persisted();
+        var currentProviderVar = builder.WithVariable<string>("CurrentProvider", "").Persisted();
+        var lastDiagnosticVar = builder.WithVariable<string>("LastDiagnostic", "").Persisted();
+        var lastResponseVar = builder.WithVariable<string>("LastResponse", "").Persisted();
+        var attemptNumberVar = builder.WithVariable<int>("AttemptNumber", 1).Persisted();
+        var maxRetriesVar = builder.WithVariable<int>("MaxRetries", 3).Persisted();
+        var providerChainVar = builder.WithVariable<object>("ProviderChain", new List<string>()).Persisted();
+        var systemPromptOverrideVar = builder.WithVariable<string>("SystemPromptOverride", "").Persisted();
+        var resolvedSystemPromptVar = builder.WithVariable<string>("ResolvedSystemPrompt", "").Persisted();
+        var resolvedToolsJsonVar = builder.WithVariable<string>("ResolvedToolsJson", "").Persisted();
 
         // Registry-resolved MaxTokens (ResolvePromptFromRegistryActivity output).
         // 0 = not yet resolved; the activity always writes ≥ 4096 once it runs.
         // Applied to the wire Params.MaxTokens only on the registry path (non-
         // empty action) — see CallLlmInlineActivity.BuildLlmCallRequest.
-        var registryMaxTokensVar = builder.WithVariable<int>("RegistryMaxTokens", 0);
+        var registryMaxTokensVar = builder.WithVariable<int>("RegistryMaxTokens", 0).Persisted();
 
         // Story 27-13 — conventions resolved from the convention store (or the
         // legacy `.tamma/config.json` string for the empty-action passthrough
         // path). Feeds {{conventions}} in the prompt-render variables.
-        var legacyConventionsVar = builder.WithVariable<string>("LegacyConventions", "");
-        var resolvedConventionsVar = builder.WithVariable<string>("ResolvedConventions", "");
+        var legacyConventionsVar = builder.WithVariable<string>("LegacyConventions", "").Persisted();
+        var resolvedConventionsVar = builder.WithVariable<string>("ResolvedConventions", "").Persisted();
 
         // Tool loop variables
-        var enableToolLoopVar = builder.WithVariable<bool>("EnableToolLoop", false);
-        var toolLoopConfigJsonVar = builder.WithVariable<string>("ToolLoopConfigJson", "");
-        var toolLoopTokensVar = builder.WithVariable<int>("ToolLoopTokens", 0);
-        var toolLoopTurnsVar = builder.WithVariable<int>("ToolLoopTurns", 0);
-        var toolLoopExhaustedVar = builder.WithVariable<bool>("ToolLoopExhausted", false);
+        var enableToolLoopVar = builder.WithVariable<bool>("EnableToolLoop", false).Persisted();
+        var toolLoopConfigJsonVar = builder.WithVariable<string>("ToolLoopConfigJson", "").Persisted();
+        var toolLoopTokensVar = builder.WithVariable<int>("ToolLoopTokens", 0).Persisted();
+        var toolLoopTurnsVar = builder.WithVariable<int>("ToolLoopTurns", 0).Persisted();
+        var toolLoopExhaustedVar = builder.WithVariable<bool>("ToolLoopExhausted", false).Persisted();
 
         // ============================================================
         // Activities

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/LlmCallWorkflow.cs
@@ -327,7 +327,17 @@ public class LlmCallWorkflow : WorkflowBase
             SystemPromptOverrideProp = new(context => systemPromptOverrideVar.Get(context))
         }, "Resolve Agent Config");
 
-        // 4. Resolve provider chain — prefers: caller input > DB agent config > default
+        // 4. Resolve provider chain — prefers: caller input > DB agent config >
+        //    Llm:DefaultProviderChain config > hardcoded default. Precedence +
+        //    filtering live in LlmProviderChainHelper (pure, unit-tested).
+        //    2026-08-13: the filter now runs against the DI-configured
+        //    ProviderAllowlist (defaults + Security:ProviderAllowlist:
+        //    AdditionalProviders) instead of the static default instance,
+        //    which silently ignored the very config key this node's rejection
+        //    message told operators to set. That DI allowlist (plus the
+        //    config-tier chain) is how the opt-in "scripted" provider becomes
+        //    selectable for the engine-driven E2E — and how any self-hosted
+        //    custom provider becomes selectable at all.
         var resolveChain = new SetVariable
         {
             Id = "ResolveChain",
@@ -337,27 +347,16 @@ public class LlmCallWorkflow : WorkflowBase
                 var raw = inputVar.Get(context);
                 var input = ParseInput(raw);
 
-                List<string> chain;
+                var dbChain = providerChainVar.Get(context) as ICollection<string>;
 
-                // Priority 1: Caller provided an explicit chain in input
-                if (input.ProviderChain.Count > 0)
-                    chain = input.ProviderChain;
-                // Priority 2: Agent config from DB set a chain (via ResolveAgentConfigActivity)
-                else if (providerChainVar.Get(context) is ICollection<string> dbChain && dbChain.Count > 0)
-                    chain = dbChain.ToList();
-                // Priority 3: Default chain
-                else
-                    chain = new List<string> { "anthropic", "openai", "openrouter" };
+                var configuration = context.GetRequiredService<Microsoft.Extensions.Configuration.IConfiguration>();
+                var configChain = Microsoft.Extensions.Configuration.ConfigurationBinder
+                    .Get<string[]>(configuration.GetSection(Helpers.LlmProviderChainHelper.DefaultChainConfigKey));
 
-                // Filter through provider allowlist — reject unknown providers
-                var filtered = ProviderAllowlist.FilterAllowedDefault(chain);
-                if (filtered.Count == 0)
-                {
-                    // All providers rejected — fail with clear error, do not silently fall back
-                    throw new InvalidOperationException(
-                        $"All providers in chain were rejected by allowlist: [{string.Join(", ", chain)}]. " +
-                        "Configure allowed providers via Security:ProviderAllowlist:AdditionalProviders.");
-                }
+                var allowlist = context.GetRequiredService<ProviderAllowlist>();
+
+                var filtered = Helpers.LlmProviderChainHelper.Resolve(
+                    input.ProviderChain, dbChain?.ToList(), configChain, allowlist);
 
                 return (object)filtered;
             })

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MentorshipWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MentorshipWorkflow.cs
@@ -52,21 +52,21 @@ public class MentorshipWorkflow : WorkflowBase
         // =====================================================================
         // Workflow Variables
         // =====================================================================
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var sessionId = builder.WithVariable<Guid>("SessionId", default(Guid));
-        var storyId = builder.WithVariable<string>("StoryId", "");
-        var juniorId = builder.WithVariable<string>("JuniorId", "");
-        var skillLevel = builder.WithVariable<int>("SkillLevel", 3);
-        var assessmentAttempt = builder.WithVariable<int>("AssessmentAttempt", 0);
-        var planIteration = builder.WithVariable<int>("PlanIteration", 0);
-        var qualityRetryCount = builder.WithVariable<int>("QualityRetryCount", 0);
-        var reviewIteration = builder.WithVariable<int>("ReviewIteration", 0);
-        var blockerEscalationLevel = builder.WithVariable<int>("BlockerEscalationLevel", 0);
-        var maxBasicRetries = builder.WithVariable<int>("MaxBasicRetries", 2);
-        var maxDebugRetries = builder.WithVariable<int>("MaxDebugRetries", 3);
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var sessionId = builder.WithVariable<Guid>("SessionId", default(Guid)).Persisted();
+        var storyId = builder.WithVariable<string>("StoryId", "").Persisted();
+        var juniorId = builder.WithVariable<string>("JuniorId", "").Persisted();
+        var skillLevel = builder.WithVariable<int>("SkillLevel", 3).Persisted();
+        var assessmentAttempt = builder.WithVariable<int>("AssessmentAttempt", 0).Persisted();
+        var planIteration = builder.WithVariable<int>("PlanIteration", 0).Persisted();
+        var qualityRetryCount = builder.WithVariable<int>("QualityRetryCount", 0).Persisted();
+        var reviewIteration = builder.WithVariable<int>("ReviewIteration", 0).Persisted();
+        var blockerEscalationLevel = builder.WithVariable<int>("BlockerEscalationLevel", 0).Persisted();
+        var maxBasicRetries = builder.WithVariable<int>("MaxBasicRetries", 2).Persisted();
+        var maxDebugRetries = builder.WithVariable<int>("MaxDebugRetries", 3).Persisted();
 
         // DispatchWorkflow result capture for AssessmentWorkflow
-        var assessmentDispatchResult = builder.WithVariable<IDictionary<string, object>?>();
+        var assessmentDispatchResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // =====================================================================
         // 1. INITIALIZATION ACTIVITIES

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeApprovalWorkflow.cs
@@ -80,24 +80,24 @@ public class MergeApprovalWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
-        var prUrlVar = builder.WithVariable<string>("PrUrl", "");
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
-        var breakingChangeVar = builder.WithVariable<bool>("BreakingChange", false);
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0).Persisted();
+        var prUrlVar = builder.WithVariable<string>("PrUrl", "").Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
+        var breakingChangeVar = builder.WithVariable<bool>("BreakingChange", false).Persisted();
 
-        var decisionVar = builder.WithVariable<string>("Decision", "");
-        var feedbackVar = builder.WithVariable<string>("Feedback", "");
-        var approverVar = builder.WithVariable<string>("Approver", "");
+        var decisionVar = builder.WithVariable<string>("Decision", "").Persisted();
+        var feedbackVar = builder.WithVariable<string>("Feedback", "").Persisted();
+        var approverVar = builder.WithVariable<string>("Approver", "").Persisted();
 
         // Result of the dispatched merge sub-workflow (CRITICAL-2) + the test loop
         // iteration counter (CRITICAL-3). subResult captures any DispatchWorkflow
         // outputs; mergeSuccessVar is the `success` flag the merge workflow emits.
-        var subResult = builder.WithVariable<IDictionary<string, object>?>();
-        var mergeSuccessVar = builder.WithVariable<bool>("MergeSuccess", false);
-        var testIterationCountVar = builder.WithVariable<int>("TestIterationCount", 0);
+        var subResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var mergeSuccessVar = builder.WithVariable<bool>("MergeSuccess", false).Persisted();
+        var testIterationCountVar = builder.WithVariable<int>("TestIterationCount", 0).Persisted();
 
         // Max test re-runs before escalating — mirrors PlanMaxRevisions /
         // TaskMaxRevisions (>=3) in SingleIssueCycleWorkflow so an unbounded

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/MergeWorkflow.cs
@@ -63,20 +63,20 @@ public class MergeWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var branchNameVar = builder.WithVariable<string>("BranchName", "");
-        var mergeStrategyVar = builder.WithVariable<string>("MergeStrategy", MergePullRequestActivity.DefaultStrategy);
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0).Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var branchNameVar = builder.WithVariable<string>("BranchName", "").Persisted();
+        var mergeStrategyVar = builder.WithVariable<string>("MergeStrategy", MergePullRequestActivity.DefaultStrategy).Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
 
-        var mergeShaVar = builder.WithVariable<string>("MergeSha", "");
-        var issueClosedVar = builder.WithVariable<bool>("IssueClosed", false);
-        var branchDeletedVar = builder.WithVariable<bool>("BranchDeleted", false);
-        var alreadyMergedVar = builder.WithVariable<bool>("AlreadyMerged", false);
-        var failureCodeVar = builder.WithVariable<string>("FailureCode", "");
-        var failureReasonVar = builder.WithVariable<string>("FailureReason", "");
-        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
+        var mergeShaVar = builder.WithVariable<string>("MergeSha", "").Persisted();
+        var issueClosedVar = builder.WithVariable<bool>("IssueClosed", false).Persisted();
+        var branchDeletedVar = builder.WithVariable<bool>("BranchDeleted", false).Persisted();
+        var alreadyMergedVar = builder.WithVariable<bool>("AlreadyMerged", false).Persisted();
+        var failureCodeVar = builder.WithVariable<string>("FailureCode", "").Persisted();
+        var failureReasonVar = builder.WithVariable<string>("FailureReason", "").Persisted();
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0).Persisted();
 
         // ================================================================
         // 1. Read inputs (the merge-approval gate dispatches repository/prNumber/

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PanelReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PanelReviewWorkflow.cs
@@ -58,40 +58,40 @@ public class PanelReviewWorkflow : WorkflowBase
             "an aggregate Review (or a typed undecidable result carrying all member reviews)";
 
         // ── Inputs threaded to each member + the aggregation ──
-        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
-        var contentJson = builder.WithVariable<string>("ContentJson", "{}");
-        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
-        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable);
-        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "");
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var correlationId = builder.WithVariable<string>("CorrelationId", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "").Persisted();
+        var contentJson = builder.WithVariable<string>("ContentJson", "{}").Persisted();
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}").Persisted();
+        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable).Persisted();
+        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "").Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var correlationId = builder.WithVariable<string>("CorrelationId", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Resolved panel config ──
-        var rosterJson = builder.WithVariable<string>("RosterJson", "[]");
-        var decisionRuleWire = builder.WithVariable<string>("DecisionRuleWire", "unanimous");
-        var minimumUsableReviews = builder.WithVariable<int>("MinimumUsableReviews", 0);
-        var memberCount = builder.WithVariable<int>("MemberCount", 0);
+        var rosterJson = builder.WithVariable<string>("RosterJson", "[]").Persisted();
+        var decisionRuleWire = builder.WithVariable<string>("DecisionRuleWire", "unanimous").Persisted();
+        var minimumUsableReviews = builder.WithVariable<int>("MinimumUsableReviews", 0).Persisted();
+        var memberCount = builder.WithVariable<int>("MemberCount", 0).Persisted();
 
         // ── Per-role member captures (JSON). Default "{}" = not dispatched. ──
         var memberVars = PanelRoles.ToDictionary(
             r => r,
-            r => builder.WithVariable<string>($"{r}MemberResultJson", "{}"));
+            r => builder.WithVariable<string>($"{r}MemberResultJson", "{}").Persisted());
 
         // ── Shared sub-workflow dispatch result ──
-        var memberResult = builder.WithVariable<IDictionary<string, object>?>();
+        var memberResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Aggregate outputs ──
-        var decided = builder.WithVariable<bool>("Decided", false);
-        var aggregateReviewJson = builder.WithVariable<string>("AggregateReviewJson", "");
-        var aggregateEnvelopeJson = builder.WithVariable<string>("AggregateEnvelopeJson", "");
-        var aggregateDocumentId = builder.WithVariable<string>("AggregateDocumentId", "");
-        var aggregateProducerRole = builder.WithVariable<string>("AggregateProducerRole", "");
-        var aggregateProducerAction = builder.WithVariable<string>("AggregateProducerAction", "");
-        var memberReviewsJson = builder.WithVariable<string>("MemberReviewsJson", "[]");
-        var undecidableReason = builder.WithVariable<string>("UndecidableReason", "");
-        var succeededCount = builder.WithVariable<int>("SucceededCount", 0);
+        var decided = builder.WithVariable<bool>("Decided", false).Persisted();
+        var aggregateReviewJson = builder.WithVariable<string>("AggregateReviewJson", "").Persisted();
+        var aggregateEnvelopeJson = builder.WithVariable<string>("AggregateEnvelopeJson", "").Persisted();
+        var aggregateDocumentId = builder.WithVariable<string>("AggregateDocumentId", "").Persisted();
+        var aggregateProducerRole = builder.WithVariable<string>("AggregateProducerRole", "").Persisted();
+        var aggregateProducerAction = builder.WithVariable<string>("AggregateProducerAction", "").Persisted();
+        var memberReviewsJson = builder.WithVariable<string>("MemberReviewsJson", "[]").Persisted();
+        var undecidableReason = builder.WithVariable<string>("UndecidableReason", "").Persisted();
+        var succeededCount = builder.WithVariable<int>("SucceededCount", 0).Persisted();
 
         // ================================================================
         // Init — resolve roster + rule + quorum (D11)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanGenerationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanGenerationWorkflow.cs
@@ -66,44 +66,44 @@ public class PlanGenerationWorkflow : WorkflowBase
         builder.Description = "Generate a reviewed implementation plan via the generic document lifecycle (produce → validate → review(panel) → revise → accept)";
 
         // ── Inputs (compat set + additive) ─────────────────────────────
-        var repository      = builder.WithVariable<string>("Repository", "");
-        var issueNumber     = builder.WithVariable<int>("IssueNumber", 0);
-        var poSummary       = builder.WithVariable<string>("POSummary", "");
-        var contextIds      = builder.WithVariable<string>("ContextIds", "[]");
-        var workItemJson    = builder.WithVariable<string>("WorkItemJson", "");
-        var reviewNotes     = builder.WithVariable<string>("ReviewNotes", "");
-        var revisionNumber  = builder.WithVariable<int>("RevisionNumber", 0);
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var issueId         = builder.WithVariable<string>("IssueId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var repository      = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber     = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var poSummary       = builder.WithVariable<string>("POSummary", "").Persisted();
+        var contextIds      = builder.WithVariable<string>("ContextIds", "[]").Persisted();
+        var workItemJson    = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var reviewNotes     = builder.WithVariable<string>("ReviewNotes", "").Persisted();
+        var revisionNumber  = builder.WithVariable<int>("RevisionNumber", 0).Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId         = builder.WithVariable<string>("IssueId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Consumed decomposition (D4) ────────────────────────────────
-        var decompositionJson = builder.WithVariable<string>("DecompositionJson", "");
-        var decompositionFound = builder.WithVariable<bool>();
-        var decompositionDocId = builder.WithVariable<string>();
-        var decompositionLineage = builder.WithVariable<string>();
+        var decompositionJson = builder.WithVariable<string>("DecompositionJson", "").Persisted();
+        var decompositionFound = builder.WithVariable<bool>().Persisted();
+        var decompositionDocId = builder.WithVariable<string>().Persisted();
+        var decompositionLineage = builder.WithVariable<string>().Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D9) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitStatus      = builder.WithVariable<string>("ExitStatus", "");
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var planJson        = builder.WithVariable<string>("PlanJson", "");
-        var decisionNotes   = builder.WithVariable<string>("DecisionNotes", "");
-        var legacyDecision  = builder.WithVariable<string>("LegacyDecision", "needsHuman");
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus    = builder.WithVariable<string>();
-        var outputError     = builder.WithVariable<string>("OutputError", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitStatus      = builder.WithVariable<string>("ExitStatus", "").Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var planJson        = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var decisionNotes   = builder.WithVariable<string>("DecisionNotes", "").Persisted();
+        var legacyDecision  = builder.WithVariable<string>("LegacyDecision", "needsHuman").Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
+        var outputError     = builder.WithVariable<string>("OutputError", "").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PlanReviewWorkflow.cs
@@ -47,29 +47,29 @@ public class PlanReviewWorkflow : WorkflowBase
         builder.Description = "Read-through shim over the document store: maps the latest accepted plan + review lineage to the legacy review output (39-14 D1)";
 
         // ── Inputs (compat set) ────────────────────────────────────────
-        var repository   = builder.WithVariable<string>("Repository", "");
-        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0);
-        var planJsonIn   = builder.WithVariable<string>("PlanJson", "");
-        var contextIds   = builder.WithVariable<string>("ContextIds", "[]");
-        var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
-        var tenantId     = builder.WithVariable<string>("TenantId", "");
-        var issueId      = builder.WithVariable<string>("IssueId", "");
+        var repository   = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber  = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var planJsonIn   = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var contextIds   = builder.WithVariable<string>("ContextIds", "[]").Persisted();
+        var workItemJson = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var tenantId     = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId      = builder.WithVariable<string>("IssueId", "").Persisted();
 
         // ── 39-10 re-entry position (trivial pure read) ────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
 
         // ── Store read result ──────────────────────────────────────────
-        var planFound    = builder.WithVariable<bool>();
-        var acceptedDocId = builder.WithVariable<string>();
-        var acceptedPlanJson = builder.WithVariable<string>("AcceptedPlanJson", "{}");
-        var lineageJson  = builder.WithVariable<string>("LineageJson", "{}");
+        var planFound    = builder.WithVariable<bool>().Persisted();
+        var acceptedDocId = builder.WithVariable<string>().Persisted();
+        var acceptedPlanJson = builder.WithVariable<string>("AcceptedPlanJson", "{}").Persisted();
+        var lineageJson  = builder.WithVariable<string>("LineageJson", "{}").Persisted();
 
         // ── Mapped legacy outputs ──────────────────────────────────────
-        var decision     = builder.WithVariable<string>("Decision", "needsHuman");
-        var planJsonOut  = builder.WithVariable<string>("PlanJsonOut", "");
-        var reviewNotes  = builder.WithVariable<string>("ReviewNotes", "");
-        var discussionLog = builder.WithVariable<string>("DiscussionLog", "[]");
+        var decision     = builder.WithVariable<string>("Decision", "needsHuman").Persisted();
+        var planJsonOut  = builder.WithVariable<string>("PlanJsonOut", "").Persisted();
+        var reviewNotes  = builder.WithVariable<string>("ReviewNotes", "").Persisted();
+        var discussionLog = builder.WithVariable<string>("DiscussionLog", "[]").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PullRequestWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/PullRequestWorkflow.cs
@@ -45,29 +45,29 @@ public class PullRequestWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var baseBranchVar = builder.WithVariable<string>("BaseBranch", "main");
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var issueTitleVar = builder.WithVariable<string>("IssueTitle", "");
-        var planJsonVar = builder.WithVariable<string>("PlanJson", "");
-        var draftVar = builder.WithVariable<bool>("Draft", false);
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
-        var changeSummaryVar = builder.WithVariable<string>("ChangeSummaryJson", "");
-        var testSummaryVar = builder.WithVariable<string>("TestSummaryJson", "");
-        var issueLabelsVar = builder.WithVariable<string>("IssueLabelsJson", "");
-        var reviewersVar = builder.WithVariable<string>("ReviewersJson", "");
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var baseBranchVar = builder.WithVariable<string>("BaseBranch", "main").Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var issueTitleVar = builder.WithVariable<string>("IssueTitle", "").Persisted();
+        var planJsonVar = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var draftVar = builder.WithVariable<bool>("Draft", false).Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
+        var changeSummaryVar = builder.WithVariable<string>("ChangeSummaryJson", "").Persisted();
+        var testSummaryVar = builder.WithVariable<string>("TestSummaryJson", "").Persisted();
+        var issueLabelsVar = builder.WithVariable<string>("IssueLabelsJson", "").Persisted();
+        var reviewersVar = builder.WithVariable<string>("ReviewersJson", "").Persisted();
 
-        var aiBodyVar = builder.WithVariable<string>("AiBody", "");
-        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
+        var aiBodyVar = builder.WithVariable<string>("AiBody", "").Persisted();
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
-        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
-        var prUrlVar = builder.WithVariable<string>("PrUrl", "");
-        var reusedVar = builder.WithVariable<bool>("Reused", false);
-        var isDraftVar = builder.WithVariable<bool>("IsDraft", false);
-        var appliedLabelsVar = builder.WithVariable<string>("AppliedLabels", "[]");
-        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
-        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0).Persisted();
+        var prUrlVar = builder.WithVariable<string>("PrUrl", "").Persisted();
+        var reusedVar = builder.WithVariable<bool>("Reused", false).Persisted();
+        var isDraftVar = builder.WithVariable<bool>("IsDraft", false).Persisted();
+        var appliedLabelsVar = builder.WithVariable<string>("AppliedLabels", "[]").Persisted();
+        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "").Persisted();
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0).Persisted();
 
         // ================================================================
         // 1. Read inputs

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ResearchWorkflow.cs
@@ -46,42 +46,42 @@ public class ResearchWorkflow : WorkflowBase
         builder.Description = "Investigate an issue/topic and synthesize a ranked, confidence-scored findings document via the generic document lifecycle";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var sessionId       = builder.WithVariable<Guid>();
-        var issueId         = builder.WithVariable<string>();
-        var topic           = builder.WithVariable<string>();
-        var repository      = builder.WithVariable<string>();
-        var issueNumber     = builder.WithVariable<int>();
-        var workItemJson    = builder.WithVariable<string>();
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var sessionId       = builder.WithVariable<Guid>().Persisted();
+        var issueId         = builder.WithVariable<string>().Persisted();
+        var topic           = builder.WithVariable<string>().Persisted();
+        var repository      = builder.WithVariable<string>().Persisted();
+        var issueNumber     = builder.WithVariable<int>().Persisted();
+        var workItemJson    = builder.WithVariable<string>().Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Context (consumes side) ────────────────────────────────────
-        var researchContext = builder.WithVariable<string>();
-        var contextIds      = builder.WithVariable<string>("[]");
+        var researchContext = builder.WithVariable<string>().Persisted();
+        var contextIds      = builder.WithVariable<string>("[]").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result containers ──────────────────────
-        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
+        var contextGatherResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ── Typed lifecycle exit ───────────────────────────────────────
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitStatus      = builder.WithVariable<string>("ExitStatus", "");
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var reportJson      = builder.WithVariable<string>("ReportJson", "{}");
-        var findingCount    = builder.WithVariable<int>();
-        var confidence      = builder.WithVariable<double>();
-        var failureDetail   = builder.WithVariable<string>("FailureDetail", "");
-        var outputStatus    = builder.WithVariable<string>();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitStatus      = builder.WithVariable<string>("ExitStatus", "").Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var reportJson      = builder.WithVariable<string>("ReportJson", "{}").Persisted();
+        var findingCount    = builder.WithVariable<int>().Persisted();
+        var confidence      = builder.WithVariable<double>().Persisted();
+        var failureDetail   = builder.WithVariable<string>("FailureDetail", "").Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/ReviewFixWorkflow.cs
@@ -123,19 +123,19 @@ public class ReviewFixWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var branchNameVar = builder.WithVariable<string>("BranchName", "");
-        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchNameVar = builder.WithVariable<string>("BranchName", "").Persisted();
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0).Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
 
-        var hasActionableVar = builder.WithVariable<bool>("HasActionable", false);
-        var analysisJsonVar = builder.WithVariable<string>("AnalysisJson", "");
-        var fixesAppliedVar = builder.WithVariable<bool>("FixesApplied", false);
-        var generateSucceededVar = builder.WithVariable<bool>("GenerateSucceeded", false);
-        var iterationVar = builder.WithVariable<int>("Iteration", 0);
-        var fixResultVar = builder.WithVariable<ReviewFixResult?>();
-        var llmResultVar = builder.WithVariable<IDictionary<string, object>?>();
+        var hasActionableVar = builder.WithVariable<bool>("HasActionable", false).Persisted();
+        var analysisJsonVar = builder.WithVariable<string>("AnalysisJson", "").Persisted();
+        var fixesAppliedVar = builder.WithVariable<bool>("FixesApplied", false).Persisted();
+        var generateSucceededVar = builder.WithVariable<bool>("GenerateSucceeded", false).Persisted();
+        var iterationVar = builder.WithVariable<int>("Iteration", 0).Persisted();
+        var fixResultVar = builder.WithVariable<ReviewFixResult?>().Persisted();
+        var llmResultVar = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // 0. Seed the fail-closed default outcome (success=false)

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/RotateSecretWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/RotateSecretWorkflow.cs
@@ -43,16 +43,16 @@ public class RotateSecretWorkflow : WorkflowBase
             + "Handler plugins (postgres, cranl, hmac, generic-http) own the "
             + "system-specific push/probe/rollback.";
 
-        var secretId = builder.WithVariable<Guid>("SecretId", Guid.Empty);
-        var correlationId = builder.WithVariable<string>("RotationCorrelationId", string.Empty);
-        var newPlaintext = builder.WithVariable<string>("NewPlaintext", string.Empty);
-        var generateLength = builder.WithVariable<int>("GenerateLength", 32);
-        var operatorUserId = builder.WithVariable<Guid>("OperatorUserId", Guid.Empty);
-        var graceSeconds = builder.WithVariable<long>("GraceWindowSeconds", 0L);
-        var resultVar = builder.WithVariable<string>("Result", string.Empty);
-        var newVersionVar = builder.WithVariable<int>("NewVersionNumber", 0);
-        var oldVersionVar = builder.WithVariable<int>("OldVersionNumber", 0);
-        var errorVar = builder.WithVariable<string>("Error", string.Empty);
+        var secretId = builder.WithVariable<Guid>("SecretId", Guid.Empty).Persisted();
+        var correlationId = builder.WithVariable<string>("RotationCorrelationId", string.Empty).Persisted();
+        var newPlaintext = builder.WithVariable<string>("NewPlaintext", string.Empty).Persisted();
+        var generateLength = builder.WithVariable<int>("GenerateLength", 32).Persisted();
+        var operatorUserId = builder.WithVariable<Guid>("OperatorUserId", Guid.Empty).Persisted();
+        var graceSeconds = builder.WithVariable<long>("GraceWindowSeconds", 0L).Persisted();
+        var resultVar = builder.WithVariable<string>("Result", string.Empty).Persisted();
+        var newVersionVar = builder.WithVariable<int>("NewVersionNumber", 0).Persisted();
+        var oldVersionVar = builder.WithVariable<int>("OldVersionNumber", 0).Persisted();
+        var errorVar = builder.WithVariable<string>("Error", string.Empty).Persisted();
 
         var initInputs = new SetVariable
         {

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -57,55 +57,55 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var workItemJson = builder.WithVariable<string>("WorkItemJson", "");
-        var repository = builder.WithVariable<string>("Repository", "");
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var botAssignee = builder.WithVariable<string>("BotAssignee", "tamma-bot");
-        var baseBranch = builder.WithVariable<string>("BaseBranch", "main");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var workItemJson = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var botAssignee = builder.WithVariable<string>("BotAssignee", "tamma-bot").Persisted();
+        var baseBranch = builder.WithVariable<string>("BaseBranch", "main").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
         // Deployment mode (dev | business) — drives the deployment pipeline's
         // production approval gate (Business Mode requires human approval before
         // prod). Read from input; defaults to dev when absent.
-        var mode = builder.WithVariable<string>("Mode", "");
+        var mode = builder.WithVariable<string>("Mode", "").Persisted();
         // Operator force-flag for the prod approval gate (Deployment:RequireProdApproval).
         // Threaded from DispatchCycleActivity so an operator can force the gate even
         // in single-user/dev mode. Read from input; defaults false.
-        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false);
+        var requireProdApproval = builder.WithVariable<bool>("RequireProdApproval", false).Persisted();
 
         // Conventions (loaded from repo config)
-        var conventions = builder.WithVariable<string>("Conventions", "");
+        var conventions = builder.WithVariable<string>("Conventions", "").Persisted();
 
         // Step outputs
-        var contextIds = builder.WithVariable<string>("ContextIds", "");
-        var poSummary = builder.WithVariable<string>("POSummary", "");
-        var planJson = builder.WithVariable<string>("PlanJson", "");
-        var reviewDecision = builder.WithVariable<string>("ReviewDecision", "");
-        var tasksJson = builder.WithVariable<string>("TasksJson", "");
-        var taskReviewDecision = builder.WithVariable<string>("TaskReviewDecision", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
+        var contextIds = builder.WithVariable<string>("ContextIds", "").Persisted();
+        var poSummary = builder.WithVariable<string>("POSummary", "").Persisted();
+        var planJson = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var reviewDecision = builder.WithVariable<string>("ReviewDecision", "").Persisted();
+        var tasksJson = builder.WithVariable<string>("TasksJson", "").Persisted();
+        var taskReviewDecision = builder.WithVariable<string>("TaskReviewDecision", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
         // Branch-creation gating (IMPORTANT-5): the cycle must NOT proceed to
         // createPR on a failed branch (empty head → doomed PR + false "branch
         // created" notify). The branch sub-workflow reports success / errorCode /
         // exitReason; we capture them to route a loud terminal on failure.
-        var branchSuccess = builder.WithVariable<bool>("BranchSuccess", false);
-        var branchErrorCode = builder.WithVariable<string>("BranchErrorCode", "");
-        var branchErrorReason = builder.WithVariable<string>("BranchErrorReason", "");
-        var prNumber = builder.WithVariable<int>("PRNumber", 0);
-        var prUrl = builder.WithVariable<string>("PRUrl", "");
-        var exitReason = builder.WithVariable<string>("ExitReason", "");
+        var branchSuccess = builder.WithVariable<bool>("BranchSuccess", false).Persisted();
+        var branchErrorCode = builder.WithVariable<string>("BranchErrorCode", "").Persisted();
+        var branchErrorReason = builder.WithVariable<string>("BranchErrorReason", "").Persisted();
+        var prNumber = builder.WithVariable<int>("PRNumber", 0).Persisted();
+        var prUrl = builder.WithVariable<string>("PRUrl", "").Persisted();
+        var exitReason = builder.WithVariable<string>("ExitReason", "").Persisted();
 
         // Fail-the-cycle sink context (Phase A): which step failed + the underlying
         // detail surfaced on the loud CYCLE.STEP_FAILED audit row. Defaults are never
         // empty (no silent failure) — every error route stamps a real stepId/detail.
-        var failedStepId = builder.WithVariable<string>("FailedStepId", "unknown-step");
-        var failedDetail = builder.WithVariable<string>("FailedDetail", "step produced no usable result");
+        var failedStepId = builder.WithVariable<string>("FailedStepId", "unknown-step").Persisted();
+        var failedDetail = builder.WithVariable<string>("FailedDetail", "step produced no usable result").Persisted();
 
         // Review / revision tracking (must be declared before activities that reference them)
-        var reviewNotes = builder.WithVariable<string>("ReviewNotes", "");
-        var planRevisionCount = builder.WithVariable<int>("PlanRevisionCount", 0);
+        var reviewNotes = builder.WithVariable<string>("ReviewNotes", "").Persisted();
+        var planRevisionCount = builder.WithVariable<int>("PlanRevisionCount", 0).Persisted();
 
         // Sub-workflow results
-        var subResult = builder.WithVariable<IDictionary<string, object>?>();
+        var subResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // 0. Read workflow inputs into variables (no side effects in activity lambdas)
@@ -516,9 +516,9 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // 10. TDD Loop (for each task in dependency order)
         // Each task: red → green → CI → refactor → commit
         // ================================================================
-        var currentTaskIndex = builder.WithVariable<int>("CurrentTaskIndex", 0);
-        var totalTasks = builder.WithVariable<int>("TotalTasks", 0);
-        var currentTaskJson = builder.WithVariable<string>("CurrentTaskJson", "");
+        var currentTaskIndex = builder.WithVariable<int>("CurrentTaskIndex", 0).Persisted();
+        var totalTasks = builder.WithVariable<int>("TotalTasks", 0).Persisted();
+        var currentTaskJson = builder.WithVariable<string>("CurrentTaskJson", "").Persisted();
 
         var initTaskLoop = Assign(totalTasks, ctx =>
         {
@@ -718,7 +718,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // `outcome` output). Defaults to "escalated" when the gate returns nothing
         // parseable so an unreadable result is treated as a loud non-merge (never a
         // silent merge), keeping the cycle on a terminal path.
-        var gateOutcome = builder.WithVariable<string>("GateOutcome", "escalated");
+        var gateOutcome = builder.WithVariable<string>("GateOutcome", "escalated").Persisted();
         var extractGateOutcome = Assign(gateOutcome, ctx =>
         {
             var result = subResult.Get(ctx);
@@ -762,7 +762,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         // ================================================================
         // 13. Wait for PR Merged (bookmark — blocks until merged)
         // ================================================================
-        var mergeSha = builder.WithVariable<string>("MergeSha", "");
+        var mergeSha = builder.WithVariable<string>("MergeSha", "").Persisted();
         var waitForMerged = new WaitForPRMergedActivity
         {
             Id = "WaitForPRMerged",
@@ -885,7 +885,7 @@ public class SingleIssueCycleWorkflow : WorkflowBase
         };
         planMaxRevisionsCheck.SetDisplayText("Plan Max Revisions?");
 
-        var taskRevisionCount = builder.WithVariable<int>("TaskRevisionCount", 0);
+        var taskRevisionCount = builder.WithVariable<int>("TaskRevisionCount", 0).Persisted();
         var incrementTaskRevision = Assign(taskRevisionCount, ctx =>
             (object)(taskRevisionCount.Get(ctx) + 1),
             "IncrTaskRevision", "Increment Task Revision");

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleIssueCycleWorkflow.cs
@@ -484,7 +484,13 @@ public class SingleIssueCycleWorkflow : WorkflowBase
             var result = subResult.Get(ctx);
             if (result != null)
             {
-                if (result.TryGetValue("prNumber", out var n) && n is int num) prNumber.Set(ctx, num);
+                // 2026-08-13 (engine-driven E2E run 32): the dispatch result crosses a
+                // SUSPENSION (the child runs on a bookmark), so the rehydrated dictionary
+                // carries JSON-inferred CLR types — a JSON number comes back as long (or
+                // JsonElement), NEVER int. `n is int` was silently false for a PR that
+                // EXISTS, so PrOk failed the cycle right after GIT.PR_OPENED.SUCCESS.
+                if (result.TryGetValue("prNumber", out var n) && CoerceInt(n) is int num && num > 0)
+                    prNumber.Set(ctx, num);
                 if (result.TryGetValue("prUrl", out var u)) prUrl.Set(ctx, u?.ToString() ?? "");
             }
             return (object)prNumber.Get(ctx);
@@ -1498,6 +1504,26 @@ public class SingleIssueCycleWorkflow : WorkflowBase
     /// result FAILS the cycle. There is deliberately NO "no explicit signal → success"
     /// fallback — an absent or unrecognised deploy verdict must NOT report success.
     /// </summary>
+    /// <summary>
+    /// 2026-08-13 (engine-driven E2E run 32) — tolerant int read for dispatch-result
+    /// values. A child's <c>SetOutput</c> int crosses the parent's suspension as a
+    /// JSON number, which Elsa's object rehydration infers as <c>long</c> (or leaves
+    /// as a <c>JsonElement</c>) — never <c>int</c>. Booleans survive as CLR bools,
+    /// which is why the sibling gates' <c>is true</c> checks pass while a bare
+    /// <c>is int</c> silently loses a REAL value. Null for anything non-numeric.
+    /// </summary>
+    internal static int? CoerceInt(object? value) => value switch
+    {
+        int i => i,
+        long l and >= int.MinValue and <= int.MaxValue => (int)l,
+        double d when double.IsInteger(d) && d is >= int.MinValue and <= int.MaxValue => (int)d,
+        decimal m when decimal.Truncate(m) == m && m is >= int.MinValue and <= int.MaxValue => (int)m,
+        string s when int.TryParse(s, out var parsed) => parsed,
+        JsonElement { ValueKind: JsonValueKind.Number } e when e.TryGetInt32(out var n) => n,
+        JsonElement { ValueKind: JsonValueKind.String } e when int.TryParse(e.GetString(), out var n) => n,
+        _ => null,
+    };
+
     internal static bool IsDeploySuccessful(IDictionary<string, object>? result)
     {
         if (result == null) return false;

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleReviewerWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/SingleReviewerWorkflow.cs
@@ -54,31 +54,31 @@ public class SingleReviewerWorkflow : WorkflowBase
 
         // ── Data-driven dispatch inputs (default "" so the drift scanner sees the
         //    one llm-call dispatch as DATA-DRIVEN, D9) ──
-        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "");
-        var reviewerAction = builder.WithVariable<string>("ReviewerAction", "");
-        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}");
-        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "");
+        var reviewerRole = builder.WithVariable<string>("ReviewerRole", "").Persisted();
+        var reviewerAction = builder.WithVariable<string>("ReviewerAction", "").Persisted();
+        var variablesJson = builder.WithVariable<string>("VariablesJson", "{}").Persisted();
+        var documentTypeKey = builder.WithVariable<string>("DocumentTypeKey", "").Persisted();
 
         // ── Lineage + config scalars ──
-        var subjectJson = builder.WithVariable<string>("SubjectJson", "");
-        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable);
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var correlationId = builder.WithVariable<string>("CorrelationId", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var maxRepairAttempts = builder.WithVariable<int>("MaxRepairAttempts", AcceptanceDefaults.DefaultMaxValidationRepairAttempts);
-        var attempts = builder.WithVariable<int>("Attempts", 0);
+        var subjectJson = builder.WithVariable<string>("SubjectJson", "").Persisted();
+        var feedbackVariableName = builder.WithVariable<string>("FeedbackVariableName", ReviewProducerHelper.DefaultFeedbackVariable).Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var correlationId = builder.WithVariable<string>("CorrelationId", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var maxRepairAttempts = builder.WithVariable<int>("MaxRepairAttempts", AcceptanceDefaults.DefaultMaxValidationRepairAttempts).Persisted();
+        var attempts = builder.WithVariable<int>("Attempts", 0).Persisted();
 
         // ── Dispatch result + routing ──
-        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
-        var everSucceededCall = builder.WithVariable<bool>("EverSucceededCall", false);
-        var validationOk = builder.WithVariable<bool>("ValidationOk", false);
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var everSucceededCall = builder.WithVariable<bool>("EverSucceededCall", false).Persisted();
+        var validationOk = builder.WithVariable<bool>("ValidationOk", false).Persisted();
 
         // ── Outputs ──
-        var reviewJson = builder.WithVariable<string>("ReviewJson", "");
-        var reviewEnvelopeJson = builder.WithVariable<string>("ReviewEnvelopeJson", "");
-        var reviewDocumentId = builder.WithVariable<string>("ReviewDocumentId", "");
-        var violationsJson = builder.WithVariable<string>("ViolationsJson", "[]");
-        var failureKind = builder.WithVariable<string>("FailureKind", "");
+        var reviewJson = builder.WithVariable<string>("ReviewJson", "").Persisted();
+        var reviewEnvelopeJson = builder.WithVariable<string>("ReviewEnvelopeJson", "").Persisted();
+        var reviewDocumentId = builder.WithVariable<string>("ReviewDocumentId", "").Persisted();
+        var violationsJson = builder.WithVariable<string>("ViolationsJson", "[]").Persisted();
+        var failureKind = builder.WithVariable<string>("FailureKind", "").Persisted();
 
         // ================================================================
         // Init — resolve reviewer (role, action) fail-loud (AC4), seed config
@@ -134,7 +134,15 @@ public class SingleReviewerWorkflow : WorkflowBase
                 ["agentRole"] = reviewerRole.Get(ctx) ?? "",
                 ["action"] = reviewerAction.Get(ctx) ?? "",
                 ["tenantId"] = tenantId.Get(ctx) ?? "",
-                ["documentType"] = documentTypeKey.Get(ctx) ?? "",
+                // 2026-08-13 (engine-driven E2E): the llm-call's documentType
+                // names the type of document THIS CALL PRODUCES — a reviewer
+                // call produces a REVIEW, not the subject's type. Passing the
+                // SUBJECT type here made the API's 39-9 content-validation
+                // ring validate every reviewer reply against the subject's
+                // validator (a plan review was ring-validated as a PLAN), so
+                // every reviewer call exhausted the repair ring and failed
+                // CONTENT_VALIDATION_FAILED before MapAndValidate ever ran.
+                ["documentType"] = "review",
                 ["issueId"] = issueId.Get(ctx) ?? "",
                 ["variables"] = ParseVarsDict(variablesJson.Get(ctx)),
                 ["enableTools"] = false,

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskCreationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskCreationWorkflow.cs
@@ -59,39 +59,39 @@ public class TaskCreationWorkflow : WorkflowBase
         builder.Description = "Break the approved plan into detailed implementation tasks via the generic document lifecycle (produce → validate → review → revise → accept)";
 
         // ── Inputs (compat set + additive) ─────────────────────────────
-        var repository      = builder.WithVariable<string>("Repository", "");
-        var issueNumber     = builder.WithVariable<int>("IssueNumber", 0);
-        var planJson        = builder.WithVariable<string>("PlanJson", "");
-        var contextIds      = builder.WithVariable<string>("ContextIds", "[]");
-        var workItemJson    = builder.WithVariable<string>("WorkItemJson", "");
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var issueId         = builder.WithVariable<string>("IssueId", "");
-        var scopedIssueId   = builder.WithVariable<string>("ScopedIssueId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var repository      = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber     = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var planJson        = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var contextIds      = builder.WithVariable<string>("ContextIds", "[]").Persisted();
+        var workItemJson    = builder.WithVariable<string>("WorkItemJson", "").Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId         = builder.WithVariable<string>("IssueId", "").Persisted();
+        var scopedIssueId   = builder.WithVariable<string>("ScopedIssueId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Consumed system plan (D2 lineage anchor) ───────────────────
-        var consumedPlanFound = builder.WithVariable<bool>();
-        var consumedPlanDocId = builder.WithVariable<string>("ConsumedPlanDocId", "");
-        var consumedPlanJson  = builder.WithVariable<string>("ConsumedPlanJson", "");
-        var consumedPlanLineage = builder.WithVariable<string>();
+        var consumedPlanFound = builder.WithVariable<bool>().Persisted();
+        var consumedPlanDocId = builder.WithVariable<string>("ConsumedPlanDocId", "").Persisted();
+        var consumedPlanJson  = builder.WithVariable<string>("ConsumedPlanJson", "").Persisted();
+        var consumedPlanLineage = builder.WithVariable<string>().Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D8) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var tasksJson       = builder.WithVariable<string>("TasksJson", "[]");
-        var outputStatus    = builder.WithVariable<string>();
-        var outputError     = builder.WithVariable<string>("OutputError", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var tasksJson       = builder.WithVariable<string>("TasksJson", "[]").Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
+        var outputError     = builder.WithVariable<string>("OutputError", "").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskReviewWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TaskReviewWorkflow.cs
@@ -49,29 +49,29 @@ public class TaskReviewWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var tasksJson = builder.WithVariable<string>("TasksJson", "[]");
-        var planJson = builder.WithVariable<string>("PlanJson", "");
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var tasksJson = builder.WithVariable<string>("TasksJson", "[]").Persisted();
+        var planJson = builder.WithVariable<string>("PlanJson", "").Persisted();
 
         // Per-role review results
-        var architectReview = builder.WithVariable<string>("ArchitectReview", "{}");
-        var seniorDevReview = builder.WithVariable<string>("SeniorDevReview", "{}");
-        var developerReview = builder.WithVariable<string>("DeveloperReview", "{}");
-        var testerReview = builder.WithVariable<string>("TesterReview", "{}");
+        var architectReview = builder.WithVariable<string>("ArchitectReview", "{}").Persisted();
+        var seniorDevReview = builder.WithVariable<string>("SeniorDevReview", "{}").Persisted();
+        var developerReview = builder.WithVariable<string>("DeveloperReview", "{}").Persisted();
+        var testerReview = builder.WithVariable<string>("TesterReview", "{}").Persisted();
 
         // Aggregation
-        var allReviewsJson = builder.WithVariable<string>("AllReviewsJson", "[]");
-        var allApproved = builder.WithVariable<bool>("AllApproved", false);
+        var allReviewsJson = builder.WithVariable<string>("AllReviewsJson", "[]").Persisted();
+        var allApproved = builder.WithVariable<bool>("AllApproved", false).Persisted();
 
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
 
         // Final outputs
-        var decision = builder.WithVariable<string>("Decision", "needsHuman");
-        var reviewNotes = builder.WithVariable<string>("ReviewNotes", "");
+        var decision = builder.WithVariable<string>("Decision", "needsHuman").Persisted();
+        var reviewNotes = builder.WithVariable<string>("ReviewNotes", "").Persisted();
 
         // Shared LLM result
-        var llmResult = builder.WithVariable<IDictionary<string, object>?>();
+        var llmResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // Role-variable mapping
         var roleVariables = new Dictionary<string, Variable<string>>

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWithDebugRetryWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWithDebugRetryWorkflow.cs
@@ -64,32 +64,32 @@ public class TddWithDebugRetryWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var storyId = builder.WithVariable<string>("StoryId", "");
-        var planJson = builder.WithVariable<string>("PlanJson", "");
-        var repositoryUrl = builder.WithVariable<string>("RepositoryUrl", "");
-        var branchName = builder.WithVariable<string>("BranchName", "");
-        var skillLevel = builder.WithVariable<int>("SkillLevel", 5);
-        var issueNumber = builder.WithVariable<int>("IssueNumber", 0);
-        var tenantId = builder.WithVariable<string>("TenantId", "");
+        var storyId = builder.WithVariable<string>("StoryId", "").Persisted();
+        var planJson = builder.WithVariable<string>("PlanJson", "").Persisted();
+        var repositoryUrl = builder.WithVariable<string>("RepositoryUrl", "").Persisted();
+        var branchName = builder.WithVariable<string>("BranchName", "").Persisted();
+        var skillLevel = builder.WithVariable<int>("SkillLevel", 5).Persisted();
+        var issueNumber = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
         // tddDebugAttempt is ALWAYS reset to 0 on entry (see initInputs) so each
         // invocation — including a re-dispatch from a parent re-run — gets the full
         // retry budget regardless of any stale counter (sibling parity with
         // CiWithDebugRetryWorkflow's ciRetryCount reset).
-        var tddDebugAttempt = builder.WithVariable<int>("TddDebugAttempt", 0);
-        var maxRetries = builder.WithVariable<int>("MaxRetries", 3);
+        var tddDebugAttempt = builder.WithVariable<int>("TddDebugAttempt", 0).Persisted();
+        var maxRetries = builder.WithVariable<int>("MaxRetries", 3).Persisted();
         // Stable per-issue/story TDD session id, derived once in init and shared by the
         // tdd-cycle and debugging dispatches so retries correlate into ONE TDD session
         // (instead of a fresh Guid per dispatch). Lets resumed runs dedupe.
-        var sessionId = builder.WithVariable<string>("SessionId", "");
+        var sessionId = builder.WithVariable<string>("SessionId", "").Persisted();
         // Real underlying failure detail captured from the failing tdd-cycle result so
         // the failure terminal can surface the actual cause (not a generic string).
-        var lastTddError = builder.WithVariable<string>("LastTddError", "TDD cycle failed");
+        var lastTddError = builder.WithVariable<string>("LastTddError", "TDD cycle failed").Persisted();
         // The terminal failure reason: tdd-not-converged (exhausted) vs debugger-escalated.
-        var finishReason = builder.WithVariable<string>("FinishReason", TddDebugEvents.ReasonNotConverged);
+        var finishReason = builder.WithVariable<string>("FinishReason", TddDebugEvents.ReasonNotConverged).Persisted();
 
         // DispatchWorkflow result capture
-        var tddResult = builder.WithVariable<IDictionary<string, object>?>();
-        var debugResult = builder.WithVariable<IDictionary<string, object>?>();
+        var tddResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var debugResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // INIT: Capture inputs, reset counter, derive a stable session id

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TddWorkflow.cs
@@ -40,41 +40,41 @@ public class TddWorkflow : WorkflowBase
         builder.Description = "Drives the red-green-refactor TDD cycle for a single implementation task";
 
         // -- Workflow variables --
-        var sessionId = builder.WithVariable<Guid>();
-        var storyId = builder.WithVariable<string>();
-        var taskDescription = builder.WithVariable<string>();
-        var taskFiles = builder.WithVariable<List<string>>();
-        var repositoryUrl = builder.WithVariable<string>();
-        var branchName = builder.WithVariable<string>();
-        var skillLevel = builder.WithVariable<int>();
-        var codeContext = builder.WithVariable<string>();
+        var sessionId = builder.WithVariable<Guid>().Persisted();
+        var storyId = builder.WithVariable<string>().Persisted();
+        var taskDescription = builder.WithVariable<string>().Persisted();
+        var taskFiles = builder.WithVariable<List<string>>().Persisted();
+        var repositoryUrl = builder.WithVariable<string>().Persisted();
+        var branchName = builder.WithVariable<string>().Persisted();
+        var skillLevel = builder.WithVariable<int>().Persisted();
+        var codeContext = builder.WithVariable<string>().Persisted();
 
         // Activity output variables (bound via Output<T>)
-        var testGenResult = builder.WithVariable<TestGenerationResult>();
-        var testSyntaxResult = builder.WithVariable<TestSyntaxValidationResult>();
-        var implResult = builder.WithVariable<ImplementationResult>();
-        var analysisResult = builder.WithVariable<RefactoringAnalysis>();
-        var refactorResult = builder.WithVariable<RefactoringResult>();
-        var commitResultVar = builder.WithVariable<CommitResult>();
+        var testGenResult = builder.WithVariable<TestGenerationResult>().Persisted();
+        var testSyntaxResult = builder.WithVariable<TestSyntaxValidationResult>().Persisted();
+        var implResult = builder.WithVariable<ImplementationResult>().Persisted();
+        var analysisResult = builder.WithVariable<RefactoringAnalysis>().Persisted();
+        var refactorResult = builder.WithVariable<RefactoringResult>().Persisted();
+        var commitResultVar = builder.WithVariable<CommitResult>().Persisted();
 
         // Phase tracking scalars
-        var rewriteAttempt = builder.WithVariable<int>();
-        var debugAttempt = builder.WithVariable<int>();
-        var debuggingInvoked = builder.WithVariable<bool>();
-        var testRunAllPassed = builder.WithVariable<bool>();
-        var testRunPassedCount = builder.WithVariable<int>();
-        var testRunFailedCount = builder.WithVariable<int>();
-        var refactorApplied = builder.WithVariable<bool>();
+        var rewriteAttempt = builder.WithVariable<int>().Persisted();
+        var debugAttempt = builder.WithVariable<int>().Persisted();
+        var debuggingInvoked = builder.WithVariable<bool>().Persisted();
+        var testRunAllPassed = builder.WithVariable<bool>().Persisted();
+        var testRunPassedCount = builder.WithVariable<int>().Persisted();
+        var testRunFailedCount = builder.WithVariable<int>().Persisted();
+        var refactorApplied = builder.WithVariable<bool>().Persisted();
 
         // Captures the result dictionary returned by DispatchWorkflow("testing-pipeline").
         // Reused across RED, GREEN, and REFACTOR phases (each dispatch overwrites it
         // before the corresponding result-extraction SetVariable runs).
-        var testingPipelineResult = builder.WithVariable<IDictionary<string, object>?>();
+        var testingPipelineResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // Phase timestamps
-        var redPhaseStart = builder.WithVariable<DateTime>();
-        var greenPhaseStart = builder.WithVariable<DateTime>();
-        var refactorPhaseStart = builder.WithVariable<DateTime>();
+        var redPhaseStart = builder.WithVariable<DateTime>().Persisted();
+        var greenPhaseStart = builder.WithVariable<DateTime>().Persisted();
+        var refactorPhaseStart = builder.WithVariable<DateTime>().Persisted();
 
         // ============================
         // Activity definitions

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantScheduledTriggerService.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TenantScheduledTriggerService.cs
@@ -217,6 +217,10 @@ public sealed class TenantScheduledTriggerService : BackgroundService
         }
 
         var dispatcher = scope.ServiceProvider.GetRequiredService<IWorkflowDispatcher>();
+        // 2026-08-13 — resolves definition VERSION ids for dispatch (see
+        // PublishedWorkflowDispatch; the request ctor takes the version id).
+        var definitionService = scope.ServiceProvider
+            .GetRequiredService<Elsa.Workflows.Management.IWorkflowDefinitionService>();
         var events = scope.ServiceProvider.GetService<IPlatformEventPublisher>();
         var now = _timeProvider.GetUtcNow();
 
@@ -264,7 +268,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
 
             try
             {
-                if (await FireDueWindowAsync(repository, dispatcher, events, trigger, now, ct)
+                if (await FireDueWindowAsync(repository, dispatcher, definitionService, events, trigger, now, ct)
                         .ConfigureAwait(false))
                 {
                     dispatched++;
@@ -289,7 +293,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
 
         // Admin run-now claims (D8): drain manual:{timestamp} ledger rows the
         // API claimed, through the same dispatch + stamp path.
-        dispatched += await DrainManualFiresAsync(repository, dispatcher, events, opts, dispatched, ct)
+        dispatched += await DrainManualFiresAsync(repository, dispatcher, definitionService, events, opts, dispatched, ct)
             .ConfigureAwait(false);
 
         // LOW-8 — give the claim-then-crash contract a real surface.
@@ -307,6 +311,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
     private async Task<bool> FireDueWindowAsync(
         IScheduledTriggerRepository repository,
         IWorkflowDispatcher dispatcher,
+        Elsa.Workflows.Management.IWorkflowDefinitionService definitionService,
         IPlatformEventPublisher? events,
         ScheduledTrigger trigger,
         DateTimeOffset now,
@@ -425,7 +430,8 @@ public sealed class TenantScheduledTriggerService : BackgroundService
         }
 
         return await DispatchAndStampAsync(
-            repository, dispatcher, events, trigger, fire, now, ct).ConfigureAwait(false);
+            repository, dispatcher, definitionService, events, trigger, fire, now, ct)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -571,6 +577,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
     private async Task<int> DrainManualFiresAsync(
         IScheduledTriggerRepository repository,
         IWorkflowDispatcher dispatcher,
+        Elsa.Workflows.Management.IWorkflowDefinitionService definitionService,
         IPlatformEventPublisher? events,
         TenantScheduledTriggerOptions opts,
         int alreadyDispatched,
@@ -604,7 +611,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
                 }
 
                 if (await DispatchAndStampAsync(
-                        repository, dispatcher, events, trigger, fire,
+                        repository, dispatcher, definitionService, events, trigger, fire,
                         _timeProvider.GetUtcNow(), ct).ConfigureAwait(false))
                 {
                     dispatched++;
@@ -635,6 +642,7 @@ public sealed class TenantScheduledTriggerService : BackgroundService
     private async Task<bool> DispatchAndStampAsync(
         IScheduledTriggerRepository repository,
         IWorkflowDispatcher dispatcher,
+        Elsa.Workflows.Management.IWorkflowDefinitionService definitionService,
         IPlatformEventPublisher? events,
         ScheduledTrigger trigger,
         ScheduledTriggerFire fire,
@@ -645,7 +653,12 @@ public sealed class TenantScheduledTriggerService : BackgroundService
         var instanceId = Guid.NewGuid().ToString();
         // The definition id is ROW DATA (AC3) — this service must never name
         // a consumer workflow's DefinitionId constant.
-        var request = new DispatchWorkflowDefinitionRequest(fire.DefinitionId)
+        // 2026-08-13 — the request ctor takes the VERSION id, not the definition
+        // id (see PublishedWorkflowDispatch); resolve the published version first
+        // or every fire dies WorkflowGraphNotFound in the dispatch queue.
+        var definitionVersionId = await Tamma.Activities.Core.PublishedWorkflowDispatch
+            .ResolvePublishedVersionIdAsync(definitionService, fire.DefinitionId, ct);
+        var request = new DispatchWorkflowDefinitionRequest(definitionVersionId)
         {
             InstanceId = instanceId,
             Input = input,

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestCaseCreationWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestCaseCreationWorkflow.cs
@@ -48,31 +48,31 @@ public class TestCaseCreationWorkflow : WorkflowBase
         builder.Description = "Generate test cases from the task breakdown via the generic document lifecycle (produce → validate(cross-doc task-ID) → review → revise → accept)";
 
         // ── Inputs (compat set + additive) ─────────────────────────────
-        var repository      = builder.WithVariable<string>("Repository", "");
-        var branchName      = builder.WithVariable<string>("BranchName", "");
-        var tasksJson       = builder.WithVariable<string>("TasksJson", "[]");
-        var contextIds      = builder.WithVariable<string>("ContextIds", "[]");
-        var tenantId        = builder.WithVariable<string>("TenantId", "");
-        var issueId         = builder.WithVariable<string>("IssueId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
+        var repository      = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchName      = builder.WithVariable<string>("BranchName", "").Persisted();
+        var tasksJson       = builder.WithVariable<string>("TasksJson", "[]").Persisted();
+        var contextIds      = builder.WithVariable<string>("ContextIds", "[]").Persisted();
+        var tenantId        = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId         = builder.WithVariable<string>("IssueId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position (D8) ───────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson  = builder.WithVariable<string>();
-        var positionStage   = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson  = builder.WithVariable<string>().Persisted();
+        var positionStage   = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched-workflow result + typed exit ────────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId       = builder.WithVariable<string>("ExitDocId", "");
-        var testCasesJson   = builder.WithVariable<string>("TestCasesJson", "[]");
-        var outputStatus    = builder.WithVariable<string>();
-        var outputError     = builder.WithVariable<string>("OutputError", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitOutcome     = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId       = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var testCasesJson   = builder.WithVariable<string>("TestCasesJson", "[]").Persisted();
+        var outputStatus    = builder.WithVariable<string>().Persisted();
+        var outputError     = builder.WithVariable<string>("OutputError", "").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
@@ -76,36 +76,36 @@ public class TestingWorkflow : WorkflowBase
         // ============================================
         // Workflow Variables
         // ============================================
-        var sessionIdVar = builder.WithVariable<Guid>("SessionId", default);
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var branchVar = builder.WithVariable<string>("Branch", "");
-        var skillLevelVar = builder.WithVariable<int>("SkillLevel", 3);
-        var consecutivePassCountVar = builder.WithVariable<int>("ConsecutivePassCount", 0);
-        var attemptNumberVar = builder.WithVariable<int>("AttemptNumber", 1);
-        var maxAttemptsVar = builder.WithVariable<int>("MaxAttempts", 3);
+        var sessionIdVar = builder.WithVariable<Guid>("SessionId", default).Persisted();
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var branchVar = builder.WithVariable<string>("Branch", "").Persisted();
+        var skillLevelVar = builder.WithVariable<int>("SkillLevel", 3).Persisted();
+        var consecutivePassCountVar = builder.WithVariable<int>("ConsecutivePassCount", 0).Persisted();
+        var attemptNumberVar = builder.WithVariable<int>("AttemptNumber", 1).Persisted();
+        var maxAttemptsVar = builder.WithVariable<int>("MaxAttempts", 3).Persisted();
         // Tenant scope (empty/single-user → platform-scope). MUST be named
         // "TenantId": TriggerCIActivity / WaitForCIResultsActivity (and
         // EventPersistenceMiddleware) resolve tenant ambiently via
         // GetVariable("TenantId") — the old name "TenantIdTag" was invisible
         // to that lookup, so the CI trigger + the DG-5 poller ran
         // platform-scoped in SaaS (Epic 31 review, F-high).
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
         // The terminal escalation reason (set just before routing into the escalation leg).
-        var escalationReasonVar = builder.WithVariable<string>("EscalationReason", "");
+        var escalationReasonVar = builder.WithVariable<string>("EscalationReason", "").Persisted();
         // The real underlying failure detail surfaced on an escalation (never empty).
-        var escalationDetailVar = builder.WithVariable<string>("EscalationDetail", "");
+        var escalationDetailVar = builder.WithVariable<string>("EscalationDetail", "").Persisted();
 
         // Result variables — activities write directly to these via Output<T>(variable)
-        var ciTriggerResultVar = builder.WithVariable<CITriggerResult>("CITriggerResult", default!);
-        var ciResultsVar = builder.WithVariable<CIResultsPayload>("CIResultsPayload", default!);
-        var evaluationResultVar = builder.WithVariable<QualityGateResult>("EvaluationResult", default!);
-        var coverageResultVar = builder.WithVariable<CoverageCheckResult>("CoverageResult", default!);
-        var lintResultVar = builder.WithVariable<LintCheckResult>("LintResult", default!);
-        var securityResultVar = builder.WithVariable<SecurityCheckResult>("SecurityResult", default!);
-        var qualityReportVar = builder.WithVariable<QualityReport>("QualityReport", default!);
-        var commitFixResultVar = builder.WithVariable<CommitFixResult>("CommitFixResult", default!);
-        var ciResultsFromWaitVar = builder.WithVariable<CIResultsPayload>("CIResultsFromWait", default!);
-        var fixDispatchResultVar = builder.WithVariable<IDictionary<string, object>?>();
+        var ciTriggerResultVar = builder.WithVariable<CITriggerResult>("CITriggerResult", default!).Persisted();
+        var ciResultsVar = builder.WithVariable<CIResultsPayload>("CIResultsPayload", default!).Persisted();
+        var evaluationResultVar = builder.WithVariable<QualityGateResult>("EvaluationResult", default!).Persisted();
+        var coverageResultVar = builder.WithVariable<CoverageCheckResult>("CoverageResult", default!).Persisted();
+        var lintResultVar = builder.WithVariable<LintCheckResult>("LintResult", default!).Persisted();
+        var securityResultVar = builder.WithVariable<SecurityCheckResult>("SecurityResult", default!).Persisted();
+        var qualityReportVar = builder.WithVariable<QualityReport>("QualityReport", default!).Persisted();
+        var commitFixResultVar = builder.WithVariable<CommitFixResult>("CommitFixResult", default!).Persisted();
+        var ciResultsFromWaitVar = builder.WithVariable<CIResultsPayload>("CIResultsFromWait", default!).Persisted();
+        var fixDispatchResultVar = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ============================================
         // Step 0: Initialize — read optional maxRetries + tenantId input
@@ -863,7 +863,18 @@ public class TestingWorkflow : WorkflowBase
         return a;
     }
 
-    private static SetOutput MakeOutput(string id, string outputName, Func<ActivityExecutionContext, object> value)
+    // 2026-08-13 (found by the engine-driven E2E): this parameter MUST be
+    // Func<ExpressionExecutionContext, object>. With the former
+    // Func<ActivityExecutionContext, object>, Input<object> has no matching
+    // delegate constructor, so `new(value)` bound the LITERAL ctor and the Func
+    // itself became the input's literal value — unserializable, which made the
+    // workflow-definition store populator throw at startup and SKIP registering
+    // this workflow AND every workflow after it in enumeration order
+    // (testing-pipeline, triage-*, update-issue-status were all absent from the
+    // engine's registry; NotifyIssue's update-issue-status dispatch then failed
+    // "no published version" inside every cycle).
+    private static SetOutput MakeOutput(
+        string id, string outputName, Func<Elsa.Expressions.Models.ExpressionExecutionContext, object> value)
     {
         var a = new SetOutput
         {

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TestingWorkflow.cs
@@ -117,6 +117,23 @@ public class TestingWorkflow : WorkflowBase
             Variable = maxAttemptsVar,
             Value = new Input<object?>(ctx =>
             {
+                // 2026-08-13 (engine-driven E2E run 36): capture the CALLER'S
+                // SessionId/Repository/Branch/SkillLevel inputs — every dispatcher
+                // (TddWorkflow, CiWithDebugRetry, Debugging, Mentorship) passes
+                // them, but nothing ever read them, so the variables kept their
+                // defaults: the CI wait suspended with repository="" and the DG-5
+                // /elsa/api/ci/waits listing (fail-closed on a blank repository)
+                // silently HID the wait — no CI seat could ever resume it and
+                // every TDD leg timed out.
+                var sid = ctx.GetInput<Guid>("SessionId");
+                if (sid != Guid.Empty) sessionIdVar.Set(ctx, sid);
+                var repo = ctx.GetInput<string>("Repository");
+                if (!string.IsNullOrWhiteSpace(repo)) repositoryVar.Set(ctx, repo);
+                var branch = ctx.GetInput<string>("Branch");
+                if (!string.IsNullOrWhiteSpace(branch)) branchVar.Set(ctx, branch);
+                var skill = ctx.GetInput<int?>("SkillLevel");
+                if (skill is > 0) skillLevelVar.Set(ctx, skill.Value);
+
                 // Best-effort tenant tag (callers may not supply it; single-user → empty).
                 var tenant = ctx.GetInput<string>("tenantId");
                 if (!string.IsNullOrWhiteSpace(tenant)) tenantIdVar.Set(ctx, tenant);

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageContextGatheringWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageContextGatheringWorkflow.cs
@@ -50,31 +50,31 @@ public class TriageContextGatheringWorkflow : WorkflowBase
         builder.Description = "Gather triage context and synthesize a typed Findings document via the generic document lifecycle";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var repository = builder.WithVariable<string>("Repository", "");
-        var itemJson = builder.WithVariable<string>("ItemJson", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
-        var itemType = builder.WithVariable<string>("ItemType", TriageContextHelper.ItemTypeIssue);
-        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var itemJson = builder.WithVariable<string>("ItemJson", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
+        var itemType = builder.WithVariable<string>("ItemType", TriageContextHelper.ItemTypeIssue).Persisted();
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0).Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson = builder.WithVariable<string>();
-        var positionStage = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson = builder.WithVariable<string>().Persisted();
+        var positionStage = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── Dispatched lifecycle result + typed exit ───────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitOutcome = builder.WithVariable<string>("ExitOutcome", "");
-        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "");
-        var contextJson = builder.WithVariable<string>("ContextJson", "{}");
-        var contextStatus = builder.WithVariable<string>("ContextStatus", TriageBindingHelper.ContextStatusFailed);
-        var failureDetail = builder.WithVariable<string>("FailureDetail", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitOutcome = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "").Persisted();
+        var contextJson = builder.WithVariable<string>("ContextJson", "{}").Persisted();
+        var contextStatus = builder.WithVariable<string>("ContextStatus", TriageBindingHelper.ContextStatusFailed).Persisted();
+        var failureDetail = builder.WithVariable<string>("FailureDetail", "").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriageItemCycleWorkflow.cs
@@ -59,35 +59,35 @@ public class TriageItemCycleWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repository = builder.WithVariable<string>("Repository", "");
-        var itemJson = builder.WithVariable<string>("ItemJson", "");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var itemKey = builder.WithVariable<string>("ItemKey", "");
-        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
-        var itemSource = builder.WithVariable<string>("ItemSource", "");
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var itemJson = builder.WithVariable<string>("ItemJson", "").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var itemKey = builder.WithVariable<string>("ItemKey", "").Persisted();
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0).Persisted();
+        var itemSource = builder.WithVariable<string>("ItemSource", "").Persisted();
 
         // 39-10 re-entry position (on the item's triage-decision document).
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson = builder.WithVariable<string>();
-        var positionStage = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson = builder.WithVariable<string>().Persisted();
+        var positionStage = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
-        var contextJson = builder.WithVariable<string>("ContextJson", "");
-        var contextStatus = builder.WithVariable<string>("ContextStatus", TriageContextEvents.StatusFailed);
-        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "");
+        var contextJson = builder.WithVariable<string>("ContextJson", "").Persisted();
+        var contextStatus = builder.WithVariable<string>("ContextStatus", TriageContextEvents.StatusFailed).Persisted();
+        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "").Persisted();
 
-        var poDecisionJson = builder.WithVariable<string>("PODecisionJson", "");
-        var poDocumentJson = builder.WithVariable<string>("PODocumentJson", "");
-        var poCallSucceeded = builder.WithVariable<bool>("PoCallSucceeded", false);
-        var decisionStatus = builder.WithVariable<string>("DecisionStatus", "");
-        var decisionType = builder.WithVariable<string>("DecisionType", "");
-        var decisionPriority = builder.WithVariable<string>("DecisionPriority", "");
-        var decisionAutomation = builder.WithVariable<string>("DecisionAutomation", "");
-        var appliedLabels = builder.WithVariable<string[]>("AppliedLabels", System.Array.Empty<string>());
-        var appliedComment = builder.WithVariable<string>("AppliedComment", "");
-        var droppedLabels = builder.WithVariable<string[]>("DroppedLabels", System.Array.Empty<string>());
+        var poDecisionJson = builder.WithVariable<string>("PODecisionJson", "").Persisted();
+        var poDocumentJson = builder.WithVariable<string>("PODocumentJson", "").Persisted();
+        var poCallSucceeded = builder.WithVariable<bool>("PoCallSucceeded", false).Persisted();
+        var decisionStatus = builder.WithVariable<string>("DecisionStatus", "").Persisted();
+        var decisionType = builder.WithVariable<string>("DecisionType", "").Persisted();
+        var decisionPriority = builder.WithVariable<string>("DecisionPriority", "").Persisted();
+        var decisionAutomation = builder.WithVariable<string>("DecisionAutomation", "").Persisted();
+        var appliedLabels = builder.WithVariable<string[]>("AppliedLabels", System.Array.Empty<string>()).Persisted();
+        var appliedComment = builder.WithVariable<string>("AppliedComment", "").Persisted();
+        var droppedLabels = builder.WithVariable<string[]>("DroppedLabels", System.Array.Empty<string>()).Persisted();
 
-        var skipReason = builder.WithVariable<string>("SkipReason", "");
-        var subResult = builder.WithVariable<IDictionary<string, object>?>();
+        var skipReason = builder.WithVariable<string>("SkipReason", "").Persisted();
+        var subResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
 
         // ================================================================
         // 1. Init — read inputs; derive itemKey/itemNumber/itemSource.

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePODecisionWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/TriagePODecisionWorkflow.cs
@@ -51,45 +51,45 @@ public class TriagePODecisionWorkflow : WorkflowBase
         builder.Description = "Produce a reviewed, typed TriageDecision via the generic document lifecycle (produce → validate → review(panel) → accept)";
 
         // ── Inputs ─────────────────────────────────────────────────────
-        var repository = builder.WithVariable<string>("Repository", "");
-        var itemJson = builder.WithVariable<string>("ItemJson", "");
-        var contextJson = builder.WithVariable<string>("ContextJson", "{}");
-        var tenantId = builder.WithVariable<string>("TenantId", "");
-        var issueId = builder.WithVariable<string>("IssueId", "");
-        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "");
-        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "");
-        var itemNumber = builder.WithVariable<int>("ItemNumber", 0);
+        var repository = builder.WithVariable<string>("Repository", "").Persisted();
+        var itemJson = builder.WithVariable<string>("ItemJson", "").Persisted();
+        var contextJson = builder.WithVariable<string>("ContextJson", "{}").Persisted();
+        var tenantId = builder.WithVariable<string>("TenantId", "").Persisted();
+        var issueId = builder.WithVariable<string>("IssueId", "").Persisted();
+        var findingsDocumentId = builder.WithVariable<string>("FindingsDocumentId", "").Persisted();
+        var acceptanceRulesJson = builder.WithVariable<string>("AcceptanceRulesJson", "").Persisted();
+        var itemNumber = builder.WithVariable<int>("ItemNumber", 0).Persisted();
 
         // ── Story 39-25 — threaded ambiguity score (leg 1) ─────────────
-        var assessmentFound = builder.WithVariable<bool>();
-        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}");
+        var assessmentFound = builder.WithVariable<bool>().Persisted();
+        var assessmentJson  = builder.WithVariable<string>("AssessmentJson", "{}").Persisted();
 
         // ── 39-10 re-entry position ────────────────────────────────────
-        var reEntryPositionJson = builder.WithVariable<string>();
-        var reEntryDocJson = builder.WithVariable<string>();
-        var positionStage = builder.WithVariable<string>("PositionStage", "produce");
+        var reEntryPositionJson = builder.WithVariable<string>().Persisted();
+        var reEntryDocJson = builder.WithVariable<string>().Persisted();
+        var positionStage = builder.WithVariable<string>("PositionStage", "produce").Persisted();
 
         // ── Dispatched lifecycle result + typed exit ───────────────────
-        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>();
-        var lifecycleAccepted = builder.WithVariable<bool>();
-        var exitOutcome = builder.WithVariable<string>("ExitOutcome", "");
-        var exitDocId = builder.WithVariable<string>("ExitDocId", "");
-        var documentJson = builder.WithVariable<string>("DocumentJson", "");
-        var decisionJson = builder.WithVariable<string>("DecisionJson", "{}");
-        var callSucceeded = builder.WithVariable<bool>("CallSucceeded", false);
-        var failureDetail = builder.WithVariable<string>("FailureDetail", "");
+        var lifecycleResult = builder.WithVariable<IDictionary<string, object>?>().Persisted();
+        var lifecycleAccepted = builder.WithVariable<bool>().Persisted();
+        var exitOutcome = builder.WithVariable<string>("ExitOutcome", "").Persisted();
+        var exitDocId = builder.WithVariable<string>("ExitDocId", "").Persisted();
+        var documentJson = builder.WithVariable<string>("DocumentJson", "").Persisted();
+        var decisionJson = builder.WithVariable<string>("DecisionJson", "{}").Persisted();
+        var callSucceeded = builder.WithVariable<bool>("CallSucceeded", false).Persisted();
+        var failureDetail = builder.WithVariable<string>("FailureDetail", "").Persisted();
 
         // Decision fields surfaced for the COMPLETED event payload.
-        var decisionStatus = builder.WithVariable<string>("DecisionStatus", "");
-        var priority = builder.WithVariable<string>("Priority", "");
-        var type = builder.WithVariable<string>("Type", "");
-        var complexity = builder.WithVariable<string>("Complexity", "");
-        var automation = builder.WithVariable<string>("Automation", "");
+        var decisionStatus = builder.WithVariable<string>("DecisionStatus", "").Persisted();
+        var priority = builder.WithVariable<string>("Priority", "").Persisted();
+        var type = builder.WithVariable<string>("Type", "").Persisted();
+        var complexity = builder.WithVariable<string>("Complexity", "").Persisted();
+        var automation = builder.WithVariable<string>("Automation", "").Persisted();
 
         // Panel mirror counts.
-        var panelMemberCount = builder.WithVariable<int>("PanelMemberCount", TriageRosterSize);
-        var panelSucceededCount = builder.WithVariable<int>("PanelSucceededCount", 0);
-        var panelFailedRolesJson = builder.WithVariable<string>("PanelFailedRolesJson", "[]");
+        var panelMemberCount = builder.WithVariable<int>("PanelMemberCount", TriageRosterSize).Persisted();
+        var panelSucceededCount = builder.WithVariable<int>("PanelSucceededCount", 0).Persisted();
+        var panelFailedRolesJson = builder.WithVariable<string>("PanelFailedRolesJson", "[]").Persisted();
 
         // ── Step 1: Read inputs ────────────────────────────────────────
         var readInputs = new SetVariable

--- a/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
+++ b/apps/tamma-elsa/src/Tamma.ElsaServer/Workflows/UpdateIssueStatusWorkflow.cs
@@ -46,19 +46,19 @@ public class UpdateIssueStatusWorkflow : WorkflowBase
         // ================================================================
         // Variables
         // ================================================================
-        var repositoryVar = builder.WithVariable<string>("Repository", "");
-        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0);
-        var messageVar = builder.WithVariable<string>("Message", "");
-        var tenantIdVar = builder.WithVariable<string>("TenantId", "");
-        var prNumberVar = builder.WithVariable<int>("PrNumber", 0);
-        var prUrlVar = builder.WithVariable<string>("PrUrl", "");
-        var addLabelsVar = builder.WithVariable<string[]>("AddLabels", Array.Empty<string>());
-        var removeLabelsVar = builder.WithVariable<string[]>("RemoveLabels", Array.Empty<string>());
+        var repositoryVar = builder.WithVariable<string>("Repository", "").Persisted();
+        var issueNumberVar = builder.WithVariable<int>("IssueNumber", 0).Persisted();
+        var messageVar = builder.WithVariable<string>("Message", "").Persisted();
+        var tenantIdVar = builder.WithVariable<string>("TenantId", "").Persisted();
+        var prNumberVar = builder.WithVariable<int>("PrNumber", 0).Persisted();
+        var prUrlVar = builder.WithVariable<string>("PrUrl", "").Persisted();
+        var addLabelsVar = builder.WithVariable<string[]>("AddLabels", Array.Empty<string>()).Persisted();
+        var removeLabelsVar = builder.WithVariable<string[]>("RemoveLabels", Array.Empty<string>()).Persisted();
 
-        var updatedVar = builder.WithVariable<bool>("Updated", false);
-        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "");
-        var errorVar = builder.WithVariable<string>("Error", "");
-        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0);
+        var updatedVar = builder.WithVariable<bool>("Updated", false).Persisted();
+        var errorCodeVar = builder.WithVariable<string>("ErrorCode", "").Persisted();
+        var errorVar = builder.WithVariable<string>("Error", "").Persisted();
+        var startedAtTicksVar = builder.WithVariable<long>("StartedAtTicks", 0).Persisted();
 
         // ================================================================
         // 1. Read inputs

--- a/apps/tamma-elsa/src/Tamma.Platforms.Gitea/GiteaPlatformClient.cs
+++ b/apps/tamma-elsa/src/Tamma.Platforms.Gitea/GiteaPlatformClient.cs
@@ -376,7 +376,27 @@ public sealed class GiteaPlatformClient : IGitPlatformClient
             },
             MergeMessage = request.CommitMessage,
         };
-        var mergeResult = await _http.PostNoContentAsync(path, body, ct).ConfigureAwait(false);
+        // 2026-08-13 (engine-driven E2E run 37): Gitea's mergeability is computed
+        // ASYNC — after any head-branch push or PR edit (the cycle un-drafts via a
+        // title PATCH seconds before merging) the merge endpoint answers
+        // "405 Please try again later" until the checker settles. That 405 is
+        // Gitea SAYING it is transient, so a bounded retry with a short backoff
+        // belongs in the driver — treating it as terminal escalated a perfectly
+        // mergeable squash to a human. Non-405 failures return immediately.
+        PlatformResult<bool> mergeResult = null!;
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            if (attempt > 0)
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt), ct).ConfigureAwait(false);
+
+            mergeResult = await _http.PostNoContentAsync(path, body, ct).ConfigureAwait(false);
+            if (mergeResult is not PlatformResult<bool>.Failed retryProbe
+                || !IsMergeabilityStillComputing(retryProbe.Error))
+            {
+                break;
+            }
+        }
+
         return mergeResult switch
         {
             PlatformResult<bool>.Ok => await GetPullRequestAsync(
@@ -386,6 +406,14 @@ public sealed class GiteaPlatformClient : IGitPlatformClient
             _ => throw new InvalidOperationException("unhandled merge result"),
         };
     }
+
+    /// <summary>Gitea's transient not-yet-computed mergeability answer: HTTP 405
+    /// with "Please try again later" in the body (both the code and the hint are
+    /// probed — the mapper's heuristic classifier may rewrite the code).</summary>
+    internal static bool IsMergeabilityStillComputing(PlatformError error) =>
+        error is PlatformError.InvalidRequest ir
+        && (string.Equals(ir.Code, "405", StringComparison.Ordinal)
+            || (ir.Hint?.Contains("try again later", StringComparison.OrdinalIgnoreCase) ?? false));
 
     // ================================================================
     // Story 31-13 verbs, made REAL in Epic 31 P5 M1. Below the version

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/EngineIssuesResponseTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/ADL/EngineIssuesResponseTests.cs
@@ -25,14 +25,33 @@ public class EngineIssuesResponseTests
 {
     private static readonly JsonSerializerOptions Options = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>The exact body shape the endpoint produces.</summary>
+    /// <summary>
+    /// The exact body shape the endpoint produces — 2026-08-13 correction
+    /// (found by the engine-driven E2E): <c>IssueToJson</c> writes labels as
+    /// GitHub-shaped OBJECTS (<c>[{"name":"..."}]</c>), not plain strings. The
+    /// previous sample here used plain strings, so this suite green-lit a
+    /// consumer that threw against the real body (the SECOND silent-intake bug
+    /// on the same wire). <see cref="LabelNamesConverter"/> now accepts both.
+    /// </summary>
     private const string EndpointBody = """
         {
           "issues": [
-            { "number": 42, "title": "Fix the thing", "labels": ["tamma-auto", "bug"] },
-            { "number": 43, "title": "Another thing", "labels": ["tamma-auto"] }
+            { "id": 42, "number": 42, "title": "Fix the thing", "state": "open", "body": "b", "html_url": "http://g/i/42",
+              "labels": [{ "name": "tamma-auto" }, { "name": "bug" }] },
+            { "id": 43, "number": 43, "title": "Another thing", "state": "open", "body": "", "html_url": "http://g/i/43",
+              "labels": [{ "name": "tamma-auto" }] }
           ],
           "total": 2
+        }
+        """;
+
+    /// <summary>The INTERNAL WorkItemJson round-trip shape (plain strings) must keep parsing.</summary>
+    private const string InternalBody = """
+        {
+          "issues": [
+            { "number": 42, "title": "Fix the thing", "labels": ["tamma-auto", "bug"] }
+          ],
+          "total": 1
         }
         """;
 
@@ -46,6 +65,34 @@ public class EngineIssuesResponseTests
         parsed.Issues.Should().HaveCount(2);
         parsed.Issues[0].Number.Should().Be(42);
         parsed.Issues[0].Labels.Should().Contain("tamma-auto");
+        parsed.Issues[0].Url.Should().Be("http://g/i/42", "html_url is the wire name");
+    }
+
+    [Test]
+    public void Deserializes_PlainStringLabels_ForTheInternalRoundTrip()
+    {
+        var parsed = JsonSerializer.Deserialize<EngineIssuesResponse>(InternalBody, Options);
+
+        parsed!.Issues[0].Labels.Should().Equal("tamma-auto", "bug");
+    }
+
+    [Test]
+    public void WorkItem_SerializesLabels_AsPlainStrings()
+    {
+        // The internal WorkItemJson round-trip (Select → DispatchCycle → cycle)
+        // writes plain strings; a shape drift here would break every consumer
+        // of the serialized work item.
+        var json = JsonSerializer.Serialize(new WorkItem
+        {
+            Number = 7,
+            Title = "t",
+            Labels = new() { "tamma-auto" },
+        });
+
+        json.Should().Contain("\"Labels\":[\"tamma-auto\"]");
+
+        var roundTripped = JsonSerializer.Deserialize<WorkItem>(json);
+        roundTripped!.Labels.Should().Equal("tamma-auto");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupSchedulerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Analytics/HourlyAnalyticsRollupSchedulerTests.cs
@@ -1,7 +1,11 @@
+using Elsa.Common.Models;
+using Elsa.Workflows.Management;
+using Elsa.Workflows.Management.Entities;
 using Elsa.Workflows.Runtime;
 using Elsa.Workflows.Runtime.Requests;
 using Elsa.Workflows.Runtime.Responses;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -83,8 +87,23 @@ public class HourlyAnalyticsRollupSchedulerTests
             FireAtMinute = 5,
             PollInterval = TimeSpan.FromSeconds(30),
         });
+        // 2026-08-13 — the scheduler now resolves the PUBLISHED definition
+        // VERSION id per fire (PublishedWorkflowDispatch); give it a scope
+        // factory whose IWorkflowDefinitionService answers a published row.
+        var definitionService = new Mock<IWorkflowDefinitionService>();
+        definitionService
+            .Setup(d => d.FindWorkflowDefinitionAsync(
+                It.IsAny<string>(), It.IsAny<VersionOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, VersionOptions _, CancellationToken _) =>
+                new WorkflowDefinition { Id = $"{id}:v1", DefinitionId = id });
+        var services = new ServiceCollection();
+        services.AddScoped(_ => definitionService.Object);
+        var scopeFactory = services.BuildServiceProvider()
+            .GetRequiredService<IServiceScopeFactory>();
+
         var scheduler = new HourlyAnalyticsRollupScheduler(
             dispatcher.Object,
+            scopeFactory,
             opts,
             time,
             NullLogger<HourlyAnalyticsRollupScheduler>.Instance,

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/HttpLifecycleReEntryServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Documents/HttpLifecycleReEntryServiceTests.cs
@@ -1,0 +1,220 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using Tamma.Activities.Documents;
+using Tamma.Core;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Resume;
+
+namespace Tamma.Activities.Tests.Documents;
+
+/// <summary>
+/// 2026-08-13 (engine-driven E2E follow-up) — pins the ENGINE-HOST re-entry
+/// implementation: <see cref="HttpLifecycleReEntryService"/>, the latest-accepted
+/// read over the API's 39-11 HTTP surface. Before it existed, the engine could only
+/// register the Null seam (the REAL service's store dependencies are API-host-only),
+/// which made the plan-review shim's <c>FetchLatestAcceptedDocumentActivity</c>
+/// structurally blind — every engine-driven cycle terminated needs-human even after
+/// the plan was accepted (E2E run 29's root cause).
+/// </summary>
+[TestFixture]
+public class HttpLifecycleReEntryServiceTests
+{
+    private const string BaseUrl = "http://api.test:3000";
+
+    // ── ReconstructAsync ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task Reconstruct_AcceptedDocumentOfTheType_YieldsComplete()
+    {
+        var docId = Guid.NewGuid();
+        var handler = new StubHandler((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be("/api/documents/issues/owner%2Frepo%231/latest");
+            req.Headers.Authorization!.Scheme.Should().Be("Bearer");
+            req.Headers.Authorization.Parameter.Should().Be("test-token");
+            return Json(HttpStatusCode.OK, $$"""
+                {"issueId":"owner/repo#1","documents":[
+                  {{Entry(docId, "plan", revision: 3)}}
+                ]}
+                """);
+        });
+
+        var position = await Service(handler).ReconstructAsync(
+            null, "owner/repo#1", "plan", CancellationToken.None);
+
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Complete);
+        position.ExistingDocumentId.Should().Be(docId);
+        position.ExistingRevision.Should().Be(3);
+    }
+
+    [Test]
+    public async Task Reconstruct_NoAcceptedDocumentOfTheType_YieldsFresh()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.OK, $$"""
+            {"issueId":"i-1","documents":[{{Entry(Guid.NewGuid(), "decomposition", 1)}}]}
+            """));
+
+        var position = await Service(handler).ReconstructAsync(
+            null, "i-1", "plan", CancellationToken.None);
+
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Produce,
+            "an accepted document of a DIFFERENT type must not read as this type's Complete");
+        position.ExistingDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task Reconstruct_BlankIssueId_IsFresh_WithoutAnyHttpCall()
+    {
+        var handler = new StubHandler((_, _) =>
+            throw new InvalidOperationException("no HTTP call expected"));
+
+        var position = await Service(handler).ReconstructAsync(
+            null, "  ", "plan", CancellationToken.None);
+
+        position.ResumeAt.Should().Be(LifecycleResumeStage.Produce);
+    }
+
+    [Test]
+    public async Task Reconstruct_NonSuccessStatus_ThrowsRetryable_NeverSilentFresh()
+    {
+        var handler = new StubHandler((_, _) => Json(HttpStatusCode.InternalServerError, "{}"));
+
+        var act = () => Service(handler).ReconstructAsync(
+            null, "i-1", "plan", CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>(
+                "a failed read yielding Fresh would re-produce work that already exists"))
+            .Which.Code.Should().Be("DOCUMENT.REENTRY.HTTP_READ_FAILED");
+    }
+
+    [Test]
+    public async Task Reconstruct_TransportFailure_ThrowsRetryable()
+    {
+        var handler = new StubHandler((_, _) => throw new HttpRequestException("boom"));
+
+        var act = () => Service(handler).ReconstructAsync(
+            null, "i-1", "plan", CancellationToken.None);
+
+        (await act.Should().ThrowAsync<TammaError>())
+            .Which.Code.Should().Be("DOCUMENT.REENTRY.HTTP_READ_FAILED");
+    }
+
+    [Test]
+    public async Task Reconstruct_ExplicitTenant_TravelsAsTheTenantHeader()
+    {
+        var tenant = Guid.NewGuid();
+        string? seenHeader = "unset";
+        var handler = new StubHandler((req, _) =>
+        {
+            seenHeader = req.Headers.TryGetValues("X-Tenant-Id", out var v)
+                ? v.Single()
+                : null;
+            return Json(HttpStatusCode.OK, """{"issueId":"i-1","documents":[]}""");
+        });
+
+        await Service(handler).ReconstructAsync(tenant, "i-1", "plan", CancellationToken.None);
+        seenHeader.Should().Be(tenant.ToString());
+
+        // Single-user gates dispatch tenantless — no header, the API's
+        // service-plane binding resolves the personal tenant.
+        await Service(handler).ReconstructAsync(null, "i-1", "plan", CancellationToken.None);
+        seenHeader.Should().BeNull();
+    }
+
+    // ── GetDocumentBodyAsync ──────────────────────────────────────────────
+
+    [Test]
+    public async Task GetDocumentBody_MapsTheWireEntryOntoAnEnvelope()
+    {
+        var docId = Guid.NewGuid();
+        var handler = new StubHandler((req, _) =>
+        {
+            req.RequestUri!.AbsolutePath.Should().Be($"/api/documents/{docId}");
+            return Json(HttpStatusCode.OK, Entry(docId, "plan", revision: 2));
+        });
+
+        var envelope = await Service(handler).GetDocumentBodyAsync(
+            null, docId, CancellationToken.None);
+
+        envelope.Should().NotBeNull();
+        envelope!.Id.Should().Be(docId);
+        envelope.Type.Should().Be("plan");
+        envelope.State.Should().Be(DocumentState.Accepted);
+        envelope.IssueId.Should().Be("owner/repo#1");
+        envelope.ProducedBy.Role.Should().Be("architect");
+        envelope.Payload.GetProperty("goal").GetString().Should().Be("scripted",
+            "the payload body must round-trip — it is the whole point of the read");
+    }
+
+    [Test]
+    public async Task GetDocumentBody_NotFound_IsNull_NotAThrow()
+    {
+        var handler = new StubHandler((_, _) =>
+            Json(HttpStatusCode.NotFound, """{"error":"document_not_found"}"""));
+
+        var envelope = await Service(handler).GetDocumentBodyAsync(
+            null, Guid.NewGuid(), CancellationToken.None);
+
+        envelope.Should().BeNull();
+    }
+
+    [Test]
+    public async Task GetDocumentBody_EmptyGuid_IsNull_WithoutAnyHttpCall()
+    {
+        var handler = new StubHandler((_, _) =>
+            throw new InvalidOperationException("no HTTP call expected"));
+
+        var envelope = await Service(handler).GetDocumentBodyAsync(
+            null, Guid.Empty, CancellationToken.None);
+
+        envelope.Should().BeNull();
+    }
+
+    // ── plumbing ──────────────────────────────────────────────────────────
+
+    private static HttpLifecycleReEntryService Service(HttpMessageHandler handler)
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                ["Tamma:ApiUrl"] = BaseUrl,
+                ["Tamma:ApiToken"] = "test-token",
+            }).Build();
+        return new HttpLifecycleReEntryService(
+            new StubFactory(handler), config,
+            NullLogger<HttpLifecycleReEntryService>.Instance);
+    }
+
+    /// <summary>A wire LineageDocumentEntry as the API serializes it (39-11 DTOs).</summary>
+    private static string Entry(Guid id, string type, int revision) => $$"""
+        {"id":"{{id}}","documentType":"{{type}}","issueId":"owner/repo#1",
+         "producedByRole":"architect","producedByAction":"plan-system-design",
+         "revision":{{revision}},"status":"accepted","audience":null,
+         "supersedesDocumentId":null,"parentDocumentId":null,"correlatingEventId":null,
+         "createdAt":"2026-08-13T10:00:00.000Z","updatedAt":"2026-08-13T10:00:01.000Z",
+         "body":{"goal":"scripted"},"reviews":[]}
+        """;
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) => new(status)
+    {
+        Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json"),
+    };
+
+    private sealed class StubHandler(
+        Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> respond)
+        : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(respond(request, cancellationToken));
+    }
+
+    private sealed class StubFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/PrMergedResumeEndpointTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Endpoints/PrMergedResumeEndpointTests.cs
@@ -73,11 +73,17 @@ public class PrMergedResumeEndpointTests
             It.IsAny<CancellationToken>()))
         .ReturnsAsync(matches.AsEnumerable());
 
+    // 2026-08-13 (run 39, self-merge race): each fixture instance carries its
+    // own reconcile buffer — bookmark-miss deliveries are now BUFFERED (202)
+    // for WaitForPRMerged's reconcile-on-register, never lost to a plain 404.
+    private readonly PendingPrMergeBuffer _pendingMerges = new();
+
     private Task<IResult> Call(
         int pr = Pr, string? sha = "abc123", string? tenant = Tenant, string? repo = Repo) =>
         PrMergedResumeEndpoint.Resume(
             new PrMergedResumeEndpoint.ResumeRequest(pr, sha, tenant, repo),
-            _bookmarks.Object, _runtime.Object, NullLoggerFactory.Instance, CancellationToken.None);
+            _bookmarks.Object, _runtime.Object, _pendingMerges, NullLoggerFactory.Instance,
+            CancellationToken.None);
 
     private static int? StatusCodeOf(IResult result)
         => (result as IStatusCodeHttpResult)?.StatusCode;
@@ -160,16 +166,26 @@ public class PrMergedResumeEndpointTests
     public async Task Resume_CrossTenantName_NeverMatchesAnotherTenantsWait()
     {
         // Tenant B's wait is suspended under B's qualified name; a caller
-        // scoped to tenant A computes A's name and must 404, never act.
+        // scoped to tenant A computes A's name and must never act on B's wait.
+        // 2026-08-13 (run 39): a miss now BUFFERS under the CALLER's own name
+        // (202) instead of 404ing — cross-tenant safety holds because only a
+        // wait registering tenant A's exact name can ever consume A's entry;
+        // tenant B's wait computes B's name and can never see it.
         var tenantB = Guid.NewGuid().ToString();
         var bName = WaitForPRMergedActivity.BookmarkName(tenantB, Repo, Pr);
         StoreHas(bName, Bookmark("bm-b", bName, "wf-b"));
 
         var result = await Call(tenant: Tenant);
 
-        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        StatusCodeOf(result).Should().Be(StatusCodes.Status202Accepted);
         _client.Verify(c => c.RunInstanceAsync(
             It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        _pendingMerges.TryConsume(bName, out _)
+            .Should().BeFalse("the buffered entry is keyed by the CALLER's (tenant A's) name — "
+                + "tenant B's wait can never consume it");
+        _pendingMerges.TryConsume(
+                WaitForPRMergedActivity.BookmarkName(Tenant, Repo, Pr), out _)
+            .Should().BeTrue("only a wait registering the caller's own qualified name consumes it");
     }
 
     // ================================================================
@@ -177,15 +193,26 @@ public class PrMergedResumeEndpointTests
     // ================================================================
 
     [Test]
-    public async Task Resume_BurnedBookmark_Returns404_NeverRunsAnInstance()
+    public async Task Resume_BookmarkMiss_BuffersForReconcile_NeverRunsAnInstance()
     {
-        // The 12h SLA edge fired first (or a duplicate delivery raced): both
-        // names resolve nothing → benign 404, never a double-advance.
+        // 2026-08-13 (run 39, self-merge race): a bookmark miss is no longer a
+        // plain 404 — when Tamma merges its own PR the webhook forward arrives
+        // BEFORE the wait registers (observed 1 s early), and 404ing LOST the
+        // once-only delivery (the merged cycle then sat on the 12 h SLA). The
+        // miss now buffers the merge keyed by the qualified name (202) so
+        // WaitForPRMerged consumes it at registration. Still never a
+        // double-advance: no instance is run here, and a late delivery for an
+        // already-resumed wait leaves an entry that expires unconsumed.
         var result = await Call();
 
-        StatusCodeOf(result).Should().Be(StatusCodes.Status404NotFound);
+        StatusCodeOf(result).Should().Be(StatusCodes.Status202Accepted);
         _client.Verify(c => c.RunInstanceAsync(
             It.IsAny<RunWorkflowInstanceRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        _pendingMerges.TryConsume(
+                WaitForPRMergedActivity.BookmarkName(Tenant, Repo, Pr), out var sha)
+            .Should().BeTrue("the miss must be consumable by the wait's reconcile-on-register");
+        sha.Should().Be("abc123", "the buffered entry must carry the merge SHA");
     }
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/LlmCall/NoDirectLlmCallTests.cs
@@ -321,8 +321,12 @@ public class NoDirectLlmCallTests
 
         roles.Should().NotBeEmpty(
             "the scan must discover the cut-over role literals; an empty set means a regex broke");
+        // 2026-08-13 (engine-driven E2E run 34): the MediatedLlmText call sites now
+        // pass CANONICAL wire roles (implementer→developer, reviewer→senior_developer)
+        // alongside their taxonomy action — the aliases dropped out of the source, so
+        // the sanity literals are the canonical trio.
         roles.Should().Contain(
-            new[] { "implementer", "tester", "reviewer", "senior_developer", "developer" },
+            new[] { "tester", "senior_developer", "developer" },
             "sanity: the known cut-over role literals must be discovered by the scan");
 
         foreach (var role in roles)

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
@@ -1,0 +1,225 @@
+using System.Text.Json;
+using FluentAssertions;
+using NUnit.Framework;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.Agents.Scripted;
+using Tamma.Core.Documents;
+using Tamma.Core.Documents.Types;
+using Tamma.ElsaServer.Workflows.Helpers;
+
+namespace Tamma.Activities.Tests.Providers;
+
+/// <summary>
+/// 2026-08-13 (Epic 31 P5 follow-up) — pins that the scripted provider's
+/// BUILT-IN cycle script satisfies every consumer the single-issue cycle
+/// actually routes it through: the real registered document validators
+/// (39-9 ring + the lifecycle's engine-side validation), the 39-7 reviewer
+/// mapping (<see cref="ReviewProducerHelper.MapReviewerReply"/>), the task
+/// review's verdict parse, the deployment pipeline's fail-closed status
+/// parse, and cross-document coherence (test-spec task ids bind to plan task
+/// ids). This fixture lives in Tamma.Activities.Tests because it needs BOTH
+/// surfaces: the script (Tamma.Api) and the workflow helpers (Tamma.ElsaServer).
+/// </summary>
+[TestFixture]
+public class ScriptedCycleScriptValidityTests
+{
+    // ── typed documents: the registry-example fallback is valid per type ──
+
+    [TestCase("plan")]
+    [TestCase("test-spec")]
+    [TestCase("decomposition")]
+    [TestCase("review")]
+    [TestCase("findings")]
+    [TestCase("ambiguity-assessment")]
+    [TestCase("triage-decision")]
+    [TestCase("clarification")]
+    public void DocumentTypedResponse_PassesTheRealValidator(string typeKey)
+    {
+        var responder = new ScriptedLlmResponder();
+        var response = responder.Respond(new ScriptedLlmCall(
+            "scripted", "architect", "any-action", typeKey, "m", "corr"));
+
+        response.Success.Should().BeTrue($"documentType '{typeKey}' must always be servable");
+
+        using var doc = JsonDocument.Parse(response.ResponseText!);
+        var verdict = DocumentTypeRegistry.Resolve(typeKey).Validate(doc.RootElement.Clone());
+        verdict.IsValid.Should().BeTrue(
+            $"the scripted '{typeKey}' payload must pass its own registered validator; got: " +
+            string.Join("; ", verdict.Violations.Select(v => $"{v.Code}: {v.Message}")));
+    }
+
+    [Test]
+    public void EveryRegisteredDocumentType_HasAServableScriptedPayload()
+    {
+        foreach (var type in DocumentTypeRegistry.All)
+        {
+            ScriptedCycleLibrary.DocumentExampleFor(type.Key).Should().NotBeNull(
+                $"type '{type.Key}' must fall back to its registry example " +
+                "(the drift suite guarantees ≥1 valid example per type)");
+        }
+    }
+
+    // ── the review payload routes ACCEPT, not revise ──
+
+    [Test]
+    public void ScriptedReviewDefault_IsAnApprovingValidReview()
+    {
+        var responder = new ScriptedLlmResponder();
+        var response = responder.Respond(new ScriptedLlmCall(
+            "scripted", "architect", "plan-review", "review", "m", "corr"));
+
+        using var doc = JsonDocument.Parse(response.ResponseText!);
+        var verdict = DocumentTypeRegistry.Resolve("review").Validate(doc.RootElement.Clone());
+        verdict.IsValid.Should().BeTrue(string.Join("; ", verdict.Violations.Select(v => v.Code)));
+
+        doc.RootElement.GetProperty("decision").GetString().Should().Be("approve",
+            "a request-changes default (the registry's first example) would loop the " +
+            "lifecycle's revise rounds instead of reaching accept");
+    }
+
+    // ── reviewer cells: ONE reply shape serves BOTH consumers ──
+
+    [Test]
+    public void ApproveVerdict_MapsToAValidApprovingReview_ViaTheSingleReviewerMapper()
+    {
+        var subject = new ReviewSubject
+        {
+            Kind = "document",
+            DocumentId = Guid.NewGuid(),
+            DocumentType = "plan",
+        };
+        var map = ReviewProducerHelper.MapReviewerReply(
+            ScriptedCycleLibrary.ApproveReviewVerdict, subject);
+
+        map.Payload.Should().NotBeNull(
+            "the 39-7 single-reviewer must map the scripted verdict onto a valid Review; violations: " +
+            string.Join("; ", map.Violations.Select(v => $"{v.Code}: {v.Message}")));
+        map.Payload!.Decision.Should().Be(ReviewDecision.Approve);
+        map.Payload.Issues.Should().BeEmpty("no blocking issues — the lifecycle routes to accept");
+    }
+
+    [Test]
+    public void ApproveVerdict_ParsesAsTaskReviewApproval()
+    {
+        // TaskReviewWorkflow reads the top-level "verdict" token directly and
+        // requires exactly "approve" on all four roles to route Approved.
+        using var doc = JsonDocument.Parse(ScriptedCycleLibrary.ApproveReviewVerdict);
+        doc.RootElement.GetProperty("verdict").GetString().Should().Be("approve");
+    }
+
+    // ── cross-document coherence: test-spec task ids ⊆ plan task ids ──
+
+    [Test]
+    public void TestSpecTaskIds_BindToThePlanTasks()
+    {
+        var responder = new ScriptedLlmResponder();
+        var planJson = responder.Respond(new ScriptedLlmCall(
+            "scripted", "architect", "plan-system-design", "plan", "m", "c")).ResponseText!;
+        var specJson = responder.Respond(new ScriptedLlmCall(
+            "scripted", "tester", "write-tests", "test-spec", "m", "c")).ResponseText!;
+
+        using var plan = JsonDocument.Parse(planJson);
+        var taskIds = plan.RootElement.GetProperty("tasks").EnumerateArray()
+            .Select(t => t.GetProperty("id").GetString())
+            .ToHashSet();
+        taskIds.Should().NotBeEmpty();
+
+        using var spec = JsonDocument.Parse(specJson);
+        foreach (var testCase in spec.RootElement.GetProperty("testCases").EnumerateArray())
+        {
+            taskIds.Should().Contain(testCase.GetProperty("taskId").GetString(),
+                "TestSpecDocumentType.ValidateWithContext binds every case to a task id " +
+                "from the consumed plan — the scripted plan and test-spec must stay coherent");
+        }
+    }
+
+    // ── deployment pipeline: fail-closed status parse ──
+
+    [Test]
+    public void StageSuccess_CarriesTheExplicitSuccessStatus()
+    {
+        using var doc = JsonDocument.Parse(ScriptedCycleLibrary.StageSuccess);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("success",
+            "DeploymentPipelineWorkflow.ExtractStageResult only advances on an explicit success");
+    }
+
+    // ── PO summary: {summary, links} contract ──
+
+    [Test]
+    public void PoSummary_ParsesWithSummaryAndLinks()
+    {
+        using var doc = JsonDocument.Parse(ScriptedCycleLibrary.PoSummary);
+        doc.RootElement.GetProperty("summary").GetString().Should().NotBeNullOrWhiteSpace();
+        doc.RootElement.GetProperty("links").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    // ── the reviewer panel roster is fully scripted ──
+
+    [Test]
+    public void EveryReviewPanelRole_HasAScriptedReviewerCell()
+    {
+        var responder = new ScriptedLlmResponder();
+        foreach (var role in Enum.GetValues<AgentRole>())
+        {
+            AgentAction action;
+            try
+            {
+                action = RolePhaseMap.GetReviewActionForRole(role);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                continue; // not on a review panel
+            }
+
+            var response = responder.Respond(new ScriptedLlmCall(
+                "scripted", role.ToWire(), action.ToWire(), null, "m", "c"));
+            response.Success.Should().BeTrue(
+                $"reviewer cell ({role.ToWire()}, {action.ToWire()}) must be scripted — " +
+                "the 39-7 panel roster dispatches it");
+            response.ResponseText.Should().Be(ScriptedCycleLibrary.ApproveReviewVerdict);
+        }
+    }
+
+    // ── chain resolution: config-driven provider selection ──
+
+    [Test]
+    public void ChainHelper_Precedence_CallerThenDbThenConfigThenDefault()
+    {
+        var allowAll = new Tamma.Activities.Security.ProviderAllowlist(
+            Microsoft.Extensions.Options.Options.Create(
+                new Tamma.Activities.Security.ProviderAllowlistOptions
+                {
+                    AdditionalProviders = { "scripted" },
+                }));
+
+        LlmProviderChainHelper.Resolve(
+                new[] { "openai" }, new[] { "anthropic" }, new[] { "scripted" }, allowAll)
+            .Should().Equal("openai");
+        LlmProviderChainHelper.Resolve(
+                null, new[] { "anthropic" }, new[] { "scripted" }, allowAll)
+            .Should().Equal("anthropic");
+        // Llm:DefaultProviderChain is the deployment-tier selection knob the
+        // engine-driven E2E uses.
+        LlmProviderChainHelper.Resolve(null, null, new[] { "scripted" }, allowAll)
+            .Should().Equal("scripted");
+        LlmProviderChainHelper.Resolve(null, null, null, allowAll)
+            .Should().Equal("anthropic", "openai", "openrouter");
+    }
+
+    [Test]
+    public void ChainHelper_FiltersThroughTheDiAllowlist_AndFailsLoudOnAllRejected()
+    {
+        var defaults = new Tamma.Activities.Security.ProviderAllowlist();
+
+        // "scripted" is filtered OUT by the default allowlist (opt-in only)…
+        LlmProviderChainHelper.Resolve(
+                new[] { "scripted", "anthropic" }, null, null, defaults)
+            .Should().Equal("anthropic");
+
+        // …and an all-rejected chain fails loud, naming the config key.
+        var act = () => LlmProviderChainHelper.Resolve(
+            new[] { "scripted" }, null, null, defaults);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Security:ProviderAllowlist:AdditionalProviders*");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
@@ -176,8 +176,26 @@ public class ScriptedCycleScriptValidityTests
             response.Success.Should().BeTrue(
                 $"reviewer cell ({role.ToWire()}, {action.ToWire()}) must be scripted — " +
                 "the 39-7 panel roster dispatches it");
-            response.ResponseText.Should().Be(ScriptedCycleLibrary.ApproveReviewVerdict);
+            // 2026-08-13: panel reviewer cells serve the CANONICAL Review —
+            // reviewer llm-calls declare documentType="review" and the 39-9
+            // ring validates them against the Review registry validator,
+            // which the legacy verdict shape does not satisfy.
+            response.ResponseText.Should().Be(ScriptedCycleLibrary.CanonicalReviewApprove);
         }
+    }
+
+    [Test]
+    public void CanonicalReviewApprove_PassesTheReviewRegistryValidator()
+    {
+        // The exact ring the reviewer replies now go through: the Review
+        // document type's registry validator (documentType="review").
+        var type = Tamma.Core.Documents.DocumentTypeRegistry.Resolve("review");
+        using var doc = JsonDocument.Parse(ScriptedCycleLibrary.CanonicalReviewApprove);
+        var result = type.Validate(doc.RootElement);
+        result.IsValid.Should().BeTrue(
+            "the scripted canonical approve must pass the Review validator, or every " +
+            $"panel member exhausts the 39-9 repair ring (violations: " +
+            $"[{string.Join("; ", result.Violations.Select(v => v.Message))}])");
     }
 
     // ── chain resolution: config-driven provider selection ──

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedCycleScriptValidityTests.cs
@@ -171,16 +171,22 @@ public class ScriptedCycleScriptValidityTests
                 continue; // not on a review panel
             }
 
-            var response = responder.Respond(new ScriptedLlmCall(
-                "scripted", role.ToWire(), action.ToWire(), null, "m", "c"));
-            response.Success.Should().BeTrue(
-                $"reviewer cell ({role.ToWire()}, {action.ToWire()}) must be scripted — " +
+            // 2026-08-13: TWO consumers, TWO shapes. The 39-7 panel path
+            // declares documentType="review" (39-9 ring validates the reply as
+            // a canonical Review); the cycle's own plan-review/task-review
+            // parse the LEGACY verdict JSON with no documentType.
+            var panelReply = responder.Respond(new ScriptedLlmCall(
+                "scripted", role.ToWire(), action.ToWire(), "review", "m", "c"));
+            panelReply.Success.Should().BeTrue(
+                $"reviewer cell ({role.ToWire()}, {action.ToWire()}, @review) must be scripted — " +
                 "the 39-7 panel roster dispatches it");
-            // 2026-08-13: panel reviewer cells serve the CANONICAL Review —
-            // reviewer llm-calls declare documentType="review" and the 39-9
-            // ring validates them against the Review registry validator,
-            // which the legacy verdict shape does not satisfy.
-            response.ResponseText.Should().Be(ScriptedCycleLibrary.CanonicalReviewApprove);
+            panelReply.ResponseText.Should().Be(ScriptedCycleLibrary.CanonicalReviewApprove);
+
+            var legacyReply = responder.Respond(new ScriptedLlmCall(
+                "scripted", role.ToWire(), action.ToWire(), null, "m", "c"));
+            legacyReply.Success.Should().BeTrue();
+            legacyReply.ResponseText.Should().Be(ScriptedCycleLibrary.ApproveReviewVerdict,
+                "the documentType-less callers (plan-review / task-review) parse the legacy verdict shape");
         }
     }
 
@@ -196,6 +202,61 @@ public class ScriptedCycleScriptValidityTests
             "the scripted canonical approve must pass the Review validator, or every " +
             $"panel member exhausts the 39-9 repair ring (violations: " +
             $"[{string.Join("; ", result.Violations.Select(v => v.Message))}])");
+    }
+
+    // ── TDD single-shot cells: each payload satisfies ITS caller's parser ──
+    // (2026-08-13, engine-driven E2E run 34 — MediatedLlmText threads the
+    // taxonomy action, so these role/action cells now serve the TDD/debug
+    // activities' single-shot calls.)
+
+    [Test]
+    public void TddTestGeneration_ParsesThroughWriteTestsActivity()
+    {
+        var result = Tamma.Activities.TDD.WriteTestsActivity.ParseTestGenerationResponse(
+            ScriptedCycleLibrary.TddTestGeneration, new List<string>());
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        result.TestCount.Should().BeGreaterThan(0);
+        result.TestFiles.Should().NotBeEmpty("CommitChanges needs the authored test files");
+        result.TestFiles.Should().OnlyContain(f => f.StartsWith("src/scripted/"),
+            "the E2E asserts the merged tree carries src/scripted/* files");
+    }
+
+    [Test]
+    public void TddImplementation_ParsesThroughWriteImplementationActivity()
+    {
+        var result = Tamma.Activities.TDD.WriteImplementationActivity.ParseImplementationResponse(
+            ScriptedCycleLibrary.TddImplementation);
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+        result.ImplementationFiles.Should().OnlyContain(f => f.StartsWith("src/scripted/"));
+    }
+
+    [Test]
+    public void TddNoRefactorNeeded_IsAnExplicitNoSuggestionsAnalysis()
+    {
+        using var doc = JsonDocument.Parse(ScriptedCycleLibrary.TddNoRefactorNeeded);
+        doc.RootElement.GetProperty("hasSuggestions").GetBoolean().Should().BeFalse(
+            "a scripted refactor suggestion would make the TDD loop nondeterministic");
+    }
+
+    [Test]
+    public void ReviewFixGeneration_ParsesThroughApplyReviewFixes()
+    {
+        var result = Tamma.Activities.ADL.ApplyReviewFixesActivity.ParseFixResponse(
+            ScriptedCycleLibrary.ReviewFixGeneration,
+            new Tamma.Activities.ADL.Models.ReviewAnalysisResult());
+        result.Success.Should().BeTrue(result.ErrorMessage ?? "");
+    }
+
+    [Test]
+    public void DebugCells_ParseAsTheirConsumersExpect()
+    {
+        using var hyp = JsonDocument.Parse(ScriptedCycleLibrary.DebugHypotheses);
+        hyp.RootElement.GetProperty("hypotheses").GetArrayLength().Should().BeGreaterThan(0,
+            "RefineHypothesis with zero hypotheses strands the debug loop");
+
+        using var reg = JsonDocument.Parse(ScriptedCycleLibrary.DebugRegressionTest);
+        reg.RootElement.GetProperty("fails_as_expected").GetBoolean().Should().BeTrue(
+            "a regression test that passes pre-fix is not a regression test");
     }
 
     // ── chain resolution: config-driven provider selection ──

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedProviderPostureTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Providers/ScriptedProviderPostureTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using Tamma.Activities.Security;
+using Tamma.Api.Services.Providers;
+
+namespace Tamma.Activities.Tests.Providers;
+
+/// <summary>
+/// 2026-08-13 (Epic 31 P5 follow-up) — the "scripted" provider's SECURITY
+/// POSTURE, pinned cross-surface (this fixture sees both ProviderAllowlist and
+/// ProviderCatalog, like ProviderCatalogTests):
+/// <list type="bullet">
+///   <item>catalogued as non-HTTP, <c>Allowlisted=false</c> — the defensive
+///   non-selectable convention, so the allowlist⇔catalog keyset agreement is
+///   UNCHANGED (no default-allowlist member was added);</item>
+///   <item>the shipped default allowlist REFUSES the key — no deployment can
+///   select it without the explicit flag;</item>
+///   <item>the flag on any production-shaped host throws at startup.</item>
+/// </list>
+/// </summary>
+[TestFixture]
+public class ScriptedProviderPostureTests
+{
+    [Test]
+    public void Scripted_IsCatalogued_NonHttp_NotAllowlisted()
+    {
+        var entry = ProviderCatalog.ResolveNonHttp("scripted");
+        entry.Should().NotBeNull("the keyset contract is total — every shipped key is catalogued");
+        entry!.Allowlisted.Should().BeFalse(
+            "scripted is never selectable by default (the claude-code defensive convention)");
+        entry.Transport.Should().Be(NonHttpProviderTransport.InProcess);
+        ProviderCatalog.Resolve("scripted").Should().BeNull("scripted is not HTTP-dispatchable");
+    }
+
+    [Test]
+    public void DefaultAllowlist_RefusesScripted()
+    {
+        new ProviderAllowlist().IsAllowed("scripted").Should().BeFalse(
+            "the shipped defaults must never admit the test provider");
+        ProviderAllowlist.IsAllowedDefault("scripted").Should().BeFalse();
+    }
+
+    [Test]
+    public void OptIn_AdmitsScripted_ViaAdditionalProvidersOnly()
+    {
+        var options = Options.Create(new ProviderAllowlistOptions
+        {
+            AdditionalProviders = { ScriptedProviderPosture.ProviderKey },
+        });
+        new ProviderAllowlist(options).IsAllowed("scripted").Should().BeTrue(
+            "the DI options path (what AddScriptedLlmProvider / the engine flag configures) " +
+            "is the ONLY way the key becomes selectable");
+    }
+
+    [Test]
+    public void FlagOff_IsDisabled_AndAssertReturnsFalse()
+    {
+        var config = Build();
+        ScriptedProviderPosture.IsEnabled(config).Should().BeFalse();
+        ScriptedProviderPosture.AssertAllowed(config).Should().BeFalse();
+    }
+
+    [Test]
+    public void FlagOn_CleanHost_IsAllowed()
+    {
+        var config = Build(("Llm:EnableScriptedProvider", "true"));
+        ScriptedProviderPosture.AssertAllowed(config).Should().BeTrue();
+    }
+
+    [TestCase("Tamma:TenantSharedSecret", "secret")]
+    [TestCase("ConnectionStrings:ControlPlane", "Host=cp")]
+    [TestCase("Tamma:Mode", "saas")]
+    public void FlagOn_ProductionSignal_Throws(string key, string value)
+    {
+        var config = Build(("Llm:EnableScriptedProvider", "true"), (key, value));
+        var act = () => ScriptedProviderPosture.AssertAllowed(config);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*refused*", "the guard is structural — the host must not start");
+    }
+
+    [Test]
+    public void ProductionSignal_MirrorsTammaModeDetection_ExplicitSingleUserIsClean()
+    {
+        // An explicit single-user mode is NOT a production signal (mirrors
+        // TammaModeProvider.Resolve: only saas / the SaaS-only config keys are).
+        var config = Build(
+            ("Llm:EnableScriptedProvider", "true"),
+            ("Tamma:Mode", "single-user"));
+        ScriptedProviderPosture.AssertAllowed(config).Should().BeTrue();
+    }
+
+    private static IConfiguration Build(params (string Key, string Value)[] pairs) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.ToDictionary(p => p.Key, p => (string?)p.Value))
+            .Build();
+}

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Scheduling/TenantScheduledTriggerServiceTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Scheduling/TenantScheduledTriggerServiceTests.cs
@@ -6,6 +6,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using NUnit.Framework;
 using Tamma.Activities.Scheduling;
 using Tamma.Data.Abstractions;
@@ -228,6 +229,25 @@ public class TenantScheduledTriggerServiceTests
         }
     }
 
+    /// <summary>2026-08-13 — answers "&lt;definitionId&gt;" verbatim as the
+    /// published VERSION id (see PublishedWorkflowDispatch) so the existing
+    /// ROW-DATA assertions keep reading the definition id they seeded.</summary>
+    private static Elsa.Workflows.Management.IWorkflowDefinitionService StubDefinitionService()
+    {
+        var mock = new Moq.Mock<Elsa.Workflows.Management.IWorkflowDefinitionService>();
+        mock.Setup(d => d.FindWorkflowDefinitionAsync(
+                Moq.It.IsAny<string>(),
+                Moq.It.IsAny<Elsa.Common.Models.VersionOptions>(),
+                Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, Elsa.Common.Models.VersionOptions _, CancellationToken _) =>
+                new Elsa.Workflows.Management.Entities.WorkflowDefinition
+                {
+                    Id = id,
+                    DefinitionId = id,
+                });
+        return mock.Object;
+    }
+
     private sealed class CapturingDispatcher : IWorkflowDispatcher
     {
         public List<DispatchWorkflowDefinitionRequest> Definitions { get; } = new();
@@ -316,6 +336,11 @@ public class TenantScheduledTriggerServiceTests
             .AddSingleton<IScheduledTriggerRepository>(repository)
             .AddSingleton<IWorkflowDispatcher>(dispatcher)
             .AddSingleton<IPlatformEventPublisher>(events)
+            // 2026-08-13 — the service now resolves the PUBLISHED definition
+            // VERSION id before dispatching (PublishedWorkflowDispatch). This
+            // stub answers "<definitionId>" verbatim as the version id so the
+            // ROW-DATA assertions keep reading the definition id they seeded.
+            .AddSingleton(StubDefinitionService())
             .BuildServiceProvider();
 
         var options = new TenantScheduledTriggerOptions
@@ -622,6 +647,7 @@ public class TenantScheduledTriggerServiceTests
                 .AddSingleton<IScheduledTriggerRepository>(repository)
                 .AddSingleton<IWorkflowDispatcher>(dispatcher)
                 .AddSingleton<IPlatformEventPublisher>(events)
+                .AddSingleton(StubDefinitionService())
                 .BuildServiceProvider();
             var service = new TenantScheduledTriggerService(
                 services,
@@ -732,6 +758,7 @@ public class TenantScheduledTriggerServiceTests
                 .AddSingleton<IScheduledTriggerRepository>(repository)
                 .AddSingleton<IWorkflowDispatcher>(dispatcher)
                 .AddSingleton<IPlatformEventPublisher>(events)
+                .AddSingleton(StubDefinitionService())
                 .BuildServiceProvider();
             var service = new TenantScheduledTriggerService(
                 services,

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlLoopDurabilityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlLoopDurabilityTests.cs
@@ -69,9 +69,21 @@ public class AdlLoopDurabilityTests
         var cooldown = flowchart.Activities.OfType<CooldownActivity>().Single();
         var restart = flowchart.Activities.OfType<DispatchAdlActivity>().Single();
 
+        // 2026-08-13 (engine-driven E2E): a timer-bookmark Delay now sits
+        // between the cooldown emit and the restart — the old in-process
+        // Task.Delay held the runtime's dispatch slot for the whole cooldown
+        // and deadlocked every subsequently dispatched workflow behind the
+        // sleeping orchestrator. The loop edge is cooldown → CooldownWait
+        // (Delay, suspends) → restart.
+        // (must be a scheduling Delay — a timer bookmark — never an in-process sleep)
+        var wait = flowchart.Activities.OfType<Elsa.Scheduling.Activities.Delay>().Single();
+
         flowchart.Connections.Should().Contain(
-            c => c.Source.Activity == cooldown && c.Target.Activity == restart,
-            "cooldown must lead to the restart dispatch — that edge IS the loop");
+            c => c.Source.Activity == cooldown && c.Target.Activity == wait,
+            "the cooldown emit must lead into the timer-bookmark wait");
+        flowchart.Connections.Should().Contain(
+            c => c.Source.Activity == wait && c.Target.Activity == restart,
+            "the timer-bookmark wait must lead to the restart dispatch — that edge IS the loop");
     }
 
     // ── The dispatch activities must not throw out into the flow ────────────

--- a/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlLoopDurabilityTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Activities.Tests/Workflows/AdlLoopDurabilityTests.cs
@@ -9,6 +9,7 @@ using Elsa.Workflows.Runtime.Requests;
 using Elsa.Workflows.Runtime.Responses;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using NUnit.Framework;
 using Tamma.Activities.ADL;
 using Tamma.Activities.Core;
@@ -198,6 +199,24 @@ public class AdlLoopDurabilityTests
         // fallback resolves it — the same path a rehydrated (JSON-constructed)
         // activity takes in production.
         services.AddSingleton(dispatcher);
+
+        // 2026-08-13 — the dispatch activities now resolve the PUBLISHED
+        // definition VERSION id first (PublishedWorkflowDispatch); stub the
+        // definition service to answer "<definitionId>" verbatim (AddElsa's
+        // real one has no published definitions in this harness).
+        var definitionService = new Moq.Mock<Elsa.Workflows.Management.IWorkflowDefinitionService>();
+        definitionService
+            .Setup(d => d.FindWorkflowDefinitionAsync(
+                Moq.It.IsAny<string>(),
+                Moq.It.IsAny<Elsa.Common.Models.VersionOptions>(),
+                Moq.It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string id, Elsa.Common.Models.VersionOptions _, CancellationToken _) =>
+                new Elsa.Workflows.Management.Entities.WorkflowDefinition
+                {
+                    Id = id,
+                    DefinitionId = id,
+                });
+        services.AddSingleton(definitionService.Object);
 
         await using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
@@ -142,8 +142,17 @@ public class ScriptedLlmProviderTests
     }
 
     [Test]
-    public void Respond_KeyResolutionOrder_QualifiedThenTypeDefaultThenBareCell()
+    public void Respond_KeyResolutionOrder_QualifiedThenBareCellThenTypeDefault()
     {
+        // 2026-08-13 correction (found by the engine-driven E2E): the BARE
+        // role/action cell now outranks the @{documentType} default. A reviewer
+        // llm-call carries the SUBJECT's documentType (a plan review arrives as
+        // documentType='plan'), and the original order answered it with the PLAN
+        // example instead of the reviewer cell — every panel member's reply then
+        // failed Review validation until exhaustion (48× VALIDATED.FAILED, four
+        // REVIEW_PANEL_UNDECIDABLE in one run). An explicitly scripted
+        // role/action is always more specific than whatever document type the
+        // call happens to carry.
         var overrides = new Dictionary<string, string>
         {
             ["architect/plan-system-design@plan"] = "QUALIFIED",
@@ -161,7 +170,16 @@ public class ScriptedLlmProviderTests
             ["architect/plan-system-design"] = "BARE",
         });
         withoutQualified.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", "plan", "m", "c"))
-            .ResponseText.Should().Be("TYPE-DEFAULT");
+            .ResponseText.Should().Be("BARE",
+                "the scripted role/action cell must beat the per-document-type default");
+
+        var typeDefaultOnly = new ScriptedLlmResponder(new Dictionary<string, string>
+        {
+            ["@plan"] = "TYPE-DEFAULT",
+        });
+        typeDefaultOnly.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", "plan", "m", "c"))
+            .ResponseText.Should().Be("TYPE-DEFAULT",
+                "with no role/action cell the per-type default still serves");
 
         // No documentType ⇒ the bare cell serves.
         responder.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", null, "m", "c"))

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
@@ -142,17 +142,18 @@ public class ScriptedLlmProviderTests
     }
 
     [Test]
-    public void Respond_KeyResolutionOrder_QualifiedThenBareCellThenTypeDefault()
+    public void Respond_KeyResolution_IsTierSplitOnDocumentType()
     {
-        // 2026-08-13 correction (found by the engine-driven E2E): the BARE
-        // role/action cell now outranks the @{documentType} default. A reviewer
-        // llm-call carries the SUBJECT's documentType (a plan review arrives as
-        // documentType='plan'), and the original order answered it with the PLAN
-        // example instead of the reviewer cell — every panel member's reply then
-        // failed Review validation until exhaustion (48× VALIDATED.FAILED, four
-        // REVIEW_PANEL_UNDECIDABLE in one run). An explicitly scripted
-        // role/action is always more specific than whatever document type the
-        // call happens to carry.
+        // 2026-08-13 correction #2 (engine-driven E2E run 34): resolution is
+        // TIER-SPLIT on documentType, and the tiers never cross. A typed call
+        // resolves qualified → @{doc} → registry example; a documentType-less
+        // call resolves the bare cell only. History: the first correction let
+        // the bare cell outrank @{doc} (reviewer calls then carried the
+        // SUBJECT's type — 48× VALIDATED.FAILED, run 22); after
+        // SingleReviewerWorkflow started declaring documentType='review', the
+        // bare-over-@doc rule re-created the same failure in reverse — the TDD
+        // single-shot cell 'tester/write-tests' (free-text test code)
+        // intercepted the test-spec PRODUCER's documentType='test-spec' call.
         var overrides = new Dictionary<string, string>
         {
             ["architect/plan-system-design@plan"] = "QUALIFIED",
@@ -170,8 +171,9 @@ public class ScriptedLlmProviderTests
             ["architect/plan-system-design"] = "BARE",
         });
         withoutQualified.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", "plan", "m", "c"))
-            .ResponseText.Should().Be("BARE",
-                "the scripted role/action cell must beat the per-document-type default");
+            .ResponseText.Should().Be("TYPE-DEFAULT",
+                "a TYPED call must be answered with a document of its type — the bare "
+                + "(free-form) cell must never intercept it");
 
         var typeDefaultOnly = new ScriptedLlmResponder(new Dictionary<string, string>
         {
@@ -184,6 +186,10 @@ public class ScriptedLlmProviderTests
         // No documentType ⇒ the bare cell serves.
         responder.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", null, "m", "c"))
             .ResponseText.Should().Be("BARE");
+
+        // …and a documentType-less call never falls back to typed-tier cells.
+        typeDefaultOnly.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", null, "m", "c"))
+            .Success.Should().BeFalse("the tiers must not cross in either direction");
     }
 
     // =====================================================================

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Agents/ScriptedLlmProviderTests.cs
@@ -1,0 +1,355 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Tamma.Activities.LlmCall.Credentials;
+using Tamma.Activities.LlmCall.Models;
+using Tamma.Activities.Security;
+using Tamma.Api.Extensions;
+using Tamma.Api.Services.Agents;
+using Tamma.Api.Services.Agents.Scripted;
+using Tamma.Core.Documents;
+
+namespace Tamma.Api.Tests.Agents;
+
+/// <summary>
+/// 2026-08-13 (Epic 31 P5 follow-up) — the opt-in "scripted" LLM provider:
+/// deterministic response selection, the unscripted-cell typed error, the
+/// script-override file, the structural production guard on registration, the
+/// credential decorator, and the runner-level dispatch (no HTTP socket ever
+/// opens for a scripted call).
+/// </summary>
+[TestFixture]
+public class ScriptedLlmProviderTests
+{
+    // =====================================================================
+    // Responder — selection + determinism
+    // =====================================================================
+
+    [Test]
+    public void CanHandle_OnlyTheScriptedKey()
+    {
+        var responder = new ScriptedLlmResponder();
+        responder.CanHandle("scripted").Should().BeTrue();
+        responder.CanHandle("SCRIPTED").Should().BeTrue();
+        responder.CanHandle(" scripted ").Should().BeTrue();
+        responder.CanHandle("anthropic").Should().BeFalse();
+        responder.CanHandle("").Should().BeFalse();
+        responder.CanHandle(null).Should().BeFalse();
+    }
+
+    [Test]
+    public void Respond_IsDeterministic_SameCallSameBytes()
+    {
+        var responder = new ScriptedLlmResponder();
+        var call = new ScriptedLlmCall(
+            "scripted", "architect", "plan-system-design", "plan", "any-model", "corr-1");
+
+        var first = responder.Respond(call);
+        var second = responder.Respond(call);
+
+        first.Success.Should().BeTrue();
+        second.ResponseText.Should().Be(first.ResponseText);
+        second.PromptTokens.Should().Be(first.PromptTokens).And.Be(0,
+            "the scripted provider spends nothing — budget/cost accounting stays truthful");
+        second.CompletionTokens.Should().Be(0);
+        first.StopReason.Should().Be(StopReason.EndTurn, "a scripted reply never asks for tools");
+        first.ToolCalls.Should().BeNull();
+    }
+
+    [Test]
+    public void Respond_DocumentTypedCall_FallsBackToTheRegistryValidExample()
+    {
+        var responder = new ScriptedLlmResponder();
+        var call = new ScriptedLlmCall(
+            "scripted", "architect", "plan-system-design", "plan", "m", "corr");
+
+        var response = responder.Respond(call);
+
+        response.Success.Should().BeTrue();
+        // The payload must PASS the real registered validator — the registry's
+        // own first VALID example guarantees it by the drift suite's self-check.
+        var validation = DocumentTypeRegistry.Resolve("plan")
+            .Validate(System.Text.Json.JsonDocument.Parse(response.ResponseText!).RootElement);
+        validation.IsValid.Should().BeTrue(
+            "the scripted produce response must satisfy the 39-9 validation ring: {0}",
+            string.Join("; ", validation.Violations.Select(v => v.Code)));
+    }
+
+    [Test]
+    public void Respond_FreeTextCell_UsesTheBuiltInCycleLibrary()
+    {
+        var responder = new ScriptedLlmResponder();
+        var response = responder.Respond(new ScriptedLlmCall(
+            "scripted", "product_owner", "summarize-stakeholder", null, "m", "corr"));
+
+        response.Success.Should().BeTrue();
+        response.ResponseText.Should().Be(ScriptedCycleLibrary.PoSummary);
+    }
+
+    [Test]
+    public void Respond_UnscriptedCell_ReturnsTypedErrorNamingTheMissingKeys()
+    {
+        var responder = new ScriptedLlmResponder();
+        var response = responder.Respond(new ScriptedLlmCall(
+            "scripted", "tech_writer", "write-runbook", null, "m", "corr"));
+
+        response.Success.Should().BeFalse();
+        response.HttpStatusCode.Should().Be(422, "an unscripted cell is non-retryable, never transient");
+        response.ErrorMessage.Should().Contain(ScriptedLlmResponder.MissingCellError)
+            .And.Contain("tech_writer/write-runbook")
+            .And.Contain("ScriptPath", "the error must tell the test author where to add the cell");
+    }
+
+    [Test]
+    public void Respond_OverrideFile_WinsOverTheBuiltInLibrary_PerKey()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"scripted-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path,
+            """{"responses":{"product_owner/summarize-stakeholder":"OVERRIDDEN","developer/custom-cell":"NEW"}}""");
+        try
+        {
+            var overrides = ScriptedLlmResponder.LoadOverrides(path);
+            var responder = new ScriptedLlmResponder(overrides);
+
+            responder.Respond(new ScriptedLlmCall(
+                    "scripted", "product_owner", "summarize-stakeholder", null, "m", "c"))
+                .ResponseText.Should().Be("OVERRIDDEN");
+            responder.Respond(new ScriptedLlmCall(
+                    "scripted", "developer", "custom-cell", null, "m", "c"))
+                .ResponseText.Should().Be("NEW");
+            // Untouched built-in keys keep serving.
+            responder.Respond(new ScriptedLlmCall(
+                    "scripted", "devops", "deploy", null, "m", "c"))
+                .ResponseText.Should().Be(ScriptedCycleLibrary.StageSuccess);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void LoadOverrides_MissingFile_FailsLoud()
+    {
+        var act = () => ScriptedLlmResponder.LoadOverrides(
+            Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json"));
+        act.Should().Throw<FileNotFoundException>(
+            "a test pointing at a wrong script path must never silently run the default script");
+    }
+
+    [Test]
+    public void Respond_KeyResolutionOrder_QualifiedThenTypeDefaultThenBareCell()
+    {
+        var overrides = new Dictionary<string, string>
+        {
+            ["architect/plan-system-design@plan"] = "QUALIFIED",
+            ["@plan"] = "TYPE-DEFAULT",
+            ["architect/plan-system-design"] = "BARE",
+        };
+        var responder = new ScriptedLlmResponder(overrides);
+
+        responder.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", "plan", "m", "c"))
+            .ResponseText.Should().Be("QUALIFIED");
+
+        var withoutQualified = new ScriptedLlmResponder(new Dictionary<string, string>
+        {
+            ["@plan"] = "TYPE-DEFAULT",
+            ["architect/plan-system-design"] = "BARE",
+        });
+        withoutQualified.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", "plan", "m", "c"))
+            .ResponseText.Should().Be("TYPE-DEFAULT");
+
+        // No documentType ⇒ the bare cell serves.
+        responder.Respond(new ScriptedLlmCall("scripted", "architect", "plan-system-design", null, "m", "c"))
+            .ResponseText.Should().Be("BARE");
+    }
+
+    // =====================================================================
+    // Runner dispatch — a scripted call opens NO HTTP socket
+    // =====================================================================
+
+    [Test]
+    public async Task Runner_ScriptedProvider_ServesInProcess_NeverTouchingHttp()
+    {
+        var factory = new Mock<IHttpClientFactory>(MockBehavior.Strict);
+        factory.Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient(new ThrowingHandler())); // any real send THROWS
+
+        var runner = new InlineToolLoopRunner(
+            NullLogger<InlineToolLoopRunner>.Instance, factory.Object, configuration: null,
+            sanitizer: null, autonomyGate: new CatalogDefaultToolLoopAutonomyGate(),
+            scriptedResponder: new ScriptedLlmResponder());
+
+        var config = new LlmProviderConfig
+        {
+            Name = "scripted",
+            ApiKey = "scripted-no-key",
+            CallRole = "devops",
+            CallAction = "deploy",
+        };
+
+        var result = await runner.RunAsync(
+            "scripted", config, "any-model", "system", "user", 4096, 0.7,
+            tools: null, enableToolLoop: false, new ToolLoopConfig(), "corr-x",
+            repair: null, CancellationToken.None);
+
+        result.Response.Success.Should().BeTrue();
+        result.Response.ResponseText.Should().Be(ScriptedCycleLibrary.StageSuccess);
+        result.Turns.Should().Be(1);
+        result.InputTokens.Should().Be(0);
+        result.OutputTokens.Should().Be(0);
+    }
+
+    [Test]
+    public async Task Runner_ScriptedProvider_RunsTheRealRepairRingValidation()
+    {
+        var runner = new InlineToolLoopRunner(
+            NullLogger<InlineToolLoopRunner>.Instance, httpClientFactory: null, configuration: null,
+            sanitizer: null, autonomyGate: new CatalogDefaultToolLoopAutonomyGate(),
+            scriptedResponder: new ScriptedLlmResponder());
+
+        var config = new LlmProviderConfig
+        {
+            Name = "scripted",
+            CallRole = "architect",
+            CallAction = "plan-system-design",
+        };
+
+        var planType = DocumentTypeRegistry.Resolve("plan");
+        var repair = new RepairRingPlan(
+            "plan",
+            text => planType.Validate(System.Text.Json.JsonDocument.Parse(text).RootElement),
+            RepairEnabled: false,
+            MaxRepairTurns: 0);
+
+        var result = await runner.RunAsync(
+            "scripted", config, "m", "system", "user", 4096, 0.7,
+            tools: null, enableToolLoop: false, new ToolLoopConfig(), "corr-y",
+            repair, CancellationToken.None);
+
+        result.Response.Success.Should().BeTrue();
+        result.ContentValid.Should().BeTrue(
+            "the scripted plan payload must pass the REAL plan validator inside the 39-9 ring");
+        result.RepairTurns.Should().Be(0);
+    }
+
+    // =====================================================================
+    // Registration — opt-in only, structurally impossible in production
+    // =====================================================================
+
+    [Test]
+    public void AddScriptedLlmProvider_FlagOff_IsAByteIdenticalNoOp()
+    {
+        var services = BaseServices();
+        services.AddScriptedLlmProvider(Config());
+
+        using var sp = services.BuildServiceProvider();
+        sp.GetService<IScriptedLlmResponder>().Should().BeNull(
+            "the default (no flag) must never register the test provider");
+        sp.GetRequiredService<IProviderCredentialResolver>().Should().BeOfType<FakeResolver>(
+            "the credential resolver must be untouched when the flag is off");
+        new ProviderAllowlist(sp.GetRequiredService<IOptions<ProviderAllowlistOptions>>())
+            .IsAllowed("scripted").Should().BeFalse();
+    }
+
+    [TestCase("Tamma:TenantSharedSecret", "hmac-secret")]
+    [TestCase("ConnectionStrings:ControlPlane", "Host=cp;Database=t")]
+    [TestCase("Tamma:Mode", "saas")]
+    public void AddScriptedLlmProvider_FlagOnWithProductionSignal_RefusesToStart(
+        string key, string value)
+    {
+        var services = BaseServices();
+        var config = Config(
+            ("Llm:EnableScriptedProvider", "true"),
+            (key, value));
+
+        var act = () => services.AddScriptedLlmProvider(config);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*refused*production*",
+                "enabling the scripted provider on a production-shaped host must fail LOUD at startup");
+    }
+
+    [Test]
+    public async Task AddScriptedLlmProvider_FlagOnCleanHost_WiresResponderAllowlistAndCredential()
+    {
+        var services = BaseServices();
+        services.AddScriptedLlmProvider(Config(("Llm:EnableScriptedProvider", "true")));
+
+        using var sp = services.BuildServiceProvider();
+
+        sp.GetRequiredService<IScriptedLlmResponder>().Should().BeOfType<ScriptedLlmResponder>();
+
+        // The DI allowlist now admits the key (the shipped defaults are untouched —
+        // pinned separately by ScriptedProviderPostureTests).
+        new ProviderAllowlist(sp.GetRequiredService<IOptions<ProviderAllowlistOptions>>())
+            .IsAllowed("scripted").Should().BeTrue();
+
+        // Credential decoration: "scripted" answers the placeholder; every other
+        // provider delegates to the inner resolver.
+        var resolver = sp.GetRequiredService<IProviderCredentialResolver>();
+        resolver.Should().BeOfType<ScriptedProviderCredentialResolver>();
+        var scripted = await resolver.ResolveAsync(null, "scripted");
+        scripted.ApiKey.Should().Be(ScriptedProviderCredentialResolver.PlaceholderKey);
+        scripted.Source.Should().Be(CredentialSource.Platform);
+
+        var delegated = await resolver.ResolveAsync(null, "anthropic");
+        delegated.ApiKey.Should().Be("inner-key", "non-scripted providers must delegate untouched");
+    }
+
+    [Test]
+    public void AddScriptedLlmProvider_WithoutCredentialResolution_FailsLoud()
+    {
+        var services = new ServiceCollection();
+        var act = () => services.AddScriptedLlmProvider(
+            Config(("Llm:EnableScriptedProvider", "true")));
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AddProviderCredentialResolution*");
+    }
+
+    [Test]
+    public void AddScriptedLlmProvider_BadScriptPath_FailsAtRegistration()
+    {
+        var services = BaseServices();
+        var act = () => services.AddScriptedLlmProvider(Config(
+            ("Llm:EnableScriptedProvider", "true"),
+            ("Llm:ScriptedProvider:ScriptPath", "/nonexistent/script.json")));
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private static IServiceCollection BaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddSingleton<IProviderCredentialResolver, FakeResolver>();
+        return services;
+    }
+
+    private static IConfiguration Config(params (string Key, string Value)[] pairs) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(pairs.ToDictionary(p => p.Key, p => (string?)p.Value))
+            .Build();
+
+    private sealed class FakeResolver : IProviderCredentialResolver
+    {
+        public Task<ProviderCredential> ResolveAsync(
+            Guid? tenantId, string providerName, CancellationToken ct = default) =>
+            Task.FromResult(new ProviderCredential("inner-key", CredentialSource.Platform, "inner", null));
+
+        public void Invalidate(Guid? tenantId, string providerName) { }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken) =>
+            throw new InvalidOperationException(
+                $"A scripted-provider call attempted a real HTTP send to {request.RequestUri} — forbidden.");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitRepoAuthorizerTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Git/GitRepoAuthorizerTests.cs
@@ -83,6 +83,35 @@ public class GitRepoAuthorizerTests
         result.Allowed.Should().BeTrue();
     }
 
+    [Test]
+    public async Task SingleUser_PersonalTenantActing_NullInstallTenant_Allows()
+    {
+        // 2026-08-13 (engine-driven E2E): single-user is grant-EXISTENCE, not id
+        // equality. The sole user's PERSONAL tenant now binds ambient on
+        // service-plane calls (EnsurePersonalTenantMiddleware), while grant rows
+        // registered before/outside that tenant carry TenantId=null — strict
+        // equality made the sole user "cross-tenant" against their own grant.
+        InstallationForRepo(tenantId: null);
+
+        var result = await Build(TammaMode.SingleUser)
+            .AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeTrue(
+            "in single-user mode there is exactly one principal — the sole user "
+            + "owns every installation row regardless of which tenant id is acting");
+    }
+
+    [Test]
+    public async Task SingleUser_NoInstallation_StillDenies()
+    {
+        // The grant-existence deny is unchanged: no registry row, no access.
+        NoInstallationForRepo();
+
+        var result = await Build(TammaMode.SingleUser).AuthorizeAsync(TenantA, Repo);
+
+        result.Allowed.Should().BeFalse("no installation row means no grant, in every mode");
+    }
+
     // ── SaaS: the F1 fail-open cases ────────────────────────────────────
 
     [Test]

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/Middleware/EnsurePersonalTenantMiddlewareTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/Middleware/EnsurePersonalTenantMiddlewareTests.cs
@@ -367,6 +367,145 @@ public class EnsurePersonalTenantMiddlewareTests
             "an already-existing tenant must NOT be re-provisioned on every request");
     }
 
+    // ── 2026-08-13 (engine-driven E2E): single-user SERVICE-PLANE binding ──
+    // The engine's mediated calls (llm/call, git callbacks, event drain)
+    // carry no user claim; in single-user mode their principal IS the sole
+    // user, and the middleware must bind (or mint) the personal tenant so
+    // tenant-resident reads (acceptance rules, document instances) resolve
+    // instead of throwing "requires an ambient tenant id" — which made the
+    // autonomy gate fail closed and 500 every engine LLM call.
+
+    private sealed class StubSoleUserProvider(Guid? id) : Tamma.Api.Services.Actions.ISoleUserProvider
+    {
+        public Task<Guid> GetSoleUserIdAsync(CancellationToken ct = default) =>
+            id is Guid g
+                ? Task.FromResult(g)
+                : throw new InvalidOperationException("no sole user");
+    }
+
+    private static DefaultHttpContext BuildAnonymousContext(string path)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Path = path;
+        ctx.Response.Body = new MemoryStream();
+        return ctx;
+    }
+
+    [Test]
+    public async Task SingleUserMode_AnonymousServiceCall_BindsTheSoleUsersExistingTenant()
+    {
+        var userId = Guid.NewGuid();
+        var existingTenantId = Guid.NewGuid();
+        var ctx = BuildAnonymousContext("/api/v1/llm/call");
+        ctx.RequestServices = new ServiceCollection()
+            .AddSingleton<ITenantProvisioningService>(new FakeTenantProvisioningService())
+            .AddSingleton<Tamma.Api.Services.Actions.ISoleUserProvider>(
+                new StubSoleUserProvider(userId))
+            .BuildServiceProvider();
+
+        var tenantContext = new StubTenantContext();
+        var tenantRepo = new Mock<ITenantRepository>(MockBehavior.Strict);
+        var membershipRepo = new Mock<ITenantMembershipRepository>(MockBehavior.Loose);
+        var userRepo = new Mock<IUserRepository>(MockBehavior.Loose);
+        var events = new Mock<IEventRepository>(MockBehavior.Loose);
+        var modeProvider = new StubModeProvider(TammaMode.SingleUser);
+
+        membershipRepo
+            .Setup(r => r.GetUserTenantsAsync(userId))
+            .ReturnsAsync(new List<TenantMembership>
+            {
+                new()
+                {
+                    TenantId = existingTenantId,
+                    UserId = userId,
+                    Role = "owner",
+                    JoinedAt = DateTime.UtcNow.AddDays(-1),
+                },
+            });
+
+        var nextCalled = false;
+        var mw = new EnsurePersonalTenantMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await mw.InvokeAsync(
+            ctx, tenantContext, tenantRepo.Object, membershipRepo.Object,
+            userRepo.Object, events.Object, modeProvider,
+            NullLogger<EnsurePersonalTenantMiddleware>.Instance);
+
+        nextCalled.Should().BeTrue();
+        tenantContext.TenantId.Should().Be(existingTenantId,
+            "an anonymous service-plane call in single-user mode binds the sole "
+            + "user's personal tenant — the ambient home every tenant-resident "
+            + "read resolves against");
+    }
+
+    [Test]
+    public async Task SingleUserMode_AnonymousServiceCall_NoSoleUser_PassesThroughTenantless()
+    {
+        // Pre-setup deployment: no configured owner, empty users table — the
+        // request proceeds tenant-less exactly as before this branch landed.
+        var ctx = BuildAnonymousContext("/api/v1/llm/call");
+        ctx.RequestServices = new ServiceCollection()
+            .AddSingleton<Tamma.Api.Services.Actions.ISoleUserProvider>(
+                new StubSoleUserProvider(null))
+            .BuildServiceProvider();
+
+        var tenantContext = new StubTenantContext();
+        var tenantRepo = new Mock<ITenantRepository>(MockBehavior.Strict);
+        var membershipRepo = new Mock<ITenantMembershipRepository>(MockBehavior.Strict);
+        var userRepo = new Mock<IUserRepository>(MockBehavior.Strict);
+        var events = new Mock<IEventRepository>(MockBehavior.Strict);
+        var modeProvider = new StubModeProvider(TammaMode.SingleUser);
+
+        var nextCalled = false;
+        var mw = new EnsurePersonalTenantMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await mw.InvokeAsync(
+            ctx, tenantContext, tenantRepo.Object, membershipRepo.Object,
+            userRepo.Object, events.Object, modeProvider,
+            NullLogger<EnsurePersonalTenantMiddleware>.Instance);
+
+        nextCalled.Should().BeTrue();
+        tenantContext.TenantId.Should().BeNull();
+    }
+
+    [Test]
+    public async Task SaaSMode_AnonymousServiceCall_IsUntouched()
+    {
+        // The single-user service-plane binding must NOT leak into SaaS —
+        // the mode short-circuit stays first.
+        var ctx = BuildAnonymousContext("/api/v1/llm/call");
+
+        var tenantContext = new StubTenantContext();
+        var tenantRepo = new Mock<ITenantRepository>(MockBehavior.Strict);
+        var membershipRepo = new Mock<ITenantMembershipRepository>(MockBehavior.Strict);
+        var userRepo = new Mock<IUserRepository>(MockBehavior.Strict);
+        var events = new Mock<IEventRepository>(MockBehavior.Strict);
+        var modeProvider = new StubModeProvider(TammaMode.SaaS);
+
+        var nextCalled = false;
+        var mw = new EnsurePersonalTenantMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        await mw.InvokeAsync(
+            ctx, tenantContext, tenantRepo.Object, membershipRepo.Object,
+            userRepo.Object, events.Object, modeProvider,
+            NullLogger<EnsurePersonalTenantMiddleware>.Instance);
+
+        nextCalled.Should().BeTrue();
+        tenantContext.TenantId.Should().BeNull();
+    }
+
     [Test]
     public async Task SingleUserMode_ProvisioningThrows_RequestFails()
     {

--- a/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/PromptEndpointsTenantAdminTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Api.Tests/PromptStore/PromptEndpointsTenantAdminTests.cs
@@ -255,7 +255,7 @@ public class PromptEndpointsTenantAdminTests
         var userId = Guid.NewGuid();
         var tc = new TenantContext();
         var principal = PrincipalWithUserId(userId, "owner");
-        var req = new RenderPromptRequest(new Dictionary<string, string>());
+        var req = new RenderPromptRequest(new Dictionary<string, System.Text.Json.JsonElement>());
 
         var result = await PromptEndpoints.RenderPrompt(
             "developer", "deploy", req, _store, principal, tc, Mode(TammaMode.SingleUser));

--- a/apps/tamma-elsa/tests/Tamma.Platforms.Gitea.Tests/GiteaPrLifecycleTests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.Gitea.Tests/GiteaPrLifecycleTests.cs
@@ -565,3 +565,38 @@ public class GiteaPrLifecycleTests
         pr.Mergeable.Should().BeTrue();
     }
 }
+
+/// <summary>
+/// 2026-08-13 (engine-driven E2E run 37) — pins the driver's transient-merge
+/// classifier: Gitea computes mergeability ASYNC, and the merge endpoint answers
+/// "405: Please try again later" until the checker settles. The driver retries
+/// exactly that answer (bounded) and treats every other failure as terminal.
+/// </summary>
+[TestFixture]
+public class GiteaMergeabilityRetryClassifierTests
+{
+    [Test]
+    public void The405TryAgainLaterAnswer_ClassifiesAsStillComputing()
+    {
+        GiteaPlatformClient.IsMergeabilityStillComputing(
+                new PlatformError.InvalidRequest("405", "Please try again later"))
+            .Should().BeTrue();
+        // The mapper's heuristic classifier may rewrite the code — the hint
+        // alone must still classify.
+        GiteaPlatformClient.IsMergeabilityStillComputing(
+                new PlatformError.InvalidRequest("merge_conflict", "405: Please try again later"))
+            .Should().BeTrue();
+    }
+
+    [Test]
+    public void TerminalMergeFailures_NeverClassifyAsTransient()
+    {
+        GiteaPlatformClient.IsMergeabilityStillComputing(
+                new PlatformError.InvalidRequest("merge_conflict", "merge conflict in src/foo"))
+            .Should().BeFalse("a REAL conflict must escalate, not spin the retry loop");
+        GiteaPlatformClient.IsMergeabilityStillComputing(new PlatformError.NotFound())
+            .Should().BeFalse();
+        GiteaPlatformClient.IsMergeabilityStillComputing(new PlatformError.PermissionDenied())
+            .Should().BeFalse();
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/DockerAvailability.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/DockerAvailability.cs
@@ -45,6 +45,26 @@ internal static class DockerAvailability
 
     static DockerAvailability()
     {
+        // 2026-08-14: one 5s probe made the per-PR job flaky — a COLD CI runner's
+        // first `docker info` regularly exceeds 5s while the daemon warms, and the
+        // whole fixture then failed OneTimeSetUp (23 tests lost to one
+        // infrastructure hiccup, PR #512). Where docker is REQUIRED (CI sets
+        // PLATFORMS_REQUIRE_DOCKER=true) retry within a 60s budget; on a laptop
+        // keep the single fast probe so a misconfigured machine never stalls test
+        // discovery.
+        var deadline = DateTime.UtcNow + (RequireDocker ? TimeSpan.FromSeconds(60) : TimeSpan.Zero);
+        while (!Probe() && DateTime.UtcNow < deadline)
+        {
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+        }
+    }
+
+    /// <summary>
+    /// One <c>docker info</c> attempt; sets <see cref="IsAvailable"/> and
+    /// <see cref="SkipReason"/>, and returns whether docker answered.
+    /// </summary>
+    private static bool Probe()
+    {
         try
         {
             var psi = new ProcessStartInfo("docker", "info")
@@ -59,7 +79,7 @@ internal static class DockerAvailability
             {
                 IsAvailable = false;
                 SkipReason = "docker: failed to start `docker info` process";
-                return;
+                return false;
             }
             // 5s — docker info on a healthy daemon is sub-second; on a
             // broken one it sits forever. We don't want to block test
@@ -69,21 +89,23 @@ internal static class DockerAvailability
                 try { proc.Kill(true); } catch { /* best effort */ }
                 IsAvailable = false;
                 SkipReason = "docker: `docker info` timed out after 5s";
-                return;
+                return false;
             }
             if (proc.ExitCode != 0)
             {
                 IsAvailable = false;
                 SkipReason = $"docker: `docker info` exited {proc.ExitCode}";
-                return;
+                return false;
             }
             IsAvailable = true;
             SkipReason = string.Empty;
+            return true;
         }
         catch (Exception ex)
         {
             IsAvailable = false;
             SkipReason = $"docker: probe threw {ex.GetType().Name}: {ex.Message}";
+            return false;
         }
     }
 

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/DockerAvailability.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/DockerAvailability.cs
@@ -23,13 +23,13 @@ internal static class DockerAvailability
     /// True if <c>docker info</c> returned exit code 0 within 5s at
     /// type init. Cached for the test run lifetime.
     /// </summary>
-    public static bool IsAvailable { get; }
+    public static bool IsAvailable { get; private set; }
 
     /// <summary>
     /// Reason string surfaced in skip messages — empty when
     /// <see cref="IsAvailable"/> is true.
     /// </summary>
-    public static string SkipReason { get; }
+    public static string SkipReason { get; private set; } = string.Empty;
 
     /// <summary>
     /// True when CI has set <c>PLATFORMS_REQUIRE_DOCKER=true</c>. In

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
@@ -1,0 +1,427 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+
+namespace Tamma.Platforms.IntegrationTests.Fixtures;
+
+/// <summary>
+/// Epic 31 P5 follow-up (2026-08-13) — the ENGINE-DRIVEN full-stack topology:
+/// everything <see cref="GiteaFullStackFixture"/> deploys (Gitea + 2× Postgres
+/// containers + the REAL Tamma.Api host process, zero GitHub configuration)
+/// PLUS the REAL Tamma.ElsaServer engine binary as a second host process, so
+/// the ACTUAL AdlOrchestrator/SingleIssueCycle workflows can drive one seeded
+/// issue end to end with no network LLM and no real agent CLI:
+///
+/// <list type="bullet">
+///   <item><b>Scripted LLM provider</b> — <c>Llm:EnableScriptedProvider=true</c>
+///   on BOTH hosts; the engine's chain is pinned to it via
+///   <c>Llm:DefaultProviderChain=[scripted]</c>, and the API serves the
+///   deterministic in-process responses (commit 1/3 of this change).</item>
+///   <item><b>Scripted agent executor</b> — <c>Agent:Local</c> points the
+///   LocalExecutor's process seam at a python3 script this fixture writes: it
+///   reads the exec-request file, makes ONE real commit to the work branch via
+///   the Gitea API (empirically required — Gitea opens a zero-diff draft PR
+///   but refuses to merge a PR with no commits), and writes a success result
+///   artifact. The agent PLANE is real; only the agent BRAIN is scripted.</item>
+///   <item><b>CI stub</b> — <c>Testing:UseMock=true</c>: TriggerCI succeeds
+///   with a synthetic run id and the suspended CI wait is resumed by the test
+///   through the engine's own DG-5 seam (<c>/elsa/api/ci/waits</c>), i.e. the
+///   harness plays the CI system, not the workflow.</item>
+///   <item><b>Engine⇄API wiring</b> — the engine's LLM/git/issue callbacks
+///   ride <c>Tamma:ApiUrl</c>/<c>Engine:CallbackUrl</c>; the API's webhook →
+///   engine resume hop rides <c>Elsa:ServerUrl</c> + the Elsa admin API key
+///   (Gitea's merged-PR webhook crosses the container gateway into the API
+///   receiver and resumes the cycle's <c>WaitForPRMerged</c> bookmark on the
+///   engine — the same P4 leg the surface suite proved, now engine-attached).</item>
+/// </list>
+///
+/// <para>The engine gets its own database (created on the app-DB container)
+/// for the Elsa stores. NOTE: <c>ConnectionStrings:ControlPlane</c> is
+/// deliberately NOT set anywhere — it is a SaaS signal that would (correctly)
+/// make the scripted provider refuse to register.</para>
+/// </summary>
+public sealed class EngineFullStackFixture : IAsyncDisposable
+{
+    /// <summary>The Elsa admin API key — UseAdminApiKey()'s AdminApiKeyProvider
+    /// accepts only the all-zero GUID (see docker/.env.example).</summary>
+    public const string ElsaAdminApiKey = "00000000-0000-0000-0000-000000000000";
+
+    public GiteaFullStackFixture Stack { get; } = new();
+
+    public GiteaContainerFixture Gitea => Stack.Gitea;
+    public string ApiBaseUrl => Stack.ApiBaseUrl;
+
+    /// <summary>Host-side base URL of the running Tamma.ElsaServer.</summary>
+    public string EngineBaseUrl { get; private set; } = string.Empty;
+
+    public bool IsReady { get; private set; }
+    public string NotReadyReason { get; private set; } = "StartAsync has not run";
+
+    private Process? _engine;
+    private string _engineLogPath = string.Empty;
+    private string _agentScriptPath = string.Empty;
+    private string _agentWorkDir = string.Empty;
+
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            // ── ports first: the API needs the engine URL (webhook→resume
+            //    hop) and the engine needs the API URL (mediation planes) ──
+            var enginePort = FreeTcpPort();
+            EngineBaseUrl = $"http://localhost:{enginePort}";
+
+            Stack.ExtraApiEnvironment["Llm__EnableScriptedProvider"] = "true";
+            Stack.ExtraApiEnvironment["Elsa__ServerUrl"] = EngineBaseUrl;
+            Stack.ExtraApiEnvironment["Elsa__ApiKey"] = ElsaAdminApiKey;
+
+            // Single-user principal: the deployed instance has an owner user
+            // from its setup flow; the fixture pins one explicitly so
+            // SoleUserProvider does not fail every autonomy/document decision
+            // with GOVERNANCE.PRINCIPAL.NO_SOLE_USER (observed run 10).
+            Stack.ExtraApiEnvironment["Tamma__SingleUser__OwnerUserId"] =
+                "aaaaaaaa-0000-0000-0000-00000000e2ee";
+
+            // The API's per-IP limiter throttles its OWN engine (one
+            // agent-config resolve per llm-call; a 7-role review panel blows
+            // through ConfigRead=100/min and the engine churns retries into
+            // 429s — observed run 21: 1452 rejects, 4× call amplification).
+            // The E2E raises the limits the way a single-box deployment would.
+            Stack.ExtraApiEnvironment["RateLimits__ConfigRead"] = "100000";
+            Stack.ExtraApiEnvironment["RateLimits__ProviderExecute"] = "100000";
+
+            await Stack.StartAsync(ct).ConfigureAwait(false);
+            if (!Stack.IsReady)
+            {
+                NotReadyReason = $"API stack not ready: {Stack.NotReadyReason}";
+                return;
+            }
+
+            // ── the single-user OWNER row (the deployed instance has one from
+            //    its registration/setup flow). With the row + the pinned
+            //    Tamma:SingleUser:OwnerUserId above, the API's single-user
+            //    service-plane binding (EnsurePersonalTenantMiddleware) mints
+            //    and binds the personal tenant on the engine's first mediated
+            //    call — the ambient-tenant home every tenant-resident read
+            //    (acceptance rules, document instances) resolves against. ──
+            await using (var db = Stack.CreateDbContext())
+            {
+                db.Users.Add(new Tamma.Data.Entities.User
+                {
+                    Id = Guid.Parse("aaaaaaaa-0000-0000-0000-00000000e2ee"),
+                    Email = "owner@e2e.local",
+                    DisplayName = "E2E Owner",
+                    Role = "owner",
+                    EmailVerified = true,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow,
+                });
+                await db.SaveChangesAsync(ct).ConfigureAwait(false);
+            }
+
+            // ── the engine SHARES the control-plane database (the deployed
+            //    compose shape: elsa-server's DefaultConnection is the same
+            //    "tamma" database the API migrates) — the Elsa stores migrate
+            //    their own tables alongside, and the engine's CP-polling
+            //    triggers (TenantCleanup/TenantDelete) find platform_events
+            //    instead of erroring every tick against a bare Elsa DB. The
+            //    API has already migrated this database (it started first). ──
+            var engineDb = Stack.ControlPlaneDb.GetConnectionString();
+
+            // ── the scripted agent executor script (the LocalExecutor CLI
+            //    protocol's other side): one REAL commit per task session ──
+            WriteAgentScript();
+
+            // ── launch the real engine binary ──
+            var engineDll = LocateDll("Tamma.ElsaServer");
+            _engineLogPath = Path.Combine(Path.GetTempPath(), $"tamma-e2e-engine-{enginePort}.log");
+
+            var psi = new ProcessStartInfo("dotnet", $"\"{engineDll}\"")
+            {
+                WorkingDirectory = Path.GetDirectoryName(engineDll)!,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            // Zero GitHub configuration on the ENGINE too (AgentExecutorFactory
+            // auto-detects GitHubActions off GitHub:AppId — scrub it away).
+            foreach (var key in psi.Environment.Keys
+                         .Where(k => k.StartsWith("GITHUB", StringComparison.OrdinalIgnoreCase)
+                                     || k.StartsWith("GitHub__", StringComparison.OrdinalIgnoreCase))
+                         .ToList())
+            {
+                psi.Environment.Remove(key);
+            }
+
+            // Production, DELIBERATELY (matching the deployed engine): under
+            // Development, DI ValidateOnBuild refuses to boot the engine on two
+            // pre-existing registration defects — HourlyAnalyticsRollupScheduler
+            // (singleton hosted service) consumes the scoped IWorkflowDispatcher,
+            // and LifecycleReEntryService needs IDocumentInstanceRepository which
+            // no engine composition registers (AddTammaData is API-only). The
+            // deployed engine never sees either (no ValidateOnBuild outside
+            // Development); the second is neutralized below via the sanctioned
+            // Documents:ReEntryDisabled seam. Recorded in
+            // .dev/findings/ (engine-driven E2E follow-up, 2026-08-13).
+            psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
+            psi.Environment["Documents__ReEntryDisabled"] = "true";
+            psi.Environment["ASPNETCORE_URLS"] = $"http://0.0.0.0:{enginePort}";
+            psi.Environment["ConnectionStrings__DefaultConnection"] = engineDb;
+            psi.Environment["Elsa__Identity__SigningKey"] =
+                "sufficiently-long-secret-signing-key-for-the-e2e-engine";
+            psi.Environment["Elsa__Server__BaseUrl"] = EngineBaseUrl;
+            psi.Environment["OpenSearch__Enabled"] = "false";
+
+            // Engine → API planes (LLM mediation, issues/git callbacks, events drain).
+            psi.Environment["Tamma__ApiUrl"] = Stack.ApiBaseUrl;
+            psi.Environment["Tamma__ApiToken"] = "e2e-engine-token"; // dev-permissive API auth
+            psi.Environment["Engine__CallbackUrl"] = Stack.ApiBaseUrl;
+
+            // Single-user / dev mode: no SaaS signal, deployment mode "dev"
+            // (no prod-approval human gate in the deployment pipeline).
+            psi.Environment["Tamma__Mode"] = "single-user";
+
+            // The scripted LLM provider: enabled + selected as THE chain.
+            psi.Environment["Llm__EnableScriptedProvider"] = "true";
+            psi.Environment["Llm__DefaultProviderChain__0"] = "scripted";
+
+            // CI stub: TriggerCI succeeds with a synthetic run id; the test
+            // resumes the suspended wait through /elsa/api/ci/waits.
+            psi.Environment["Testing__UseMock"] = "true";
+
+            // The scripted agent executor (LocalExecutor process seam).
+            psi.Environment["Agent__Local__NodeExecutable"] = "python3";
+            psi.Environment["Agent__Local__CliEntryPoint"] = _agentScriptPath;
+            psi.Environment["Agent__Local__WorkingDirectory"] = _agentWorkDir;
+            psi.Environment["Agent__Local__CleanupAfterRun"] = "false"; // keep artifacts for debugging
+
+            _engine = new Process { StartInfo = psi };
+            var log = new StreamWriter(_engineLogPath, append: false) { AutoFlush = true };
+            _engine.OutputDataReceived += (_, e) => { if (e.Data is not null) { lock (log) log.WriteLine(e.Data); } };
+            _engine.ErrorDataReceived += (_, e) => { if (e.Data is not null) { lock (log) log.WriteLine("[err] " + e.Data); } };
+            _engine.Start();
+            _engine.BeginOutputReadLine();
+            _engine.BeginErrorReadLine();
+
+            await WaitForEngineHealthyAsync(TimeSpan.FromMinutes(4), ct).ConfigureAwait(false);
+
+            // /health goes green BEFORE Elsa's workflow registry has
+            // materialized the CLR workflow definitions — a dispatch in that
+            // window is queued and then fails "Workflow graph not found"
+            // (observed on the first run of this fixture). Wait until the
+            // definition the test dispatches actually resolves.
+            await WaitForWorkflowDefinitionAsync(
+                "adl-orchestrator", TimeSpan.FromMinutes(3), ct).ConfigureAwait(false);
+
+            IsReady = true;
+            NotReadyReason = string.Empty;
+        }
+        catch (Exception ex)
+        {
+            NotReadyReason = $"{ex.GetType().Name}: {ex.Message}";
+            IsReady = false;
+        }
+    }
+
+    public string EngineLogTail(int maxChars = 4000)
+    {
+        try
+        {
+            if (!File.Exists(_engineLogPath)) return "(no engine log)";
+            var text = File.ReadAllText(_engineLogPath);
+            return text.Length <= maxChars ? text : text[^maxChars..];
+        }
+        catch (Exception ex)
+        {
+            return $"(engine log unreadable: {ex.Message})";
+        }
+    }
+
+    public string ApiLogTail(int maxChars = 4000) => Stack.ApiLogTail(maxChars);
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            if (_engine is { HasExited: false })
+            {
+                _engine.Kill(entireProcessTree: true);
+                _engine.WaitForExit(10_000);
+            }
+            _engine?.Dispose();
+        }
+        catch { /* best effort */ }
+
+        await Stack.DisposeAsync().ConfigureAwait(false);
+    }
+
+    // ── internals ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The scripted no-LLM agent: reads the LocalExecutor exec-request file,
+    /// commits one deterministic file to the work branch via the Gitea
+    /// contents API (unique path per session, so the two-task TDD loop makes
+    /// two clean commits), and writes the success result artifact. Empirically
+    /// load-bearing: Gitea opens a zero-diff draft PR but refuses to merge a
+    /// PR whose branch carries no commits, and the engine-driven cycle opens
+    /// its PR BEFORE the TDD loop runs.
+    /// </summary>
+    private void WriteAgentScript()
+    {
+        _agentWorkDir = Path.Combine(Path.GetTempPath(), $"tamma-e2e-agent-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_agentWorkDir);
+        _agentScriptPath = Path.Combine(_agentWorkDir, "scripted-agent.py");
+
+        var script = $$"""
+import base64, json, sys, time, urllib.request
+
+GITEA = {{ToPyString(Gitea.BaseUrl)}}
+TOKEN = {{ToPyString(Gitea.BotToken)}}
+
+def main() -> int:
+    args = sys.argv[1:]
+    req_path = args[args.index("--request") + 1]
+    out_path = args[args.index("--output") + 1]
+    with open(req_path, encoding="utf-8") as f:
+        req = json.load(f)
+
+    repository = req["repository"]          # owner/repo
+    branch = req["branch_name"]
+    session = req.get("tamma_session_id") or f"s{int(time.time())}"
+
+    file_path = f"src/scripted/{session}.txt"
+    body = json.dumps({
+        "branch": branch,
+        "content": base64.b64encode(
+            f"scripted agent change for {session}\n".encode()).decode(),
+        "message": f"feat: scripted agent change ({session})",
+    }).encode()
+
+    http = urllib.request.Request(
+        f"{GITEA}/api/v1/repos/{repository}/contents/{file_path}",
+        data=body, method="POST",
+        headers={"Content-Type": "application/json",
+                 "Authorization": f"token {TOKEN}"})
+    with urllib.request.urlopen(http, timeout=30) as resp:
+        created = json.load(resp)
+    sha = created.get("commit", {}).get("sha", "") or ""
+
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({
+            "success": True,
+            "commit_sha": sha,
+            "files_changed": [file_path],
+            "tokens_used": 0,
+            "duration_seconds": 1,
+            "agent_provider": "scripted",
+            "agent_version": "e2e-1",
+            "agent_log_summary": f"scripted agent committed {file_path} to {branch}",
+        }, f)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())
+""";
+        File.WriteAllText(_agentScriptPath, script);
+    }
+
+    private static string ToPyString(string value) =>
+        System.Text.Json.JsonSerializer.Serialize(value);
+
+    private async Task WaitForEngineHealthyAsync(TimeSpan timeout, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        Exception? last = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (_engine is { HasExited: true })
+            {
+                throw new InvalidOperationException(
+                    $"Tamma.ElsaServer exited during startup (code {_engine.ExitCode}). Log tail:\n{EngineLogTail()}");
+            }
+            try
+            {
+                using var resp = await http.GetAsync($"{EngineBaseUrl}/health", ct).ConfigureAwait(false);
+                if (resp.IsSuccessStatusCode) return;
+                last = new Exception($"/health answered HTTP {(int)resp.StatusCode}");
+            }
+            catch (Exception ex)
+            {
+                last = ex;
+            }
+            await Task.Delay(TimeSpan.FromSeconds(2), ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"Tamma.ElsaServer did not become healthy within {timeout.TotalSeconds}s. Log tail:\n{EngineLogTail()}",
+            last);
+    }
+
+    private async Task WaitForWorkflowDefinitionAsync(
+        string definitionId, TimeSpan timeout, CancellationToken ct)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        http.DefaultRequestHeaders.Add("Authorization", $"ApiKey {ElsaAdminApiKey}");
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        var url = $"{EngineBaseUrl}/elsa/api/workflow-definitions/by-definition-id/{definitionId}";
+        Exception? last = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            try
+            {
+                using var resp = await http.GetAsync(url, ct).ConfigureAwait(false);
+                if (resp.IsSuccessStatusCode) return;
+                last = new Exception($"{url} answered HTTP {(int)resp.StatusCode}");
+            }
+            catch (Exception ex)
+            {
+                last = ex;
+            }
+            await Task.Delay(TimeSpan.FromSeconds(3), ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"Workflow definition '{definitionId}' did not materialize within {timeout.TotalSeconds}s. "
+            + $"Engine log tail:\n{EngineLogTail()}", last);
+    }
+
+    private static int FreeTcpPort()
+    {
+        var listener = TcpListener.Create(0);
+        listener.Start();
+        var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    /// <summary>Locate a built src project dll next to this repo checkout —
+    /// same pattern as <see cref="GiteaFullStackFixture"/>.</summary>
+    private static string LocateDll(string project)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Tamma.sln")))
+        {
+            dir = dir.Parent;
+        }
+        if (dir is null)
+        {
+            throw new InvalidOperationException(
+                "could not locate Tamma.sln above the test bin directory");
+        }
+
+        var configs = AppContext.BaseDirectory.Contains($"{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}")
+            ? new[] { "Release", "Debug" }
+            : new[] { "Debug", "Release" };
+        foreach (var config in configs)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", project, "bin", config, "net8.0", $"{project}.dll");
+            if (File.Exists(candidate)) return candidate;
+        }
+        throw new InvalidOperationException(
+            $"{project}.dll not found under {dir.FullName}/src/{project}/bin — build the solution first "
+            + "(the E2E vehicle runs the real binaries)");
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
@@ -155,17 +155,19 @@ public sealed class EngineFullStackFixture : IAsyncDisposable
             }
 
             // Production, DELIBERATELY (matching the deployed engine): under
-            // Development, DI ValidateOnBuild refuses to boot the engine on two
-            // pre-existing registration defects — HourlyAnalyticsRollupScheduler
-            // (singleton hosted service) consumes the scoped IWorkflowDispatcher,
-            // and LifecycleReEntryService needs IDocumentInstanceRepository which
-            // no engine composition registers (AddTammaData is API-only). The
-            // deployed engine never sees either (no ValidateOnBuild outside
-            // Development); the second is neutralized below via the sanctioned
-            // Documents:ReEntryDisabled seam. Recorded in
-            // .dev/findings/ (engine-driven E2E follow-up, 2026-08-13).
+            // Development, DI ValidateOnBuild refuses to boot the engine on a
+            // pre-existing registration defect — HourlyAnalyticsRollupScheduler
+            // (singleton hosted service) consumes the scoped IWorkflowDispatcher.
+            // The deployed engine never sees it (no ValidateOnBuild outside
+            // Development). Recorded in .dev/findings/ (engine-driven E2E
+            // follow-up, 2026-08-13).
+            //
+            // Documents:ReEntryDisabled is deliberately NOT set: the engine now
+            // defaults to HttpLifecycleReEntryService (latest-accepted read over
+            // the API), which the plan-review shim REQUIRES — with the Null seam
+            // the shim can never see the accepted plan and every cycle terminates
+            // needs-human (run 29's root cause).
             psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Production";
-            psi.Environment["Documents__ReEntryDisabled"] = "true";
             psi.Environment["ASPNETCORE_URLS"] = $"http://0.0.0.0:{enginePort}";
             psi.Environment["ConnectionStrings__DefaultConnection"] = engineDb;
             psi.Environment["Elsa__Identity__SigningKey"] =

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/EngineFullStackFixture.cs
@@ -184,9 +184,15 @@ public sealed class EngineFullStackFixture : IAsyncDisposable
             // (no prod-approval human gate in the deployment pipeline).
             psi.Environment["Tamma__Mode"] = "single-user";
 
-            // The scripted LLM provider: enabled + selected as THE chain.
+            // The scripted LLM provider: enabled + selected as THE chain, and
+            // ALLOW-LISTED. All three are required: enablement registers it,
+            // the chain selects it, and the egress allowlist admits it — the
+            // tool-loop rejects any provider outside the allowlist and falls
+            // back to the platform default (which, in this fixture, is a real
+            // vendor with no credentials, so every call returned empty).
             psi.Environment["Llm__EnableScriptedProvider"] = "true";
             psi.Environment["Llm__DefaultProviderChain__0"] = "scripted";
+            psi.Environment["Security__ProviderAllowlist__AdditionalProviders__0"] = "scripted";
 
             // CI stub: TriggerCI succeeds with a synthetic run id; the test
             // resumes the suspended wait through /elsa/api/ci/waits.

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/GiteaFullStackFixture.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/Fixtures/GiteaFullStackFixture.cs
@@ -73,6 +73,16 @@ public sealed class GiteaFullStackFixture : IAsyncDisposable
     public IReadOnlyList<string> ScrubbedGitHubEnvKeys => _scrubbedGitHubKeys;
     private readonly List<string> _scrubbedGitHubKeys = new();
 
+    /// <summary>
+    /// Engine-driven E2E (2026-08-13) — extra environment applied to the API
+    /// child process AFTER the built-ins (so an entry here can also override).
+    /// The engine-full-stack fixture uses it to enable the scripted LLM
+    /// provider and to point the API's "elsa" client at the launched engine.
+    /// Populate BEFORE <see cref="StartAsync"/>.
+    /// </summary>
+    public IDictionary<string, string> ExtraApiEnvironment { get; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
     public async Task StartAsync(CancellationToken ct = default)
     {
         try
@@ -91,6 +101,26 @@ public sealed class GiteaFullStackFixture : IAsyncDisposable
                 ControlPlaneDb.StartAsync(ct),
                 AppDb.StartAsync(ct),
                 Gitea.StartAsync(ct)).ConfigureAwait(false);
+
+            // ── 1b. tenant-schema migrations on the app DB ────────────
+            // 2026-08-13 (engine-driven E2E): the API's SYSTEM STORE
+            // (SystemStoreDbContextFactory — conventions, document instances,
+            // domain events, …) rides ConnectionStrings:TammaAppDb, but NOTHING
+            // in API startup migrates the Tenant schema onto it — deployment
+            // does that once, operator-side (AdminTenantMigrationEndpoints /
+            // `dotnet ef database update`). Without this, ConventionStoreSeeder
+            // fails at boot ("relation \"conventions\" does not exist") and
+            // every /api/conventions/resolve 500s. The fixture plays the
+            // operator: apply the Tenant migrations before the API boots so
+            // its seeders find the tables.
+            {
+                var tenantOptions = new DbContextOptionsBuilder<TenantDbContext>()
+                    .UseNpgsql(AppDb.GetConnectionString(), npgsql =>
+                        npgsql.MigrationsHistoryTable("__TenantMigrationsHistory"))
+                    .Options;
+                await using var tenantDb = new TenantDbContext(tenantOptions);
+                await tenantDb.Database.MigrateAsync(ct).ConfigureAwait(false);
+            }
 
             // ── 2. launch the real Tamma.Api as a host process ────────
             var apiDll = LocateApiDll();
@@ -139,6 +169,13 @@ public sealed class GiteaFullStackFixture : IAsyncDisposable
             psi.Environment["Tamma__PublicBaseUrl"] = PublicBaseUrl;
             psi.Environment["Webhooks__RegisterOnStartup"] = "true";
             psi.Environment["Webhooks__Secrets__gitea"] = WebhookSecret;
+
+            // Engine-driven E2E (2026-08-13) — caller-supplied extras, applied
+            // LAST so they may extend or override the built-ins above.
+            foreach (var (key, value) in ExtraApiEnvironment)
+            {
+                psi.Environment[key] = value;
+            }
 
             _api = new Process { StartInfo = psi };
             var log = new StreamWriter(_apiLogPath, append: false) { AutoFlush = true };

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaEngineDrivenE2ETests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaEngineDrivenE2ETests.cs
@@ -19,7 +19,7 @@ namespace Tamma.Platforms.IntegrationTests;
 /// (LocalExecutor's process seam). One issue is seeded in Gitea; the ACTUAL
 /// AdlOrchestrator → SingleIssueCycle workflows drive it.
 ///
-/// <para><b>What the harness plays, and why that is honest.</b> Three seams
+/// <para><b>What the harness plays, and why that is honest.</b> Four seams
 /// are, BY DESIGN, external actors the deployed product also waits on — the
 /// test drives each through its shipped public seam, never a shortcut:</para>
 /// <list type="bullet">
@@ -37,6 +37,11 @@ namespace Tamma.Platforms.IntegrationTests;
 ///   <c>merge</c> decision on the engine's merge-approval resume seam once
 ///   the PR is un-drafted and mergeable — the gate is a HUMAN wait by design;
 ///   autonomy here would be a product change, not a test fidelity gap.</item>
+///   <item><b>the production-deploy approver</b> (43-9 Seam E): at the
+///   default autonomy dial the deploy-control effect gate routes the PROD
+///   deploy to a human; the test approves it through the shipped
+///   <c>/elsa/api/adl/deploy-approval/resume</c> seam after the merge —
+///   same rationale as the merge approver.</item>
 /// </list>
 ///
 /// <para><b>What is then proven end-to-end with no human and no network
@@ -195,9 +200,24 @@ public class GiteaEngineDrivenE2ETests
         }
 
         // ── 7. the cycle runs to COMPLETION (post-merge deployment included) ──
-        await WaitForEventAsync("CYCLE.COMPLETED", TimeSpan.FromMinutes(5),
-            "after the merge webhook resumes WaitForPRMerged, the deployment pipeline "
-            + "(scripted qa/uat/prod deploys) must finish and the cycle must emit its terminal");
+        // The FOURTH by-design external actor (2026-08-13, run 43): the
+        // deploy-control effect gate (43-9 Seam E) routes the PRODUCTION deploy
+        // to a human at the default autonomy dial — approve it through the
+        // shipped resume seam (/elsa/api/adl/deploy-approval/resume), exactly
+        // like the merge approver seat, then the scripted prod deploy runs and
+        // the cycle emits its terminal.
+        // Gitea's PR JSON spells it `merge_commit_sha` (run 45: the misspelled
+        // read produced a "none" sha segment and the resume 404'd forever).
+        var mergeShaForDeploy = pr.TryGetProperty("merge_commit_sha", out var msha)
+            ? msha.GetString()
+            : pr.TryGetProperty("merged_commit_sha", out var msha2) ? msha2.GetString() : null;
+        var completed = await ApproveProdDeployAndAwaitCompletionAsync(
+            issueNumber, mergeShaForDeploy, TimeSpan.FromMinutes(5));
+        completed.Should().BeTrue(
+            "after the merge webhook resumes WaitForPRMerged and the harness approves the "
+            + "production-deploy gate, the deployment pipeline (scripted qa/uat/prod deploys) "
+            + "must finish and the cycle must emit CYCLE.COMPLETED. "
+            + $"api log tail:\n{_stack.ApiLogTail(1500)}\nengine log tail:\n{_stack.EngineLogTail(2000)}");
 
         // ── 8. audit trail: every leg left its durable event ──
         var types = await EventTypesAsync();
@@ -313,6 +333,44 @@ public class GiteaEngineDrivenE2ETests
         return false;
     }
 
+    /// <summary>
+    /// The production-deploy approver seat (2026-08-13, run 43): poll for
+    /// CYCLE.COMPLETED while approving the deployment pipeline's prod-approval
+    /// gate through its shipped resume seam once it suspends (404 = not
+    /// suspended yet — retry next tick, the merge-approval convention).
+    /// </summary>
+    private async Task<bool> ApproveProdDeployAndAwaitCompletionAsync(
+        int issueNumber, string? mergeSha, TimeSpan budget)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(budget);
+        var approved = false;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if ((await EventTypesAsync()).Contains("CYCLE.COMPLETED")) return true;
+
+            if (!approved)
+            {
+                using var resp = await _engine.PostAsJsonAsync(
+                    "/elsa/api/adl/deploy-approval/resume", new
+                    {
+                        issueNumber,
+                        decision = "approve",
+                        feedback = "e2e harness: production deploy approved",
+                        approver = "e2e-harness",
+                        tenantId = (string?)null,
+                        repository = RepoSlug,
+                        mergeSha,
+                    }, Json);
+                TestContext.Out.WriteLine(
+                    $"[pump] deploy approval issue={issueNumber} sha={mergeSha} -> {(int)resp.StatusCode}");
+                if (resp.StatusCode != HttpStatusCode.NotFound) approved = true;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+        return false;
+    }
+
     /// <summary>Session ids of APPROVAL.REQUESTED audit rows (the cycle's own
     /// durable trace of suspended accept gates).</summary>
     private async Task<IReadOnlyList<string>> PendingDecisionSessionsAsync()
@@ -364,7 +422,15 @@ public class GiteaEngineDrivenE2ETests
         foreach (var pr in doc.RootElement.EnumerateArray())
         {
             var head = pr.GetProperty("head").GetProperty("ref").GetString() ?? "";
-            if (head.StartsWith("adl/", StringComparison.Ordinal))
+            var title = pr.TryGetProperty("title", out var t) ? t.GetString() ?? "" : "";
+            // 2026-08-13 (run 44): the cycle DELETES the head branch after a
+            // successful merge, and Gitea then rewrites the closed PR's
+            // head.ref to "refs/pull/{n}/head" — the branch-prefix match alone
+            // never sees the merged PR and the pump loops past its own
+            // terminal. The cycle's PR title prefix is the stable identity.
+            if (head.StartsWith("adl/", StringComparison.Ordinal)
+                || title.StartsWith("[ADL]", StringComparison.Ordinal)
+                || title.StartsWith("WIP: [ADL]", StringComparison.Ordinal))
             {
                 return pr.Clone();
             }

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaEngineDrivenE2ETests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaEngineDrivenE2ETests.cs
@@ -1,0 +1,493 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+using Tamma.Platforms.IntegrationTests.Fixtures;
+
+namespace Tamma.Platforms.IntegrationTests;
+
+/// <summary>
+/// Epic 31 P5 follow-up (2026-08-13) — the ENGINE-DRIVEN autonomous headline:
+/// the previously-Ignored <c>FullEngineCycle_SingleIssue_CompletesOnGitea</c>,
+/// now REAL. The <see cref="EngineFullStackFixture"/> joins the REAL
+/// Tamma.ElsaServer engine binary to the P5 topology (Gitea + 2× Postgres +
+/// the real Tamma.Api, zero GitHub configuration), configured with the
+/// scripted LLM provider (no network LLM) and the scripted agent executor
+/// (LocalExecutor's process seam). One issue is seeded in Gitea; the ACTUAL
+/// AdlOrchestrator → SingleIssueCycle workflows drive it.
+///
+/// <para><b>What the harness plays, and why that is honest.</b> Three seams
+/// are, BY DESIGN, external actors the deployed product also waits on — the
+/// test drives each through its shipped public seam, never a shortcut:</para>
+/// <list type="bullet">
+///   <item><b>the document decider</b> (39-8): every document lifecycle
+///   suspends on the accept gate until the orchestrator agent / a human
+///   decides. No autonomous decider service ships in this deployment, so the
+///   test accepts each request via the API's own
+///   <c>POST /api/documents/decisions/{sessionId}/resume</c> — discovering
+///   sessions from the cycle's own APPROVAL.REQUESTED audit events.</item>
+///   <item><b>the CI system</b>: with <c>Testing:UseMock=true</c> TriggerCI
+///   succeeds with a synthetic run id; the test resumes the suspended wait
+///   through the engine's DG-5 seam (<c>/elsa/api/ci/waits</c>) with a green
+///   result — the same seam the production CI completion poller drives.</item>
+///   <item><b>the merge approver</b> (FR-19 human gate): the test posts the
+///   <c>merge</c> decision on the engine's merge-approval resume seam once
+///   the PR is un-drafted and mergeable — the gate is a HUMAN wait by design;
+///   autonomy here would be a product change, not a test fidelity gap.</item>
+/// </list>
+///
+/// <para><b>What is then proven end-to-end with no human and no network
+/// LLM:</b> work selected off the seeded label → context scans + PO summary →
+/// plan produced/validated/panel-reviewed/accepted (typed documents through
+/// the REAL validators) → tasks + test-spec accepted → branch + zero-diff
+/// DRAFT PR in Gitea → scripted agent commits real code per task → CI-stub
+/// leg green through the DG-5 seam → code review → un-draft → merge decision
+/// → REAL squash-merge in Gitea → Gitea's merged-PR webhook crosses the
+/// container gateway into the API receiver and resumes the cycle's
+/// WaitForPRMerged bookmark → deployment pipeline (scripted deploys) →
+/// CYCLE.COMPLETED. Zero GitHub configuration anywhere.</para>
+/// </summary>
+[TestFixture]
+[Category("Integration")]
+[Category("Platforms")]
+[Category("Gitea")]
+[Category("GiteaE2E")]
+[Category("Nightly")]
+public class GiteaEngineDrivenE2ETests
+{
+    private EngineFullStackFixture _stack = null!;
+    private HttpClient _api = null!;
+    private HttpClient _gitea = null!;
+    private HttpClient _engine = null!;
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
+
+    private string Owner => _stack.Gitea.OwnerLogin;
+    private string Repo => _stack.Gitea.RepoName;
+    private string RepoSlug => $"{Owner}/{Repo}";
+
+    /// <summary>The work-selection label the orchestrator is configured with.</summary>
+    private const string AutoLabel = "tamma-auto";
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        DockerAvailability.RequireOrSkip();
+
+        _stack = new EngineFullStackFixture();
+        await _stack.StartAsync(CancellationToken.None);
+        if (!_stack.IsReady)
+        {
+            TestContext.Error.WriteLine(
+                $"EngineFullStackFixture did not reach ready state: {_stack.NotReadyReason}\n"
+                + $"API log tail:\n{_stack.ApiLogTail()}\n"
+                + $"Engine log tail:\n{_stack.EngineLogTail()}");
+            return;
+        }
+
+        _api = new HttpClient { BaseAddress = new Uri(_stack.ApiBaseUrl), Timeout = TimeSpan.FromSeconds(60) };
+        _gitea = new HttpClient { BaseAddress = new Uri(_stack.Gitea.BaseUrl) };
+        _gitea.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("token", _stack.Gitea.BotToken);
+        _engine = new HttpClient { BaseAddress = new Uri(_stack.EngineBaseUrl), Timeout = TimeSpan.FromSeconds(60) };
+        _engine.DefaultRequestHeaders.Add(
+            "Authorization", $"ApiKey {EngineFullStackFixture.ElsaAdminApiKey}");
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        _api?.Dispose();
+        _gitea?.Dispose();
+        _engine?.Dispose();
+        if (_stack is not null) await _stack.DisposeAsync();
+    }
+
+    private void RequireReady()
+    {
+        if (_stack.IsReady) return;
+        if (DockerAvailability.RequireDocker)
+        {
+            Assert.Fail(
+                $"PLATFORMS_REQUIRE_DOCKER=true but the engine full-stack fixture failed: {_stack.NotReadyReason}");
+        }
+        Assert.Inconclusive(
+            $"EngineFullStackFixture not ready ({_stack.NotReadyReason}) — see OneTimeSetUp output.");
+    }
+
+    // ================================================================
+    // THE headline — the full engine-driven autonomous cycle
+    // ================================================================
+
+    [Test, Timeout(1_500_000)] // 25 min: container-warm topology + one full cycle
+    public async Task FullEngineCycle_SingleIssue_CompletesOnGitea()
+    {
+        RequireReady();
+
+        // ── 1. seed the work item: the auto label + one issue carrying it ──
+        await PostGiteaAsync($"/api/v1/repos/{Owner}/{Repo}/labels",
+            new { name = AutoLabel, color = "#00aabb", description = "tamma work-selection label" });
+        var labels = await GetGiteaAsync($"/api/v1/repos/{Owner}/{Repo}/labels");
+        var labelId = labels.EnumerateArray()
+            .First(l => l.GetProperty("name").GetString() == AutoLabel)
+            .GetProperty("id").GetInt64();
+
+        var issue = await PostGiteaAsync($"/api/v1/repos/{Owner}/{Repo}/issues", new
+        {
+            title = "E2E: implement the scripted feature",
+            body = "Seeded by GiteaEngineDrivenE2ETests — the engine-driven autonomous headline.",
+            labels = new[] { labelId },
+        });
+        var issueNumber = (int)issue.GetProperty("number").GetInt64();
+
+        // ── 2. start the autonomous loop: dispatch the REAL adl-orchestrator ──
+        // cooldownSeconds is set high ON PURPOSE: the loop's self-restart would
+        // otherwise re-select the same still-open issue (Gitea cannot close
+        // issues — IssueLifecycle is capability-degraded), and this test wants
+        // exactly ONE deterministic cycle in its window.
+        var dispatch = await _engine.PostAsJsonAsync(
+            "/elsa/api/workflow-definitions/adl-orchestrator/dispatch", new
+            {
+                input = new Dictionary<string, object>
+                {
+                    ["repository"] = RepoSlug,
+                    ["issueLabels"] = new[] { AutoLabel },
+                    ["botAssignee"] = _stack.Gitea.OwnerLogin,
+                    ["baseBranch"] = _stack.Gitea.DefaultBranch,
+                    ["configJson"] = """{"cooldownSeconds": 3600, "maxIssuesPerRun": 1}""",
+                },
+            }, Json);
+        var dispatchBody = await dispatch.Content.ReadAsStringAsync();
+        dispatch.IsSuccessStatusCode.Should().BeTrue(
+            $"adl-orchestrator dispatch answered {(int)dispatch.StatusCode}: {dispatchBody}\n"
+            + $"engine log tail:\n{_stack.EngineLogTail(1500)}");
+
+        // ── 3. the cycle must actually start (work selected + dispatched) ──
+        await WaitForEventAsync("CYCLE.STARTED", TimeSpan.FromMinutes(4),
+            "the orchestrator must select the seeded issue and dispatch the single-issue cycle");
+
+        // ── 4. drive the three BY-DESIGN external seams until the PR merges ──
+        var merged = await PumpUntilMergedAsync(issueNumber, TimeSpan.FromMinutes(14));
+        merged.Should().BeTrue(
+            "the cycle must reach a REAL merged PR in Gitea. "
+            + $"api log tail:\n{_stack.ApiLogTail(2000)}\nengine log tail:\n{_stack.EngineLogTail(3000)}");
+
+        // ── 5. the platform's own verdict ──
+        var prNumber = await FindCyclePrNumberAsync(state: "closed");
+        prNumber.Should().NotBeNull("the cycle's PR must exist in Gitea");
+        var pr = await GetGiteaAsync($"/api/v1/repos/{Owner}/{Repo}/pulls/{prNumber}");
+        pr.GetProperty("merged").GetBoolean().Should().BeTrue("the epic's headline: really merged on the Gitea side");
+        pr.GetProperty("title").GetString().Should().NotStartWith("WIP:",
+            "the cycle must have un-drafted the PR before the merge gate");
+
+        // ── 6. the scripted agent's commits are REAL code on the merged tree ──
+        using (var files = await GetGiteaRawAsync(
+                   $"/api/v1/repos/{Owner}/{Repo}/pulls/{prNumber}/files?limit=50"))
+        {
+            var paths = files.RootElement.EnumerateArray()
+                .Select(f => f.GetProperty("filename").GetString())
+                .ToList();
+            paths.Should().Contain(p => p!.StartsWith("src/scripted/"),
+                "the TDD loop's scripted agent executor must have committed real files to the branch "
+                + $"(files: [{string.Join(", ", paths)}])");
+        }
+
+        // ── 7. the cycle runs to COMPLETION (post-merge deployment included) ──
+        await WaitForEventAsync("CYCLE.COMPLETED", TimeSpan.FromMinutes(5),
+            "after the merge webhook resumes WaitForPRMerged, the deployment pipeline "
+            + "(scripted qa/uat/prod deploys) must finish and the cycle must emit its terminal");
+
+        // ── 8. audit trail: every leg left its durable event ──
+        var types = await EventTypesAsync();
+
+        // The git surface, engine-driven this time.
+        types.Should().Contain("GIT.BRANCH_CREATED.SUCCESS");
+        types.Should().Contain("GIT.PR_OPENED.SUCCESS");
+        types.Should().Contain("GIT.PR_DRAFT_SET.SUCCESS", "the cycle un-drafts before the merge gate");
+        types.Should().Contain("GIT.PR_MERGED.SUCCESS");
+
+        // The webhook→engine resume leg (P4/DG-6), now cycle-attached.
+        types.Should().Contain("CYCLE.PR_MERGE_WAIT.RESUMED",
+            "the merged-PR webhook must cross the container gateway, be verified by the receiver, "
+            + "and resume the engine's WaitForPRMerged bookmark");
+
+        // The document plane: typed documents were produced AND accepted.
+        types.Should().Contain("DOCUMENT.ACCEPTED",
+            "the plan/tasks/test-spec lifecycles must reach accepted terminals");
+        types.Should().Contain("APPROVAL.REQUESTED");
+        types.Should().Contain("APPROVAL.PROVIDED");
+
+        // The LLM plane ran managed + scripted (no network LLM anywhere).
+        types.Should().Contain("AGENT.RUN.SUCCESS", "the managed llm-call path served the cycle");
+        var scriptedRun = await AnyEventWithTagAsync("AGENT.RUN.SUCCESS", "\"provider\":\"scripted\"");
+        scriptedRun.Should().BeTrue("the runs must have been served by the scripted provider");
+
+        // The CI leg (stub trigger + DG-5 resume): the gate evaluated and passed.
+        types.Should().Contain("GATE.EVALUATED.SUCCESS");
+        types.Should().Contain("GATE.PASSED.SUCCESS",
+            "the green DG-5 resume (build passed, coverage forwarded) must pass the quality gate");
+    }
+
+    // ================================================================
+    // the pump — plays the three BY-DESIGN external actors
+    // ================================================================
+
+    private async Task<bool> PumpUntilMergedAsync(int issueNumber, TimeSpan budget)
+    {
+        var handledSessions = new HashSet<string>();
+        var mergeDecisionPosted = false;
+        var deadline = DateTimeOffset.UtcNow.Add(budget);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            // (a) accept every pending document decision (the orchestrator seat).
+            foreach (var sessionId in await PendingDecisionSessionsAsync())
+            {
+                if (!handledSessions.Add(sessionId)) continue;
+                using var resp = await _api.PostAsJsonAsync(
+                    $"/api/documents/decisions/{sessionId}/resume",
+                    new { kind = "accept", feedback = "e2e harness: accepted" }, Json);
+                // 404 = already decided / gate burned — benign; anything else is
+                // surfaced via the final assertion timing out.
+                TestContext.Out.WriteLine(
+                    $"[pump] decision accept session={sessionId} -> {(int)resp.StatusCode}");
+            }
+
+            // (b) resume every suspended CI wait with a green result (the CI seat).
+            foreach (var wait in await ListCiWaitsAsync())
+            {
+                using var resp = await _engine.PostAsJsonAsync("/elsa/api/ci/waits/resume", new
+                {
+                    bookmarkId = wait.BookmarkId,
+                    runId = wait.RunId,
+                    status = "Succeeded",
+                    buildPassed = true,
+                    totalTests = 5,
+                    passedTests = 5,
+                    failedTests = 0,
+                    coveragePercentage = 100.0,
+                    lintWarnings = 0,
+                    lintErrors = 0,
+                }, Json);
+                TestContext.Out.WriteLine(
+                    $"[pump] ci resume bookmark={wait.BookmarkId} run={wait.RunId} -> {(int)resp.StatusCode}");
+            }
+
+            // (c) the human merge decision (the approver seat) — once the PR is
+            // un-drafted AND Gitea's async mergeability checker has settled.
+            var openPr = await FindCyclePrAsync(state: "open");
+            if (!mergeDecisionPosted && openPr is { } p
+                && p.TryGetProperty("title", out var t) && !(t.GetString() ?? "").StartsWith("WIP:")
+                && p.TryGetProperty("mergeable", out var m) && m.GetBoolean())
+            {
+                var prNumber = (int)p.GetProperty("number").GetInt64();
+                using var resp = await _engine.PostAsJsonAsync("/elsa/api/adl/merge-approval/resume", new
+                {
+                    issueNumber,
+                    prNumber,
+                    decision = "merge",
+                    feedback = "e2e harness: approved",
+                    approver = "e2e-harness",
+                    tenantId = (string?)null,
+                    repository = RepoSlug,
+                }, Json);
+                TestContext.Out.WriteLine(
+                    $"[pump] merge decision pr={prNumber} -> {(int)resp.StatusCode}");
+                // 404 = the gate is not suspended yet — retry next tick.
+                if (resp.StatusCode != HttpStatusCode.NotFound) mergeDecisionPosted = true;
+            }
+
+            // Terminal check: the PR is merged in Gitea.
+            var mergedPr = await FindCyclePrAsync(state: "closed");
+            if (mergedPr is { } mp
+                && mp.TryGetProperty("merged", out var mrgd) && mrgd.GetBoolean())
+            {
+                return true;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        return false;
+    }
+
+    /// <summary>Session ids of APPROVAL.REQUESTED audit rows (the cycle's own
+    /// durable trace of suspended accept gates).</summary>
+    private async Task<IReadOnlyList<string>> PendingDecisionSessionsAsync()
+    {
+        var rows = (await AllDurableEventsAsync())
+            .Where(e => e.Type == "APPROVAL.REQUESTED")
+            .Select(e => e.Tags)
+            .ToList();
+
+        var sessions = new List<string>();
+        foreach (var tags in rows)
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(tags);
+                if (doc.RootElement.TryGetProperty("sessionId", out var s)
+                    && s.GetString() is { Length: > 0 } sid)
+                {
+                    sessions.Add(sid);
+                }
+            }
+            catch (JsonException) { /* malformed tags row — skip */ }
+        }
+        return sessions;
+    }
+
+    private sealed record CiWait(string BookmarkId, string RunId);
+
+    private async Task<IReadOnlyList<CiWait>> ListCiWaitsAsync()
+    {
+        using var resp = await _engine.GetAsync("/elsa/api/ci/waits");
+        if (!resp.IsSuccessStatusCode) return Array.Empty<CiWait>();
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        if (!doc.RootElement.TryGetProperty("waits", out var waits)) return Array.Empty<CiWait>();
+        return waits.EnumerateArray()
+            .Select(w => new CiWait(
+                w.GetProperty("bookmarkId").GetString() ?? "",
+                w.GetProperty("runId").GetString() ?? ""))
+            .Where(w => w.BookmarkId.Length > 0)
+            .ToList();
+    }
+
+    private async Task<JsonElement?> FindCyclePrAsync(string state)
+    {
+        using var resp = await _gitea.GetAsync(
+            $"/api/v1/repos/{Owner}/{Repo}/pulls?state={state}&limit=20");
+        if (!resp.IsSuccessStatusCode) return null;
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        foreach (var pr in doc.RootElement.EnumerateArray())
+        {
+            var head = pr.GetProperty("head").GetProperty("ref").GetString() ?? "";
+            if (head.StartsWith("adl/", StringComparison.Ordinal))
+            {
+                return pr.Clone();
+            }
+        }
+        return null;
+    }
+
+    private async Task<int?> FindCyclePrNumberAsync(string state)
+    {
+        var pr = await FindCyclePrAsync(state);
+        return pr is { } p ? (int)p.GetProperty("number").GetInt64() : null;
+    }
+
+    private async Task WaitForEventAsync(string type, TimeSpan timeout, string because)
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(timeout);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if ((await AllDurableEventsAsync()).Any(e => e.Type == type))
+            {
+                return;
+            }
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+        Assert.Fail(
+            $"Event '{type}' did not appear within {timeout.TotalSeconds}s — {because}.\n"
+            + $"api log tail:\n{_stack.ApiLogTail(2000)}\nengine log tail:\n{_stack.EngineLogTail(3000)}");
+    }
+
+    private async Task<IReadOnlyList<string>> EventTypesAsync()
+        => (await AllDurableEventsAsync()).Select(e => e.Type).Distinct().ToList();
+
+    private async Task<bool> AnyEventWithTagAsync(string type, string tagFragment)
+        => (await AllDurableEventsAsync())
+            .Any(e => e.Type == type && e.Tags.Contains(tagFragment, StringComparison.Ordinal));
+
+    /// <summary>
+    /// ALL durable audit rows the cycle writes, across BOTH planes:
+    /// the control-plane <c>platform_events</c> table AND every tenant schema's
+    /// <c>t_&lt;hex&gt;.domain_events</c> on the same central database. The
+    /// single-user service-plane binding (EnsurePersonalTenantMiddleware, item
+    /// 12 of the engine-DI finding) means the engine's mediated calls carry the
+    /// sole user's PERSONAL tenant — so the cycle's DCB events land in that
+    /// tenant's schema, not the platform plane, exactly as they do on a
+    /// deployed single-user instance.
+    /// </summary>
+    private async Task<IReadOnlyList<(string Type, string Tags)>> AllDurableEventsAsync()
+    {
+        var events = new List<(string Type, string Tags)>();
+
+        await using var db = _stack.Stack.CreateDbContext();
+        events.AddRange((await db.PlatformEvents.AsNoTracking()
+                .OrderBy(e => e.CreatedAt)
+                .Select(e => new { e.Type, e.Tags })
+                .ToListAsync())
+            .Select(e => (e.Type, e.Tags)));
+
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+        {
+            await conn.OpenAsync();
+        }
+
+        var schemas = new List<string>();
+        await using (var cmd = conn.CreateCommand())
+        {
+            cmd.CommandText = "SELECT nspname FROM pg_namespace WHERE nspname LIKE 't#_%' ESCAPE '#'";
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                schemas.Add(reader.GetString(0));
+            }
+        }
+
+        foreach (var schema in schemas)
+        {
+            try
+            {
+                await using var cmd = conn.CreateCommand();
+                // schema name comes from pg_namespace (t_<hex> minted by the
+                // provisioner) — not attacker-controlled; quoted for safety.
+                cmd.CommandText =
+                    $"SELECT \"Type\", \"Tags\"::text FROM \"{schema}\".domain_events ORDER BY \"CreatedAt\"";
+                await using var reader = await cmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    events.Add((reader.GetString(0), reader.GetString(1)));
+                }
+            }
+            catch (Npgsql.PostgresException ex) when (ex.SqlState == "42P01")
+            {
+                // The schema exists but its tables are still MID-PROVISION
+                // (CreateSchema landed, EfTenantDbMigrator has not) — the
+                // poll simply catches it on the next tick.
+            }
+        }
+
+        return events;
+    }
+
+    // ── wire helpers ─────────────────────────────────────────────────
+
+    private async Task<JsonElement> PostGiteaAsync(string path, object body)
+    {
+        using var resp = await _gitea.PostAsJsonAsync(path, body, Json);
+        var text = await resp.Content.ReadAsStringAsync();
+        resp.IsSuccessStatusCode.Should().BeTrue($"POST {path} → {(int)resp.StatusCode}: {text}");
+        return JsonDocument.Parse(text).RootElement.Clone();
+    }
+
+    private async Task<JsonElement> GetGiteaAsync(string path)
+    {
+        using var resp = await _gitea.GetAsync(path);
+        var text = await resp.Content.ReadAsStringAsync();
+        resp.IsSuccessStatusCode.Should().BeTrue($"GET {path} → {(int)resp.StatusCode}: {text}");
+        return JsonDocument.Parse(text).RootElement.Clone();
+    }
+
+    private async Task<JsonDocument> GetGiteaRawAsync(string path)
+    {
+        using var resp = await _gitea.GetAsync(path);
+        var text = await resp.Content.ReadAsStringAsync();
+        resp.IsSuccessStatusCode.Should().BeTrue($"GET {path} → {(int)resp.StatusCode}: {text}");
+        return JsonDocument.Parse(text);
+    }
+}

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaFullStackE2ETests.cs
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/GiteaFullStackE2ETests.cs
@@ -384,22 +384,18 @@ public class GiteaFullStackE2ETests
     }
 
     // ================================================================
-    // 7 — the engine-driven headline (recorded gap)
+    // 7 — the engine-driven headline: UN-BLOCKED (2026-08-13)
     // ================================================================
-
-    [Test, Order(7)]
-    public void FullEngineCycle_SingleIssue_CompletesOnGitea()
-    {
-        Assert.Ignore(
-            "Deferred pending an LLM stub: the single-issue-cycle workflow's plan/review/task "
-            + "steps run through POST /api/v1/llm/call and the codebase ships no fake/echo LLM "
-            + "provider — a scripted no-LLM seam exists only for the AGENT plane "
-            + "(LocalExecutor's IProcessRunner/CLI protocol). Every git-plane leg the engine "
-            + "would drive is proven above through the SAME governed routes the engine's "
-            + "activities call (CycleGitSurface_SeededIssue_To_MergedPr_OnGitea + the webhook "
-            + "receiver leg); the remaining delta is the Elsa host + LLM stub, tracked for the "
-            + "P5 follow-up in docs/stories/epic-31/EXECUTION-PLAN.md §3 P5.");
-    }
+    //
+    // The formerly-Ignored FullEngineCycle_SingleIssue_CompletesOnGitea now
+    // runs for real in GiteaEngineDrivenE2ETests: the scripted LLM provider
+    // (Llm:EnableScriptedProvider — the missing fake/echo provider this test
+    // was deferred on) plus the scripted agent executor join the REAL
+    // Tamma.ElsaServer process to this same topology, and the ACTUAL
+    // AdlOrchestrator/SingleIssueCycle workflows drive one seeded issue from
+    // selection to merged-in-Gitea + CYCLE.COMPLETED. This suite keeps proving
+    // the governed git SURFACE in isolation (faster, sharper failure
+    // localization); the engine-driven suite proves the cycle DRIVES it.
 
     // ── wire helpers ─────────────────────────────────────────────────
 

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/README.md
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/README.md
@@ -149,11 +149,56 @@ Topology (one logical deployment):
   dotnet test tests/Tamma.Platforms.IntegrationTests --filter "TestCategory=GiteaE2E"
   ```
 
-Recorded gap (see the explicitly-Ignored
-`FullEngineCycle_SingleIssue_CompletesOnGitea`): driving the cycle from
-the Tamma.ElsaServer engine process needs an LLM stub — the plan/review/
-task steps run through `POST /api/v1/llm/call` and no fake/echo provider
-exists in the codebase. The scripted no-LLM seam that DOES exist
-(`LocalExecutor`'s `IProcessRunner` / CLI exec-request protocol) covers
-only the agent plane. Until an LLM stub lands, the engine-driven variant
-cannot run anywhere, nightly CI included.
+## The engine-driven autonomous E2E (2026-08-13 — the recorded gap, closed)
+
+`GiteaEngineDrivenE2ETests` (+ `Fixtures/EngineFullStackFixture`) is the
+formerly-Ignored headline made real: the LLM stub the gap was recorded
+against now exists (the opt-in **scripted LLM provider**,
+`Llm:EnableScriptedProvider` — deterministic in-process responses keyed
+on role/action/document-type, structurally un-enablable on any
+production-shaped host), so the REAL `Tamma.ElsaServer` binary joins the
+P5 topology as a second host process and the ACTUAL
+AdlOrchestrator → SingleIssueCycle workflows drive one seeded issue:
+
+```
+┌ containers ────────────────────────────┐  ┌ host processes ──────────────┐
+│ gitea/gitea:1.21   postgres:17 ×2      │  │ Tamma.Api  (real binary)     │
+│  └ webhooks → host.docker.internal ────┼─▶│   ▲ llm/git/issue mediation  │
+│                                        │◀─┼─  │  + scripted LLM provider │
+│  (engine DB = 3rd database on the      │  │ Tamma.ElsaServer (real       │
+│   app-DB container)                    │  │   binary, drives the cycle)  │
+└────────────────────────────────────────┘  └──────────────────────────────┘
+```
+
+- **Engine config:** `Llm:DefaultProviderChain=[scripted]` (the config-tier
+  provider selection), `Testing:UseMock=true` (CI-stub trigger),
+  `Agent:Local:*` → a python3 scripted agent that makes ONE real commit
+  per task via the Gitea API (empirically required: Gitea opens a
+  zero-diff draft PR but refuses to merge a commit-less one).
+- **The harness plays only the BY-DESIGN external actors**, each through
+  its shipped seam: the document decider
+  (`POST /api/documents/decisions/{sessionId}/resume`, sessions discovered
+  from APPROVAL.REQUESTED audit rows), the CI system (the engine's DG-5
+  `/elsa/api/ci/waits` seam, now forwarding the full result fields), and
+  the human merge approver (`/elsa/api/adl/merge-approval/resume`).
+- **What it proves end-to-end:** work selected off the seeded label →
+  typed documents (plan/tasks/test-spec) produced against the REAL
+  validators and accepted → branch + draft PR in Gitea → scripted agent
+  commits → CI-stub leg green → un-draft → merge decision → REAL
+  squash-merge → the merged-PR webhook crosses the container gateway and
+  resumes `WaitForPRMerged` → scripted deployment pipeline →
+  `CYCLE.COMPLETED`. Zero GitHub configuration, zero network LLM.
+- Same nightly gating as the P5 suite (`GiteaE2E` + `Nightly`; the
+  `gitea-e2e-nightly` job / `run-gitea-e2e` PR label). Locally:
+  `dotnet build Tamma.sln` then
+  `dotnet test tests/Tamma.Platforms.IntegrationTests --filter "TestCategory=GiteaE2E"`.
+- The engine runs as `ASPNETCORE_ENVIRONMENT=Production` (matching the
+  deployed engine) — one pre-existing engine DI composition defect
+  (`HourlyAnalyticsRollupScheduler`, a captive dependency) refuses a
+  Development boot and is outside this suite's scope. Re-entry is
+  ENABLED: the engine host now defaults to the HTTP-backed
+  latest-accepted read (`HttpLifecycleReEntryService`) — the plan-review
+  shim REQUIRES that read, so the old `Documents:ReEntryDisabled=true`
+  posture made every cycle terminate needs-human. The full defect
+  inventory this suite surfaced (23 items) is recorded in
+  `.dev/findings/engine-di-composition-gaps-found-by-e2e.md`.

--- a/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/README.md
+++ b/apps/tamma-elsa/tests/Tamma.Platforms.IntegrationTests/README.md
@@ -202,3 +202,44 @@ AdlOrchestrator → SingleIssueCycle workflows drive one seeded issue:
   posture made every cycle terminate needs-human. The full defect
   inventory this suite surfaced (23 items) is recorded in
   `.dev/findings/engine-di-composition-gaps-found-by-e2e.md`.
+
+## Running these suites in a locked-down sandbox (2026-08-14)
+
+A cloud dev sandbox may have neither the .NET SDK nor open registry access, and
+container resets can remove both mid-session. The recipe that works — recorded
+so the next run does not rediscover it:
+
+1. **No local SDK, and the installer host is blocked by network policy.** Run
+   every `dotnet` command inside the official SDK image instead, with the agent
+   proxy, the CA bundle, the NuGet cache, the docker socket AND the host's
+   `docker` binary mounted (the SDK image has no docker CLI, so the availability
+   probe throws `Win32Exception` and every fixture skips):
+
+   ```bash
+   docker run --rm --network host \
+     -e HTTP_PROXY -e HTTPS_PROXY -e NO_PROXY -e SSL_CERT_FILE=/ca/ca-bundle.crt \
+     -e TESTCONTAINERS_RYUK_DISABLED=true -e TMPDIR=/e2e-tmp \
+     -v /root/.ccr:/ca:ro -v <repo>:/src -v /root/.nuget:/root/.nuget \
+     -v <host-log-dir>:/e2e-tmp \
+     -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker:ro \
+     -w /src/apps/tamma-elsa mcr.microsoft.com/dotnet/sdk:8.0 dotnet test ...
+   ```
+
+   `TMPDIR` matters: the fixtures write their API/engine logs to the temp
+   directory, and without the mount those logs die with the container — which is
+   exactly what you need when a run fails.
+
+2. **Docker Hub blob downloads answer 403 through the proxy.** Pull from the
+   GCR mirror and retag to the names the fixtures request:
+
+   ```bash
+   docker pull mirror.gcr.io/library/postgres:17-alpine
+   docker tag  mirror.gcr.io/library/postgres:17-alpine postgres:17-alpine
+   docker pull mirror.gcr.io/gitea/gitea:1.21
+   docker tag  mirror.gcr.io/gitea/gitea:1.21 gitea/gitea:1.21
+   ```
+
+3. **The docker daemon stops on its own.** `docker info || ((sudo -n dockerd
+   >/tmp/dockerd.log 2>&1 &); sleep 15)` before any run.
+
+None of this applies to CI, which has a real SDK and registry access.

--- a/docs/sprint-status.yaml
+++ b/docs/sprint-status.yaml
@@ -467,8 +467,15 @@ development_status:
   #   P3 CI/agent-dispatch/engine callbacks on the driver plane + CI completion poller (DG-5); P4 webhook handlers + registration + CI secrets;
   #   P5 Gitea lifecycle + degradation pairs + full-stack Gitea E2E (headline: the cycle's git surface completes on Gitea, zero GitHub config);
   #   P6 GitLab lifecycle + diff_refs hardening + GitLab harness real (nightly) + mediation-level GitLab acceptance (full-stack GitLab E2E deferred per §7 owner default).
-  # Recorded follow-ups (outside the epic): (a) engine-DRIVEN E2E blocked on an LLM stub — no fake/echo LLM provider exists, so a fully autonomous
-  #   no-network-LLM cycle cannot execute anywhere incl. nightly CI (GiteaFullStackE2ETests documents this honestly);
+  # Recorded follow-ups (outside the epic): (a) CLOSED 2026-08-13 — the engine-DRIVEN E2E is no longer blocked: the scripted LLM provider landed
+  #   (opt-in "scripted" key, Llm:EnableScriptedProvider, deterministic role/action/document-type-keyed responses that pass the real 39-x validators;
+  #   structurally un-enablable on production-shaped hosts) and GiteaEngineDrivenE2ETests + EngineFullStackFixture now run the REAL Tamma.ElsaServer
+  #   against the P5 topology: seeded issue → AdlOrchestrator selects → SingleIssueCycle drives plan/tasks/test-spec (typed docs accepted) → branch +
+  #   draft PR → scripted agent commits → CI-stub leg (DG-5 resume, result fields now forwarded) → un-draft → merge decision → REAL Gitea squash-merge →
+  #   merged-PR webhook resumes WaitForPRMerged → scripted deployment pipeline → CYCLE.COMPLETED; zero GitHub config, zero network LLM. The harness
+  #   plays only the by-design external actors (document decider, CI system, human merge approver) through their shipped seams. The 23 real engine/API
+  #   defects the E2E surfaced en route (all fixed in the same change except two open DI composition gaps) are recorded in
+  #   .dev/findings/engine-di-composition-gaps-found-by-e2e.md;
   #   (b) github_installations naming — the guard-registry table is GitHub-named but carries non-GitHub single-user grants (P5 finding);
   #   (c) GitLab loop verbs (issue lifecycle/releases/commits/security-alerts) stay typed-unsupported by design — the DG degradation paths keep cycles alive.
   epic-31-retrospective: optional


### PR DESCRIPTION
**Diagnostic PR — do not review or merge. It will be closed once it has served its purpose.**

Same head as #512 (`755d1b0`), pushed under a differently-named branch to test one hypothesis: seven CI runs on `claude/wiki-docs-sync-r31nvo` have been cancelled externally mid-run, with no competing push, no human actor, and no concurrency-group collision (see `.dev/findings/external-ci-run-cancellations-pr-511.md`).

If this PR's CI completes normally, the canceller is scoped to that branch name (or to whatever watches it) rather than to the commits — which both identifies the culprit's scope and gives the Epic 31 follow-up work its one uninterrupted verification run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d

---
_Generated by [Claude Code](https://claude.ai/code/session_015i9QH51AQnxeW4hp9F482d)_